### PR TITLE
ci: sync changelog after release

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -14,6 +14,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 jobs:
   prepare-release:
@@ -149,8 +150,14 @@ jobs:
           TAG="v${VERSION}"
           PREV_TAG="${{ needs.prepare-release.outputs.latest_tag }}"
           chmod +x scripts/ci/extract_changelog_section.sh
+          chmod +x scripts/ci/materialize_unreleased.sh
           NOTES_FILE="$(mktemp)"
-          scripts/ci/extract_changelog_section.sh Unreleased CHANGELOG.md > "$NOTES_FILE"
+          SECTION_FILE="$(mktemp)"
+          scripts/ci/materialize_unreleased.sh "${VERSION}" "$(date +%Y-%m-%d)" CHANGELOG.md
+          scripts/ci/extract_changelog_section.sh "${VERSION}" CHANGELOG.md > "$SECTION_FILE"
+          cp CHANGELOG.md /tmp/postrelease-changelog.md
+          git checkout -- CHANGELOG.md
+          cat "$SECTION_FILE" > "$NOTES_FILE"
           {
             echo ""
             echo "### Release Validation"
@@ -181,6 +188,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
           echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+          echo "postrelease_changelog=/tmp/postrelease-changelog.md" >> "$GITHUB_OUTPUT"
 
       - name: Create release tag
         run: |
@@ -249,3 +257,40 @@ jobs:
             dist/loki-vl-proxy-*
             dist/checksums.txt
             dist/loki-vl-proxy-*.tgz
+
+      - name: Open changelog sync PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.meta.outputs.version }}"
+          BRANCH="postrelease/v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          cp "${{ steps.meta.outputs.postrelease_changelog }}" CHANGELOG.md
+          git add CHANGELOG.md
+          git diff --cached --quiet && exit 0
+          git commit -m "docs: finalize changelog for v${VERSION}"
+          git push --force origin "$BRANCH"
+
+          EXISTING_PR_URL="$(gh pr list --state open --base main --head "$BRANCH" --json url --jq '.[0].url // empty')"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "## Post-release changelog sync"
+            echo ""
+            echo "- add the released \`v${VERSION}\` section to \`CHANGELOG.md\`"
+            echo "- reset \`Unreleased\` for the next change window"
+          } > "$BODY_FILE"
+
+          if [ -n "$EXISTING_PR_URL" ]; then
+            gh pr edit "$EXISTING_PR_URL" \
+              --title "docs: finalize changelog for v${VERSION}" \
+              --body-file "$BODY_FILE"
+          else
+            gh pr create \
+              --title "docs: finalize changelog for v${VERSION}" \
+              --body-file "$BODY_FILE" \
+              --base main \
+              --head "$BRANCH"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-04-06
+
 ### Features
 
 - observability guide with metrics catalog, JSON log schema, and collector/agent integration examples

--- a/scripts/ci/materialize_unreleased.sh
+++ b/scripts/ci/materialize_unreleased.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ $# -gt 3 ]; then
+  echo "usage: $0 <version> [date] [changelog-file]" >&2
+  exit 1
+fi
+
+VERSION="${1#v}"
+RELEASE_DATE="${2:-$(date +%Y-%m-%d)}"
+CHANGELOG_FILE="${3:-CHANGELOG.md}"
+
+if [ ! -f "$CHANGELOG_FILE" ]; then
+  echo "changelog file not found: $CHANGELOG_FILE" >&2
+  exit 1
+fi
+
+UNRELEASED_SECTION="$(
+  awk '
+    /^## \[Unreleased\]/ { in_section = 1; found = 1 }
+    in_section && /^## \[/ && $0 != "## [Unreleased]" { exit }
+    in_section { print }
+    END {
+      if (!found) {
+        exit 2
+      }
+    }
+  ' "$CHANGELOG_FILE"
+)" || {
+  echo "unreleased section not found in $CHANGELOG_FILE" >&2
+  exit 1
+}
+
+SECTION_BODY="$(printf '%s\n' "$UNRELEASED_SECTION" | tail -n +2 | sed '/./,$!d')"
+
+if ! printf '%s\n' "$SECTION_BODY" | grep -qE '^(### |- )'; then
+  echo "unreleased section is empty" >&2
+  exit 1
+fi
+
+VERSION_SECTION="$(mktemp)"
+{
+  echo "## [${VERSION}] - ${RELEASE_DATE}"
+  echo ""
+  printf '%s\n' "$SECTION_BODY" | awk 'NF { blank = 0; print; next } !blank { print; blank = 1 }'
+  echo ""
+} > "$VERSION_SECTION"
+
+TEMP_FILE="$(mktemp)"
+awk -v insert_file="$VERSION_SECTION" '
+  BEGIN { inserted = 0; skip_unreleased = 0 }
+  /^## \[Unreleased\]/ {
+    print "## [Unreleased]"
+    print ""
+    inserted = 1
+    while ((getline line < insert_file) > 0) {
+      print line
+    }
+    close(insert_file)
+    skip_unreleased = 1
+    next
+  }
+  skip_unreleased && /^## \[/ {
+    skip_unreleased = 0
+  }
+  {
+    if (skip_unreleased) {
+      next
+    }
+    print
+  }
+  END {
+    if (!inserted) {
+      exit 3
+    }
+  }
+' "$CHANGELOG_FILE" > "$TEMP_FILE"
+
+mv "$TEMP_FILE" "$CHANGELOG_FILE"


### PR DESCRIPTION
## Summary
- add a post-release changelog sync path to Auto Release
- materialize  into a versioned section for release notes and a follow-up PR
- repair the missing  changelog entry on main

## Validation
- bash -n scripts/ci/materialize_unreleased.sh scripts/ci/extract_changelog_section.sh
- python YAML parse for .github/workflows/auto-release.yaml