### PR TITLE
ci: release directly from main

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths-ignore:
       - "README.md"
-      - "CHANGELOG.md"
   workflow_dispatch:
 
 concurrency:
@@ -14,16 +13,16 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: write
+  packages: write
 
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    # Skip if this push is from a release PR merge or badge update
-    if: "github.event_name == 'workflow_dispatch' || (!contains(github.event.head_commit.message, '[skip ci]') && !startsWith(github.event.head_commit.message, 'chore: release'))"
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
       next_version: ${{ steps.check.outputs.next_version }}
+      latest_tag: ${{ steps.check.outputs.latest_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,41 +31,37 @@ jobs:
       - name: Determine version bump
         id: check
         run: |
+          set -euo pipefail
           LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | head -1 || echo "v0.0.0")
+          echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           echo "Latest tag: $LATEST_TAG"
 
           COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
-          REAL=$(echo "$COMMITS" | grep -v "^ci:" | grep -v "\[skip ci\]" | grep -v "^Merge" | grep -v "^chore: release" || true)
+          REAL=$(echo "$COMMITS" | grep -v '^ci:' | grep -v '^docs:' | grep -v '\[skip ci\]' | grep -v '^Merge' || true)
 
           if [ -z "$REAL" ]; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Smart version bump based on commit scope + impact
-          # - BREAKING CHANGE → major
-          # - feat touching translator/proxy/cache/middleware → minor (core functionality)
-          # - feat touching only docs/ci/helm → patch
-          # - fix → patch
-          # - docs/ci/chore only → no release
           BUMP="none"
           FILES_CHANGED=$(git diff --name-only "${LATEST_TAG}..HEAD" 2>/dev/null || git diff --name-only HEAD~1)
-          HAS_CORE_CHANGES=$(echo "$FILES_CHANGED" | grep -E "^(internal/|cmd/)" || true)
-          HAS_FEAT=$(echo "$COMMITS" | grep -qE "^feat(\(|:)" && echo "yes" || echo "no")
+          HAS_CORE_CHANGES=$(echo "$FILES_CHANGED" | grep -E '^(internal/|cmd/|pkg/)' || true)
+          HAS_FEAT=$(echo "$COMMITS" | grep -qE '^feat(\(|:)' && echo "yes" || echo "no")
 
-          if echo "$COMMITS" | grep -qE "BREAKING CHANGE|^feat.*!:|^fix.*!:"; then
+          if echo "$COMMITS" | grep -qE 'BREAKING CHANGE|^feat.*!:|^fix.*!:'; then
             BUMP="major"
           elif [ "$HAS_FEAT" = "yes" ] && [ -n "$HAS_CORE_CHANGES" ]; then
-            BUMP="minor"  # Feature touching core code
+            BUMP="minor"
           elif [ "$HAS_FEAT" = "yes" ]; then
-            BUMP="patch"  # Feature but only docs/ci/helm
-          elif echo "$COMMITS" | grep -qE "^fix(\(|:)|^perf(\(|:)"; then
+            BUMP="patch"
+          elif echo "$COMMITS" | grep -qE '^fix(\(|:)|^perf(\(|:)'; then
             BUMP="patch"
           fi
 
           if [ "$BUMP" = "none" ]; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Only docs/ci/chore commits — skipping release"
+            echo "Only docs/ci/chore commits detected; skipping release"
             exit 0
           fi
 
@@ -80,16 +75,15 @@ jobs:
 
           echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "next_version=${MAJ}.${MIN}.${PAT}" >> "$GITHUB_OUTPUT"
-          echo "Bump: $BUMP → v${MAJ}.${MIN}.${PAT}"
+          echo "Bump: $BUMP -> v${MAJ}.${MIN}.${PAT}"
 
-  create-release-pr:
+  validate-release:
     needs: prepare-release
     if: needs.prepare-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     outputs:
-      pr_created: ${{ steps.create_release_pr.outputs.pr_created }}
-      release_branch: ${{ steps.create_release_pr.outputs.release_branch }}
-      pr_url: ${{ steps.create_release_pr.outputs.pr_url }}
+      test_count: ${{ steps.metrics.outputs.tests }}
+      coverage: ${{ steps.metrics.outputs.coverage }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,214 +94,158 @@ jobs:
           go-version: "1.26.1"
           cache: true
 
-      - name: Collect metrics
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Verify unreleased changelog section exists
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/extract_changelog_section.sh
+          scripts/ci/extract_changelog_section.sh Unreleased CHANGELOG.md > /tmp/release-section.md
+          test -s /tmp/release-section.md
+          if ! grep -qE '^(### |- )' /tmp/release-section.md; then
+            echo "Unreleased changelog section is empty"
+            exit 1
+          fi
+
+      - name: Run release validation tests
+        run: go test ./... -count=1
+
+      - name: Collect validation metrics
         id: metrics
         run: |
+          set -euo pipefail
           TESTS=$(go test ./... -count=1 -json 2>/dev/null | jq -r 'select(.Action=="pass" and .Test != null) | .Test' | wc -l | tr -d ' ')
-          go test ./... -coverprofile=coverage.out -count=1 2>/dev/null
+          go test ./... -coverprofile=coverage.out -count=1 >/dev/null 2>&1
           COV=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
           echo "tests=${TESTS}" >> "$GITHUB_OUTPUT"
           echo "coverage=${COV}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate changelog entry
-        id: changelog
-        run: |
-          VERSION="${{ needs.prepare-release.outputs.next_version }}"
-          LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | head -1 || echo "v0.0.0")
-          DATE=$(date +%Y-%m-%d)
-          RANGE="${LATEST_TAG}..HEAD"
+      - name: Helm lint
+        run: helm lint charts/loki-vl-proxy/
 
-          ENTRY=$(mktemp)
-          FEATS=$(git log "$RANGE" --pretty=format:'%s' --grep='^feat' | sed 's/^feat([^)]*): //' | sed 's/^feat: //' || true)
-          FIXES=$(git log "$RANGE" --pretty=format:'%s' --grep='^fix' | sed 's/^fix([^)]*): //' | sed 's/^fix: //' || true)
-          {
-            echo "## [${VERSION}] - ${DATE}"
-            echo ""
-
-            if [ -n "$FEATS" ]; then
-              echo "### Features"
-              echo ""
-              printf '%s\n' "$FEATS" | while read -r line; do
-                echo "- $line"
-              done
-              echo ""
-            fi
-
-            if [ -n "$FIXES" ]; then
-              echo "### Bug Fixes"
-              echo ""
-              printf '%s\n' "$FIXES" | while read -r line; do
-                echo "- $line"
-              done
-              echo ""
-            fi
-
-            echo "### Tests"
-            echo ""
-            echo "- ${{ steps.metrics.outputs.tests }} total tests (${{ steps.metrics.outputs.coverage }} coverage)"
-            echo ""
-          } > "$ENTRY"
-
-          cat "$ENTRY"
-          # Save for PR body
-          {
-            echo "ENTRY<<EOF"
-            cat "$ENTRY"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-          # Keep Unreleased at the top and place the new version under it.
-          TEMP=$(mktemp)
-          awk -v entry="$(cat "$ENTRY")" '
-            /^## \[[0-9]/ && !done { print entry; print ""; done=1 }
-            { print }
-            END {
-              if (!done) {
-                print ""
-                print entry
-              }
-            }
-          ' CHANGELOG.md > "$TEMP"
-          mv "$TEMP" CHANGELOG.md
-
-      - name: Update README badges
-        run: |
-          TESTS="${{ steps.metrics.outputs.tests }}"
-          VERSION="${{ needs.prepare-release.outputs.next_version }}"
-
-          sed -i "s|tests-[0-9]*%20passed|tests-${TESTS}%20passed|g" README.md
-          sed -i "s/^version: .*/version: ${VERSION}/" charts/loki-vl-proxy/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" charts/loki-vl-proxy/Chart.yaml
-          sed -i "s/\"service.version\": \".*\"/\"service.version\": \"${VERSION}\"/" docs/observability.md
-
-      - name: Render release PR body
-        id: pr_body
-        run: |
-          set -euo pipefail
-          chmod +x scripts/ci/extract_changelog_section.sh
-          VERSION="${{ needs.prepare-release.outputs.next_version }}"
-          TESTS="${{ steps.metrics.outputs.tests }}"
-          COV="${{ steps.metrics.outputs.coverage }}"
-          SECTION="$(scripts/ci/extract_changelog_section.sh "$VERSION" CHANGELOG.md)"
-          BODY_FILE="$(mktemp)"
-          {
-            echo "## Release v${VERSION}"
-            echo ""
-            echo "${SECTION}"
-            echo ""
-            echo "### Release Validation"
-            echo ""
-            echo "- ${TESTS} total tests"
-            echo "- ${COV} coverage"
-            echo "- Release workflow will build binaries, package the Helm chart, publish the container image, and create the GitHub release from this changelog section."
-          } > "$BODY_FILE"
-          echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
-
-      - name: Create release PR
-        id: create_release_pr
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ needs.prepare-release.outputs.next_version }}"
-          BRANCH="release/v${VERSION}"
-          EXISTING_PR_URL="$(gh pr list --state open --base main --head "$BRANCH" --json url --jq '.[0].url // empty')"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${BRANCH}:${BRANCH}" || true
-          git checkout -B "$BRANCH"
-          git add CHANGELOG.md README.md docs/observability.md
-          git add -f charts/loki-vl-proxy/Chart.yaml
-          git diff --cached --quiet && { echo "No changes to release"; exit 0; }
-          git commit -m "chore: release v${VERSION}"
-          git push --force origin "$BRANCH"
-
-          echo "release_branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "pr_created=false" >> "$GITHUB_OUTPUT"
-
-          if [ -n "$EXISTING_PR_URL" ]; then
-            gh pr edit "$EXISTING_PR_URL" \
-              --title "chore: release v${VERSION}" \
-              --body-file "${{ steps.pr_body.outputs.body_file }}" \
-              --add-label "release"
-            echo "pr_created=true" >> "$GITHUB_OUTPUT"
-            echo "pr_url=${EXISTING_PR_URL}" >> "$GITHUB_OUTPUT"
-            echo "Updated existing release PR: ${EXISTING_PR_URL}"
-          elif PR_URL=$(gh pr create \
-            --title "chore: release v${VERSION}" \
-            --body-file "${{ steps.pr_body.outputs.body_file }}" \
-            --base main \
-            --head "$BRANCH" \
-            --label "release" 2>pr_create.err); then
-            echo "pr_created=true" >> "$GITHUB_OUTPUT"
-            echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
-            echo "Created release PR: ${PR_URL}"
-          else
-            ERR_MSG=$(cat pr_create.err)
-            if echo "$ERR_MSG" | grep -q "GitHub Actions is not permitted to create or approve pull requests"; then
-              echo "::warning::GitHub policy blocked automatic release PR creation. Enable 'Allow GitHub Actions to create and approve pull requests' or create a PR manually from ${BRANCH}."
-              {
-                echo "## Auto Release manual handoff"
-                echo ""
-                echo "GitHub rejected \`gh pr create\` for \`${BRANCH}\` because this repository does not allow \`GITHUB_TOKEN\` to create pull requests."
-                echo ""
-                echo "- Branch pushed: \`${BRANCH}\`"
-                echo "- Create PR manually: https://github.com/${{ github.repository }}/pull/new/${BRANCH}"
-                echo "- Repo setting to enable full automation: Settings -> Actions -> General -> Workflow permissions -> Allow GitHub Actions to create and approve pull requests"
-              } >> "$GITHUB_STEP_SUMMARY"
-              exit 0
-            fi
-
-            echo "$ERR_MSG"
-            exit 1
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Dispatch release PR validation workflows
-        if: steps.create_release_pr.outputs.pr_created == 'true'
-        run: |
-          set -euo pipefail
-          BRANCH="${{ steps.create_release_pr.outputs.release_branch }}"
-          gh workflow run release-pr-validation.yaml --ref "$BRANCH"
-          gh workflow run codeql.yaml --ref "$BRANCH"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Enable auto-merge for release PR
-        if: steps.create_release_pr.outputs.pr_created == 'true'
-        run: |
-          set -euo pipefail
-          sleep 5
-          gh pr merge "${{ steps.create_release_pr.outputs.release_branch }}" --squash --auto --delete-branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  tag-release:
-    if: "startsWith(github.event.head_commit.message, 'chore: release v')"
+  publish-release:
+    needs: [prepare-release, validate-release]
+    if: needs.prepare-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Tag merged release commit
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+          cache: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Extract release metadata
+        id: meta
         run: |
-          VERSION=$(printf '%s' "$HEAD_COMMIT_MESSAGE" | sed -n 's/^chore: release v\([0-9][0-9.]*\).*/\1/p')
-          if [ -z "$VERSION" ]; then
-            echo "Could not parse release version from commit message: $HEAD_COMMIT_MESSAGE"
-            exit 1
+          set -euo pipefail
+          VERSION="${{ needs.prepare-release.outputs.next_version }}"
+          TAG="v${VERSION}"
+          PREV_TAG="${{ needs.prepare-release.outputs.latest_tag }}"
+          chmod +x scripts/ci/extract_changelog_section.sh
+          NOTES_FILE="$(mktemp)"
+          scripts/ci/extract_changelog_section.sh Unreleased CHANGELOG.md > "$NOTES_FILE"
+          {
+            echo ""
+            echo "### Release Validation"
+            echo ""
+            echo "- Tests: ${{ needs.validate-release.outputs.test_count }}"
+            echo "- Coverage: ${{ needs.validate-release.outputs.coverage }}"
+            echo ""
+            echo "### Installation"
+            echo ""
+            echo '```bash'
+            echo "# Docker"
+            echo "docker pull ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${VERSION}"
+            echo ""
+            echo "# Helm"
+            echo "helm install loki-vl-proxy ./charts/loki-vl-proxy \\"
+            echo "  --set image.tag=${VERSION} \\"
+            echo "  --set extraArgs.backend=http://victorialogs:9428"
+            echo '```'
+            echo ""
+            echo "### Release Assets"
+            echo ""
+            echo "- Linux and macOS binaries for amd64 and arm64"
+            echo "- SHA256 checksums"
+            echo "- Versioned Helm chart package"
+            echo "- Multi-arch GHCR image"
+          } >> "$NOTES_FILE"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release tag
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.meta.outputs.tag }}"
+          git fetch --tags origin
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists"
+          else
+            git tag "${TAG}" "${GITHUB_SHA}"
+            git push origin "${TAG}"
           fi
 
-          git fetch origin --tags
-          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists; nothing to do."
-            exit 0
-          fi
+      - name: Build release binaries
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.meta.outputs.version }}"
+          mkdir -p dist
+          for GOOS_GOARCH in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            GOOS="${GOOS_GOARCH%/*}"
+            GOARCH="${GOOS_GOARCH#*/}"
+            OUT="dist/loki-vl-proxy-${GOOS}-${GOARCH}"
+            CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+              go build -ldflags="-s -w -X main.version=${VERSION}" \
+              -o "$OUT" ./cmd/proxy
+          done
+          cd dist && sha256sum loki-vl-proxy-* > checksums.txt
 
-          git tag "v${VERSION}" "${GITHUB_SHA}"
-          git push origin "v${VERSION}"
-          echo "Tagged v${VERSION} from merged release commit ${GITHUB_SHA}"
-        env:
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          GH_TOKEN: ${{ github.token }}
+      - name: Package Helm chart
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          helm package charts/loki-vl-proxy \
+            --version "${VERSION}" \
+            --app-version "${VERSION}" \
+            --destination dist
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${{ steps.meta.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          body_path: ${{ steps.meta.outputs.notes_file }}
+          files: |
+            dist/loki-vl-proxy-*
+            dist/checksums.txt
+            dist/loki-vl-proxy-*.tgz

--- a/.github/workflows/compat-drilldown.yaml
+++ b/.github/workflows/compat-drilldown.yaml
@@ -10,7 +10,7 @@ on:
     - cron: "45 3 * * 1"
 
 jobs:
-  matrix-source:
+  drilldown-matrix-source:
     runs-on: ubuntu-latest
     outputs:
       drilldown_versions: ${{ steps.matrix.outputs.drilldown_versions }}
@@ -19,9 +19,9 @@ jobs:
       - id: matrix
         run: echo "drilldown_versions=$(jq -c '.stack.logs_drilldown_contract.matrix_versions' test/e2e-compat/compatibility-matrix.json)" >> "$GITHUB_OUTPUT"
 
-  pinned-runtime:
+  drilldown-pinned-runtime:
     if: github.event_name != 'schedule'
-    needs: matrix-source
+    needs: drilldown-matrix-source
     runs-on: ubuntu-latest
     env:
       LOKI_IMAGE: grafana/loki:3.7.1
@@ -45,14 +45,14 @@ jobs:
         working-directory: test/e2e-compat
         run: docker compose down -v
 
-  contract-matrix:
+  drilldown-contract-matrix:
     if: github.event_name == 'schedule'
-    needs: matrix-source
+    needs: drilldown-matrix-source
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        drilldown_version: ${{ fromJson(needs.matrix-source.outputs.drilldown_versions) }}
+        drilldown_version: ${{ fromJson(needs.drilldown-matrix-source.outputs.drilldown_versions) }}
     steps:
       - uses: actions/checkout@v4
       - name: Check Drilldown app contracts

--- a/.github/workflows/compat-loki.yaml
+++ b/.github/workflows/compat-loki.yaml
@@ -10,7 +10,7 @@ on:
     - cron: "15 3 * * 1"
 
 jobs:
-  matrix-source:
+  loki-matrix-source:
     runs-on: ubuntu-latest
     outputs:
       loki_versions: ${{ steps.matrix.outputs.loki_versions }}
@@ -19,9 +19,9 @@ jobs:
       - id: matrix
         run: echo "loki_versions=$(jq -c '.stack.loki.matrix_versions' test/e2e-compat/compatibility-matrix.json)" >> "$GITHUB_OUTPUT"
 
-  pinned:
+  loki-pinned:
     if: github.event_name != 'schedule'
-    needs: matrix-source
+    needs: loki-matrix-source
     runs-on: ubuntu-latest
     env:
       LOKI_IMAGE: grafana/loki:3.7.1
@@ -45,14 +45,14 @@ jobs:
         working-directory: test/e2e-compat
         run: docker compose down -v
 
-  matrix:
+  loki-matrix:
     if: github.event_name == 'schedule'
-    needs: matrix-source
+    needs: loki-matrix-source
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        loki_version: ${{ fromJson(needs.matrix-source.outputs.loki_versions) }}
+        loki_version: ${{ fromJson(needs.loki-matrix-source.outputs.loki_versions) }}
     env:
       VICTORIALOGS_IMAGE: victoriametrics/victoria-logs:v1.49.0
       GRAFANA_IMAGE: grafana/grafana:12.4.2

--- a/.github/workflows/compat-vl.yaml
+++ b/.github/workflows/compat-vl.yaml
@@ -10,7 +10,7 @@ on:
     - cron: "15 4 * * 1"
 
 jobs:
-  matrix-source:
+  vl-matrix-source:
     runs-on: ubuntu-latest
     outputs:
       vl_versions: ${{ steps.matrix.outputs.vl_versions }}
@@ -19,9 +19,9 @@ jobs:
       - id: matrix
         run: echo "vl_versions=$(jq -c '.stack.victorialogs.matrix_versions' test/e2e-compat/compatibility-matrix.json)" >> "$GITHUB_OUTPUT"
 
-  pinned:
+  vl-pinned:
     if: github.event_name != 'schedule'
-    needs: matrix-source
+    needs: vl-matrix-source
     runs-on: ubuntu-latest
     env:
       LOKI_IMAGE: grafana/loki:3.7.1
@@ -45,14 +45,14 @@ jobs:
         working-directory: test/e2e-compat
         run: docker compose down -v
 
-  matrix:
+  vl-matrix:
     if: github.event_name == 'schedule'
-    needs: matrix-source
+    needs: vl-matrix-source
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        vl_version: ${{ fromJson(needs.matrix-source.outputs.vl_versions) }}
+        vl_version: ${{ fromJson(needs.vl-matrix-source.outputs.vl_versions) }}
     env:
       LOKI_IMAGE: grafana/loki:3.7.1
       GRAFANA_IMAGE: grafana/grafana:12.4.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,10 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-  workflow_run:
-    workflows: ["Auto Release"]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to publish, for example v0.25.0
+        description: Release tag to publish, for example v0.26.0
         required: true
         type: string
 
@@ -20,19 +13,14 @@ permissions:
   packages: write
 
 jobs:
-  test:
-    if: >-
-      github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      startsWith(github.event.workflow_run.head_commit.message, 'chore: release v'))
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref) }}
+          ref: ${{ inputs.tag }}
+
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26.1"
@@ -40,185 +28,61 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
-      - name: Run tests with race detector
-        run: go test ./... -count=1 -race
-
-  compat-check:
-    if: >-
-      github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      startsWith(github.event.workflow_run.head_commit.message, 'chore: release v'))
-    runs-on: ubuntu-latest
-    outputs:
-      loki_detail: ${{ steps.compat.outputs.LOKI_DETAIL }}
-      loki_pct: ${{ steps.compat.outputs.LOKI_PCT }}
-      drilldown_detail: ${{ steps.compat.outputs.DRILLDOWN_DETAIL }}
-      drilldown_pct: ${{ steps.compat.outputs.DRILLDOWN_PCT }}
-      vl_detail: ${{ steps.compat.outputs.VL_DETAIL }}
-      vl_pct: ${{ steps.compat.outputs.VL_PCT }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref) }}
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.26.1"
-          cache: true
-
-      - name: Start e2e stack
-        working-directory: test/e2e-compat
-        run: |
-          docker compose up -d --build
-          sleep 20
-          docker compose ps
-
-      - name: Run compatibility tests
-        id: compat
-        run: |
-          set -o pipefail
-          run_score() {
-            local test_name="$1"
-            local output line
-            output=$(go test -v -tags=e2e -timeout=120s -run "^${test_name}$" ./test/e2e-compat/ 2>&1) || true
-            echo "$output"
-            line=$(printf '%s\n' "$output" | grep -oE 'Score: [0-9]+/[0-9]+ \([0-9.]+%\)' | tail -1 || true)
-            if [ -z "$line" ]; then
-              echo "0|0|0.0"
-              return
-            fi
-            printf '%s\n' "$line" | sed -E 's/.*Score: ([0-9]+)\/([0-9]+) \(([0-9.]+)%\).*/\1|\2|\3/'
-          }
-
-          IFS='|' read -r LOKI_PASS LOKI_TOTAL LOKI_PCT <<< "$(run_score TestLokiTrackScore)"
-          IFS='|' read -r DRILL_PASS DRILL_TOTAL DRILL_PCT <<< "$(run_score TestDrilldownTrackScore)"
-          IFS='|' read -r VL_PASS VL_TOTAL VL_PCT <<< "$(run_score TestVLTrackScore)"
-
-          {
-            echo "LOKI_DETAIL=${LOKI_PASS}/${LOKI_TOTAL}"
-            echo "LOKI_PCT=${LOKI_PCT}%"
-            echo "DRILLDOWN_DETAIL=${DRILL_PASS}/${DRILL_TOTAL}"
-            echo "DRILLDOWN_PCT=${DRILL_PCT}%"
-            echo "VL_DETAIL=${VL_PASS}/${VL_TOTAL}"
-            echo "VL_PCT=${VL_PCT}%"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Tear down e2e stack
-        if: always()
-        working-directory: test/e2e-compat
-        run: docker compose down -v
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [test, compat-check]
-    if: >-
-      (github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      startsWith(github.event.workflow_run.head_commit.message, 'chore: release v'))) &&
-      always() &&
-      needs.test.result == 'success'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref) }}
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.26.1"
-          cache: true
 
       - name: Extract version
         id: version
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          elif [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
-            TAG="$(printf '%s' "$WORKFLOW_RUN_HEAD_COMMIT_MESSAGE" | sed -n 's/^chore: release v\([0-9][0-9.]*\).*/v\1/p')"
-          else
-            TAG="${GITHUB_REF_NAME}"
-          fi
-          if [ -z "$TAG" ]; then
-            echo "Could not determine release tag for event ${GITHUB_EVENT_NAME}"
-            exit 1
-          fi
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
-          # Find previous tag for changelog range
-          PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | grep -vx "$TAG" | head -1)
-          echo "PREV_TAG=${PREV_TAG:-}" >> "$GITHUB_OUTPUT"
-        env:
-          WORKFLOW_RUN_HEAD_COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | grep -vx "$TAG" | head -1 || true)
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Render release notes
         id: release_notes
         run: |
+          set -euo pipefail
           chmod +x scripts/ci/extract_changelog_section.sh
-          VERSION="${{ steps.version.outputs.VERSION }}"
-          SECTION_FILE="$(mktemp)"
-          scripts/ci/extract_changelog_section.sh "$VERSION" CHANGELOG.md > "$SECTION_FILE"
-          TEST_COUNT=$(go test ./... -count=1 -json 2>/dev/null | jq -r 'select(.Action=="pass" and .Test != null) | .Test' | wc -l | tr -d ' ' || echo "0")
-          go test ./... -coverprofile=coverage.out -count=1 >/dev/null 2>&1 || true
-          COV=$(go tool cover -func=coverage.out 2>/dev/null | tail -1 | awk '{print $NF}' || echo "N/A")
+          VERSION="${{ steps.version.outputs.version }}"
           NOTES_FILE="$(mktemp)"
-          {
-            cat "$SECTION_FILE"
-            echo ""
-            echo "### Release Validation"
-            echo ""
-            echo "- Tests: ${TEST_COUNT}"
-            echo "- Coverage: ${COV}"
-            echo "- Loki compatibility: ${{ needs.compat-check.outputs.loki_detail }} (${{ needs.compat-check.outputs.loki_pct }})"
-            echo "- Logs Drilldown compatibility: ${{ needs.compat-check.outputs.drilldown_detail }} (${{ needs.compat-check.outputs.drilldown_pct }})"
-            echo "- VictoriaLogs compatibility: ${{ needs.compat-check.outputs.vl_detail }} (${{ needs.compat-check.outputs.vl_pct }})"
-            echo ""
-            echo "### Installation"
-            echo ""
-            echo '```bash'
-            echo "# Docker"
-            echo "docker pull ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${VERSION}"
-            echo ""
-            echo "# Helm"
-            echo "helm install loki-vl-proxy ./charts/loki-vl-proxy \\"
-            echo "  --set image.tag=${VERSION} \\"
-            echo "  --set extraArgs.backend=http://victorialogs:9428"
-            echo '```'
-            echo ""
-            echo "### Release Assets"
-            echo ""
-            echo "- Linux and macOS binaries for amd64 and arm64"
-            echo "- SHA256 checksums"
-            echo "- Versioned Helm chart package"
-            echo "- Multi-arch GHCR image"
-          } > "$NOTES_FILE"
+          if scripts/ci/extract_changelog_section.sh "${VERSION}" CHANGELOG.md > "$NOTES_FILE" 2>/dev/null; then
+            :
+          else
+            PREV_TAG="${{ steps.version.outputs.prev_tag }}"
+            {
+              echo "## [${VERSION}]"
+              echo ""
+              echo "### Changes"
+              echo ""
+              if [ -n "$PREV_TAG" ]; then
+                git log "${PREV_TAG}..${{ steps.version.outputs.tag }}" --pretty=format:'- %s'
+              else
+                git log "${{ steps.version.outputs.tag }}" --pretty=format:'- %s'
+              fi
+            } > "$NOTES_FILE"
+          fi
           echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Build release binaries
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
           mkdir -p dist
-
           for GOOS_GOARCH in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
             GOOS="${GOOS_GOARCH%/*}"
             GOARCH="${GOOS_GOARCH#*/}"
             OUT="dist/loki-vl-proxy-${GOOS}-${GOARCH}"
-            echo "Building ${OUT}..."
             CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
               go build -ldflags="-s -w -X main.version=${VERSION}" \
               -o "$OUT" ./cmd/proxy
           done
-
-          # Create checksums
           cd dist && sha256sum loki-vl-proxy-* > checksums.txt
 
       - name: Package Helm chart
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
+          VERSION="${{ steps.version.outputs.version }}"
           helm package charts/loki-vl-proxy \
             --version "${VERSION}" \
             --app-version "${VERSION}" \
@@ -241,16 +105,16 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${{ steps.version.outputs.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${{ steps.version.outputs.version }}
           labels: |
-            org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.TAG }}
-          name: "v${{ steps.version.outputs.VERSION }}"
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
           body_path: ${{ steps.release_notes.outputs.notes_file }}
           files: |
             dist/loki-vl-proxy-*

--- a/scripts/ci/extract_changelog_section.sh
+++ b/scripts/ci/extract_changelog_section.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
-  echo "usage: $0 <version> [changelog-file]" >&2
+  echo "usage: $0 <version-or-section> [changelog-file]" >&2
   exit 1
 fi
 
-VERSION="${1#v}"
+TARGET="$1"
 CHANGELOG_FILE="${2:-CHANGELOG.md}"
 
 if [ ! -f "$CHANGELOG_FILE" ]; then
@@ -14,12 +14,16 @@ if [ ! -f "$CHANGELOG_FILE" ]; then
   exit 1
 fi
 
+if [ "$TARGET" = "Unreleased" ] || [ "$TARGET" = "[Unreleased]" ]; then
+  HEADER="## [Unreleased]"
+else
+  VERSION="${TARGET#v}"
+  HEADER="## [${VERSION}]"
+fi
+
 SECTION="$(
-  awk -v version="$VERSION" '
-    BEGIN {
-      header = "## [" version "]"
-      in_section = 0
-    }
+  awk -v header="$HEADER" '
+    BEGIN { in_section = 0 }
     index($0, header) == 1 {
       in_section = 1
       found = 1
@@ -37,7 +41,7 @@ SECTION="$(
     }
   ' "$CHANGELOG_FILE"
 )" || {
-  echo "version section not found in $CHANGELOG_FILE: $VERSION" >&2
+  echo "section not found in $CHANGELOG_FILE: $TARGET" >&2
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- remove the bot-authored release PR path from Auto Release
- publish tags, binaries, helm package, image, and GitHub release directly from protected main
- keep Release as a manual replay path and teach changelog extraction to read Unreleased

## Validation
- go test ./...
- bash -n scripts/ci/extract_changelog_section.sh
- python YAML parse for .github/workflows/auto-release.yaml and .github/workflows/release.yaml