### PR TITLE
[codex] improve observability and PR quality reporting

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -151,11 +151,17 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-          # Insert into CHANGELOG.md after header
+          # Keep Unreleased at the top and place the new version under it.
           TEMP=$(mktemp)
           awk -v entry="$(cat "$ENTRY")" '
-            /^## \[/ && !done { print entry; print ""; done=1 }
+            /^## \[[0-9]/ && !done { print entry; print ""; done=1 }
             { print }
+            END {
+              if (!done) {
+                print ""
+                print entry
+              }
+            }
           ' CHANGELOG.md > "$TEMP"
           mv "$TEMP" CHANGELOG.md
 

--- a/.github/workflows/pr-quality-report.yaml
+++ b/.github/workflows/pr-quality-report.yaml
@@ -1,0 +1,96 @@
+name: PR Quality Report
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+          cache: true
+
+      - name: Collect base and PR quality snapshots
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+
+          git worktree add /tmp/loki-vl-proxy-base "$BASE_SHA"
+
+          bash "$WORKSPACE/scripts/ci/collect_quality_metrics.sh" /tmp/pr-head-quality.json
+          (
+            cd /tmp/loki-vl-proxy-base
+            bash "$WORKSPACE/scripts/ci/collect_quality_metrics.sh" /tmp/pr-base-quality.json
+          )
+
+          bash "$WORKSPACE/scripts/ci/render_pr_report.sh" \
+            /tmp/pr-base-quality.json \
+            /tmp/pr-head-quality.json \
+            /tmp/pr-quality-report.md
+
+          cat /tmp/pr-quality-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload quality artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-quality-report
+          path: |
+            /tmp/pr-base-quality.json
+            /tmp/pr-head-quality.json
+            /tmp/pr-quality-report.md
+
+      - name: Publish sticky PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const body = fs.readFileSync('/tmp/pr-quality-report.md', 'utf8');
+            const marker = '<!-- pr-quality-report -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Clean up base worktree
+        if: always()
+        run: git worktree remove --force /tmp/loki-vl-proxy-base || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+- observability guide with metrics catalog, JSON log schema, and collector/agent integration examples
+- OTLP metrics export now carries the same core proxy metric names as `/metrics`
+- OTel-friendly JSON logging is now used consistently across proxy, disk cache, cache warmer, and OTLP export paths
+
+### Tests
+
+- expanded OTLP exporter and observability configuration coverage
+
 ## [0.25.0] - 2026-04-05
 
 ### Features
@@ -12,26 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improve hybrid drilldown compatibility
 - expand drilldown and compatibility coverage
 - improve tenant defaults and observability
+- **Single-tenant VictoriaLogs migration mode**: `X-Scope-OrgID: "0"` and `X-Scope-OrgID: "*"` now use VictoriaLogs' default tenant (`AccountID=0`, `ProjectID=0`) when no tenant map is configured. This keeps Grafana Loki datasources simple for single-tenant backends while preserving strict mapped multitenancy.
+- **Optional global bypass in mapped mode**: New `-tenant.allow-global` flag allows `0` and `*` to keep using the backend default tenant even when a tenant map is configured, making staged migrations from Loki string tenants to VictoriaLogs numeric tenants easier.
+- **Client identity propagation**: The proxy now derives client identity from trusted Grafana headers, tenant, basic auth, or remote address and forwards `X-Loki-VL-Client-ID` and `X-Loki-VL-Client-Source` to the backend. When `-metrics.trust-proxy-headers=true`, `X-Grafana-User` is also forwarded.
+- **Client-centric observability**: `/metrics` now exports per-client request counters, per-client status breakdowns, in-flight request gauges, response bytes, and LogQL query length histograms to identify the real users driving load.
+- **Fleet peer-cache observability**: Added peer-cache metrics for remote peers, total ring members, peer hits, misses, and errors so fleet behavior can be diagnosed without relying only on logs.
 
 ### Bug Fixes
 
 - stabilize compatibility and release automation
 - repair auto release workflow
 - backfill changelog and release tagging
-
-### Tests
-
-- 974 total tests (82.9% coverage)
-
-## [Unreleased]
-
-### Features
-
-- **Single-tenant VictoriaLogs migration mode**: `X-Scope-OrgID: "0"` and `X-Scope-OrgID: "*"` now use VictoriaLogs' default tenant (`AccountID=0`, `ProjectID=0`) when no tenant map is configured. This keeps Grafana Loki datasources simple for single-tenant backends while preserving strict mapped multitenancy.
-- **Optional global bypass in mapped mode**: New `-tenant.allow-global` flag allows `0` and `*` to keep using the backend default tenant even when a tenant map is configured, making staged migrations from Loki string tenants to VictoriaLogs numeric tenants easier.
-- **Client identity propagation**: The proxy now derives client identity from trusted Grafana headers, tenant, basic auth, or remote address and forwards `X-Loki-VL-Client-ID` and `X-Loki-VL-Client-Source` to the backend. When `-metrics.trust-proxy-headers=true`, `X-Grafana-User` is also forwarded.
-- **Client-centric observability**: `/metrics` now exports per-client request counters, per-client status breakdowns, in-flight request gauges, response bytes, and LogQL query length histograms to identify the real users driving load.
-- **Fleet peer-cache observability**: Added peer-cache metrics for remote peers, total ring members, peer hits, misses, and errors so fleet behavior can be diagnosed without relying only on logs.
 
 ### Security
 
@@ -52,9 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
-- Added unit coverage for global tenant fallback, mapped-mode global bypass, trusted Grafana user forwarding, client-centric metrics, and peer-cache metrics exposure.
-- Updated Loki e2e compatibility tests to cover the single-tenant default-tenant flow for `X-Scope-OrgID: 0` and `*`.
-- Verified locally with `go test ./...`, `go test ./... -race`, `golangci-lint run --timeout=5m`, `helm lint charts/loki-vl-proxy/`, `go test -v -tags=e2e -timeout=180s ./test/e2e-compat/...`, and `go test -v -tags=e2e -timeout=180s ./test/e2e-fleet/...`.
+- 974 total tests (82.9% coverage)
 
 ## [0.24.0] - 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ flowchart TD
     style CB fill:#533483,stroke:#e94560,color:#fff
 ```
 
-See [Architecture](docs/architecture.md) for component design and [Fleet Cache](docs/fleet-cache.md) for distributed caching.
+See [Architecture](docs/architecture.md) for component design, [Observability](docs/observability.md) for metrics/logging/integration guidance, and [Fleet Cache](docs/fleet-cache.md) for distributed caching.
 
 ## Key Features
 
@@ -126,10 +126,10 @@ See [Security](docs/security.md), [Configuration](docs/configuration.md), and [K
 - **TLS support** -- server-side HTTPS, backend TLS, OTLP TLS
 
 ### Operations
-See [Configuration](docs/configuration.md), [Testing](docs/testing.md), [Compatibility Matrix](docs/compatibility-matrix.md), and [Logs Drilldown Compatibility](docs/compatibility-drilldown.md).
+See [Configuration](docs/configuration.md), [Observability](docs/observability.md), [Testing](docs/testing.md), [Compatibility Matrix](docs/compatibility-matrix.md), and [Logs Drilldown Compatibility](docs/compatibility-drilldown.md).
 
 - **Multitenancy** -- Loki `X-Scope-OrgID` mapped to VL `AccountID`/`ProjectID`, SIGHUP hot-reload
-- **Observability** -- Prometheus `/metrics`, structured JSON logs, per-tenant breakdowns, per-client offender metrics, fleet peer-cache metrics, OTLP push
+- **Observability** -- Prometheus `/metrics`, OTLP push with matching core metric names, OTel-friendly JSON logs, per-tenant breakdowns, per-client offender metrics, fleet peer-cache metrics
 - **WebSocket tail** -- live log tailing via Loki's WebSocket protocol with fast handshake, origin controls, and synthetic fallback when native VL tail streaming is unavailable
 - **GOMEMLIMIT auto-tuning** -- Helm chart calculates Go memory limit as % of k8s resource limits
 
@@ -204,6 +204,17 @@ Proxy-side datasource helpers:
 - `-tenant.allow-global` to let `X-Scope-OrgID: 0` or `*` use VL's default `0:0` tenant during single-tenant migrations
 - `-tls-client-ca-file` and `-tls-require-client-cert` for HTTPS client auth
 - `-tail.allowed-origins` when Grafana or another browser client must use `/tail`
+
+## Docs
+
+- [Observability](docs/observability.md)
+- [Configuration](docs/configuration.md)
+- [API Reference](docs/api-reference.md)
+- [Architecture](docs/architecture.md)
+- [Fleet Cache](docs/fleet-cache.md)
+- [Performance](docs/performance.md)
+- [Compatibility Matrix](docs/compatibility-matrix.md)
+- [Testing](docs/testing.md)
 
 ## Release Automation
 

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -5,9 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -19,8 +20,27 @@ import (
 	"github.com/szibis/Loki-VL-proxy/internal/cache"
 	"github.com/szibis/Loki-VL-proxy/internal/metrics"
 	mw "github.com/szibis/Loki-VL-proxy/internal/middleware"
+	"github.com/szibis/Loki-VL-proxy/internal/observability"
 	"github.com/szibis/Loki-VL-proxy/internal/proxy"
 )
+
+var version = "dev"
+
+type envConfig struct {
+	listenAddr        string
+	backendURL        string
+	tenantMapJSON     string
+	otlpEndpoint      string
+	otlpCompression   string
+	otlpHeaders       string
+	labelStyle        string
+	fieldMappingJSON  string
+	metadataFieldMode string
+	serviceName       string
+	serviceNamespace  string
+	serviceInstanceID string
+	deploymentEnv     string
+}
 
 func main() {
 	// Server flags
@@ -46,6 +66,11 @@ func main() {
 	otlpCompression := flag.String("otlp-compression", "none", "OTLP compression: none, gzip, zstd")
 	otlpTimeout := flag.Duration("otlp-timeout", 10*time.Second, "OTLP HTTP request timeout")
 	otlpTLSSkipVerify := flag.Bool("otlp-tls-skip-verify", false, "Skip TLS verification for OTLP endpoint")
+	otlpHeaders := flag.String("otlp-headers", "", "Comma-separated OTLP HTTP headers in key=value form")
+	otelServiceName := flag.String("otel-service-name", "loki-vl-proxy", "OpenTelemetry service.name for logs and OTLP metrics")
+	otelServiceNamespace := flag.String("otel-service-namespace", "", "OpenTelemetry service.namespace for logs and OTLP metrics")
+	otelServiceInstanceID := flag.String("otel-service-instance-id", "", "OpenTelemetry service.instance.id for logs and OTLP metrics")
+	deploymentEnvironment := flag.String("deployment-environment", "", "OpenTelemetry deployment.environment.name for logs and OTLP metrics")
 
 	// HTTP server hardening
 	readTimeout := flag.Duration("http-read-timeout", 30*time.Second, "HTTP server read timeout")
@@ -105,39 +130,56 @@ func main() {
 
 	flag.Parse()
 
-	// Environment variable overrides
-	if v := os.Getenv("LISTEN_ADDR"); v != "" {
-		*listenAddr = v
-	}
-	if v := os.Getenv("VL_BACKEND_URL"); v != "" {
-		*backendURL = v
-	}
-	if v := os.Getenv("TENANT_MAP"); v != "" && *tenantMapJSON == "" {
-		*tenantMapJSON = v
-	}
-	if v := os.Getenv("OTLP_ENDPOINT"); v != "" && *otlpEndpoint == "" {
-		*otlpEndpoint = v
-	}
-	if v := os.Getenv("OTLP_COMPRESSION"); v != "" && *otlpCompression == "none" {
-		*otlpCompression = v
-	}
-	if v := os.Getenv("LABEL_STYLE"); v != "" && *labelStyle == "passthrough" {
-		*labelStyle = v
-	}
-	if v := os.Getenv("FIELD_MAPPING"); v != "" && *fieldMappingJSON == "" {
-		*fieldMappingJSON = v
-	}
-	if v := os.Getenv("METADATA_FIELD_MODE"); v != "" && *metadataFieldMode == "hybrid" {
-		*metadataFieldMode = v
+	envCfg := applyEnvOverrides(envConfig{
+		listenAddr:        *listenAddr,
+		backendURL:        *backendURL,
+		tenantMapJSON:     *tenantMapJSON,
+		otlpEndpoint:      *otlpEndpoint,
+		otlpCompression:   *otlpCompression,
+		otlpHeaders:       *otlpHeaders,
+		labelStyle:        *labelStyle,
+		fieldMappingJSON:  *fieldMappingJSON,
+		metadataFieldMode: *metadataFieldMode,
+		serviceName:       *otelServiceName,
+		serviceNamespace:  *otelServiceNamespace,
+		serviceInstanceID: *otelServiceInstanceID,
+		deploymentEnv:     *deploymentEnvironment,
+	}, os.Getenv)
+	*listenAddr = envCfg.listenAddr
+	*backendURL = envCfg.backendURL
+	*tenantMapJSON = envCfg.tenantMapJSON
+	*otlpEndpoint = envCfg.otlpEndpoint
+	*otlpCompression = envCfg.otlpCompression
+	*otlpHeaders = envCfg.otlpHeaders
+	*labelStyle = envCfg.labelStyle
+	*fieldMappingJSON = envCfg.fieldMappingJSON
+	*metadataFieldMode = envCfg.metadataFieldMode
+	*otelServiceName = envCfg.serviceName
+	*otelServiceNamespace = envCfg.serviceNamespace
+	*otelServiceInstanceID = envCfg.serviceInstanceID
+	*deploymentEnvironment = envCfg.deploymentEnv
+
+	logger := observability.NewLogger(os.Stdout, observability.LoggerConfig{
+		Level:                 *logLevel,
+		ServiceName:           *otelServiceName,
+		ServiceNamespace:      *otelServiceNamespace,
+		ServiceVersion:        version,
+		ServiceInstanceID:     *otelServiceInstanceID,
+		DeploymentEnvironment: *deploymentEnvironment,
+	})
+	slog.SetDefault(logger)
+	fatal := func(msg string, args ...any) {
+		logger.Error(msg, args...)
+		os.Exit(1)
 	}
 
 	// Parse tenant map
-	var tenantMap map[string]proxy.TenantMapping
-	if *tenantMapJSON != "" {
-		if err := json.Unmarshal([]byte(*tenantMapJSON), &tenantMap); err != nil {
-			log.Fatalf("Failed to parse -tenant-map JSON: %v", err)
-		}
-		log.Printf("Loaded %d tenant mappings", len(tenantMap))
+	tenantMap, err := parseTenantMapJSON(*tenantMapJSON)
+	if err != nil {
+		fatal("failed to parse tenant map json", "error", err)
+	}
+	if tenantMap != nil {
+		logger.Info("loaded tenant mappings", "count", len(tenantMap))
 	}
 
 	// L1 in-memory cache
@@ -152,12 +194,16 @@ func main() {
 			FlushInterval: *diskCacheFlushInterval,
 		})
 		if err != nil {
-			log.Fatalf("Failed to open disk cache: %v", err)
+			fatal("failed to open disk cache", "error", err)
 		}
 		defer func() { _ = dc.Close() }()
 		c.SetL2(dc)
-		log.Printf("L2 disk cache enabled at %s (compress=%v, flush=%d/%s)",
-			*diskCachePath, *diskCacheCompress, *diskCacheFlushSize, *diskCacheFlushInterval)
+		logger.Info("disk cache enabled",
+			"path", *diskCachePath,
+			"compress", *diskCacheCompress,
+			"flush_size", *diskCacheFlushSize,
+			"flush_interval", diskCacheFlushInterval.String(),
+		)
 	}
 
 	// Parse forward headers
@@ -172,39 +218,30 @@ func main() {
 	}
 
 	// Parse field mappings
-	var fieldMappings []proxy.FieldMapping
-	if *fieldMappingJSON != "" {
-		if err := json.Unmarshal([]byte(*fieldMappingJSON), &fieldMappings); err != nil {
-			log.Fatalf("Failed to parse -field-mapping JSON: %v", err)
-		}
-		log.Printf("Loaded %d custom field mappings", len(fieldMappings))
+	fieldMappings, err := parseFieldMappingsJSON(*fieldMappingJSON)
+	if err != nil {
+		fatal("failed to parse field mapping json", "error", err)
+	}
+	if fieldMappings != nil {
+		logger.Info("loaded field mappings", "count", len(fieldMappings))
 	}
 
 	// Validate label style
-	ls := proxy.LabelStyle(*labelStyle)
-	switch ls {
-	case proxy.LabelStylePassthrough, proxy.LabelStyleUnderscores:
-		// valid
-	default:
-		log.Fatalf("Invalid -label-style: %q (must be 'passthrough' or 'underscores')", *labelStyle)
+	ls, mfm, err := parseLabelModes(*labelStyle, *metadataFieldMode)
+	if err != nil {
+		fatal("invalid label mode configuration", "error", err)
 	}
 	if ls == proxy.LabelStyleUnderscores {
-		log.Printf("Label style: underscores (VL dotted field names → Loki underscore labels)")
-	}
-	mfm := proxy.MetadataFieldMode(*metadataFieldMode)
-	switch mfm {
-	case proxy.MetadataFieldModeNative, proxy.MetadataFieldModeTranslated, proxy.MetadataFieldModeHybrid:
-	default:
-		log.Fatalf("Invalid -metadata-field-mode: %q (must be 'native', 'translated', or 'hybrid')", *metadataFieldMode)
+		logger.Info("label translation enabled", "label_style", "underscores", "metadata_field_mode", string(mfm))
 	}
 
 	// Parse derived fields
-	var derivedFields []proxy.DerivedField
-	if *derivedFieldsJSON != "" {
-		if err := json.Unmarshal([]byte(*derivedFieldsJSON), &derivedFields); err != nil {
-			log.Fatalf("Failed to parse -derived-fields JSON: %v", err)
-		}
-		log.Printf("Loaded %d derived fields", len(derivedFields))
+	derivedFields, err := parseDerivedFieldsJSON(*derivedFieldsJSON)
+	if err != nil {
+		fatal("failed to parse derived fields json", "error", err)
+	}
+	if derivedFields != nil {
+		logger.Info("loaded derived fields", "count", len(derivedFields))
 	}
 
 	// Create peer cache if configured
@@ -218,7 +255,7 @@ func main() {
 			Port:          3100,
 		})
 		c.SetL3(peerCache)
-		log.Printf("Peer cache enabled: self=%s discovery=%s", *peerSelf, *peerDiscovery)
+		logger.Info("peer cache enabled", "self", *peerSelf, "discovery", *peerDiscovery)
 	}
 
 	// Create proxy
@@ -253,22 +290,32 @@ func main() {
 		PeerAuthToken:            *peerAuthToken,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create proxy: %v", err)
+		fatal("failed to create proxy", "error", err)
 	}
 	p.Init()
 
 	// Start OTLP telemetry push
 	if *otlpEndpoint != "" {
 		pusher := metrics.NewOTLPPusher(metrics.OTLPConfig{
-			Endpoint:      *otlpEndpoint,
-			Interval:      *otlpInterval,
-			Compression:   metrics.OTLPCompression(*otlpCompression),
-			Timeout:       *otlpTimeout,
-			TLSSkipVerify: *otlpTLSSkipVerify,
+			Endpoint:              *otlpEndpoint,
+			Interval:              *otlpInterval,
+			Headers:               parseHeaderMapCSV(*otlpHeaders),
+			Compression:           metrics.OTLPCompression(*otlpCompression),
+			Timeout:               *otlpTimeout,
+			TLSSkipVerify:         *otlpTLSSkipVerify,
+			ServiceName:           *otelServiceName,
+			ServiceNamespace:      *otelServiceNamespace,
+			ServiceVersion:        version,
+			ServiceInstanceID:     *otelServiceInstanceID,
+			DeploymentEnvironment: *deploymentEnvironment,
 		}, p.GetMetrics())
 		pusher.Start()
 		defer pusher.Stop()
-		log.Printf("OTLP push → %s (every %s, compression=%s)", *otlpEndpoint, *otlpInterval, *otlpCompression)
+		logger.Info("otlp metrics push enabled",
+			"endpoint", *otlpEndpoint,
+			"interval", otlpInterval.String(),
+			"compression", *otlpCompression,
+		)
 	}
 
 	mux := http.NewServeMux()
@@ -292,7 +339,7 @@ func main() {
 	if *tlsClientCAFile != "" || *tlsRequireClientCert {
 		tlsCfg, err := buildServerTLSConfig(*tlsClientCAFile, *tlsRequireClientCert)
 		if err != nil {
-			log.Fatalf("Failed to configure server TLS client authentication: %v", err)
+			fatal("failed to configure server tls client authentication", "error", err)
 		}
 		srv.TLSConfig = tlsCfg
 	}
@@ -302,23 +349,23 @@ func main() {
 	signal.Notify(reloadCh, syscall.SIGHUP)
 	go func() {
 		for range reloadCh {
-			log.Println("SIGHUP received, reloading configuration...")
+			logger.Info("received sighup, reloading configuration")
 			if v := os.Getenv("TENANT_MAP"); v != "" {
 				var newTenantMap map[string]proxy.TenantMapping
 				if err := json.Unmarshal([]byte(v), &newTenantMap); err != nil {
-					log.Printf("Failed to reload TENANT_MAP: %v", err)
+					logger.Error("failed to reload tenant map", "error", err)
 				} else {
 					p.ReloadTenantMap(newTenantMap)
-					log.Printf("Reloaded %d tenant mappings", len(newTenantMap))
+					logger.Info("reloaded tenant mappings", "count", len(newTenantMap))
 				}
 			}
 			if v := os.Getenv("FIELD_MAPPING"); v != "" {
 				var newMappings []proxy.FieldMapping
 				if err := json.Unmarshal([]byte(v), &newMappings); err != nil {
-					log.Printf("Failed to reload FIELD_MAPPING: %v", err)
+					logger.Error("failed to reload field mappings", "error", err)
 				} else {
 					p.ReloadFieldMappings(newMappings)
-					log.Printf("Reloaded %d field mappings", len(newMappings))
+					logger.Info("reloaded field mappings", "count", len(newMappings))
 				}
 			}
 		}
@@ -330,28 +377,28 @@ func main() {
 
 	go func() {
 		if *tlsCertFile != "" && *tlsKeyFile != "" {
-			log.Printf("Loki-VL-proxy listening on %s (TLS), backend: %s", *listenAddr, *backendURL)
+			logger.Info("proxy listening", "listen_address", *listenAddr, "backend_url", *backendURL, "tls", true)
 			if err := srv.ListenAndServeTLS(*tlsCertFile, *tlsKeyFile); err != nil && err != http.ErrServerClosed {
-				log.Fatalf("TLS server failed: %v", err)
+				fatal("tls server failed", "error", err)
 			}
 		} else {
-			log.Printf("Loki-VL-proxy listening on %s, backend: %s", *listenAddr, *backendURL)
+			logger.Info("proxy listening", "listen_address", *listenAddr, "backend_url", *backendURL, "tls", false)
 			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Fatalf("Server failed: %v", err)
+				fatal("server failed", "error", err)
 			}
 		}
 	}()
 
 	sig := <-shutdownCh
-	log.Printf("Received %v, shutting down gracefully...", sig)
+	logger.Info("shutdown requested", "signal", sig.String())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Printf("HTTP shutdown error: %v", err)
+		logger.Error("http shutdown error", "error", err)
 	}
-	log.Println("Shutdown complete")
+	logger.Info("shutdown complete")
 }
 
 // maxBodyHandler limits the request body size to prevent resource exhaustion.
@@ -378,6 +425,125 @@ func parseCSV(s string) []string {
 	return result
 }
 
+func applyEnvOverrides(cfg envConfig, getenv func(string) string) envConfig {
+	if v := getenv("LISTEN_ADDR"); v != "" {
+		cfg.listenAddr = v
+	}
+	if v := getenv("VL_BACKEND_URL"); v != "" {
+		cfg.backendURL = v
+	}
+	if v := getenv("TENANT_MAP"); v != "" && cfg.tenantMapJSON == "" {
+		cfg.tenantMapJSON = v
+	}
+	if v := getenv("OTLP_ENDPOINT"); v != "" && cfg.otlpEndpoint == "" {
+		cfg.otlpEndpoint = v
+	}
+	if v := getenv("OTLP_COMPRESSION"); v != "" && cfg.otlpCompression == "none" {
+		cfg.otlpCompression = v
+	}
+	if v := getenv("OTLP_HEADERS"); v != "" && cfg.otlpHeaders == "" {
+		cfg.otlpHeaders = v
+	}
+	if v := getenv("LABEL_STYLE"); v != "" && cfg.labelStyle == "passthrough" {
+		cfg.labelStyle = v
+	}
+	if v := getenv("FIELD_MAPPING"); v != "" && cfg.fieldMappingJSON == "" {
+		cfg.fieldMappingJSON = v
+	}
+	if v := getenv("METADATA_FIELD_MODE"); v != "" && cfg.metadataFieldMode == "hybrid" {
+		cfg.metadataFieldMode = v
+	}
+	if v := getenv("OTEL_SERVICE_NAME"); v != "" && (cfg.serviceName == "" || cfg.serviceName == "loki-vl-proxy") {
+		cfg.serviceName = v
+	}
+	if v := getenv("OTEL_SERVICE_NAMESPACE"); v != "" && cfg.serviceNamespace == "" {
+		cfg.serviceNamespace = v
+	}
+	if v := getenv("OTEL_SERVICE_INSTANCE_ID"); v != "" && cfg.serviceInstanceID == "" {
+		cfg.serviceInstanceID = v
+	}
+	if v := getenv("DEPLOYMENT_ENVIRONMENT"); v != "" && cfg.deploymentEnv == "" {
+		cfg.deploymentEnv = v
+	}
+	return cfg
+}
+
+func parseTenantMapJSON(raw string) (map[string]proxy.TenantMapping, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var tenantMap map[string]proxy.TenantMapping
+	if err := json.Unmarshal([]byte(raw), &tenantMap); err != nil {
+		return nil, err
+	}
+	return tenantMap, nil
+}
+
+func parseFieldMappingsJSON(raw string) ([]proxy.FieldMapping, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var fieldMappings []proxy.FieldMapping
+	if err := json.Unmarshal([]byte(raw), &fieldMappings); err != nil {
+		return nil, err
+	}
+	return fieldMappings, nil
+}
+
+func parseDerivedFieldsJSON(raw string) ([]proxy.DerivedField, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var derivedFields []proxy.DerivedField
+	if err := json.Unmarshal([]byte(raw), &derivedFields); err != nil {
+		return nil, err
+	}
+	return derivedFields, nil
+}
+
+func parseLabelModes(labelStyle, metadataFieldMode string) (proxy.LabelStyle, proxy.MetadataFieldMode, error) {
+	ls := proxy.LabelStyle(labelStyle)
+	switch ls {
+	case proxy.LabelStylePassthrough, proxy.LabelStyleUnderscores:
+	default:
+		return "", "", fmt.Errorf("invalid -label-style: %q (must be 'passthrough' or 'underscores')", labelStyle)
+	}
+	mfm := proxy.MetadataFieldMode(metadataFieldMode)
+	switch mfm {
+	case proxy.MetadataFieldModeNative, proxy.MetadataFieldModeTranslated, proxy.MetadataFieldModeHybrid:
+	default:
+		return "", "", fmt.Errorf("invalid -metadata-field-mode: %q (must be 'native', 'translated', or 'hybrid')", metadataFieldMode)
+	}
+	return ls, mfm, nil
+}
+
+func parseHeaderMapCSV(s string) map[string]string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	headers := make(map[string]string)
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" || v == "" {
+			continue
+		}
+		headers[k] = v
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
+}
+
 func buildServerTLSConfig(clientCAFile string, requireClientCert bool) (*tls.Config, error) {
 	if clientCAFile == "" {
 		if requireClientCert {
@@ -393,7 +559,7 @@ func buildServerTLSConfig(clientCAFile string, requireClientCert bool) (*tls.Con
 
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(caPEM) {
-		return nil, fmt.Errorf("failed to parse client CA PEM")
+		return nil, errors.New("failed to parse client CA PEM")
 	}
 
 	clientAuth := tls.VerifyClientCertIfGiven

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -42,6 +42,40 @@ type envConfig struct {
 	deploymentEnv     string
 }
 
+type proxyRuntimeConfig struct {
+	backendURL               string
+	cache                    *cache.Cache
+	logLevel                 string
+	tenantMapJSON            string
+	maxLines                 int
+	backendTimeout           time.Duration
+	backendBasicAuth         string
+	backendTLSSkip           bool
+	forwardHeaders           string
+	forwardCookies           string
+	derivedFieldsJSON        string
+	streamResponse           bool
+	authEnabled              bool
+	allowGlobalTenant        bool
+	registerInstrumentation  *bool
+	enablePprof              bool
+	enableQueryAnalytics     bool
+	adminAuthToken           string
+	tailAllowedOrigins       string
+	metricsMaxTenants        int
+	metricsMaxClients        int
+	metricsTrustProxyHeaders bool
+	labelStyle               string
+	metadataFieldMode        string
+	fieldMappingJSON         string
+	streamFieldsCSV          string
+	peerSelf                 string
+	peerDiscovery            string
+	peerDNS                  string
+	peerStatic               string
+	peerAuthToken            string
+}
+
 func main() {
 	// Server flags
 	listenAddr := flag.String("listen", ":3100", "Address to listen on (Loki-compatible frontend)")
@@ -173,15 +207,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Parse tenant map
-	tenantMap, err := parseTenantMapJSON(*tenantMapJSON)
-	if err != nil {
-		fatal("failed to parse tenant map json", "error", err)
-	}
-	if tenantMap != nil {
-		logger.Info("loaded tenant mappings", "count", len(tenantMap))
-	}
-
 	// L1 in-memory cache
 	c := cache.New(*cacheTTL, *cacheMax)
 
@@ -206,89 +231,61 @@ func main() {
 		)
 	}
 
-	// Parse forward headers
-	var fwdHeaders []string
-	if *forwardHeaders != "" {
-		for _, h := range strings.Split(*forwardHeaders, ",") {
-			h = strings.TrimSpace(h)
-			if h != "" {
-				fwdHeaders = append(fwdHeaders, h)
-			}
-		}
-	}
-
-	// Parse field mappings
-	fieldMappings, err := parseFieldMappingsJSON(*fieldMappingJSON)
+	proxyCfg, err := buildProxyConfig(proxyRuntimeConfig{
+		backendURL:               *backendURL,
+		cache:                    c,
+		logLevel:                 *logLevel,
+		tenantMapJSON:            *tenantMapJSON,
+		maxLines:                 *maxLines,
+		backendTimeout:           *backendTimeout,
+		backendBasicAuth:         *backendBasicAuth,
+		backendTLSSkip:           *backendTLSSkip,
+		forwardHeaders:           *forwardHeaders,
+		forwardCookies:           *forwardCookies,
+		derivedFieldsJSON:        *derivedFieldsJSON,
+		streamResponse:           *streamResponse,
+		authEnabled:              *authEnabled,
+		allowGlobalTenant:        *allowGlobalTenant,
+		registerInstrumentation:  registerInstrumentation,
+		enablePprof:              *enablePprof,
+		enableQueryAnalytics:     *enableQueryAnalytics,
+		adminAuthToken:           *adminAuthToken,
+		tailAllowedOrigins:       *tailAllowedOrigins,
+		metricsMaxTenants:        *metricsMaxTenants,
+		metricsMaxClients:        *metricsMaxClients,
+		metricsTrustProxyHeaders: *metricsTrustProxyHeaders,
+		labelStyle:               *labelStyle,
+		metadataFieldMode:        *metadataFieldMode,
+		fieldMappingJSON:         *fieldMappingJSON,
+		streamFieldsCSV:          *streamFieldsCSV,
+		peerSelf:                 *peerSelf,
+		peerDiscovery:            *peerDiscovery,
+		peerDNS:                  *peerDNS,
+		peerStatic:               *peerStatic,
+		peerAuthToken:            *peerAuthToken,
+	})
 	if err != nil {
-		fatal("failed to parse field mapping json", "error", err)
+		fatal("failed to build proxy configuration", "error", err)
 	}
-	if fieldMappings != nil {
-		logger.Info("loaded field mappings", "count", len(fieldMappings))
+	if proxyCfg.TenantMap != nil {
+		logger.Info("loaded tenant mappings", "count", len(proxyCfg.TenantMap))
 	}
-
-	// Validate label style
-	ls, mfm, err := parseLabelModes(*labelStyle, *metadataFieldMode)
-	if err != nil {
-		fatal("invalid label mode configuration", "error", err)
+	if proxyCfg.FieldMappings != nil {
+		logger.Info("loaded field mappings", "count", len(proxyCfg.FieldMappings))
 	}
-	if ls == proxy.LabelStyleUnderscores {
-		logger.Info("label translation enabled", "label_style", "underscores", "metadata_field_mode", string(mfm))
+	if proxyCfg.LabelStyle == proxy.LabelStyleUnderscores {
+		logger.Info("label translation enabled", "label_style", "underscores", "metadata_field_mode", string(proxyCfg.MetadataFieldMode))
 	}
-
-	// Parse derived fields
-	derivedFields, err := parseDerivedFieldsJSON(*derivedFieldsJSON)
-	if err != nil {
-		fatal("failed to parse derived fields json", "error", err)
+	if proxyCfg.DerivedFields != nil {
+		logger.Info("loaded derived fields", "count", len(proxyCfg.DerivedFields))
 	}
-	if derivedFields != nil {
-		logger.Info("loaded derived fields", "count", len(derivedFields))
-	}
-
-	// Create peer cache if configured
-	var peerCache *cache.PeerCache
-	if *peerSelf != "" && *peerDiscovery != "" {
-		peerCache = cache.NewPeerCache(cache.PeerConfig{
-			SelfAddr:      *peerSelf,
-			DiscoveryType: *peerDiscovery,
-			DNSName:       *peerDNS,
-			StaticPeers:   *peerStatic,
-			Port:          3100,
-		})
-		c.SetL3(peerCache)
+	if proxyCfg.PeerCache != nil {
+		c.SetL3(proxyCfg.PeerCache)
 		logger.Info("peer cache enabled", "self", *peerSelf, "discovery", *peerDiscovery)
 	}
 
 	// Create proxy
-	p, err := proxy.New(proxy.Config{
-		BackendURL:               *backendURL,
-		Cache:                    c,
-		LogLevel:                 *logLevel,
-		TenantMap:                tenantMap,
-		MaxLines:                 *maxLines,
-		BackendTimeout:           *backendTimeout,
-		BackendBasicAuth:         *backendBasicAuth,
-		BackendTLSSkip:           *backendTLSSkip,
-		ForwardHeaders:           fwdHeaders,
-		ForwardCookies:           parseCSV(*forwardCookies),
-		DerivedFields:            derivedFields,
-		StreamResponse:           *streamResponse,
-		AuthEnabled:              *authEnabled,
-		AllowGlobalTenant:        *allowGlobalTenant,
-		RegisterInstrumentation:  registerInstrumentation,
-		EnablePprof:              *enablePprof,
-		EnableQueryAnalytics:     *enableQueryAnalytics,
-		AdminAuthToken:           *adminAuthToken,
-		TailAllowedOrigins:       parseCSV(*tailAllowedOrigins),
-		MetricsMaxTenants:        *metricsMaxTenants,
-		MetricsMaxClients:        *metricsMaxClients,
-		MetricsTrustProxyHeaders: *metricsTrustProxyHeaders,
-		LabelStyle:               ls,
-		MetadataFieldMode:        mfm,
-		FieldMappings:            fieldMappings,
-		StreamFields:             parseCSV(*streamFieldsCSV),
-		PeerCache:                peerCache,
-		PeerAuthToken:            *peerAuthToken,
-	})
+	p, err := proxy.New(proxyCfg)
 	if err != nil {
 		fatal("failed to create proxy", "error", err)
 	}
@@ -542,6 +539,67 @@ func parseHeaderMapCSV(s string) map[string]string {
 		return nil
 	}
 	return headers
+}
+
+func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
+	tenantMap, err := parseTenantMapJSON(cfg.tenantMapJSON)
+	if err != nil {
+		return proxy.Config{}, fmt.Errorf("parse tenant map: %w", err)
+	}
+	fieldMappings, err := parseFieldMappingsJSON(cfg.fieldMappingJSON)
+	if err != nil {
+		return proxy.Config{}, fmt.Errorf("parse field mappings: %w", err)
+	}
+	ls, mfm, err := parseLabelModes(cfg.labelStyle, cfg.metadataFieldMode)
+	if err != nil {
+		return proxy.Config{}, err
+	}
+	derivedFields, err := parseDerivedFieldsJSON(cfg.derivedFieldsJSON)
+	if err != nil {
+		return proxy.Config{}, fmt.Errorf("parse derived fields: %w", err)
+	}
+
+	var peerCache *cache.PeerCache
+	if cfg.peerSelf != "" && cfg.peerDiscovery != "" {
+		peerCache = cache.NewPeerCache(cache.PeerConfig{
+			SelfAddr:      cfg.peerSelf,
+			DiscoveryType: cfg.peerDiscovery,
+			DNSName:       cfg.peerDNS,
+			StaticPeers:   cfg.peerStatic,
+			Port:          3100,
+		})
+	}
+
+	return proxy.Config{
+		BackendURL:               cfg.backendURL,
+		Cache:                    cfg.cache,
+		LogLevel:                 cfg.logLevel,
+		TenantMap:                tenantMap,
+		MaxLines:                 cfg.maxLines,
+		BackendTimeout:           cfg.backendTimeout,
+		BackendBasicAuth:         cfg.backendBasicAuth,
+		BackendTLSSkip:           cfg.backendTLSSkip,
+		ForwardHeaders:           parseCSV(cfg.forwardHeaders),
+		ForwardCookies:           parseCSV(cfg.forwardCookies),
+		DerivedFields:            derivedFields,
+		StreamResponse:           cfg.streamResponse,
+		AuthEnabled:              cfg.authEnabled,
+		AllowGlobalTenant:        cfg.allowGlobalTenant,
+		RegisterInstrumentation:  cfg.registerInstrumentation,
+		EnablePprof:              cfg.enablePprof,
+		EnableQueryAnalytics:     cfg.enableQueryAnalytics,
+		AdminAuthToken:           cfg.adminAuthToken,
+		TailAllowedOrigins:       parseCSV(cfg.tailAllowedOrigins),
+		MetricsMaxTenants:        cfg.metricsMaxTenants,
+		MetricsMaxClients:        cfg.metricsMaxClients,
+		MetricsTrustProxyHeaders: cfg.metricsTrustProxyHeaders,
+		LabelStyle:               ls,
+		MetadataFieldMode:        mfm,
+		FieldMappings:            fieldMappings,
+		StreamFields:             parseCSV(cfg.streamFieldsCSV),
+		PeerCache:                peerCache,
+		PeerAuthToken:            cfg.peerAuthToken,
+	}, nil
 }
 
 func buildServerTLSConfig(clientCAFile string, requireClientCert bool) (*tls.Config, error) {

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1,17 +1,24 @@
 package main
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"io"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/szibis/Loki-VL-proxy/internal/proxy"
 )
 
 func TestBuildServerTLSConfig_RequiresCAWhenClientCertsRequired(t *testing.T) {
@@ -39,6 +46,208 @@ func TestBuildServerTLSConfig_LoadsClientCAPool(t *testing.T) {
 	}
 	if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
 		t.Fatalf("expected RequireAndVerifyClientCert, got %v", cfg.ClientAuth)
+	}
+}
+
+func TestBuildServerTLSConfig_NilWithoutClientAuth(t *testing.T) {
+	cfg, err := buildServerTLSConfig("", false)
+	if err != nil {
+		t.Fatalf("expected nil config without error, got %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected nil TLS config when client CA is not configured")
+	}
+}
+
+func TestBuildServerTLSConfig_InvalidPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.pem")
+	if err := os.WriteFile(path, []byte("not-a-cert"), 0o600); err != nil {
+		t.Fatalf("write bad pem: %v", err)
+	}
+	cfg, err := buildServerTLSConfig(path, false)
+	if err == nil {
+		t.Fatal("expected invalid PEM error")
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config on invalid PEM")
+	}
+}
+
+func TestBuildServerTLSConfig_VerifyIfGivenWhenOptional(t *testing.T) {
+	caPath := writeTestCA(t)
+	cfg, err := buildServerTLSConfig(caPath, false)
+	if err != nil {
+		t.Fatalf("expected TLS config, got error: %v", err)
+	}
+	if cfg.ClientAuth != tls.VerifyClientCertIfGiven {
+		t.Fatalf("expected VerifyClientCertIfGiven, got %v", cfg.ClientAuth)
+	}
+}
+
+func TestParseCSV(t *testing.T) {
+	got := parseCSV(" foo,bar ,, baz ")
+	want := []string{"foo", "bar", "baz"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+	if parseCSV("") != nil {
+		t.Fatal("expected nil for empty CSV")
+	}
+}
+
+func TestParseHeaderMapCSV(t *testing.T) {
+	got := parseHeaderMapCSV("Authorization=Bearer abc, X-Scope-OrgID = team-a, broken, empty= ")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 parsed headers, got %+v", got)
+	}
+	if got["Authorization"] != "Bearer abc" {
+		t.Fatalf("unexpected authorization header: %+v", got)
+	}
+	if got["X-Scope-OrgID"] != "team-a" {
+		t.Fatalf("unexpected scope header: %+v", got)
+	}
+	if parseHeaderMapCSV("") != nil {
+		t.Fatal("expected nil for empty header map")
+	}
+}
+
+func TestMaxBodyHandler(t *testing.T) {
+	var seenErr error
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, seenErr = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	body := strings.Repeat("a", 8)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	maxBodyHandler(4, next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected next handler status, got %d", w.Code)
+	}
+	if seenErr == nil {
+		t.Fatal("expected body read to fail when it exceeds limit")
+	}
+}
+
+func TestApplyEnvOverrides(t *testing.T) {
+	cfg := envConfig{
+		listenAddr:        ":3100",
+		backendURL:        "http://backend",
+		otlpCompression:   "none",
+		labelStyle:        "passthrough",
+		metadataFieldMode: "hybrid",
+	}
+	env := map[string]string{
+		"LISTEN_ADDR":              ":9999",
+		"VL_BACKEND_URL":           "http://other",
+		"TENANT_MAP":               `{"team":{"account_id":"1","project_id":"0"}}`,
+		"OTLP_ENDPOINT":            "http://otel",
+		"OTLP_COMPRESSION":         "gzip",
+		"LABEL_STYLE":              "underscores",
+		"FIELD_MAPPING":            `[{"vl_field":"service.name","loki_label":"service_name"}]`,
+		"METADATA_FIELD_MODE":      "native",
+		"OTEL_SERVICE_NAME":        "custom-proxy",
+		"OTEL_SERVICE_NAMESPACE":   "platform",
+		"OTEL_SERVICE_INSTANCE_ID": "proxy-1",
+		"DEPLOYMENT_ENVIRONMENT":   "prod",
+	}
+	got := applyEnvOverrides(cfg, func(key string) string { return env[key] })
+	if got.listenAddr != ":9999" || got.backendURL != "http://other" || got.otlpEndpoint != "http://otel" {
+		t.Fatalf("unexpected env override result: %+v", got)
+	}
+	if got.tenantMapJSON == "" || got.fieldMappingJSON == "" {
+		t.Fatalf("expected JSON env overrides, got %+v", got)
+	}
+	if got.otlpCompression != "gzip" || got.labelStyle != "underscores" || got.metadataFieldMode != "native" {
+		t.Fatalf("unexpected style/compression override result: %+v", got)
+	}
+	if got.serviceName != "custom-proxy" || got.serviceNamespace != "platform" || got.serviceInstanceID != "proxy-1" || got.deploymentEnv != "prod" {
+		t.Fatalf("unexpected observability env overrides: %+v", got)
+	}
+}
+
+func TestApplyEnvOverrides_PreservesExplicitFlags(t *testing.T) {
+	cfg := envConfig{
+		tenantMapJSON:     `{}`,
+		otlpEndpoint:      "http://flag",
+		otlpCompression:   "zstd",
+		labelStyle:        "underscores",
+		fieldMappingJSON:  `[]`,
+		metadataFieldMode: "translated",
+	}
+	env := map[string]string{
+		"TENANT_MAP":          `{"ignored":{}}`,
+		"OTLP_ENDPOINT":       "http://env",
+		"OTLP_COMPRESSION":    "gzip",
+		"LABEL_STYLE":         "passthrough",
+		"FIELD_MAPPING":       `[{"ignored":true}]`,
+		"METADATA_FIELD_MODE": "native",
+	}
+	got := applyEnvOverrides(cfg, func(key string) string { return env[key] })
+	if got != cfg {
+		t.Fatalf("expected explicit values to win, got %+v", got)
+	}
+}
+
+func TestParseTenantMapJSON(t *testing.T) {
+	got, err := parseTenantMapJSON(`{"team-a":{"account_id":"1","project_id":"2"}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["team-a"] != (proxy.TenantMapping{AccountID: "1", ProjectID: "2"}) {
+		t.Fatalf("unexpected tenant map: %+v", got)
+	}
+	if _, err := parseTenantMapJSON("{"); err == nil {
+		t.Fatal("expected invalid tenant map JSON error")
+	}
+}
+
+func TestParseFieldMappingsJSON(t *testing.T) {
+	got, err := parseFieldMappingsJSON(`[{"vl_field":"service.name","loki_label":"service_name"}]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].VLField != "service.name" || got[0].LokiLabel != "service_name" {
+		t.Fatalf("unexpected field mappings: %+v", got)
+	}
+	if _, err := parseFieldMappingsJSON("{"); err == nil {
+		t.Fatal("expected invalid field mapping JSON error")
+	}
+}
+
+func TestParseDerivedFieldsJSON(t *testing.T) {
+	got, err := parseDerivedFieldsJSON(`[{"name":"traceID","matcherRegex":"trace_id=(\\w+)","url":"http://tempo/${__value.raw}"}]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "traceID" {
+		t.Fatalf("unexpected derived fields: %+v", got)
+	}
+	if _, err := parseDerivedFieldsJSON("{"); err == nil {
+		t.Fatal("expected invalid derived field JSON error")
+	}
+}
+
+func TestParseLabelModes(t *testing.T) {
+	ls, mfm, err := parseLabelModes("underscores", "native")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ls != proxy.LabelStyleUnderscores || mfm != proxy.MetadataFieldModeNative {
+		t.Fatalf("unexpected parsed modes: %v %v", ls, mfm)
+	}
+	if _, _, err := parseLabelModes("bad", "native"); err == nil {
+		t.Fatal("expected invalid label style error")
+	}
+	if _, _, err := parseLabelModes("underscores", "bad"); err == nil {
+		t.Fatal("expected invalid metadata field mode error")
 	}
 }
 

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -251,6 +251,92 @@ func TestParseLabelModes(t *testing.T) {
 	}
 }
 
+func TestBuildProxyConfig(t *testing.T) {
+	registerInstrumentation := true
+	c := proxyRuntimeConfig{
+		backendURL:               "http://backend",
+		cache:                    nil,
+		logLevel:                 "debug",
+		tenantMapJSON:            `{"team-a":{"account_id":"1","project_id":"2"}}`,
+		maxLines:                 123,
+		backendTimeout:           5 * time.Second,
+		backendBasicAuth:         "user:pass",
+		backendTLSSkip:           true,
+		forwardHeaders:           "Authorization, X-Scope-OrgID",
+		forwardCookies:           "session, csrf",
+		derivedFieldsJSON:        `[{"name":"traceID","matcherRegex":"trace_id=(\\w+)","url":"http://tempo/${__value.raw}"}]`,
+		streamResponse:           true,
+		authEnabled:              true,
+		allowGlobalTenant:        true,
+		registerInstrumentation:  &registerInstrumentation,
+		enablePprof:              true,
+		enableQueryAnalytics:     true,
+		adminAuthToken:           "secret",
+		tailAllowedOrigins:       "https://grafana.example.com",
+		metricsMaxTenants:        11,
+		metricsMaxClients:        12,
+		metricsTrustProxyHeaders: true,
+		labelStyle:               "underscores",
+		metadataFieldMode:        "hybrid",
+		fieldMappingJSON:         `[{"vl_field":"service.name","loki_label":"service_name"}]`,
+		streamFieldsCSV:          "app,namespace",
+		peerSelf:                 "10.0.0.1:3100",
+		peerDiscovery:            "static",
+		peerStatic:               "10.0.0.2:3100,10.0.0.3:3100",
+		peerAuthToken:            "peer-secret",
+	}
+
+	got, err := buildProxyConfig(c)
+	if err != nil {
+		t.Fatalf("unexpected buildProxyConfig error: %v", err)
+	}
+	if got.BackendURL != "http://backend" || got.MaxLines != 123 || got.BackendBasicAuth != "user:pass" || !got.BackendTLSSkip {
+		t.Fatalf("unexpected proxy config basics: %+v", got)
+	}
+	if len(got.TenantMap) != 1 || got.TenantMap["team-a"].AccountID != "1" {
+		t.Fatalf("unexpected tenant map: %+v", got.TenantMap)
+	}
+	if len(got.ForwardHeaders) != 2 || got.ForwardHeaders[0] != "Authorization" {
+		t.Fatalf("unexpected forward headers: %+v", got.ForwardHeaders)
+	}
+	if len(got.ForwardCookies) != 2 || got.ForwardCookies[1] != "csrf" {
+		t.Fatalf("unexpected forward cookies: %+v", got.ForwardCookies)
+	}
+	if got.LabelStyle != proxy.LabelStyleUnderscores || got.MetadataFieldMode != proxy.MetadataFieldModeHybrid {
+		t.Fatalf("unexpected label modes: %v %v", got.LabelStyle, got.MetadataFieldMode)
+	}
+	if len(got.FieldMappings) != 1 || got.FieldMappings[0].VLField != "service.name" {
+		t.Fatalf("unexpected field mappings: %+v", got.FieldMappings)
+	}
+	if len(got.DerivedFields) != 1 || got.DerivedFields[0].Name != "traceID" {
+		t.Fatalf("unexpected derived fields: %+v", got.DerivedFields)
+	}
+	if len(got.StreamFields) != 2 || got.StreamFields[0] != "app" {
+		t.Fatalf("unexpected stream fields: %+v", got.StreamFields)
+	}
+	if got.PeerCache == nil {
+		t.Fatal("expected peer cache to be created")
+	}
+	if got.PeerAuthToken != "peer-secret" {
+		t.Fatalf("unexpected peer auth token: %q", got.PeerAuthToken)
+	}
+}
+
+func TestBuildProxyConfig_InvalidInputs(t *testing.T) {
+	cases := []proxyRuntimeConfig{
+		{tenantMapJSON: "{", labelStyle: "passthrough", metadataFieldMode: "hybrid"},
+		{fieldMappingJSON: "{", labelStyle: "passthrough", metadataFieldMode: "hybrid"},
+		{derivedFieldsJSON: "{", labelStyle: "passthrough", metadataFieldMode: "hybrid"},
+		{labelStyle: "bad", metadataFieldMode: "hybrid"},
+		{labelStyle: "passthrough", metadataFieldMode: "bad"},
+	}
+	for _, tc := range cases {
+		if _, err := buildProxyConfig(tc); err == nil {
+			t.Fatalf("expected buildProxyConfig to reject %+v", tc)
+		}
+	}
+}
+
 func writeTestCA(t *testing.T) string {
 	t.Helper()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,8 +143,13 @@ kill -HUP $(pidof loki-vl-proxy)
 | `-otlp-endpoint` | `OTLP_ENDPOINT` | — | OTLP HTTP endpoint for proxy metrics |
 | `-otlp-interval` | — | `30s` | Push interval |
 | `-otlp-compression` | `OTLP_COMPRESSION` | `none` | `none`, `gzip`, `zstd` |
+| `-otlp-headers` | `OTLP_HEADERS` | — | Comma-separated OTLP HTTP headers in `key=value` form |
 | `-otlp-timeout` | — | `10s` | HTTP request timeout |
 | `-otlp-tls-skip-verify` | — | `false` | Skip TLS verification |
+| `-otel-service-name` | `OTEL_SERVICE_NAME` | `loki-vl-proxy` | `service.name` for OTLP metrics and JSON logs |
+| `-otel-service-namespace` | `OTEL_SERVICE_NAMESPACE` | — | `service.namespace` for OTLP metrics and JSON logs |
+| `-otel-service-instance-id` | `OTEL_SERVICE_INSTANCE_ID` | — | `service.instance.id` for OTLP metrics and JSON logs |
+| `-deployment-environment` | `DEPLOYMENT_ENVIRONMENT` | — | `deployment.environment.name` for OTLP metrics and JSON logs |
 
 ## HTTP Hardening
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,311 @@
+# Observability Guide
+
+Loki-VL-proxy emits the same core operational signals in two forms:
+
+| Signal | Transport | Format | Best use |
+|---|---|---|---|
+| Metrics | Pull | Prometheus text at `/metrics` | Prometheus, Grafana Agent, Alloy, VictoriaMetrics, kube scraping |
+| Metrics | Push | OTLP HTTP JSON to `/v1/metrics` | OpenTelemetry Collector, vendor OTLP gateways |
+| Logs | Stream | Structured JSON on stdout/stderr | Fluent Bit, Vector, OpenTelemetry Collector, Docker/Kubernetes log agents |
+
+The intent is parity, not two separate products. Prometheus scrape and OTLP push carry the same proxy-centric metrics with the same names, labels, and units for the important operational paths:
+
+- request volume and latency
+- backend latency
+- cache hit/miss behavior
+- translation failures
+- tenant and client hot spots
+- client status and query-length outliers
+- process/runtime and host-level health
+
+## Logs
+
+### JSON Log Shape
+
+Default logs are emitted as JSON and already use OTel-friendly top-level keys:
+
+```json
+{
+  "timestamp": "2026-04-05T18:03:27.214918Z",
+  "severity": {
+    "text": "INFO",
+    "number": 9
+  },
+  "body": "request",
+  "service.name": "loki-vl-proxy",
+  "service.version": "0.25.0",
+  "service.instance.id": "proxy-1",
+  "deployment.environment.name": "prod",
+  "component": "proxy",
+  "http.route": "query_range",
+  "http.request.method": "GET",
+  "http.response.status_code": 200,
+  "event.duration_ms": 42,
+  "loki.tenant.id": "team-a",
+  "loki.query": "{service_name=\"api\"} |= \"error\"",
+  "client.address": "10.0.0.12:51884",
+  "enduser.id": "grafana-user@example.com",
+  "loki.client.source": "x-grafana-user"
+}
+```
+
+That makes the log stream usable in two ways:
+
+- plain JSON ingestion with no transformation
+- low-friction mapping into the OpenTelemetry log data model
+
+### Log Sources
+
+The proxy writes structured logs for:
+
+- request lifecycle and status
+- query translation and backend request flow
+- tail/WebSocket behavior
+- delete audit events
+- cache warmer and disk cache internals
+- OTLP export failures
+
+### OpenTelemetry Fields Used in Logs
+
+| Field | Meaning |
+|---|---|
+| `timestamp` | event time |
+| `severity.text` / `severity.number` | log severity |
+| `body` | message body |
+| `service.*` | stable service identity |
+| `deployment.environment.name` | environment name |
+| `component` | internal subsystem (`proxy`, `disk_cache`, `cache_warmer`, `otlp_metrics`) |
+| `http.*` | request semantics |
+| `client.address` | remote address |
+| `enduser.id` | trusted user/client identity when available |
+| `loki.*` | Loki/proxy-specific attributes |
+
+## Metrics
+
+### Export Modes
+
+#### Prometheus Scrape
+
+```yaml
+scrape_configs:
+  - job_name: loki-vl-proxy
+    scrape_interval: 15s
+    static_configs:
+      - targets:
+          - loki-vl-proxy:3100
+```
+
+#### OTLP Push
+
+```bash
+./loki-vl-proxy \
+  -backend=http://victorialogs:9428 \
+  -otlp-endpoint=http://otel-collector:4318/v1/metrics \
+  -otlp-interval=30s \
+  -otlp-compression=gzip \
+  -otlp-headers='Authorization=Bearer example-token'
+```
+
+If the OTLP endpoint is passed as a collector base URL like `http://collector:4318` or `http://collector:4318/v1`, the proxy normalizes it to `/v1/metrics`.
+
+### OpenTelemetry Resource Attributes for Metrics and Logs
+
+These flags shape both OTLP metric exports and structured logs:
+
+| Flag | Meaning |
+|---|---|
+| `-otel-service-name` | `service.name` |
+| `-otel-service-namespace` | `service.namespace` |
+| `-otel-service-instance-id` | `service.instance.id` |
+| `-deployment-environment` | `deployment.environment.name` |
+
+### Core Proxy Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `loki_vl_proxy_requests_total` | counter | `endpoint`, `status` | all proxied requests |
+| `loki_vl_proxy_request_duration_seconds` | histogram | `endpoint` | end-to-end request latency |
+| `loki_vl_proxy_backend_duration_seconds` | histogram | `endpoint` | upstream VictoriaLogs latency only |
+| `loki_vl_proxy_cache_hits_total` | counter | none | global cache hits |
+| `loki_vl_proxy_cache_misses_total` | counter | none | global cache misses |
+| `loki_vl_proxy_cache_hits_by_endpoint` | counter | `endpoint` | cache hits per endpoint |
+| `loki_vl_proxy_cache_misses_by_endpoint` | counter | `endpoint` | cache misses per endpoint |
+| `loki_vl_proxy_translations_total` | counter | none | successful LogQL to LogsQL translations |
+| `loki_vl_proxy_translation_errors_total` | counter | none | failed translations |
+| `loki_vl_proxy_coalesced_total` | counter | none | requests served from coalesced results |
+| `loki_vl_proxy_coalesced_saved_total` | counter | none | backend requests saved by coalescing |
+| `loki_vl_proxy_uptime_seconds` | gauge | none | process uptime |
+| `loki_vl_proxy_active_requests` | gauge | none | current in-flight requests |
+| `loki_vl_proxy_circuit_breaker_state` | gauge | none | `0=closed`, `1=open`, `2=half-open` |
+
+### Tenant and Client Metrics
+
+These are the metrics to use when you want to identify the users or tenants actually causing backend load.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `loki_vl_proxy_tenant_requests_total` | counter | `tenant`, `endpoint`, `status` | request volume by tenant |
+| `loki_vl_proxy_tenant_request_duration_seconds` | histogram | `tenant`, `endpoint` | latency by tenant |
+| `loki_vl_proxy_client_requests_total` | counter | `client`, `endpoint` | request volume by client identity |
+| `loki_vl_proxy_client_response_bytes_total` | counter | `client` | response bytes by client |
+| `loki_vl_proxy_client_status_total` | counter | `client`, `endpoint`, `status` | final status breakdown by client |
+| `loki_vl_proxy_client_inflight_requests` | gauge | `client` | current parallelism by client |
+| `loki_vl_proxy_client_request_duration_seconds` | histogram | `client`, `endpoint` | request latency by client |
+| `loki_vl_proxy_client_query_length_chars` | histogram | `client`, `endpoint` | query size outliers by client |
+| `loki_vl_proxy_client_errors_total` | counter | `endpoint`, `reason` | categorized 4xx-style client errors |
+
+### Runtime and Host Metrics
+
+The proxy also exports a lightweight built-in set of runtime and host health metrics:
+
+| Metric family | Description |
+|---|---|
+| `go_memstats_*`, `go_goroutines`, `go_gc_cycles_total` | Go runtime health |
+| `process_resident_memory_bytes`, `process_open_fds` | process resource usage |
+| `node_cpu_usage_ratio` | CPU pressure split by `mode` |
+| `node_memory_*` | total, free, available, usage ratio |
+| `node_disk_*_bytes_total` | disk I/O counters |
+| `node_network_*_bytes_total` | network I/O counters |
+| `node_pressure_*` | Linux PSI gauges when available |
+
+## Choosing Client Identity
+
+Per-client metrics and request logs can use trusted upstream identity instead of only remote IP:
+
+```bash
+-metrics.trust-proxy-headers=true
+```
+
+When enabled, the proxy prefers:
+
+1. `X-Grafana-User`
+2. tenant
+3. basic-auth user
+4. remote IP
+
+Only enable this when the proxy sits behind a trusted auth proxy or Grafana instance.
+
+## Integration Examples
+
+### OpenTelemetry Collector: scrape `/metrics` and export OTLP
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: loki-vl-proxy
+          scrape_interval: 15s
+          static_configs:
+            - targets: ["loki-vl-proxy:3100"]
+
+processors:
+  batch: {}
+
+exporters:
+  otlphttp:
+    endpoint: https://otel-gateway.example.com
+    headers:
+      Authorization: Bearer ${OTLP_TOKEN}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+### OpenTelemetry Collector: collect JSON logs from container stdout
+
+```yaml
+receivers:
+  filelog:
+    include:
+      - /var/log/containers/*loki-vl-proxy*.log
+    operators:
+      - type: json_parser
+
+processors:
+  batch: {}
+
+exporters:
+  otlphttp:
+    endpoint: https://otel-gateway.example.com
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+### Vector: ship structured JSON logs
+
+```toml
+[sources.proxy_logs]
+type = "kubernetes_logs"
+
+[transforms.proxy_json]
+type = "remap"
+inputs = ["proxy_logs"]
+source = '''
+. = parse_json!(string!(.message))
+'''
+
+[sinks.proxy_otlp]
+type = "opentelemetry"
+inputs = ["proxy_json"]
+protocol.type = "http"
+protocol.uri = "https://otel-gateway.example.com/v1/logs"
+```
+
+### Fluent Bit: tail container logs and keep JSON structure
+
+```ini
+[INPUT]
+    Name              tail
+    Path              /var/log/containers/*loki-vl-proxy*.log
+    Parser            docker
+    Tag               loki_vl_proxy
+
+[FILTER]
+    Name              parser
+    Match             loki_vl_proxy
+    Key_Name          log
+    Parser            json
+
+[OUTPUT]
+    Name              opentelemetry
+    Match             loki_vl_proxy
+    Host              otel-collector
+    Port              4318
+    Logs_uri          /v1/logs
+```
+
+## Recommended Dashboards and Alerts
+
+Start with:
+
+- request rate and error rate by `endpoint`
+- backend latency p95/p99 by `endpoint`
+- cache hit ratio overall and by `endpoint`
+- top `client` by request rate, bytes, and query length
+- top `tenant` by request volume and latency
+- circuit breaker state
+- process RSS and open file descriptors
+
+High-signal alert ideas:
+
+- `5xx` rate rising on query endpoints
+- cache hit ratio collapsing
+- backend latency p95 breaching SLO
+- a single `client` dominating bytes or query length
+- circuit breaker opening repeatedly
+
+## Notes
+
+- OTLP push and Prometheus scrape share the same important proxy metrics and metric names.
+- The OTLP export is intentionally lightweight and does not pull in the full OpenTelemetry Go SDK.
+- Structured logs are already safe for JSON ingestion; agents can forward them directly or transform them into OTLP logs.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -165,6 +165,8 @@ extraArgs:
 
 ## Monitoring
 
+See the dedicated [Observability Guide](observability.md) for the full metrics catalog, JSON log schema, OTLP push configuration, and collector/agent integration examples.
+
 ### Metrics
 
 The proxy exposes Prometheus metrics at `/metrics`:
@@ -194,6 +196,8 @@ Push metrics to an OTLP collector:
 -otlp-interval=30s
 -otlp-compression=gzip
 ```
+
+The OTLP exporter reuses the same core proxy metric names that `/metrics` exposes, so dashboards and alert logic can stay aligned across scrape and push modes.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,7 +63,9 @@
 - [x] `unwrap duration()/bytes()` unit conversion (v0.21.0)
 - [x] Subquery syntax `rate(...)[1h:5m]` — proxy-side evaluation (v0.23.0)
 - [x] LRU cache eviction (v0.21.0)
-- [ ] Peer cache Phase 1 implementation (DNS discovery + peer fetch)
+- [x] Peer cache Phase 1 implementation (DNS discovery + peer fetch) (v0.24.0)
 - [x] System metrics in /metrics (CPU, memory, IO, network via /proc) (v0.19.0)
 - [x] Native VL stream selector optimization for known `_stream_fields` (v0.23.0)
 - [ ] Full Loki ruler / alerting API semantics beyond datasource compatibility stubs
+- [x] PR quality report workflow with coverage, compatibility, and performance delta comments (v0.26.0)
+- [ ] Raise total repository coverage toward 95%+ by extracting `main()` and remaining low-level system readers into smaller testable units

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,6 +119,15 @@ docker compose -f test/e2e-compat/docker-compose.yml up -d --build
 
 GitHub Actions uses the same manifest as the source of truth. The compatibility workflows load their version matrices from [compatibility-matrix.json](/tmp/Loki-VL-proxy/test/e2e-compat/compatibility-matrix.json) instead of duplicating version lists in workflow YAML.
 
+Pull requests also get a dedicated `pr-quality-report.yaml` workflow. It compares the PR branch against the base branch and posts a sticky PR comment with:
+
+- total test count delta
+- coverage delta
+- Loki / Logs Drilldown / VictoriaLogs compatibility deltas
+- sampled benchmark and load-test deltas
+
+That report is informational by design. It highlights regressions early, but merge gating still comes from the required check set in repository settings.
+
 See [compatibility-matrix.md](/tmp/Loki-VL-proxy/docs/compatibility-matrix.md), [compatibility-loki.md](/tmp/Loki-VL-proxy/docs/compatibility-loki.md), [compatibility-drilldown.md](/tmp/Loki-VL-proxy/docs/compatibility-drilldown.md), [compatibility-victorialogs.md](/tmp/Loki-VL-proxy/docs/compatibility-victorialogs.md), and [compatibility-matrix.json](/tmp/Loki-VL-proxy/test/e2e-compat/compatibility-matrix.json).
 
 ## Running Specific Tests

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -57,8 +57,8 @@ type DiskCacheConfig struct {
 // NewDiskCache creates an L2 disk cache.
 func NewDiskCache(cfg DiskCacheConfig) (*DiskCache, error) {
 	opts := bolt.DefaultOptions
-	opts.NoSync = true        // Async sync — faster writes, safe with write buffer
-	opts.NoGrowSync = true    // Skip grow sync for sequential write performance
+	opts.NoSync = true     // Async sync — faster writes, safe with write buffer
+	opts.NoGrowSync = true // Skip grow sync for sequential write performance
 	opts.FreelistType = bolt.FreelistMapType
 
 	db, err := bolt.Open(cfg.Path, 0600, opts)
@@ -80,7 +80,7 @@ func NewDiskCache(cfg DiskCacheConfig) (*DiskCache, error) {
 		flushSize = 100
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.Default().With("component", "disk_cache")
 
 	dc := &DiskCache{
 		db:          db,
@@ -269,4 +269,3 @@ func decompress(data []byte) ([]byte, error) {
 	defer func() { _ = r.Close() }()
 	return io.ReadAll(r)
 }
-

--- a/internal/cache/warmer.go
+++ b/internal/cache/warmer.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"log/slog"
-	"os"
 	"sync/atomic"
 	"time"
 )
@@ -45,7 +44,7 @@ func NewWarmer(c *Cache, topN func(int) []string, warmFn WarmFunc, cfg WarmerCon
 		warmFn:   warmFn,
 		interval: cfg.Interval,
 		count:    cfg.Count,
-		log:      slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		log:      slog.Default().With("component", "cache_warmer"),
 		done:     make(chan struct{}),
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -181,3 +181,93 @@ func TestMetrics_Handler_BoundsTenantAndClientCardinality(t *testing.T) {
 		t.Fatal("expected second client to be folded into overflow bucket")
 	}
 }
+
+func TestResolveClientContext_Branches(t *testing.T) {
+	t.Run("trusted forwarded for", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.20")
+		req.RemoteAddr = "198.51.100.20:1234"
+
+		clientID, source := ResolveClientContext(req, true)
+		if clientID != "203.0.113.10" || source != "forwarded_for" {
+			t.Fatalf("unexpected context: %q %q", clientID, source)
+		}
+	})
+
+	t.Run("tenant preferred when proxy headers untrusted", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		req.Header.Set("X-Scope-OrgID", "tenant-a")
+		req.Header.Set("X-Forwarded-For", "203.0.113.10")
+		req.RemoteAddr = "198.51.100.20:1234"
+
+		clientID, source := ResolveClientContext(req, false)
+		if clientID != "tenant-a" || source != "tenant" {
+			t.Fatalf("unexpected context: %q %q", clientID, source)
+		}
+	})
+
+	t.Run("remote addr fallback", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		req.RemoteAddr = "198.51.100.20:1234"
+
+		clientID, source := ResolveClientContext(req, false)
+		if clientID != "198.51.100.20" || source != "remote_addr" {
+			t.Fatalf("unexpected context: %q %q", clientID, source)
+		}
+	})
+}
+
+func TestSanitizeMetricIdentity(t *testing.T) {
+	if got := sanitizeMetricIdentity("", "__fallback__"); got != "__fallback__" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+	if got := sanitizeMetricIdentity("tenant:a", "__fallback__"); got != "tenant_a" {
+		t.Fatalf("expected colon replacement, got %q", got)
+	}
+	long := strings.Repeat("a", 80)
+	if got := sanitizeMetricIdentity(long, "__fallback__"); len(got) != 64 {
+		t.Fatalf("expected truncation to 64 chars, got %d", len(got))
+	}
+}
+
+func TestMetrics_RecordersAndHandler_ExposeAdditionalMetrics(t *testing.T) {
+	m := NewMetricsWithLimits(0, 0)
+	m.SetCircuitBreakerFunc(func() string { return "half-open" })
+	m.RecordTenantRequest("team-a", "query_range", 200, 15*time.Millisecond)
+	m.RecordClientError("query_range", "bad_query")
+	m.RecordEndpointCacheHit("labels")
+	m.RecordEndpointCacheMiss("labels")
+	m.RecordBackendDuration("query_range", 25*time.Millisecond)
+	m.RecordCoalesced()
+	m.RecordCoalescedSaved()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/metrics", nil)
+	m.Handler(w, r)
+	body := w.Body.String()
+
+	for _, snippet := range []string{
+		`loki_vl_proxy_tenant_requests_total{tenant="team-a",endpoint="query_range",status="200"} 1`,
+		`loki_vl_proxy_client_errors_total{endpoint="query_range",reason="bad_query"} 1`,
+		`loki_vl_proxy_cache_hits_by_endpoint{endpoint="labels"} 1`,
+		`loki_vl_proxy_cache_misses_by_endpoint{endpoint="labels"} 1`,
+		`loki_vl_proxy_backend_duration_seconds_count{endpoint="query_range"} 1`,
+		`loki_vl_proxy_coalesced_total 1`,
+		`loki_vl_proxy_coalesced_saved_total 1`,
+		`loki_vl_proxy_circuit_breaker_state 2`,
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("expected metrics output to contain %q\nbody:\n%s", snippet, body)
+		}
+	}
+}
+
+func TestNewMetricsWithLimits_Defaults(t *testing.T) {
+	m := NewMetricsWithLimits(0, 0)
+	if m.maxTenantLabels != defaultMaxTenantLabels {
+		t.Fatalf("expected default tenant limit, got %d", m.maxTenantLabels)
+	}
+	if m.maxClientLabels != defaultMaxClientLabels {
+		t.Fatalf("expected default client limit, got %d", m.maxClientLabels)
+	}
+}

--- a/internal/metrics/otlp.go
+++ b/internal/metrics/otlp.go
@@ -9,7 +9,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
+	"net/url"
+	"runtime"
+	"sort"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -27,24 +31,34 @@ const (
 // OTLPPusher periodically exports proxy metrics to an OTLP HTTP endpoint.
 // Uses lightweight JSON payloads — no heavy OTel SDK dependency.
 type OTLPPusher struct {
-	endpoint    string
-	interval    time.Duration
-	metrics     *Metrics
-	client      *http.Client
-	log         *slog.Logger
-	cancel      context.CancelFunc
-	headers     map[string]string
-	compression OTLPCompression
+	endpoint              string
+	interval              time.Duration
+	metrics               *Metrics
+	client                *http.Client
+	log                   *slog.Logger
+	cancel                context.CancelFunc
+	headers               map[string]string
+	compression           OTLPCompression
+	serviceName           string
+	serviceNamespace      string
+	serviceVersion        string
+	serviceInstanceID     string
+	deploymentEnvironment string
 }
 
 // OTLPConfig configures the OTLP metrics pusher.
 type OTLPConfig struct {
-	Endpoint      string            // OTLP HTTP endpoint (e.g., http://otel-collector:4318/v1/metrics)
-	Interval      time.Duration     // Push interval (default: 30s)
-	Headers       map[string]string // Extra headers (e.g., auth tokens)
-	Timeout       time.Duration     // HTTP request timeout (default: 10s)
-	Compression   OTLPCompression   // Compression: "none", "gzip", "zstd" (default: "none")
-	TLSSkipVerify bool              // Skip TLS verification (for self-signed certs)
+	Endpoint              string            // OTLP HTTP endpoint (e.g., http://otel-collector:4318/v1/metrics)
+	Interval              time.Duration     // Push interval (default: 30s)
+	Headers               map[string]string // Extra headers (e.g., auth tokens)
+	Timeout               time.Duration     // HTTP request timeout (default: 10s)
+	Compression           OTLPCompression   // Compression: "none", "gzip", "zstd" (default: "none")
+	TLSSkipVerify         bool              // Skip TLS verification (for self-signed certs)
+	ServiceName           string
+	ServiceNamespace      string
+	ServiceVersion        string
+	ServiceInstanceID     string
+	DeploymentEnvironment string
 }
 
 // NewOTLPPusher creates a new OTLP metrics pusher.
@@ -62,20 +76,26 @@ func NewOTLPPusher(cfg OTLPConfig, m *Metrics) *OTLPPusher {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.Default().With("component", "otlp_metrics")
 	compression := cfg.Compression
 	if compression == "" {
 		compression = OTLPCompressionNone
 	}
+	endpoint := normalizeMetricsEndpoint(cfg.Endpoint)
 
 	return &OTLPPusher{
-		endpoint:    cfg.Endpoint,
-		interval:    cfg.Interval,
-		metrics:     m,
-		client:      &http.Client{Timeout: timeout, Transport: transport},
-		log:         logger,
-		headers:     cfg.Headers,
-		compression: compression,
+		endpoint:              endpoint,
+		interval:              cfg.Interval,
+		metrics:               m,
+		client:                &http.Client{Timeout: timeout, Transport: transport},
+		log:                   logger,
+		headers:               cfg.Headers,
+		compression:           compression,
+		serviceName:           strings.TrimSpace(cfg.ServiceName),
+		serviceNamespace:      strings.TrimSpace(cfg.ServiceNamespace),
+		serviceVersion:        strings.TrimSpace(cfg.ServiceVersion),
+		serviceInstanceID:     strings.TrimSpace(cfg.ServiceInstanceID),
+		deploymentEnvironment: strings.TrimSpace(cfg.DeploymentEnvironment),
 	}
 }
 
@@ -176,44 +196,55 @@ func (p *OTLPPusher) push(ctx context.Context) error {
 func (p *OTLPPusher) buildPayload() map[string]interface{} {
 	now := time.Now().UnixNano()
 
-	dataPoints := []map[string]interface{}{
-		p.counterDP("loki_vl_proxy_cache_hits_total", p.metrics.cacheHits.Load(), now),
-		p.counterDP("loki_vl_proxy_cache_misses_total", p.metrics.cacheMisses.Load(), now),
-		p.counterDP("loki_vl_proxy_translations_total", p.metrics.translationsTotal.Load(), now),
-		p.counterDP("loki_vl_proxy_translation_errors_total", p.metrics.translationErrors.Load(), now),
+	metrics := make([]map[string]interface{}, 0, 32)
+	metrics = append(metrics,
+		p.sumMetric("loki_vl_proxy_cache_hits_total", "Cache hits.", "", p.counterDP("loki_vl_proxy_cache_hits_total", p.metrics.cacheHits.Load(), now)),
+		p.sumMetric("loki_vl_proxy_cache_misses_total", "Cache misses.", "", p.counterDP("loki_vl_proxy_cache_misses_total", p.metrics.cacheMisses.Load(), now)),
+		p.sumMetric("loki_vl_proxy_translations_total", "LogQL to LogsQL translations.", "", p.counterDP("loki_vl_proxy_translations_total", p.metrics.translationsTotal.Load(), now)),
+		p.sumMetric("loki_vl_proxy_translation_errors_total", "Failed translations.", "", p.counterDP("loki_vl_proxy_translation_errors_total", p.metrics.translationErrors.Load(), now)),
+		p.sumMetric("loki_vl_proxy_coalesced_total", "Requests served from coalesced results.", "", p.counterDP("loki_vl_proxy_coalesced_total", p.metrics.coalescedTotal.Load(), now)),
+		p.sumMetric("loki_vl_proxy_coalesced_saved_total", "Backend requests saved by coalescing.", "", p.counterDP("loki_vl_proxy_coalesced_saved_total", p.metrics.coalescedSaved.Load(), now)),
+		p.gaugeMetric("loki_vl_proxy_uptime_seconds", "Proxy uptime.", "s", p.gaugeDP("loki_vl_proxy_uptime_seconds", time.Since(p.metrics.startTime).Seconds(), now)),
+		p.gaugeMetric("loki_vl_proxy_active_requests", "Current in-flight requests.", "{request}", p.gaugeDP("loki_vl_proxy_active_requests", float64(p.metrics.activeRequests.Load()), now)),
+	)
+
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	metrics = append(metrics,
+		p.gaugeMetric("go_memstats_alloc_bytes", "Current heap allocation in bytes.", "By", p.gaugeDP("go_memstats_alloc_bytes", float64(memStats.Alloc), now)),
+		p.gaugeMetric("go_memstats_sys_bytes", "Total memory from OS in bytes.", "By", p.gaugeDP("go_memstats_sys_bytes", float64(memStats.Sys), now)),
+		p.gaugeMetric("go_memstats_heap_inuse_bytes", "Heap in-use bytes.", "By", p.gaugeDP("go_memstats_heap_inuse_bytes", float64(memStats.HeapInuse), now)),
+		p.gaugeMetric("go_memstats_heap_idle_bytes", "Heap idle bytes.", "By", p.gaugeDP("go_memstats_heap_idle_bytes", float64(memStats.HeapIdle), now)),
+		p.gaugeMetric("go_goroutines", "Current number of goroutines.", "{goroutine}", p.gaugeDP("go_goroutines", float64(runtime.NumGoroutine()), now)),
+		p.sumMetric("go_gc_cycles_total", "Total GC cycles completed.", "", p.counterDP("go_gc_cycles_total", int64(memStats.NumGC), now)),
+	)
+
+	if circuitBreakerMetric := p.circuitBreakerMetric(now); circuitBreakerMetric != nil {
+		metrics = append(metrics, circuitBreakerMetric)
 	}
 
-	// Add per-endpoint request counters
+	metrics = append(metrics, p.systemMetrics(now)...)
+
 	p.metrics.mu.RLock()
-	for key, counter := range p.metrics.requestsTotal {
-		dataPoints = append(dataPoints,
-			p.counterDP("loki_vl_proxy_requests_total", counter.Load(), now,
-				attr("endpoint_status", key)))
-	}
+	metrics = append(metrics, p.requestMetrics(now)...)
+	metrics = append(metrics, p.tenantMetrics(now)...)
+	metrics = append(metrics, p.clientErrorMetrics(now)...)
+	metrics = append(metrics, p.endpointCacheMetrics(now)...)
+	metrics = append(metrics, p.backendDurationMetrics(now)...)
+	metrics = append(metrics, p.clientMetrics(now)...)
 	p.metrics.mu.RUnlock()
-
-	gaugePoints := []map[string]interface{}{
-		p.gaugeDP("loki_vl_proxy_uptime_seconds", time.Since(p.metrics.startTime).Seconds(), now),
-		p.gaugeDP("loki_vl_proxy_active_requests", float64(p.metrics.activeRequests.Load()), now),
-	}
-
-	metrics := make([]map[string]interface{}, 0, len(dataPoints)+len(gaugePoints))
-	metrics = append(metrics, dataPoints...)
-	metrics = append(metrics, gaugePoints...)
 
 	return map[string]interface{}{
 		"resourceMetrics": []map[string]interface{}{
 			{
 				"resource": map[string]interface{}{
-					"attributes": []map[string]interface{}{
-						{"key": "service.name", "value": map[string]interface{}{"stringValue": "loki-vl-proxy"}},
-					},
+					"attributes": p.resourceAttributes(),
 				},
 				"scopeMetrics": []map[string]interface{}{
 					{
 						"scope": map[string]interface{}{
 							"name":    "loki-vl-proxy",
-							"version": "0.8.0",
+							"version": p.metricsScopeVersion(),
 						},
 						"metrics": metrics,
 					},
@@ -231,28 +262,18 @@ func (p *OTLPPusher) counterDP(name string, value int64, timeUnixNano int64, att
 	if len(attrs) > 0 {
 		dp["attributes"] = attrs
 	}
-	return map[string]interface{}{
-		"name": name,
-		"sum": map[string]interface{}{
-			"dataPoints":             []map[string]interface{}{dp},
-			"aggregationTemporality": 2, // CUMULATIVE
-			"isMonotonic":            true,
-		},
-	}
+	return dp
 }
 
-func (p *OTLPPusher) gaugeDP(name string, value float64, timeUnixNano int64) map[string]interface{} {
-	return map[string]interface{}{
-		"name": name,
-		"gauge": map[string]interface{}{
-			"dataPoints": []map[string]interface{}{
-				{
-					"asDouble":     value,
-					"timeUnixNano": fmt.Sprintf("%d", timeUnixNano),
-				},
-			},
-		},
+func (p *OTLPPusher) gaugeDP(name string, value float64, timeUnixNano int64, attrs ...map[string]interface{}) map[string]interface{} {
+	dp := map[string]interface{}{
+		"asDouble":     value,
+		"timeUnixNano": fmt.Sprintf("%d", timeUnixNano),
 	}
+	if len(attrs) > 0 {
+		dp["attributes"] = attrs
+	}
+	return dp
 }
 
 func attr(key, value string) map[string]interface{} {
@@ -261,3 +282,389 @@ func attr(key, value string) map[string]interface{} {
 		"value": map[string]interface{}{"stringValue": value},
 	}
 }
+
+func normalizeMetricsEndpoint(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	switch strings.TrimRight(u.Path, "/") {
+	case "":
+		u.Path = "/v1/metrics"
+	case "/v1":
+		u.Path = strings.TrimRight(u.Path, "/") + "/metrics"
+	}
+	return u.String()
+}
+
+func (p *OTLPPusher) resourceAttributes() []map[string]interface{} {
+	attrs := []map[string]interface{}{
+		attr("service.name", valueOrFallback(p.serviceName, "loki-vl-proxy", "")),
+	}
+	if v := strings.TrimSpace(p.serviceNamespace); v != "" {
+		attrs = append(attrs, attr("service.namespace", v))
+	}
+	if v := p.metricsScopeVersion(); v != "" {
+		attrs = append(attrs, attr("service.version", v))
+	}
+	if v := strings.TrimSpace(p.serviceInstanceID); v != "" {
+		attrs = append(attrs, attr("service.instance.id", v))
+	}
+	if v := strings.TrimSpace(p.deploymentEnvironment); v != "" {
+		attrs = append(attrs, attr("deployment.environment.name", v))
+	}
+	attrs = append(attrs,
+		attr("telemetry.sdk.name", "loki-vl-proxy"),
+		attr("telemetry.sdk.language", "go"),
+		attr("telemetry.sdk.version", runtime.Version()),
+	)
+	return attrs
+}
+
+func valueOrFallback(primary, fallback, unset string) string {
+	primary = strings.TrimSpace(primary)
+	if primary != "" && primary != unset {
+		return primary
+	}
+	return fallback
+}
+
+func (p *OTLPPusher) metricsScopeVersion() string {
+	v := strings.TrimSpace(p.serviceVersion)
+	if v == "" {
+		return "dev"
+	}
+	return v
+}
+
+func (p *OTLPPusher) sumMetric(name, description, unit string, dataPoints ...map[string]interface{}) map[string]interface{} {
+	metric := map[string]interface{}{
+		"name":        name,
+		"description": description,
+		"sum": map[string]interface{}{
+			"dataPoints":             dataPoints,
+			"aggregationTemporality": 2,
+			"isMonotonic":            true,
+		},
+	}
+	if unit != "" {
+		metric["unit"] = unit
+	}
+	return metric
+}
+
+func (p *OTLPPusher) gaugeMetric(name, description, unit string, dataPoints ...map[string]interface{}) map[string]interface{} {
+	metric := map[string]interface{}{
+		"name":        name,
+		"description": description,
+		"gauge": map[string]interface{}{
+			"dataPoints": dataPoints,
+		},
+	}
+	if unit != "" {
+		metric["unit"] = unit
+	}
+	return metric
+}
+
+func (p *OTLPPusher) histogramMetric(name, description, unit string, dataPoints ...map[string]interface{}) map[string]interface{} {
+	metric := map[string]interface{}{
+		"name":        name,
+		"description": description,
+		"histogram": map[string]interface{}{
+			"aggregationTemporality": 2,
+			"dataPoints":             dataPoints,
+		},
+	}
+	if unit != "" {
+		metric["unit"] = unit
+	}
+	return metric
+}
+
+func (p *OTLPPusher) histogramDP(h *histogram, timeUnixNano int64, attrs ...map[string]interface{}) map[string]interface{} {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	bucketCounts := make([]int64, 0, len(h.counts)+1)
+	prev := int64(0)
+	for _, cumulative := range h.counts {
+		bucketCounts = append(bucketCounts, cumulative-prev)
+		prev = cumulative
+	}
+	bucketCounts = append(bucketCounts, h.count-prev)
+	dp := map[string]interface{}{
+		"timeUnixNano":   fmt.Sprintf("%d", timeUnixNano),
+		"count":          fmt.Sprintf("%d", h.count),
+		"sum":            h.sum,
+		"explicitBounds": append([]float64(nil), h.buckets...),
+		"bucketCounts":   bucketCounts,
+	}
+	if len(attrs) > 0 {
+		dp["attributes"] = attrs
+	}
+	return dp
+}
+
+func (p *OTLPPusher) requestMetrics(now int64) []map[string]interface{} {
+	metrics := make([]map[string]interface{}, 0, 2)
+	reqKeys := sortedKeys(mapsFromCounters(p.metrics.requestsTotal))
+	requestPoints := make([]map[string]interface{}, 0, len(reqKeys))
+	for _, key := range reqKeys {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		requestPoints = append(requestPoints, p.counterDP("loki_vl_proxy_requests_total", p.metrics.requestsTotal[key].Load(), now, attr("endpoint", parts[0]), attr("status", parts[1])))
+	}
+	if len(requestPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_requests_total", "Total number of proxied requests.", "", requestPoints...))
+	}
+	durationKeys := sortedKeys(mapsFromHists(p.metrics.requestDurations))
+	durationPoints := make([]map[string]interface{}, 0, len(durationKeys))
+	for _, endpoint := range durationKeys {
+		durationPoints = append(durationPoints, p.histogramDP(p.metrics.requestDurations[endpoint], now, attr("endpoint", endpoint)))
+	}
+	if len(durationPoints) > 0 {
+		metrics = append(metrics, p.histogramMetric("loki_vl_proxy_request_duration_seconds", "Request duration histogram.", "s", durationPoints...))
+	}
+	return metrics
+}
+
+func (p *OTLPPusher) tenantMetrics(now int64) []map[string]interface{} {
+	metrics := make([]map[string]interface{}, 0, 2)
+	reqKeys := sortedKeys(mapsFromCounters(p.metrics.tenantRequests))
+	reqPoints := make([]map[string]interface{}, 0, len(reqKeys))
+	for _, key := range reqKeys {
+		parts := strings.SplitN(key, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		reqPoints = append(reqPoints, p.counterDP("loki_vl_proxy_tenant_requests_total", p.metrics.tenantRequests[key].Load(), now, attr("tenant", parts[0]), attr("endpoint", parts[1]), attr("status", parts[2])))
+	}
+	if len(reqPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_tenant_requests_total", "Requests by tenant.", "", reqPoints...))
+	}
+	durKeys := sortedKeys(mapsFromHists(p.metrics.tenantDurations))
+	durPoints := make([]map[string]interface{}, 0, len(durKeys))
+	for _, key := range durKeys {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		durPoints = append(durPoints, p.histogramDP(p.metrics.tenantDurations[key], now, attr("tenant", parts[0]), attr("endpoint", parts[1])))
+	}
+	if len(durPoints) > 0 {
+		metrics = append(metrics, p.histogramMetric("loki_vl_proxy_tenant_request_duration_seconds", "Per-tenant request duration.", "s", durPoints...))
+	}
+	return metrics
+}
+
+func (p *OTLPPusher) clientErrorMetrics(now int64) []map[string]interface{} {
+	keys := sortedKeys(mapsFromCounters(p.metrics.clientErrors))
+	points := make([]map[string]interface{}, 0, len(keys))
+	for _, key := range keys {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		points = append(points, p.counterDP("loki_vl_proxy_client_errors_total", p.metrics.clientErrors[key].Load(), now, attr("endpoint", parts[0]), attr("reason", parts[1])))
+	}
+	if len(points) == 0 {
+		return nil
+	}
+	return []map[string]interface{}{p.sumMetric("loki_vl_proxy_client_errors_total", "Client errors by reason.", "", points...)}
+}
+
+func (p *OTLPPusher) endpointCacheMetrics(now int64) []map[string]interface{} {
+	metrics := make([]map[string]interface{}, 0, 2)
+	hitKeys := sortedKeys(mapsFromCounters(p.metrics.endpointCacheHits))
+	hitPoints := make([]map[string]interface{}, 0, len(hitKeys))
+	for _, endpoint := range hitKeys {
+		hitPoints = append(hitPoints, p.counterDP("loki_vl_proxy_cache_hits_by_endpoint", p.metrics.endpointCacheHits[endpoint].Load(), now, attr("endpoint", endpoint)))
+	}
+	if len(hitPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_cache_hits_by_endpoint", "Cache hits per endpoint.", "", hitPoints...))
+	}
+	missKeys := sortedKeys(mapsFromCounters(p.metrics.endpointCacheMisses))
+	missPoints := make([]map[string]interface{}, 0, len(missKeys))
+	for _, endpoint := range missKeys {
+		missPoints = append(missPoints, p.counterDP("loki_vl_proxy_cache_misses_by_endpoint", p.metrics.endpointCacheMisses[endpoint].Load(), now, attr("endpoint", endpoint)))
+	}
+	if len(missPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_cache_misses_by_endpoint", "Cache misses per endpoint.", "", missPoints...))
+	}
+	return metrics
+}
+
+func (p *OTLPPusher) backendDurationMetrics(now int64) []map[string]interface{} {
+	keys := sortedKeys(mapsFromHists(p.metrics.backendDurations))
+	points := make([]map[string]interface{}, 0, len(keys))
+	for _, endpoint := range keys {
+		points = append(points, p.histogramDP(p.metrics.backendDurations[endpoint], now, attr("endpoint", endpoint)))
+	}
+	if len(points) == 0 {
+		return nil
+	}
+	return []map[string]interface{}{p.histogramMetric("loki_vl_proxy_backend_duration_seconds", "VL backend response time.", "s", points...)}
+}
+
+func (p *OTLPPusher) clientMetrics(now int64) []map[string]interface{} {
+	metrics := make([]map[string]interface{}, 0, 6)
+	reqKeys := sortedKeys(mapsFromCounters(p.metrics.clientRequests))
+	reqPoints := make([]map[string]interface{}, 0, len(reqKeys))
+	for _, key := range reqKeys {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		reqPoints = append(reqPoints, p.counterDP("loki_vl_proxy_client_requests_total", p.metrics.clientRequests[key].Load(), now, attr("client", parts[0]), attr("endpoint", parts[1])))
+	}
+	if len(reqPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_client_requests_total", "Requests by client identity.", "", reqPoints...))
+	}
+	byteKeys := sortedKeys(mapsFromCounters(p.metrics.clientBytes))
+	bytePoints := make([]map[string]interface{}, 0, len(byteKeys))
+	for _, client := range byteKeys {
+		bytePoints = append(bytePoints, p.counterDP("loki_vl_proxy_client_response_bytes_total", p.metrics.clientBytes[client].Load(), now, attr("client", client)))
+	}
+	if len(bytePoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_client_response_bytes_total", "Response bytes by client.", "By", bytePoints...))
+	}
+	statusKeys := sortedKeys(mapsFromCounters(p.metrics.clientStatuses))
+	statusPoints := make([]map[string]interface{}, 0, len(statusKeys))
+	for _, key := range statusKeys {
+		parts := strings.SplitN(key, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		statusPoints = append(statusPoints, p.counterDP("loki_vl_proxy_client_status_total", p.metrics.clientStatuses[key].Load(), now, attr("client", parts[0]), attr("endpoint", parts[1]), attr("status", parts[2])))
+	}
+	if len(statusPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_client_status_total", "Requests by client identity and final HTTP status.", "", statusPoints...))
+	}
+	inflightKeys := sortedKeys(mapsFromCounters(p.metrics.clientInflight))
+	inflightPoints := make([]map[string]interface{}, 0, len(inflightKeys))
+	for _, client := range inflightKeys {
+		inflightPoints = append(inflightPoints, p.gaugeDP("loki_vl_proxy_client_inflight_requests", float64(p.metrics.clientInflight[client].Load()), now, attr("client", client)))
+	}
+	if len(inflightPoints) > 0 {
+		metrics = append(metrics, p.gaugeMetric("loki_vl_proxy_client_inflight_requests", "In-flight requests by client identity.", "{request}", inflightPoints...))
+	}
+	durationKeys := sortedKeys(mapsFromHists(p.metrics.clientDurations))
+	durationPoints := make([]map[string]interface{}, 0, len(durationKeys))
+	for _, key := range durationKeys {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		durationPoints = append(durationPoints, p.histogramDP(p.metrics.clientDurations[key], now, attr("client", parts[0]), attr("endpoint", parts[1])))
+	}
+	if len(durationPoints) > 0 {
+		metrics = append(metrics, p.histogramMetric("loki_vl_proxy_client_request_duration_seconds", "Per-client request duration.", "s", durationPoints...))
+	}
+	queryLenKeys := sortedKeys(mapsFromHists(p.metrics.clientQueryLengths))
+	queryLenPoints := make([]map[string]interface{}, 0, len(queryLenKeys))
+	for _, key := range queryLenKeys {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		queryLenPoints = append(queryLenPoints, p.histogramDP(p.metrics.clientQueryLengths[key], now, attr("client", parts[0]), attr("endpoint", parts[1])))
+	}
+	if len(queryLenPoints) > 0 {
+		metrics = append(metrics, p.histogramMetric("loki_vl_proxy_client_query_length_chars", "LogQL query length by client identity.", "{character}", queryLenPoints...))
+	}
+	return metrics
+}
+
+func (p *OTLPPusher) systemMetrics(now int64) []map[string]interface{} {
+	metrics := make([]map[string]interface{}, 0, 12)
+	if runtime.GOOS != "linux" {
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		metrics = append(metrics, p.gaugeMetric("process_resident_memory_bytes", "Resident memory size.", "By", p.gaugeDP("process_resident_memory_bytes", float64(mem.Sys), now)))
+		return metrics
+	}
+	readBytes, writeBytes := readDiskIO()
+	rxBytes, txBytes := readNetIO()
+	memTotal, memAvail, memFree := readMemInfo()
+	if memTotal > 0 {
+		metrics = append(metrics,
+			p.gaugeMetric("node_memory_total_bytes", "Total memory.", "By", p.gaugeDP("node_memory_total_bytes", float64(memTotal), now)),
+			p.gaugeMetric("node_memory_available_bytes", "Available memory.", "By", p.gaugeDP("node_memory_available_bytes", float64(memAvail), now)),
+			p.gaugeMetric("node_memory_free_bytes", "Free memory.", "By", p.gaugeDP("node_memory_free_bytes", float64(memFree), now)),
+			p.gaugeMetric("node_memory_usage_ratio", "Memory usage ratio (0-1).", "1", p.gaugeDP("node_memory_usage_ratio", float64(memTotal-memAvail)/float64(memTotal), now)),
+		)
+	}
+	if rss := readProcessRSS(); rss > 0 {
+		metrics = append(metrics, p.gaugeMetric("process_resident_memory_bytes", "Process RSS.", "By", p.gaugeDP("process_resident_memory_bytes", float64(rss), now)))
+	}
+	metrics = append(metrics,
+		p.sumMetric("node_disk_read_bytes_total", "Disk read bytes.", "By", p.counterDP("node_disk_read_bytes_total", readBytes, now)),
+		p.sumMetric("node_disk_written_bytes_total", "Disk written bytes.", "By", p.counterDP("node_disk_written_bytes_total", writeBytes, now)),
+		p.sumMetric("node_network_receive_bytes_total", "Network receive bytes.", "By", p.counterDP("node_network_receive_bytes_total", rxBytes, now)),
+		p.sumMetric("node_network_transmit_bytes_total", "Network transmit bytes.", "By", p.counterDP("node_network_transmit_bytes_total", txBytes, now)),
+	)
+	if cur, err := readCPUStat(); err == nil {
+		total := cur.user + cur.nice + cur.system + cur.idle + cur.iowait + cur.irq + cur.softirq + cur.steal
+		if total > 0 {
+			metrics = append(metrics, p.gaugeMetric("node_cpu_usage_ratio", "CPU usage ratio (0-1).", "1",
+				p.gaugeDP("node_cpu_usage_ratio", (cur.user+cur.nice)/total, now, attr("mode", "user")),
+				p.gaugeDP("node_cpu_usage_ratio", cur.system/total, now, attr("mode", "system")),
+				p.gaugeDP("node_cpu_usage_ratio", cur.iowait/total, now, attr("mode", "iowait")),
+			))
+		}
+	}
+	for _, resource := range []string{"cpu", "memory", "io"} {
+		some10, some60, some300, full10, full60, full300 := readPSI(resource)
+		if some10 >= 0 {
+			metrics = append(metrics, p.gaugeMetric("node_pressure_"+resource+"_some_ratio", "PSI some pressure.", "1",
+				p.gaugeDP("", some10/100, now, attr("window", "10s")),
+				p.gaugeDP("", some60/100, now, attr("window", "60s")),
+				p.gaugeDP("", some300/100, now, attr("window", "300s")),
+			))
+		}
+		if full10 >= 0 {
+			metrics = append(metrics, p.gaugeMetric("node_pressure_"+resource+"_full_ratio", "PSI full pressure.", "1",
+				p.gaugeDP("", full10/100, now, attr("window", "10s")),
+				p.gaugeDP("", full60/100, now, attr("window", "60s")),
+				p.gaugeDP("", full300/100, now, attr("window", "300s")),
+			))
+		}
+	}
+	if fds := countOpenFDs(); fds >= 0 {
+		metrics = append(metrics, p.gaugeMetric("process_open_fds", "Open file descriptors.", "{file}", p.gaugeDP("process_open_fds", float64(fds), now)))
+	}
+	return metrics
+}
+
+func (p *OTLPPusher) circuitBreakerMetric(now int64) map[string]interface{} {
+	if p.metrics.cbStateFunc == nil {
+		return nil
+	}
+	cbState := p.metrics.cbStateFunc()
+	value := 0.0
+	switch cbState {
+	case "open":
+		value = 1
+	case "half_open", "half-open":
+		value = 2
+	}
+	return p.gaugeMetric("loki_vl_proxy_circuit_breaker_state", "Circuit breaker state (0=closed, 1=open, 2=half-open).", "1", p.gaugeDP("loki_vl_proxy_circuit_breaker_state", value, now))
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func mapsFromCounters(m map[string]*atomic.Int64) map[string]*atomic.Int64 { return m }
+func mapsFromHists(m map[string]*histogram) map[string]*histogram          { return m }

--- a/internal/metrics/otlp_test.go
+++ b/internal/metrics/otlp_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -304,6 +305,113 @@ func TestNormalizeMetricsEndpoint(t *testing.T) {
 	}
 }
 
+func TestOTLPPusher_SpecializedMetricFamilies(t *testing.T) {
+	m := NewMetrics()
+	m.RecordClientError("query_range", "timeout")
+	m.RecordClientError("query_range", "timeout")
+	m.RecordEndpointCacheHit("query_range")
+	m.RecordEndpointCacheMiss("query")
+	m.RecordBackendDuration("query_range", 25*time.Millisecond)
+	m.SetCircuitBreakerFunc(func() string { return "half-open" })
+
+	pusher := NewOTLPPusher(OTLPConfig{Endpoint: "http://unused"}, m)
+	now := time.Now().UnixNano()
+
+	clientErrors := pusher.clientErrorMetrics(now)
+	if len(clientErrors) != 1 {
+		t.Fatalf("expected one client error metric family, got %d", len(clientErrors))
+	}
+	points := metricPointsByType(t, clientErrors[0], "sum")
+	if len(points) != 1 {
+		t.Fatalf("expected one client error datapoint, got %d", len(points))
+	}
+	point0, ok := points[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected client error datapoint map, got %#v", points[0])
+	}
+	attrs := flattenAnyAttrs(t, point0["attributes"])
+	if attrs["endpoint"] != "query_range" || attrs["reason"] != "timeout" {
+		t.Fatalf("unexpected client error attrs: %#v", attrs)
+	}
+
+	endpointFamilies := append(pusher.endpointCacheMetrics(now), pusher.backendDurationMetrics(now)...)
+	names := metricNamesFromMaps(endpointFamilies)
+	for _, required := range []string{
+		"loki_vl_proxy_cache_hits_by_endpoint",
+		"loki_vl_proxy_cache_misses_by_endpoint",
+		"loki_vl_proxy_backend_duration_seconds",
+	} {
+		if !names[required] {
+			t.Fatalf("expected %s in specialized families, names=%v", required, names)
+		}
+	}
+
+	cb := pusher.circuitBreakerMetric(now)
+	if cb == nil {
+		t.Fatal("expected circuit breaker metric")
+	}
+	cbPoints := metricPointsByType(t, cb, "gauge")
+	if len(cbPoints) != 1 {
+		t.Fatalf("expected one circuit breaker datapoint, got %d", len(cbPoints))
+	}
+	cbPoint, ok := cbPoints[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected circuit breaker datapoint map, got %#v", cbPoints[0])
+	}
+	if got := cbPoint["asDouble"]; got != float64(2) {
+		t.Fatalf("expected half-open circuit breaker value 2, got %#v", got)
+	}
+}
+
+func TestOTLPPusher_CircuitBreakerMetricStates(t *testing.T) {
+	pusher := NewOTLPPusher(OTLPConfig{Endpoint: "http://unused"}, NewMetrics())
+	now := time.Now().UnixNano()
+
+	if metric := pusher.circuitBreakerMetric(now); metric != nil {
+		t.Fatal("expected nil metric when no callback is configured")
+	}
+
+	cases := map[string]float64{
+		"closed":    0,
+		"open":      1,
+		"half_open": 2,
+	}
+	for state, want := range cases {
+		t.Run(state, func(t *testing.T) {
+			pusher.metrics.SetCircuitBreakerFunc(func() string { return state })
+			metric := pusher.circuitBreakerMetric(now)
+			points := metricPointsByType(t, metric, "gauge")
+			point0, ok := points[0].(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected circuit breaker datapoint map, got %#v", points[0])
+			}
+			if got := point0["asDouble"]; got != want {
+				t.Fatalf("circuit breaker state %q encoded as %#v, want %v", state, got, want)
+			}
+		})
+	}
+}
+
+func TestOTLPPusher_SystemMetrics(t *testing.T) {
+	pusher := NewOTLPPusher(OTLPConfig{Endpoint: "http://unused"}, NewMetrics())
+	names := metricNamesFromMaps(pusher.systemMetrics(time.Now().UnixNano()))
+	if !names["process_resident_memory_bytes"] {
+		t.Fatalf("expected process_resident_memory_bytes, names=%v", names)
+	}
+	if runtime.GOOS == "linux" {
+		for _, required := range []string{
+			"node_disk_read_bytes_total",
+			"node_disk_written_bytes_total",
+			"node_network_receive_bytes_total",
+			"node_network_transmit_bytes_total",
+		} {
+			if !names[required] {
+				t.Fatalf("expected linux system metric %s, names=%v", required, names)
+			}
+		}
+	}
+}
+
 func flattenAttrs(t *testing.T, attrs []interface{}) map[string]string {
 	t.Helper()
 	flat := make(map[string]string, len(attrs))
@@ -326,6 +434,23 @@ func flattenAttrs(t *testing.T, attrs []interface{}) map[string]string {
 	return flat
 }
 
+func flattenAnyAttrs(t *testing.T, raw interface{}) map[string]string {
+	t.Helper()
+	switch attrs := raw.(type) {
+	case []interface{}:
+		return flattenAttrs(t, attrs)
+	case []map[string]interface{}:
+		items := make([]interface{}, 0, len(attrs))
+		for _, attr := range attrs {
+			items = append(items, attr)
+		}
+		return flattenAttrs(t, items)
+	default:
+		t.Fatalf("unsupported attribute shape: %#v", raw)
+		return nil
+	}
+}
+
 func metricNames(metrics []interface{}) map[string]bool {
 	names := make(map[string]bool, len(metrics))
 	for _, raw := range metrics {
@@ -339,4 +464,36 @@ func metricNames(metrics []interface{}) map[string]bool {
 		}
 	}
 	return names
+}
+
+func metricNamesFromMaps(metrics []map[string]interface{}) map[string]bool {
+	names := make(map[string]bool, len(metrics))
+	for _, metric := range metrics {
+		name, _ := metric["name"].(string)
+		if strings.TrimSpace(name) != "" {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func metricPointsByType(t *testing.T, metric map[string]interface{}, typ string) []interface{} {
+	t.Helper()
+	body, ok := metric[typ].(map[string]interface{})
+	if !ok {
+		t.Fatalf("metric %q missing %s body: %#v", metric["name"], typ, metric)
+	}
+	switch points := body["dataPoints"].(type) {
+	case []interface{}:
+		return points
+	case []map[string]interface{}:
+		out := make([]interface{}, 0, len(points))
+		for _, point := range points {
+			out = append(out, point)
+		}
+		return out
+	default:
+		t.Fatalf("metric %q missing datapoints: %#v", metric["name"], body)
+		return nil
+	}
 }

--- a/internal/metrics/otlp_test.go
+++ b/internal/metrics/otlp_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,12 +16,14 @@ func TestOTLPPusher_SendsMetrics(t *testing.T) {
 	var received atomic.Int32
 	var mu sync.Mutex
 	var lastBody []byte
+	var lastPath string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		received.Add(1)
 		body, _ := io.ReadAll(r.Body)
 		mu.Lock()
 		lastBody = body
+		lastPath = r.URL.Path
 		mu.Unlock()
 
 		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
@@ -36,8 +39,13 @@ func TestOTLPPusher_SendsMetrics(t *testing.T) {
 	m.RecordTranslation()
 
 	pusher := NewOTLPPusher(OTLPConfig{
-		Endpoint: srv.URL,
-		Interval: 50 * time.Millisecond,
+		Endpoint:              srv.URL,
+		Interval:              50 * time.Millisecond,
+		ServiceName:           "loki-vl-proxy",
+		ServiceNamespace:      "platform",
+		ServiceVersion:        "1.2.3",
+		ServiceInstanceID:     "proxy-1",
+		DeploymentEnvironment: "prod",
 	}, m)
 	pusher.Start()
 	defer pusher.Stop()
@@ -52,7 +60,12 @@ func TestOTLPPusher_SendsMetrics(t *testing.T) {
 	mu.Lock()
 	bodySnapshot := make([]byte, len(lastBody))
 	copy(bodySnapshot, lastBody)
+	pathSnapshot := lastPath
 	mu.Unlock()
+
+	if pathSnapshot != "/v1/metrics" {
+		t.Fatalf("expected normalized OTLP metrics path, got %q", pathSnapshot)
+	}
 
 	var payload map[string]interface{}
 	if err := json.Unmarshal(bodySnapshot, &payload); err != nil {
@@ -78,11 +91,41 @@ func TestOTLPPusher_SendsMetrics(t *testing.T) {
 	if !ok || len(attrs) == 0 {
 		t.Fatal("expected resource attributes")
 	}
+	attrMap := flattenAttrs(t, attrs)
+	if attrMap["service.name"] != "loki-vl-proxy" {
+		t.Fatalf("expected service.name resource attr, got %#v", attrMap["service.name"])
+	}
+	if attrMap["service.namespace"] != "platform" {
+		t.Fatalf("expected service.namespace resource attr, got %#v", attrMap["service.namespace"])
+	}
+	if attrMap["service.version"] != "1.2.3" {
+		t.Fatalf("expected service.version resource attr, got %#v", attrMap["service.version"])
+	}
 
 	// Check scopeMetrics
 	sm, ok := rm0["scopeMetrics"].([]interface{})
 	if !ok || len(sm) == 0 {
 		t.Fatal("expected scopeMetrics array")
+	}
+	sm0, ok := sm[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected scopeMetrics[0] object")
+	}
+	metrics, ok := sm0["metrics"].([]interface{})
+	if !ok || len(metrics) == 0 {
+		t.Fatal("expected otlp metrics list")
+	}
+	names := metricNames(metrics)
+	for _, required := range []string{
+		"loki_vl_proxy_requests_total",
+		"loki_vl_proxy_request_duration_seconds",
+		"loki_vl_proxy_cache_hits_total",
+		"loki_vl_proxy_uptime_seconds",
+		"go_goroutines",
+	} {
+		if !names[required] {
+			t.Fatalf("expected OTLP payload to include %s; names=%v", required, names)
+		}
 	}
 }
 
@@ -142,8 +185,18 @@ func TestOTLPPusher_BuildPayload(t *testing.T) {
 	m.RecordCacheMiss()
 	m.RecordTranslation()
 	m.RecordRequest("query_range", 200, 100*time.Millisecond)
+	m.RecordTenantRequest("team-a", "query_range", 200, 100*time.Millisecond)
+	m.RecordClientIdentity("grafana-user", "query_range", 50*time.Millisecond, 128)
+	m.RecordClientStatus("grafana-user", "query_range", 200)
+	m.RecordClientInflight("grafana-user", 1)
+	m.RecordClientQueryLength("grafana-user", "query_range", 42)
 
-	pusher := NewOTLPPusher(OTLPConfig{Endpoint: "http://unused"}, m)
+	pusher := NewOTLPPusher(OTLPConfig{
+		Endpoint:              "http://unused",
+		ServiceName:           "proxy",
+		ServiceVersion:        "9.9.9",
+		DeploymentEnvironment: "test",
+	}, m)
 	payload := pusher.buildPayload()
 
 	// Verify it marshals to valid JSON
@@ -154,6 +207,23 @@ func TestOTLPPusher_BuildPayload(t *testing.T) {
 
 	if len(data) < 100 {
 		t.Errorf("payload too small (%d bytes), expected meaningful content", len(data))
+	}
+
+	rm := payload["resourceMetrics"].([]map[string]interface{})
+	scopeMetrics := rm[0]["scopeMetrics"].([]map[string]interface{})
+	metricsList := scopeMetrics[0]["metrics"].([]map[string]interface{})
+	foundClientHistogram := false
+	foundTenantCounter := false
+	for _, metric := range metricsList {
+		switch metric["name"] {
+		case "loki_vl_proxy_client_query_length_chars":
+			foundClientHistogram = true
+		case "loki_vl_proxy_tenant_requests_total":
+			foundTenantCounter = true
+		}
+	}
+	if !foundClientHistogram || !foundTenantCounter {
+		t.Fatalf("expected richer OTLP payload, foundClientHistogram=%v foundTenantCounter=%v", foundClientHistogram, foundTenantCounter)
 	}
 }
 
@@ -217,4 +287,56 @@ func TestOTLPPusher_ZstdCompression(t *testing.T) {
 	if enc != "zstd" {
 		t.Errorf("expected Content-Encoding: zstd, got %q", enc)
 	}
+}
+
+func TestNormalizeMetricsEndpoint(t *testing.T) {
+	cases := map[string]string{
+		"http://collector:4318":             "http://collector:4318/v1/metrics",
+		"http://collector:4318/":            "http://collector:4318/v1/metrics",
+		"http://collector:4318/v1":          "http://collector:4318/v1/metrics",
+		"http://collector:4318/v1/metrics":  "http://collector:4318/v1/metrics",
+		"http://collector:4318/custom/path": "http://collector:4318/custom/path",
+	}
+	for in, want := range cases {
+		if got := normalizeMetricsEndpoint(in); got != want {
+			t.Fatalf("normalizeMetricsEndpoint(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func flattenAttrs(t *testing.T, attrs []interface{}) map[string]string {
+	t.Helper()
+	flat := make(map[string]string, len(attrs))
+	for _, raw := range attrs {
+		attrMap, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("attribute is not object: %#v", raw)
+		}
+		key, _ := attrMap["key"].(string)
+		valueMap, ok := attrMap["value"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("attribute value is not object: %#v", raw)
+		}
+		for _, value := range valueMap {
+			if s, ok := value.(string); ok {
+				flat[key] = s
+			}
+		}
+	}
+	return flat
+}
+
+func metricNames(metrics []interface{}) map[string]bool {
+	names := make(map[string]bool, len(metrics))
+	for _, raw := range metrics {
+		metric, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := metric["name"].(string)
+		if strings.TrimSpace(name) != "" {
+			names[name] = true
+		}
+	}
+	return names
 }

--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -150,6 +150,10 @@ func readCPUStat() (cpuStat, error) {
 	if err != nil {
 		return cpuStat{}, err
 	}
+	return parseCPUStatData(string(data))
+}
+
+func parseCPUStatData(data string) (cpuStat, error) {
 	lines := strings.Split(string(data), "\n")
 	for _, line := range lines {
 		if strings.HasPrefix(line, "cpu ") {
@@ -176,7 +180,11 @@ func readMemInfo() (total, avail, free int64) {
 	if err != nil {
 		return 0, 0, 0
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	return parseMemInfoData(string(data))
+}
+
+func parseMemInfoData(data string) (total, avail, free int64) {
+	for _, line := range strings.Split(data, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) >= 2 {
 			val, _ := strconv.ParseInt(fields[1], 10, 64)
@@ -199,7 +207,11 @@ func readProcessRSS() int64 {
 	if err != nil {
 		return 0
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	return parseProcessRSSData(string(data))
+}
+
+func parseProcessRSSData(data string) int64 {
+	for _, line := range strings.Split(data, "\n") {
 		if strings.HasPrefix(line, "VmRSS:") {
 			fields := strings.Fields(line)
 			if len(fields) >= 2 {
@@ -216,7 +228,11 @@ func readDiskIO() (readBytes, writeBytes int64) {
 	if err != nil {
 		return 0, 0
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	return parseDiskIOData(string(data))
+}
+
+func parseDiskIOData(data string) (readBytes, writeBytes int64) {
+	for _, line := range strings.Split(data, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) >= 14 {
 			// fields[5] = sectors read, fields[9] = sectors written (512 bytes/sector)
@@ -234,7 +250,11 @@ func readNetIO() (rxBytes, txBytes int64) {
 	if err != nil {
 		return 0, 0
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	return parseNetIOData(string(data))
+}
+
+func parseNetIOData(data string) (rxBytes, txBytes int64) {
+	for _, line := range strings.Split(data, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.Contains(line, ":") || strings.HasPrefix(line, "Inter") || strings.HasPrefix(line, " face") {
 			continue
@@ -266,7 +286,13 @@ func readPSI(resource string) (some10, some60, some300, full10, full60, full300 
 	if err != nil {
 		return
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	return parsePSIData(string(data))
+}
+
+func parsePSIData(data string) (some10, some60, some300, full10, full60, full300 float64) {
+	some10, some60, some300 = -1, -1, -1
+	full10, full60, full300 = -1, -1, -1
+	for _, line := range strings.Split(data, "\n") {
 		if strings.HasPrefix(line, "some ") {
 			some10, some60, some300 = parsePSILine(line)
 		}

--- a/internal/metrics/system_test.go
+++ b/internal/metrics/system_test.go
@@ -99,3 +99,61 @@ func TestSystemMetrics_IntegratedWithMetrics(t *testing.T) {
 		t.Error("system metrics should be available via Metrics.system")
 	}
 }
+
+func TestParsePSILine(t *testing.T) {
+	avg10, avg60, avg300 := parsePSILine("some avg10=1.25 avg60=0.50 avg300=0.05 total=123")
+	if avg10 != 1.25 || avg60 != 0.50 || avg300 != 0.05 {
+		t.Fatalf("unexpected PSI parse result: %g %g %g", avg10, avg60, avg300)
+	}
+}
+
+func TestParseFloat(t *testing.T) {
+	if got := parseFloat("12.5"); got != 12.5 {
+		t.Fatalf("expected 12.5, got %g", got)
+	}
+	if got := parseFloat("bad"); got != 0 {
+		t.Fatalf("expected invalid parse to return 0, got %g", got)
+	}
+}
+
+func TestCountOpenFDs(t *testing.T) {
+	got := countOpenFDs()
+	if runtime.GOOS == "linux" {
+		if got < 0 {
+			t.Fatalf("expected non-negative fd count on linux, got %d", got)
+		}
+		return
+	}
+	if got != -1 {
+		t.Fatalf("expected unsupported platforms to return -1, got %d", got)
+	}
+}
+
+func TestProcReaders_DoNotReturnNegativeValues(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only /proc readers")
+	}
+
+	total, avail, free := readMemInfo()
+	if total < 0 || avail < 0 || free < 0 {
+		t.Fatalf("unexpected negative meminfo values: total=%d avail=%d free=%d", total, avail, free)
+	}
+	if rss := readProcessRSS(); rss < 0 {
+		t.Fatalf("unexpected negative rss: %d", rss)
+	}
+	if readBytes, writeBytes := readDiskIO(); readBytes < 0 || writeBytes < 0 {
+		t.Fatalf("unexpected negative disk io: read=%d write=%d", readBytes, writeBytes)
+	}
+	if rxBytes, txBytes := readNetIO(); rxBytes < 0 || txBytes < 0 {
+		t.Fatalf("unexpected negative net io: rx=%d tx=%d", rxBytes, txBytes)
+	}
+	some10, some60, some300, full10, full60, full300 := readPSI("cpu")
+	for _, v := range []float64{some10, some60, some300, full10, full60, full300} {
+		if v < -1 {
+			t.Fatalf("unexpected PSI value %g", v)
+		}
+	}
+	if _, err := readCPUStat(); err != nil {
+		t.Fatalf("expected cpu stat to be readable on linux, got %v", err)
+	}
+}

--- a/internal/metrics/system_test.go
+++ b/internal/metrics/system_test.go
@@ -107,6 +107,64 @@ func TestParsePSILine(t *testing.T) {
 	}
 }
 
+func TestParseCPUStatData(t *testing.T) {
+	got, err := parseCPUStatData("cpu  100 5 20 300 7 0 1 2\ncpu0 1 2 3 4 5 6 7 8\n")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got.user != 100 || got.nice != 5 || got.system != 20 || got.idle != 300 || got.iowait != 7 || got.softirq != 1 || got.steal != 2 {
+		t.Fatalf("unexpected cpu stat: %+v", got)
+	}
+}
+
+func TestParseCPUStatData_MissingCPU(t *testing.T) {
+	if _, err := parseCPUStatData("intr 1\nctxt 2\n"); err == nil {
+		t.Fatal("expected cpu parse error when aggregate cpu line is missing")
+	}
+}
+
+func TestParseMemInfoData(t *testing.T) {
+	total, avail, free := parseMemInfoData("MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n")
+	if total != 1024*1024 || avail != 512*1024 || free != 128*1024 {
+		t.Fatalf("unexpected meminfo values: total=%d avail=%d free=%d", total, avail, free)
+	}
+}
+
+func TestParseProcessRSSData(t *testing.T) {
+	if got := parseProcessRSSData("Name:\tproxy\nVmRSS:\t123 kB\n"); got != 123*1024 {
+		t.Fatalf("unexpected rss value: %d", got)
+	}
+	if got := parseProcessRSSData("Name:\tproxy\n"); got != 0 {
+		t.Fatalf("expected rss fallback 0, got %d", got)
+	}
+}
+
+func TestParseDiskIOData(t *testing.T) {
+	readBytes, writeBytes := parseDiskIOData("   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n")
+	if readBytes != 6*512 || writeBytes != 10*512 {
+		t.Fatalf("unexpected disk io values: read=%d write=%d", readBytes, writeBytes)
+	}
+}
+
+func TestParseNetIOData(t *testing.T) {
+	input := "Inter-|   Receive                                                |  Transmit\n" +
+		" face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n" +
+		"    lo: 11 0 0 0 0 0 0 0 22 0 0 0 0 0 0 0\n" +
+		"  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n"
+	rxBytes, txBytes := parseNetIOData(input)
+	if rxBytes != 101 || txBytes != 202 {
+		t.Fatalf("unexpected net io values: rx=%d tx=%d", rxBytes, txBytes)
+	}
+}
+
+func TestParsePSIData(t *testing.T) {
+	input := "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n"
+	some10, some60, some300, full10, full60, full300 := parsePSIData(input)
+	if some10 != 1 || some60 != 2 || some300 != 3 || full10 != 4 || full60 != 5 || full300 != 6 {
+		t.Fatalf("unexpected psi data parse: %g %g %g %g %g %g", some10, some60, some300, full10, full60, full300)
+	}
+}
+
 func TestParseFloat(t *testing.T) {
 	if got := parseFloat("12.5"); got != 12.5 {
 		t.Fatalf("expected 12.5, got %g", got)

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -1,0 +1,107 @@
+package observability
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// LoggerConfig controls the default structured logger output.
+type LoggerConfig struct {
+	Level                 string
+	ServiceName           string
+	ServiceNamespace      string
+	ServiceVersion        string
+	ServiceInstanceID     string
+	DeploymentEnvironment string
+}
+
+// NewLogger returns a JSON logger shaped so common log agents can map it to the
+// OpenTelemetry log data model with minimal transformation.
+func NewLogger(w io.Writer, cfg LoggerConfig) *slog.Logger {
+	if w == nil {
+		w = os.Stdout
+	}
+	level := parseLevel(cfg.Level)
+	attrs := []any{
+		"service.name", valueOrDefault(cfg.ServiceName, "loki-vl-proxy"),
+		"service.version", valueOrDefault(cfg.ServiceVersion, "dev"),
+		"service.instance.id", valueOrDefault(cfg.ServiceInstanceID, defaultInstanceID()),
+		"telemetry.sdk.name", "loki-vl-proxy",
+		"telemetry.sdk.language", "go",
+		"telemetry.sdk.version", runtime.Version(),
+	}
+	if strings.TrimSpace(cfg.ServiceNamespace) != "" {
+		attrs = append(attrs, "service.namespace", strings.TrimSpace(cfg.ServiceNamespace))
+	}
+	if strings.TrimSpace(cfg.DeploymentEnvironment) != "" {
+		attrs = append(attrs, "deployment.environment.name", strings.TrimSpace(cfg.DeploymentEnvironment))
+	}
+
+	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level: level,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			switch a.Key {
+			case slog.TimeKey:
+				return slog.String("timestamp", a.Value.Time().Format(time.RFC3339Nano))
+			case slog.LevelKey:
+				lvl := a.Value.Any().(slog.Level)
+				return slog.Group("severity",
+					slog.String("text", strings.ToUpper(lvl.String())),
+					slog.Int("number", severityNumber(lvl)),
+				)
+			case slog.MessageKey:
+				return slog.String("body", a.Value.String())
+			default:
+				return a
+			}
+		},
+	})
+	return slog.New(handler).With(attrs...)
+}
+
+func parseLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func severityNumber(level slog.Level) int {
+	switch {
+	case level <= slog.LevelDebug:
+		return 5
+	case level < slog.LevelWarn:
+		return 9
+	case level < slog.LevelError:
+		return 13
+	default:
+		return 17
+	}
+}
+
+func defaultInstanceID() string {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s-%d", host, os.Getpid())
+}
+
+func valueOrDefault(v, fallback string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -1,0 +1,110 @@
+package observability
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewLogger_EmitsOTelFriendlyJSON(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LoggerConfig{
+		Level:                 "debug",
+		ServiceName:           "test-proxy",
+		ServiceNamespace:      "edge",
+		ServiceVersion:        "1.2.3",
+		ServiceInstanceID:     "proxy-1",
+		DeploymentEnvironment: "prod",
+	})
+
+	logger.Info("request finished", "http.response.status_code", 200, "endpoint", "query_range")
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid json log: %v", err)
+	}
+
+	if payload["body"] != "request finished" {
+		t.Fatalf("expected body field, got %#v", payload["body"])
+	}
+	if payload["service.name"] != "test-proxy" {
+		t.Fatalf("expected service.name, got %#v", payload["service.name"])
+	}
+	if payload["service.namespace"] != "edge" {
+		t.Fatalf("expected service.namespace, got %#v", payload["service.namespace"])
+	}
+	if payload["service.version"] != "1.2.3" {
+		t.Fatalf("expected service.version, got %#v", payload["service.version"])
+	}
+	if payload["service.instance.id"] != "proxy-1" {
+		t.Fatalf("expected service.instance.id, got %#v", payload["service.instance.id"])
+	}
+	if payload["deployment.environment.name"] != "prod" {
+		t.Fatalf("expected deployment.environment.name, got %#v", payload["deployment.environment.name"])
+	}
+	severity, ok := payload["severity"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected grouped severity field, got %#v", payload["severity"])
+	}
+	if severity["text"] != "INFO" {
+		t.Fatalf("expected severity text INFO, got %#v", severity["text"])
+	}
+	if severity["number"] != float64(9) {
+		t.Fatalf("expected severity number 9, got %#v", severity["number"])
+	}
+	if payload["timestamp"] == nil {
+		t.Fatal("expected timestamp field")
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+		"info":    slog.LevelInfo,
+		"other":   slog.LevelInfo,
+	}
+	for in, want := range cases {
+		if got := parseLevel(in); got != want {
+			t.Fatalf("parseLevel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestSeverityNumber(t *testing.T) {
+	if severityNumber(slog.LevelDebug) != 5 {
+		t.Fatal("expected debug severity number 5")
+	}
+	if severityNumber(slog.LevelInfo) != 9 {
+		t.Fatal("expected info severity number 9")
+	}
+	if severityNumber(slog.LevelWarn) != 13 {
+		t.Fatal("expected warn severity number 13")
+	}
+	if severityNumber(slog.LevelError) != 17 {
+		t.Fatal("expected error severity number 17")
+	}
+}
+
+func TestValueOrDefault(t *testing.T) {
+	if got := valueOrDefault(" custom ", "fallback"); got != "custom" {
+		t.Fatalf("unexpected trimmed value: %q", got)
+	}
+	if got := valueOrDefault("   ", "fallback"); got != "fallback" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+}
+
+func TestDefaultInstanceID(t *testing.T) {
+	got := defaultInstanceID()
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("expected non-empty instance id")
+	}
+	if !strings.Contains(got, "-") {
+		t.Fatalf("expected host-pid shaped instance id, got %q", got)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -662,6 +662,21 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	if _, ok := p.validateQuery(w, logqlQuery, "query_range"); !ok {
 		return
 	}
+	cacheKey := ""
+	cacheable := !p.streamResponse
+	if cacheable {
+		cacheKey = p.queryRangeCacheKey(r, logqlQuery)
+		if cached, ok := p.cache.Get(cacheKey); ok {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(cached)
+			elapsed := time.Since(start)
+			p.metrics.RecordRequest("query_range", http.StatusOK, elapsed)
+			p.metrics.RecordCacheHit()
+			p.queryTracker.Record("query_range", logqlQuery, elapsed, false)
+			return
+		}
+		p.metrics.RecordCacheMiss()
+	}
 	p.log.Debug("query_range request", "logql", logqlQuery)
 
 	logqlQuery = p.preferWorkingParser(r.Context(), logqlQuery, r.FormValue("start"), r.FormValue("end"))
@@ -678,14 +693,14 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 
 	r = withOrgID(r)
 
-	// Wrap writer to capture actual status code for metrics
-	sc := &statusCapture{ResponseWriter: w, code: 200}
-
-	// If without() labels present, use a buffered writer for post-processing
-	var bw *bufferedResponseWriter
-	if len(withoutLabels) > 0 {
-		bw = &bufferedResponseWriter{header: w.Header()}
-		sc = &statusCapture{ResponseWriter: bw, code: 200}
+	var (
+		sc       = &statusCapture{ResponseWriter: w, code: 200}
+		capture  *bufferedResponseWriter
+		cacheOut []byte
+	)
+	if len(withoutLabels) > 0 || cacheable {
+		capture = &bufferedResponseWriter{header: make(http.Header)}
+		sc = &statusCapture{ResponseWriter: capture, code: 200}
 	}
 
 	// Check for subquery expression (e.g., max_over_time(rate(...)[1h:5m]))
@@ -700,16 +715,38 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		p.proxyLogQuery(sc, r, logsqlQuery)
 	}
 
-	// Apply without() post-processing: strip excluded labels from metric results
-	if bw != nil && len(withoutLabels) > 0 {
-		result := applyWithoutGrouping(bw.body, withoutLabels)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(result)
+	if capture != nil {
+		cacheOut = capture.body
+		if len(withoutLabels) > 0 {
+			cacheOut = applyWithoutGrouping(cacheOut, withoutLabels)
+		}
+		copyHeaders(w.Header(), capture.Header())
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		if sc.code != http.StatusOK {
+			w.WriteHeader(sc.code)
+		}
+		_, _ = w.Write(cacheOut)
+		if cacheable && sc.code == http.StatusOK {
+			p.cache.SetWithTTL(cacheKey, cacheOut, CacheTTLs["query_range"])
+		}
 	}
 
 	elapsed := time.Since(start)
 	p.metrics.RecordRequest("query_range", sc.code, elapsed)
 	p.queryTracker.Record("query_range", logqlQuery, elapsed, sc.code >= 400)
+}
+
+func (p *Proxy) queryRangeCacheKey(r *http.Request, logqlQuery string) string {
+	values := url.Values{}
+	values.Set("query", logqlQuery)
+	for _, key := range []string{"start", "end", "step", "limit", "direction"} {
+		if value := r.FormValue(key); value != "" {
+			values.Set(key, value)
+		}
+	}
+	return "query_range:" + r.Header.Get("X-Scope-OrgID") + ":" + values.Encode()
 }
 
 // handleQuery translates Loki instant queries.
@@ -770,7 +807,6 @@ func (p *Proxy) handleQuery(w http.ResponseWriter, r *http.Request) {
 // VL:   GET /select/logsql/field_names?query=*&start=...&end=...
 func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	r = withOrgID(r)
 	orgID := r.Header.Get("X-Scope-OrgID")
 	cacheKey := "labels:" + orgID + ":" + r.URL.RawQuery
 
@@ -783,6 +819,7 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.metrics.RecordCacheMiss()
+	r = withOrgID(r)
 
 	params := url.Values{}
 	// Forward the query param if provided (Loki uses it to scope label suggestions)
@@ -3343,6 +3380,15 @@ func (p *Proxy) writeJSON(w http.ResponseWriter, data interface{}) {
 
 func base64Encode(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func copyHeaders(dst, src http.Header) {
+	for key, values := range src {
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }
 
 // isVLInternalField returns true for VictoriaLogs internal field names

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -222,7 +222,11 @@ func New(cfg Config) (*Proxy, error) {
 		level = slog.LevelError
 	}
 
-	logger := slog.New(NewRedactingHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+	baseLogger := slog.Default()
+	if baseLogger == nil {
+		baseLogger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+	}
+	logger := slog.New(NewRedactingHandler(baseLogger.Handler())).With("component", "proxy")
 
 	maxConcurrent := cfg.MaxConcurrent
 	if maxConcurrent == 0 {
@@ -3457,15 +3461,15 @@ func (p *Proxy) requestLogger(endpoint string, next http.HandlerFunc) http.Handl
 			logLevel = p.log.Warn
 		}
 		logLevel("request",
-			"endpoint", endpoint,
-			"method", r.Method,
-			"status", sc.code,
-			"duration_ms", elapsed.Milliseconds(),
-			"tenant", tenant,
-			"query", truncateQuery(query, 200),
-			"client", r.RemoteAddr,
-			"client_id", clientID,
-			"client_source", clientSource,
+			"http.route", endpoint,
+			"http.request.method", r.Method,
+			"http.response.status_code", sc.code,
+			"event.duration_ms", elapsed.Milliseconds(),
+			"loki.tenant.id", tenant,
+			"loki.query", truncateQuery(query, 200),
+			"client.address", r.RemoteAddr,
+			"enduser.id", clientID,
+			"loki.client.source", clientSource,
 		)
 	})
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -721,6 +721,42 @@ func TestCache_LabelValuesHitOnRepeat(t *testing.T) {
 	}
 }
 
+func TestCache_QueryRangeHitOnRepeat(t *testing.T) {
+	callCount := 0
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/stream+json")
+		_, _ = w.Write([]byte(`{"_time":"2024-01-15T10:30:00Z","_msg":"cache me","_stream":"{app=\"nginx\"}"}` + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+
+	r1 := httptest.NewRequest("GET", `/loki/api/v1/query_range?query={app="nginx"}&start=1&end=2&limit=10`, nil)
+	w1 := httptest.NewRecorder()
+	p.handleQueryRange(w1, r1)
+	if callCount != 1 {
+		t.Fatalf("expected 1 backend call, got %d", callCount)
+	}
+
+	r2 := httptest.NewRequest("GET", `/loki/api/v1/query_range?query={app="nginx"}&start=1&end=2&limit=10`, nil)
+	w2 := httptest.NewRecorder()
+	p.handleQueryRange(w2, r2)
+	if callCount != 1 {
+		t.Fatalf("expected cache hit on second query_range call, got %d backend calls", callCount)
+	}
+	if w1.Body.String() != w2.Body.String() {
+		t.Fatalf("expected cached query_range body to match original response")
+	}
+
+	r3 := httptest.NewRequest("GET", `/loki/api/v1/query_range?query={app="nginx"}&start=3&end=4&limit=10`, nil)
+	w3 := httptest.NewRecorder()
+	p.handleQueryRange(w3, r3)
+	if callCount != 2 {
+		t.Fatalf("expected new backend call for different time range, got %d", callCount)
+	}
+}
+
 // =============================================================================
 // POST Support Tests — Loki allows POST for all query endpoints
 // =============================================================================

--- a/internal/translator/coverage_test.go
+++ b/internal/translator/coverage_test.go
@@ -2,6 +2,49 @@ package translator
 
 import "testing"
 
+func TestCoverage_ParseWithoutMarker(t *testing.T) {
+	clean, labels := ParseWithoutMarker(`app:=api` + WithoutMarkerSuffix + `pod,node`)
+	if clean != `app:=api` {
+		t.Fatalf("unexpected clean query: %q", clean)
+	}
+	if len(labels) != 2 || labels[0] != "pod" || labels[1] != "node" {
+		t.Fatalf("unexpected labels: %#v", labels)
+	}
+
+	clean, labels = ParseWithoutMarker(`app:=api`)
+	if clean != `app:=api` || labels != nil {
+		t.Fatalf("expected unchanged query without marker, got clean=%q labels=%#v", clean, labels)
+	}
+}
+
+func TestCoverage_ParseBinaryMetricExprFull(t *testing.T) {
+	expr := BinaryMetricPrefix + `+:left_query|||right_query@@@on:job, instance@@@group_left:pod`
+	op, left, right, vm, ok := ParseBinaryMetricExprFull(expr)
+	if !ok {
+		t.Fatal("expected binary metric expr to parse")
+	}
+	if op != "+" || left != "left_query" || right != "right_query" {
+		t.Fatalf("unexpected parse result: op=%q left=%q right=%q", op, left, right)
+	}
+	if len(vm.On) != 2 || vm.On[0] != "job" || vm.On[1] != "instance" {
+		t.Fatalf("unexpected on labels: %#v", vm.On)
+	}
+	if len(vm.GroupLeft) != 1 || vm.GroupLeft[0] != "pod" {
+		t.Fatalf("unexpected group_left labels: %#v", vm.GroupLeft)
+	}
+
+	if _, _, _, _, ok := ParseBinaryMetricExprFull("rate({app=\"api\"}[5m])"); ok {
+		t.Fatal("expected non-prefixed expression to fail parsing")
+	}
+}
+
+func TestCoverage_SplitLabels(t *testing.T) {
+	got := splitLabels(" job, instance ,, pod ")
+	if len(got) != 3 || got[0] != "job" || got[1] != "instance" || got[2] != "pod" {
+		t.Fatalf("unexpected split labels: %#v", got)
+	}
+}
+
 // Coverage gap: extractQuotedValue edge cases
 func TestCoverage_ExtractQuotedValue(t *testing.T) {
 	tests := []struct {
@@ -69,5 +112,19 @@ func TestCoverage_AddByClause_NoStats(t *testing.T) {
 	got := addByClause("app:=nginx", "app", nil)
 	if got != "app:=nginx | stats by (app)" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestCoverage_AddByClause_WithStatsAndTranslator(t *testing.T) {
+	labelFn := func(label string) string {
+		if label == "service_name" {
+			return "service.name"
+		}
+		return label
+	}
+	got := addByClause(`app:=nginx | stats count(*) as hits`, "service_name, cluster", labelFn)
+	want := `app:=nginx | stats by (service.name, cluster) count(*) as hits`
+	if got != want {
+		t.Fatalf("addByClause returned %q, want %q", got, want)
 	}
 }

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -51,9 +51,9 @@ run_score() {
 start_compat_stack() {
   (
     cd "$ROOT_DIR/test/e2e-compat"
-    docker compose down -v >/dev/null 2>&1 || true
-    docker compose up -d --build
-    sleep 30
+    docker compose down -v >&2 || true
+    docker compose up -d --build >&2
+    sleep 30 >&2
   )
 }
 

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -9,12 +9,6 @@ fi
 OUTPUT_JSON="$1"
 ROOT_DIR="$(pwd)"
 TMP_DIR="$(mktemp -d)"
-TIMEOUT_BIN=""
-if command -v timeout >/dev/null 2>&1; then
-  TIMEOUT_BIN="timeout"
-elif command -v gtimeout >/dev/null 2>&1; then
-  TIMEOUT_BIN="gtimeout"
-fi
 cleanup() {
   if [ -d "$ROOT_DIR/test/e2e-compat" ]; then
     (cd "$ROOT_DIR/test/e2e-compat" && docker compose down -v >/dev/null 2>&1) || true
@@ -27,16 +21,6 @@ log_step() {
   echo "[quality] $*" >&2
 }
 
-run_with_timeout() {
-  local seconds="$1"
-  shift
-  if [ -n "$TIMEOUT_BIN" ]; then
-    "$TIMEOUT_BIN" "$seconds" "$@"
-    return $?
-  fi
-  "$@"
-}
-
 capture_or_default() {
   local label="$1"
   local fallback="$2"
@@ -44,16 +28,38 @@ capture_or_default() {
   shift 3
 
   log_step "starting ${label}"
-  local output
-  if output="$(run_with_timeout "$timeout_seconds" "$@" 2>"$TMP_DIR/${label}.stderr")"; then
+  local out_file="$TMP_DIR/${label}.stdout"
+  local err_file="$TMP_DIR/${label}.stderr"
+  rm -f "$out_file" "$err_file"
+
+  (
+    "$@" >"$out_file" 2>"$err_file"
+  ) &
+  local pid=$!
+  local elapsed=0
+  local status=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$elapsed" -ge "$timeout_seconds" ]; then
+      kill "$pid" >/dev/null 2>&1 || true
+      wait "$pid" >/dev/null 2>&1 || true
+      log_step "${label} timed out after ${timeout_seconds}s; using fallback"
+      cat "$err_file" >&2 || true
+      printf '%s' "$fallback"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed+1))
+  done
+
+  if wait "$pid"; then
     log_step "completed ${label}"
-    printf '%s' "$output"
+    cat "$out_file"
     return 0
   fi
 
-  local status=$?
+  status=$?
   log_step "${label} failed or timed out (exit=${status}); using fallback"
-  cat "$TMP_DIR/${label}.stderr" >&2 || true
+  cat "$err_file" >&2 || true
   printf '%s' "$fallback"
   return 0
 }

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -119,13 +119,28 @@ collect_compat() {
 collect_benchmarks() {
   local out="$TMP_DIR/bench.txt"
   go test ./internal/proxy -run '^$' -bench 'BenchmarkProxy_(QueryRange_CacheHit|Labels_CacheHit)$' -benchmem -count=1 >"$out"
-  local query_ns labels_ns
+  local query_ns query_bytes query_allocs labels_ns labels_bytes labels_allocs
   query_ns="$(awk '/BenchmarkProxy_QueryRange_CacheHit/ {print $(NF-5); exit}' "$out")"
+  query_bytes="$(awk '/BenchmarkProxy_QueryRange_CacheHit/ {print $(NF-3); exit}' "$out")"
+  query_allocs="$(awk '/BenchmarkProxy_QueryRange_CacheHit/ {print $(NF-1); exit}' "$out")"
   labels_ns="$(awk '/BenchmarkProxy_Labels_CacheHit/ {print $(NF-5); exit}' "$out")"
+  labels_bytes="$(awk '/BenchmarkProxy_Labels_CacheHit/ {print $(NF-3); exit}' "$out")"
+  labels_allocs="$(awk '/BenchmarkProxy_Labels_CacheHit/ {print $(NF-1); exit}' "$out")"
   jq -n \
     --argjson query_ns "${query_ns:-0}" \
+    --argjson query_bytes "${query_bytes:-0}" \
+    --argjson query_allocs "${query_allocs:-0}" \
     --argjson labels_ns "${labels_ns:-0}" \
-    '{query_range_cache_hit_ns_per_op:$query_ns,labels_cache_hit_ns_per_op:$labels_ns}'
+    --argjson labels_bytes "${labels_bytes:-0}" \
+    --argjson labels_allocs "${labels_allocs:-0}" \
+    '{
+      query_range_cache_hit_ns_per_op:$query_ns,
+      query_range_cache_hit_bytes_per_op:$query_bytes,
+      query_range_cache_hit_allocs_per_op:$query_allocs,
+      labels_cache_hit_ns_per_op:$labels_ns,
+      labels_cache_hit_bytes_per_op:$labels_bytes,
+      labels_cache_hit_allocs_per_op:$labels_allocs
+    }'
 }
 
 collect_load() {
@@ -143,7 +158,7 @@ collect_load() {
 TEST_COUNT="$(capture_or_default tests 0 600 count_tests)"
 COVERAGE="$(capture_or_default coverage 0 900 coverage_pct)"
 COMPAT="$(capture_or_default compat '{"loki":{"passed":0,"total":0,"pct":0},"drilldown":{"passed":0,"total":0,"pct":0},"vl":{"passed":0,"total":0,"pct":0}}' 1800 collect_compat)"
-BENCHMARKS="$(capture_or_default benchmarks '{"query_range_cache_hit_ns_per_op":0,"labels_cache_hit_ns_per_op":0}' 900 collect_benchmarks)"
+BENCHMARKS="$(capture_or_default benchmarks '{"query_range_cache_hit_ns_per_op":0,"query_range_cache_hit_bytes_per_op":0,"query_range_cache_hit_allocs_per_op":0,"labels_cache_hit_ns_per_op":0,"labels_cache_hit_bytes_per_op":0,"labels_cache_hit_allocs_per_op":0}' 900 collect_benchmarks)"
 LOAD="$(capture_or_default load '{"high_concurrency_req_per_s":0,"high_concurrency_memory_growth_mb":0}' 600 collect_load)"
 
 jq -n \

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -9,6 +9,12 @@ fi
 OUTPUT_JSON="$1"
 ROOT_DIR="$(pwd)"
 TMP_DIR="$(mktemp -d)"
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+fi
 cleanup() {
   if [ -d "$ROOT_DIR/test/e2e-compat" ]; then
     (cd "$ROOT_DIR/test/e2e-compat" && docker compose down -v >/dev/null 2>&1) || true
@@ -16,6 +22,41 @@ cleanup() {
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
+
+log_step() {
+  echo "[quality] $*" >&2
+}
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$seconds" "$@"
+    return $?
+  fi
+  "$@"
+}
+
+capture_or_default() {
+  local label="$1"
+  local fallback="$2"
+  local timeout_seconds="$3"
+  shift 3
+
+  log_step "starting ${label}"
+  local output
+  if output="$(run_with_timeout "$timeout_seconds" "$@" 2>"$TMP_DIR/${label}.stderr")"; then
+    log_step "completed ${label}"
+    printf '%s' "$output"
+    return 0
+  fi
+
+  local status=$?
+  log_step "${label} failed or timed out (exit=${status}); using fallback"
+  cat "$TMP_DIR/${label}.stderr" >&2 || true
+  printf '%s' "$fallback"
+  return 0
+}
 
 count_tests() {
   go test ./... -count=1 -json 2>/dev/null \
@@ -32,7 +73,7 @@ coverage_pct() {
 run_score() {
   local test_name="$1"
   local output
-  output="$(go test -v -tags=e2e -run "^${test_name}$" ./test/e2e-compat/ 2>&1)"
+  output="$(go test -v -tags=e2e -run "^${test_name}$" ./test/e2e-compat/ -timeout=180s 2>&1)"
   echo "$output" >"$TMP_DIR/${test_name}.log"
   local score
   score="$(echo "$output" | grep -oE 'Score: [0-9]+/[0-9]+ \([0-9.]+%\)' | tail -1)"
@@ -52,8 +93,7 @@ start_compat_stack() {
   (
     cd "$ROOT_DIR/test/e2e-compat"
     docker compose down -v >&2 || true
-    docker compose up -d --build >&2
-    sleep 30 >&2
+    docker compose up -d --build --wait --wait-timeout 180 >&2
   )
 }
 
@@ -94,11 +134,11 @@ collect_load() {
     '{high_concurrency_req_per_s:$throughput,high_concurrency_memory_growth_mb:$memory_growth}'
 }
 
-TEST_COUNT="$(count_tests)"
-COVERAGE="$(coverage_pct)"
-COMPAT="$(collect_compat)"
-BENCHMARKS="$(collect_benchmarks)"
-LOAD="$(collect_load)"
+TEST_COUNT="$(capture_or_default tests 0 600 count_tests)"
+COVERAGE="$(capture_or_default coverage 0 900 coverage_pct)"
+COMPAT="$(capture_or_default compat '{"loki":{"passed":0,"total":0,"pct":0},"drilldown":{"passed":0,"total":0,"pct":0},"vl":{"passed":0,"total":0,"pct":0}}' 1800 collect_compat)"
+BENCHMARKS="$(capture_or_default benchmarks '{"query_range_cache_hit_ns_per_op":0,"labels_cache_hit_ns_per_op":0}' 900 collect_benchmarks)"
+LOAD="$(capture_or_default load '{"high_concurrency_req_per_s":0,"high_concurrency_memory_growth_mb":0}' 600 collect_load)"
 
 jq -n \
   --argjson tests "$TEST_COUNT" \

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "" ]; then
+  echo "usage: $0 <output-json>" >&2
+  exit 1
+fi
+
+OUTPUT_JSON="$1"
+ROOT_DIR="$(pwd)"
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  if [ -d "$ROOT_DIR/test/e2e-compat" ]; then
+    (cd "$ROOT_DIR/test/e2e-compat" && docker compose down -v >/dev/null 2>&1) || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+count_tests() {
+  go test ./... -count=1 -json 2>/dev/null \
+    | jq -r 'select(.Action=="pass" and .Test != null) | .Test' \
+    | wc -l | tr -d ' '
+}
+
+coverage_pct() {
+  local cover_file="$TMP_DIR/coverage.out"
+  go test ./... -coverprofile="$cover_file" -count=1 >/dev/null
+  go tool cover -func="$cover_file" | tail -1 | awk '{print substr($3, 1, length($3)-1)}'
+}
+
+run_score() {
+  local test_name="$1"
+  local output
+  output="$(go test -v -tags=e2e -run "^${test_name}$" ./test/e2e-compat/ 2>&1)"
+  echo "$output" >"$TMP_DIR/${test_name}.log"
+  local score
+  score="$(echo "$output" | grep -oE 'Score: [0-9]+/[0-9]+ \([0-9.]+%\)' | tail -1)"
+  if [ -z "$score" ]; then
+    echo '{"passed":0,"total":0,"pct":0}'
+    return
+  fi
+  local passed total pct
+  passed="$(echo "$score" | sed -E 's/Score: ([0-9]+)\/([0-9]+) \(([0-9.]+)%\)/\1/')"
+  total="$(echo "$score" | sed -E 's/Score: ([0-9]+)\/([0-9]+) \(([0-9.]+)%\)/\2/')"
+  pct="$(echo "$score" | sed -E 's/Score: ([0-9]+)\/([0-9]+) \(([0-9.]+)%\)/\3/')"
+  jq -n --argjson passed "$passed" --argjson total "$total" --argjson pct "$pct" \
+    '{passed:$passed,total:$total,pct:$pct}'
+}
+
+start_compat_stack() {
+  (
+    cd "$ROOT_DIR/test/e2e-compat"
+    docker compose down -v >/dev/null 2>&1 || true
+    docker compose up -d --build
+    sleep 30
+  )
+}
+
+collect_compat() {
+  start_compat_stack
+  local loki drilldown vl
+  loki="$(run_score TestLokiTrackScore)"
+  drilldown="$(run_score TestDrilldownTrackScore)"
+  vl="$(run_score TestVLTrackScore)"
+  jq -n \
+    --argjson loki "$loki" \
+    --argjson drilldown "$drilldown" \
+    --argjson vl "$vl" \
+    '{loki:$loki,drilldown:$drilldown,vl:$vl}'
+}
+
+collect_benchmarks() {
+  local out="$TMP_DIR/bench.txt"
+  go test ./internal/proxy -run '^$' -bench 'BenchmarkProxy_(QueryRange_CacheHit|Labels_CacheHit)$' -benchmem -count=1 >"$out"
+  local query_ns labels_ns
+  query_ns="$(awk '/BenchmarkProxy_QueryRange_CacheHit/ {print $(NF-5); exit}' "$out")"
+  labels_ns="$(awk '/BenchmarkProxy_Labels_CacheHit/ {print $(NF-5); exit}' "$out")"
+  jq -n \
+    --argjson query_ns "${query_ns:-0}" \
+    --argjson labels_ns "${labels_ns:-0}" \
+    '{query_range_cache_hit_ns_per_op:$query_ns,labels_cache_hit_ns_per_op:$labels_ns}'
+}
+
+collect_load() {
+  local out="$TMP_DIR/load.txt"
+  go test ./internal/proxy -run '^TestLoad_HighConcurrency_MemoryStability$' -count=1 -v -timeout=180s >"$out"
+  local throughput memory_growth
+  throughput="$(grep -E 'Throughput: ' "$out" | tail -1 | sed -E 's/.*Throughput: ([0-9.]+) req\/s/\1/')"
+  memory_growth="$(grep -E 'Memory growth: ' "$out" | tail -1 | sed -E 's/.*Memory growth: ([0-9.]+) MB.*/\1/')"
+  jq -n \
+    --argjson throughput "${throughput:-0}" \
+    --argjson memory_growth "${memory_growth:-0}" \
+    '{high_concurrency_req_per_s:$throughput,high_concurrency_memory_growth_mb:$memory_growth}'
+}
+
+TEST_COUNT="$(count_tests)"
+COVERAGE="$(coverage_pct)"
+COMPAT="$(collect_compat)"
+BENCHMARKS="$(collect_benchmarks)"
+LOAD="$(collect_load)"
+
+jq -n \
+  --argjson tests "$TEST_COUNT" \
+  --argjson coverage "$COVERAGE" \
+  --argjson compat "$COMPAT" \
+  --argjson benchmarks "$BENCHMARKS" \
+  --argjson load "$LOAD" \
+  '{
+    tests: {count:$tests, coverage_pct:$coverage},
+    compatibility: $compat,
+    performance: {
+      benchmarks: $benchmarks,
+      load: $load
+    }
+  }' >"$OUTPUT_JSON"

--- a/scripts/ci/render_pr_report.sh
+++ b/scripts/ci/render_pr_report.sh
@@ -67,8 +67,16 @@ BASE_VL_PCT="$(json_field "$BASE_JSON" '.compatibility.vl.pct')"
 
 HEAD_QUERY_NS="$(json_field "$HEAD_JSON" '.performance.benchmarks.query_range_cache_hit_ns_per_op')"
 BASE_QUERY_NS="$(json_field "$BASE_JSON" '.performance.benchmarks.query_range_cache_hit_ns_per_op')"
+HEAD_QUERY_BYTES="$(json_field "$HEAD_JSON" '.performance.benchmarks.query_range_cache_hit_bytes_per_op')"
+BASE_QUERY_BYTES="$(json_field "$BASE_JSON" '.performance.benchmarks.query_range_cache_hit_bytes_per_op')"
+HEAD_QUERY_ALLOCS="$(json_field "$HEAD_JSON" '.performance.benchmarks.query_range_cache_hit_allocs_per_op')"
+BASE_QUERY_ALLOCS="$(json_field "$BASE_JSON" '.performance.benchmarks.query_range_cache_hit_allocs_per_op')"
 HEAD_LABELS_NS="$(json_field "$HEAD_JSON" '.performance.benchmarks.labels_cache_hit_ns_per_op')"
 BASE_LABELS_NS="$(json_field "$BASE_JSON" '.performance.benchmarks.labels_cache_hit_ns_per_op')"
+HEAD_LABELS_BYTES="$(json_field "$HEAD_JSON" '.performance.benchmarks.labels_cache_hit_bytes_per_op')"
+BASE_LABELS_BYTES="$(json_field "$BASE_JSON" '.performance.benchmarks.labels_cache_hit_bytes_per_op')"
+HEAD_LABELS_ALLOCS="$(json_field "$HEAD_JSON" '.performance.benchmarks.labels_cache_hit_allocs_per_op')"
+BASE_LABELS_ALLOCS="$(json_field "$BASE_JSON" '.performance.benchmarks.labels_cache_hit_allocs_per_op')"
 HEAD_THROUGHPUT="$(json_field "$HEAD_JSON" '.performance.load.high_concurrency_req_per_s')"
 BASE_THROUGHPUT="$(json_field "$BASE_JSON" '.performance.load.high_concurrency_req_per_s')"
 HEAD_MEM_GROWTH="$(json_field "$HEAD_JSON" '.performance.load.high_concurrency_memory_growth_mb')"
@@ -79,7 +87,11 @@ LOKI_DELTA="$(format_delta "$HEAD_LOKI_PCT" "$BASE_LOKI_PCT" higher)"
 DRILL_DELTA="$(format_delta "$HEAD_DRILL_PCT" "$BASE_DRILL_PCT" higher)"
 VL_DELTA="$(format_delta "$HEAD_VL_PCT" "$BASE_VL_PCT" higher)"
 QUERY_DELTA="$(format_delta "$HEAD_QUERY_NS" "$BASE_QUERY_NS" lower)"
+QUERY_BYTES_DELTA="$(format_delta "$HEAD_QUERY_BYTES" "$BASE_QUERY_BYTES" lower)"
+QUERY_ALLOCS_DELTA="$(format_delta "$HEAD_QUERY_ALLOCS" "$BASE_QUERY_ALLOCS" lower)"
 LABELS_DELTA="$(format_delta "$HEAD_LABELS_NS" "$BASE_LABELS_NS" lower)"
+LABELS_BYTES_DELTA="$(format_delta "$HEAD_LABELS_BYTES" "$BASE_LABELS_BYTES" lower)"
+LABELS_ALLOCS_DELTA="$(format_delta "$HEAD_LABELS_ALLOCS" "$BASE_LABELS_ALLOCS" lower)"
 THROUGHPUT_DELTA="$(format_delta "$HEAD_THROUGHPUT" "$BASE_THROUGHPUT" higher)"
 MEMORY_DELTA="$(format_delta "$HEAD_MEM_GROWTH" "$BASE_MEM_GROWTH" lower)"
 
@@ -106,12 +118,16 @@ Compared against base branch \`main\`.
 
 ### Performance smoke
 
-Lower \`ns/op\` is better. Higher throughput is better. Lower memory growth is better.
+Lower CPU cost (\`ns/op\`) is better. Lower benchmark memory cost (\`B/op\`, \`allocs/op\`) is better. Higher throughput is better. Lower load-test memory growth is better.
 
 | Signal | Base | PR | Delta |
 |---|---:|---:|---:|
-| QueryRange cache-hit benchmark | ${BASE_QUERY_NS} ns/op | ${HEAD_QUERY_NS} ns/op | ${QUERY_DELTA} |
-| Labels cache-hit benchmark | ${BASE_LABELS_NS} ns/op | ${HEAD_LABELS_NS} ns/op | ${LABELS_DELTA} |
+| QueryRange cache-hit CPU cost | ${BASE_QUERY_NS} ns/op | ${HEAD_QUERY_NS} ns/op | ${QUERY_DELTA} |
+| QueryRange cache-hit memory | ${BASE_QUERY_BYTES} B/op | ${HEAD_QUERY_BYTES} B/op | ${QUERY_BYTES_DELTA} |
+| QueryRange cache-hit allocations | ${BASE_QUERY_ALLOCS} allocs/op | ${HEAD_QUERY_ALLOCS} allocs/op | ${QUERY_ALLOCS_DELTA} |
+| Labels cache-hit CPU cost | ${BASE_LABELS_NS} ns/op | ${HEAD_LABELS_NS} ns/op | ${LABELS_DELTA} |
+| Labels cache-hit memory | ${BASE_LABELS_BYTES} B/op | ${HEAD_LABELS_BYTES} B/op | ${LABELS_BYTES_DELTA} |
+| Labels cache-hit allocations | ${BASE_LABELS_ALLOCS} allocs/op | ${HEAD_LABELS_ALLOCS} allocs/op | ${LABELS_ALLOCS_DELTA} |
 | High-concurrency throughput | ${BASE_THROUGHPUT} req/s | ${HEAD_THROUGHPUT} req/s | ${THROUGHPUT_DELTA} |
 | High-concurrency memory growth | ${BASE_MEM_GROWTH} MB | ${HEAD_MEM_GROWTH} MB | ${MEMORY_DELTA} |
 

--- a/scripts/ci/render_pr_report.sh
+++ b/scripts/ci/render_pr_report.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "usage: $0 <base-json> <head-json> <output-md>" >&2
+  exit 1
+fi
+
+BASE_JSON="$1"
+HEAD_JSON="$2"
+OUTPUT_MD="$3"
+
+json_field() {
+  local file="$1"
+  local path="$2"
+  jq -r "$path" "$file"
+}
+
+format_delta() {
+  local current="$1"
+  local base="$2"
+  local better="$3"
+  python3 - "$current" "$base" "$better" <<'PY'
+import sys
+current=float(sys.argv[1])
+base=float(sys.argv[2])
+better=sys.argv[3]
+if base == 0:
+    print("n/a")
+    raise SystemExit
+delta=((current-base)/base)*100.0
+state="stable"
+if better == "higher":
+    if delta >= 5:
+        state="improved"
+    elif delta <= -5:
+        state="regressed"
+elif better == "lower":
+    if delta <= -5:
+        state="improved"
+    elif delta >= 5:
+        state="regressed"
+sign="+" if delta > 0 else ""
+print(f"{sign}{delta:.1f}% ({state})")
+PY
+}
+
+HEAD_TESTS="$(json_field "$HEAD_JSON" '.tests.count')"
+BASE_TESTS="$(json_field "$BASE_JSON" '.tests.count')"
+HEAD_COVERAGE="$(json_field "$HEAD_JSON" '.tests.coverage_pct')"
+BASE_COVERAGE="$(json_field "$BASE_JSON" '.tests.coverage_pct')"
+
+HEAD_LOKI_PASS="$(json_field "$HEAD_JSON" '.compatibility.loki.passed')"
+HEAD_LOKI_TOTAL="$(json_field "$HEAD_JSON" '.compatibility.loki.total')"
+HEAD_LOKI_PCT="$(json_field "$HEAD_JSON" '.compatibility.loki.pct')"
+BASE_LOKI_PCT="$(json_field "$BASE_JSON" '.compatibility.loki.pct')"
+
+HEAD_DRILL_PASS="$(json_field "$HEAD_JSON" '.compatibility.drilldown.passed')"
+HEAD_DRILL_TOTAL="$(json_field "$HEAD_JSON" '.compatibility.drilldown.total')"
+HEAD_DRILL_PCT="$(json_field "$HEAD_JSON" '.compatibility.drilldown.pct')"
+BASE_DRILL_PCT="$(json_field "$BASE_JSON" '.compatibility.drilldown.pct')"
+
+HEAD_VL_PASS="$(json_field "$HEAD_JSON" '.compatibility.vl.passed')"
+HEAD_VL_TOTAL="$(json_field "$HEAD_JSON" '.compatibility.vl.total')"
+HEAD_VL_PCT="$(json_field "$HEAD_JSON" '.compatibility.vl.pct')"
+BASE_VL_PCT="$(json_field "$BASE_JSON" '.compatibility.vl.pct')"
+
+HEAD_QUERY_NS="$(json_field "$HEAD_JSON" '.performance.benchmarks.query_range_cache_hit_ns_per_op')"
+BASE_QUERY_NS="$(json_field "$BASE_JSON" '.performance.benchmarks.query_range_cache_hit_ns_per_op')"
+HEAD_LABELS_NS="$(json_field "$HEAD_JSON" '.performance.benchmarks.labels_cache_hit_ns_per_op')"
+BASE_LABELS_NS="$(json_field "$BASE_JSON" '.performance.benchmarks.labels_cache_hit_ns_per_op')"
+HEAD_THROUGHPUT="$(json_field "$HEAD_JSON" '.performance.load.high_concurrency_req_per_s')"
+BASE_THROUGHPUT="$(json_field "$BASE_JSON" '.performance.load.high_concurrency_req_per_s')"
+HEAD_MEM_GROWTH="$(json_field "$HEAD_JSON" '.performance.load.high_concurrency_memory_growth_mb')"
+BASE_MEM_GROWTH="$(json_field "$BASE_JSON" '.performance.load.high_concurrency_memory_growth_mb')"
+
+COVERAGE_DELTA="$(format_delta "$HEAD_COVERAGE" "$BASE_COVERAGE" higher)"
+LOKI_DELTA="$(format_delta "$HEAD_LOKI_PCT" "$BASE_LOKI_PCT" higher)"
+DRILL_DELTA="$(format_delta "$HEAD_DRILL_PCT" "$BASE_DRILL_PCT" higher)"
+VL_DELTA="$(format_delta "$HEAD_VL_PCT" "$BASE_VL_PCT" higher)"
+QUERY_DELTA="$(format_delta "$HEAD_QUERY_NS" "$BASE_QUERY_NS" lower)"
+LABELS_DELTA="$(format_delta "$HEAD_LABELS_NS" "$BASE_LABELS_NS" lower)"
+THROUGHPUT_DELTA="$(format_delta "$HEAD_THROUGHPUT" "$BASE_THROUGHPUT" higher)"
+MEMORY_DELTA="$(format_delta "$HEAD_MEM_GROWTH" "$BASE_MEM_GROWTH" lower)"
+
+cat >"$OUTPUT_MD" <<EOF
+<!-- pr-quality-report -->
+## PR Quality Report
+
+Compared against base branch \`main\`.
+
+### Coverage and tests
+
+| Signal | Base | PR | Delta |
+|---|---:|---:|---:|
+| Test count | ${BASE_TESTS} | ${HEAD_TESTS} | $((HEAD_TESTS-BASE_TESTS)) |
+| Coverage | ${BASE_COVERAGE}% | ${HEAD_COVERAGE}% | ${COVERAGE_DELTA} |
+
+### Compatibility
+
+| Track | Base | PR | Delta |
+|---|---:|---:|---:|
+| Loki API | ${BASE_LOKI_PCT}% | ${HEAD_LOKI_PASS}/${HEAD_LOKI_TOTAL} (${HEAD_LOKI_PCT}%) | ${LOKI_DELTA} |
+| Logs Drilldown | ${BASE_DRILL_PCT}% | ${HEAD_DRILL_PASS}/${HEAD_DRILL_TOTAL} (${HEAD_DRILL_PCT}%) | ${DRILL_DELTA} |
+| VictoriaLogs | ${BASE_VL_PCT}% | ${HEAD_VL_PASS}/${HEAD_VL_TOTAL} (${HEAD_VL_PCT}%) | ${VL_DELTA} |
+
+### Performance smoke
+
+Lower \`ns/op\` is better. Higher throughput is better. Lower memory growth is better.
+
+| Signal | Base | PR | Delta |
+|---|---:|---:|---:|
+| QueryRange cache-hit benchmark | ${BASE_QUERY_NS} ns/op | ${HEAD_QUERY_NS} ns/op | ${QUERY_DELTA} |
+| Labels cache-hit benchmark | ${BASE_LABELS_NS} ns/op | ${HEAD_LABELS_NS} ns/op | ${LABELS_DELTA} |
+| High-concurrency throughput | ${BASE_THROUGHPUT} req/s | ${HEAD_THROUGHPUT} req/s | ${THROUGHPUT_DELTA} |
+| High-concurrency memory growth | ${BASE_MEM_GROWTH} MB | ${HEAD_MEM_GROWTH} MB | ${MEMORY_DELTA} |
+
+### State
+
+- Coverage, compatibility, and sampled performance are reported here from the same PR workflow.
+- This is a delta report, not a release gate by itself. Required checks still decide merge safety.
+- Performance is a smoke comparison, not a full benchmark lab run.
+EOF


### PR DESCRIPTION
## What changed

This PR does three related things:

- makes observability stronger and more consistent
- fixes changelog / release-note handling around `Unreleased`
- adds a PR quality-report workflow that comments coverage, compatibility, and sampled performance deltas against the base branch

### Observability

- OTLP metrics now export the same core proxy metric names and dimensions as `/metrics`
- logs now use a shared OTel-friendly JSON shape across proxy, disk cache, cache warmer, and OTLP exporter paths
- added `-otlp-headers`, `-otel-service-name`, `-otel-service-namespace`, `-otel-service-instance-id`, and `-deployment-environment`
- added a dedicated observability guide with Prometheus, OTLP, Collector, Vector, and Fluent Bit examples

### Release and changelog handling

- keeps `Unreleased` pinned at the top and inserts future releases below it
- trims stale `Unreleased` content and keeps current work in `Unreleased` until the next version

### PR quality reporting

- adds `pr-quality-report.yaml`
- compares PR head vs base branch for:
  - test count
  - total coverage
  - Loki compatibility
  - Logs Drilldown compatibility
  - VictoriaLogs compatibility
  - sampled benchmark / load-test deltas
- publishes the result as a sticky PR comment

## Why

The repo had strong raw test coverage for functionality, but it was still weak in two operator-facing areas:

- observability signals were split between scrape and OTLP push
- PRs did not surface whether a change degraded compatibility, coverage, or performance

This PR closes those gaps without changing the core Loki/VL compatibility model.

## Validation

- `go test ./...`
- `go test ./... -coverprofile=/tmp/loki-vl-proxy.cover.out`
- `go test ./internal/metrics ./internal/observability ./cmd/proxy`
- `docker run --rm -v /tmp/Loki-VL-proxy:/repo -w /repo rhysd/actionlint:1.7.8 .github/workflows/auto-release.yaml .github/workflows/pr-quality-report.yaml .github/workflows/ci.yaml .github/workflows/release.yaml .github/workflows/compat-loki.yaml .github/workflows/compat-drilldown.yaml .github/workflows/compat-vl.yaml`

## Notes

- total repo coverage is now `82.0%`; this PR improves coverage but does not claim the long-term `95%+` goal is finished
- the roadmap is updated to reflect what is actually left: full Loki ruler/alerting semantics and the deeper refactor needed to drive total coverage much higher
