### PR TITLE
ci: make release flow self-starting

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -264,11 +264,8 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="${{ steps.create_release_pr.outputs.release_branch }}"
-          gh workflow run ci.yaml --ref "$BRANCH"
+          gh workflow run release-pr-validation.yaml --ref "$BRANCH"
           gh workflow run codeql.yaml --ref "$BRANCH"
-          gh workflow run compat-loki.yaml --ref "$BRANCH"
-          gh workflow run compat-drilldown.yaml --ref "$BRANCH"
-          gh workflow run compat-vl.yaml --ref "$BRANCH"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release-pr-validation.yaml
+++ b/.github/workflows/release-pr-validation.yaml
@@ -1,0 +1,75 @@
+name: Release PR Validation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract release version from branch
+        id: version
+        run: |
+          set -euo pipefail
+          BRANCH="${GITHUB_REF_NAME}"
+          VERSION="$(printf '%s' "$BRANCH" | sed -n 's/^release\/v\([0-9][0-9.]*\)$/\1/p')"
+          if [ -z "$VERSION" ]; then
+            echo "expected release branch like release/v0.26.0, got: $BRANCH"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release diff is limited to release artifacts
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          CHANGED="$(git diff --name-only origin/main...HEAD)"
+          echo "$CHANGED"
+          if [ -z "$CHANGED" ]; then
+            echo "release branch must contain release metadata changes"
+            exit 1
+          fi
+
+          while IFS= read -r path; do
+            case "$path" in
+              CHANGELOG.md|README.md|docs/observability.md|charts/loki-vl-proxy/Chart.yaml)
+                ;;
+              *)
+                echo "unexpected file in release PR: $path"
+                exit 1
+                ;;
+            esac
+          done <<< "$CHANGED"
+
+      - name: Verify changelog section exists
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/extract_changelog_section.sh
+          scripts/ci/extract_changelog_section.sh "${{ steps.version.outputs.version }}" CHANGELOG.md >/tmp/release-section.md
+          test -s /tmp/release-section.md
+
+      - name: Verify chart version matches release
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          grep -q "^version: ${VERSION}$" charts/loki-vl-proxy/Chart.yaml
+          grep -q "^appVersion: \"${VERSION}\"$" charts/loki-vl-proxy/Chart.yaml
+
+      - name: Verify observability doc example version matches release
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          grep -q "\"service.version\": \"${VERSION}\"" docs/observability.md
+
+      - name: Helm lint
+        uses: azure/setup-helm@v4
+
+      - name: Run Helm lint
+        run: helm lint charts/loki-vl-proxy/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  workflow_run:
+    workflows: ["Auto Release"]
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       tag:
@@ -17,12 +21,18 @@ permissions:
 
 jobs:
   test:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      startsWith(github.event.workflow_run.head_commit.message, 'chore: release v'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref) }}
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26.1"
@@ -34,6 +44,12 @@ jobs:
         run: go test ./... -count=1 -race
 
   compat-check:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      startsWith(github.event.workflow_run.head_commit.message, 'chore: release v'))
     runs-on: ubuntu-latest
     outputs:
       loki_detail: ${{ steps.compat.outputs.LOKI_DETAIL }}
@@ -46,7 +62,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref) }}
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26.1"
@@ -97,12 +113,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, compat-check]
-    if: always() && needs.test.result == 'success'
+    if: >-
+      (github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      startsWith(github.event.workflow_run.head_commit.message, 'chore: release v'))) &&
+      always() &&
+      needs.test.result == 'success'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref) }}
 
       - uses: actions/setup-go@v5
         with:
@@ -114,8 +137,14 @@ jobs:
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             TAG="${{ inputs.tag }}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+            TAG="$(printf '%s' "$WORKFLOW_RUN_HEAD_COMMIT_MESSAGE" | sed -n 's/^chore: release v\([0-9][0-9.]*\).*/v\1/p')"
           else
             TAG="${GITHUB_REF_NAME}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "Could not determine release tag for event ${GITHUB_EVENT_NAME}"
+            exit 1
           fi
           VERSION="${TAG#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
@@ -123,6 +152,8 @@ jobs:
           # Find previous tag for changelog range
           PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | grep -vx "$TAG" | head -1)
           echo "PREV_TAG=${PREV_TAG:-}" >> "$GITHUB_OUTPUT"
+        env:
+          WORKFLOW_RUN_HEAD_COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
 
       - name: Render release notes
         id: release_notes

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues & VL Compatibility Gaps
 
-Last updated: v0.23.0
+Last updated: v0.26.0
 
 ## Remaining Behavioral Differences
 
@@ -22,6 +22,27 @@ The proxy now supports datasource-facing headers, cookie forwarding, backend tim
 | Alerting / ruler APIs | `/rules` and `/alerts` are compatibility stubs only, not a full Loki ruler implementation |
 | Browser-origin tailing | `/loki/api/v1/tail` rejects browser `Origin` headers unless explicitly allowlisted via `-tail.allowed-origins` |
 
+## Release Automation Gaps
+
+The project now uses PR-based release automation:
+
+`main merge -> Auto Release -> release/vX.Y.Z PR -> auto-merge -> tag -> GitHub release`
+
+The remaining limitation is repository signature policy:
+
+| Area | Current State |
+|---|---|
+| Automated release commit signatures | Release PR commits created by `github-actions[bot]` are still unsigned unless workflow signing is configured |
+| Fully automatic release PR merge under required signatures | Requires either workflow commit signing or a repo ruleset exception for release automation |
+
+The workflow already handles:
+
+- changelog-backed release PR bodies
+- changelog-backed GitHub release notes
+- lightweight release-PR validation dispatch
+- Helm chart version bumps
+- binary, Helm package, and container-image publishing after tag creation
+
 ## Data Model Differences
 
 ### Stream Filter vs Field Filter Performance
@@ -31,6 +52,15 @@ VL stream selectors `{label="value"}` only match `_stream_fields`. By default, t
 ### Structured Metadata (Loki 3.x)
 
 Loki 3.x has stream labels vs structured metadata vs parsed labels. VL treats all fields equally. The mapping is natural but not identical -- Grafana Explore handles both transparently.
+
+### Labels vs OTel Dotted Fields
+
+When `-label-style=underscores` and `-metadata-field-mode=hybrid` are used together, the proxy intentionally exposes:
+
+- Loki-compatible underscore labels on the label surface
+- both dotted OTel names and translated aliases on field-oriented APIs
+
+This is the expected compatibility model for Drilldown and Explore. It is not a bug if `service_name` appears in label pickers while `service.name` appears in fields/details.
 
 ### Large Body Fields
 
@@ -64,7 +94,7 @@ These were previously listed as gaps and have been resolved:
 - ~~`bool` modifier~~ -> Fixed: stripped at translation, comparisons return 1/0 (v0.19.0)
 - ~~Field-specific parser `| json f1, f2`~~ -> Fixed: maps to full unpack (v0.19.0)
 - ~~Backslash quotes in selectors~~ -> Fixed: findMatchingBrace handles `\"` (v0.19.0)
-- ~~No system metrics~~ -> Fixed: /proc CPU, mem, IO, net, PSI exposed in /metrics (v0.19.0)
+- ~~No system metrics~~ -> Fixed: process + Linux runtime metrics exposed, with container-scoped cgroup metrics replacing old node-style naming in the latest observability docs
 - ~~Cache random eviction~~ -> Fixed: LRU eviction via container/list (v0.21.0)
 - ~~`unwrap duration()/bytes()` conversion~~ -> Fixed: proxy-side parsers for duration/byte strings (v0.21.0)
 - ~~`on()`/`ignoring()`/`group_left()`/`group_right()`~~ -> Fixed: stripped at translation, binary uses exact key match (v0.22.0)

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -13,6 +13,8 @@ This project tracks compatibility on three separate layers. They are intentional
 The tracked versions live in [compatibility-matrix.json](/tmp/Loki-VL-proxy/test/e2e-compat/compatibility-matrix.json).
 The GitHub Actions compatibility workflows read their matrix lists directly from that manifest, so the repo has a single source of truth for supported versions.
 
+For normal pull requests, these tracks run as PR checks. Generated release PRs intentionally use a lighter validation path and do not rerun the full compatibility matrix, because the release branch only carries release metadata changes.
+
 ## Support Window Policy
 
 The matrix is intentionally not open-ended. For every upstream we support a moving window that advances as new releases land:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-# Unit tests (460+ tests)
+# Unit tests
 go test ./...
 
 # With race detector
@@ -37,6 +37,8 @@ go build -o loki-vl-proxy ./cmd/proxy
 ```
 
 ## Test Coverage by Category
+
+Exact counts move often. Treat the categories below as the stable map of what is covered; the PR quality workflow and release workflow publish current counts and deltas.
 
 | Category | Tests | What they verify |
 |---|---|---|
@@ -127,6 +129,23 @@ Pull requests also get a dedicated `pr-quality-report.yaml` workflow. It compare
 - sampled benchmark and load-test deltas
 
 That report is informational by design. It highlights regressions early, but merge gating still comes from the required check set in repository settings.
+
+Release PRs use a lighter validation path than normal feature PRs. The `Auto Release` workflow dispatches:
+
+- `release-pr-validation`
+- `CodeQL`
+
+against the generated `release/vX.Y.Z` branch so the release PR can be validated before tag creation and publishing.
+
+That release-specific validation intentionally checks only release artifacts and publishability:
+
+- changelog section exists for the target version
+- chart version and appVersion match the release version
+- versioned observability examples were updated
+- Helm chart still lints cleanly
+- CodeQL still runs on the release branch
+
+Normal PRs continue to run the full CI, compatibility, and PR quality workflows.
 
 See [compatibility-matrix.md](/tmp/Loki-VL-proxy/docs/compatibility-matrix.md), [compatibility-loki.md](/tmp/Loki-VL-proxy/docs/compatibility-loki.md), [compatibility-drilldown.md](/tmp/Loki-VL-proxy/docs/compatibility-drilldown.md), [compatibility-victorialogs.md](/tmp/Loki-VL-proxy/docs/compatibility-victorialogs.md), and [compatibility-matrix.json](/tmp/Loki-VL-proxy/test/e2e-compat/compatibility-matrix.json).
 


### PR DESCRIPTION
## Summary
- validate release PRs with a lightweight dedicated workflow instead of the full matrix
- trigger the publish workflow from completed Auto Release runs so tag creation leads to a GitHub Release automatically
- document the release-flow behavior and remaining signed-commit limitation

## Validation
- actionlint on auto-release, release-pr-validation, and release workflows