### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2026-04-05
+
+### Features
+
+- improve hybrid drilldown compatibility
+- expand drilldown and compatibility coverage
+- improve tenant defaults and observability
+
+### Bug Fixes
+
+- stabilize compatibility and release automation
+- repair auto release workflow
+- backfill changelog and release tagging
+
+### Tests
+
+- 974 total tests (82.9% coverage)
+
 ## [Unreleased]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![VictoriaLogs Compatibility](https://github.com/szibis/Loki-VL-proxy/actions/workflows/compat-vl.yaml/badge.svg)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/compat-vl.yaml)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/szibis/Loki-VL-proxy)](https://go.dev/)
 [![Release](https://img.shields.io/github/v/release/szibis/Loki-VL-proxy)](https://github.com/szibis/Loki-VL-proxy/releases)
-[![Tests](https://img.shields.io/badge/tests-887%20passed-brightgreen)](#tests)
+[![Tests](https://img.shields.io/badge/tests-974%20passed-brightgreen)](#tests)
 [![LogQL Coverage](https://img.shields.io/badge/LogQL%20coverage-100%25-brightgreen)](#logql-compatibility)
 [![License](https://img.shields.io/github/license/szibis/Loki-VL-proxy)](LICENSE)
 [![CodeQL](https://github.com/szibis/Loki-VL-proxy/actions/workflows/codeql.yaml/badge.svg)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/codeql.yaml)

--- a/charts/loki-vl-proxy/Chart.yaml
+++ b/charts/loki-vl-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-vl-proxy
 description: HTTP proxy translating Loki API to VictoriaLogs
 type: application
-version: 0.24.0
-appVersion: "0.24.0"
+version: 0.25.0
+appVersion: "0.25.0"
 home: https://github.com/szibis/Loki-VL-proxy
 sources:
   - https://github.com/szibis/Loki-VL-proxy


### PR DESCRIPTION
## Release v0.25.0

Auto-generated from conventional commits.

## [0.25.0] - 2026-04-05

### Features

- improve hybrid drilldown compatibility
- expand drilldown and compatibility coverage
- improve tenant defaults and observability

### Bug Fixes

- stabilize compatibility and release automation
- repair auto release workflow
- backfill changelog and release tagging

### Tests

- 974 total tests (82.9% coverage)

**Stats**: 974 tests, 82.9% coverage

> After merge, tag `v0.25.0` will be created and the release workflow will build binaries, Docker images, checksums, and the Helm chart package.