### PR TITLE
test: harden tail, multitenant UI, and proxy entrypoint coverage

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -155,7 +155,6 @@ jobs:
           SECTION_FILE="$(mktemp)"
           scripts/ci/materialize_unreleased.sh "${VERSION}" "$(date +%Y-%m-%d)" CHANGELOG.md
           scripts/ci/extract_changelog_section.sh "${VERSION}" CHANGELOG.md > "$SECTION_FILE"
-          cp CHANGELOG.md /tmp/postrelease-changelog.md
           git checkout -- CHANGELOG.md
           cat "$SECTION_FILE" > "$NOTES_FILE"
           {
@@ -184,12 +183,12 @@ jobs:
             echo "- Versioned Helm chart package"
             echo "- Multi-arch GHCR image"
           } >> "$NOTES_FILE"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
-          echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
-          echo "postrelease_changelog=/tmp/postrelease-changelog.md" >> "$GITHUB_OUTPUT"
-
+          {
+            echo "tag=${TAG}"
+            echo "version=${VERSION}"
+            echo "prev_tag=${PREV_TAG}"
+            echo "notes_file=${NOTES_FILE}"
+          } >> "$GITHUB_OUTPUT"
       - name: Create release tag
         run: |
           set -euo pipefail
@@ -257,40 +256,3 @@ jobs:
             dist/loki-vl-proxy-*
             dist/checksums.txt
             dist/loki-vl-proxy-*.tgz
-
-      - name: Open changelog sync PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.meta.outputs.version }}"
-          BRANCH="postrelease/v${VERSION}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$BRANCH"
-          cp "${{ steps.meta.outputs.postrelease_changelog }}" CHANGELOG.md
-          git add CHANGELOG.md
-          git diff --cached --quiet && exit 0
-          git commit -m "docs: finalize changelog for v${VERSION}"
-          git push --force origin "$BRANCH"
-
-          EXISTING_PR_URL="$(gh pr list --state open --base main --head "$BRANCH" --json url --jq '.[0].url // empty')"
-          BODY_FILE="$(mktemp)"
-          {
-            echo "## Post-release changelog sync"
-            echo ""
-            echo "- add the released \`v${VERSION}\` section to \`CHANGELOG.md\`"
-            echo "- reset \`Unreleased\` for the next change window"
-          } > "$BODY_FILE"
-
-          if [ -n "$EXISTING_PR_URL" ]; then
-            gh pr edit "$EXISTING_PR_URL" \
-              --title "docs: finalize changelog for v${VERSION}" \
-              --body-file "$BODY_FILE"
-          else
-            gh pr create \
-              --title "docs: finalize changelog for v${VERSION}" \
-              --body-file "$BODY_FILE" \
-              --base main \
-              --head "$BRANCH"
-          fi

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -41,7 +41,7 @@ jobs:
           for old in size/XS size/S size/M size/L size/XL; do
             gh pr edit "$PR_NUMBER" --remove-label "$old" 2>/dev/null || true
           done
-          gh pr edit "$PR_NUMBER" --add-label "$SIZE"
+          gh pr edit "$PR_NUMBER" --add-label "$SIZE" 2>/dev/null || true
 
           # --- Scope labels ---
           FILES=$(gh pr diff "$PR_NUMBER" --name-only)
@@ -64,24 +64,25 @@ jobs:
           done
 
           # --- Impact label ---
-          TITLE="${{ github.event.pull_request.title }}"
+          TITLE="$PR_TITLE"
           if echo "$TITLE" | grep -qE "^feat.*(!:|BREAKING)"; then
-            gh pr edit "$PR_NUMBER" --add-label "breaking-change"
+            gh pr edit "$PR_NUMBER" --add-label "breaking-change" 2>/dev/null || true
           fi
           if echo "$TITLE" | grep -qE "^feat(\(|:)"; then
-            gh pr edit "$PR_NUMBER" --add-label "feature"
+            gh pr edit "$PR_NUMBER" --add-label "feature" 2>/dev/null || true
           elif echo "$TITLE" | grep -qE "^fix(\(|:)"; then
-            gh pr edit "$PR_NUMBER" --add-label "bugfix"
+            gh pr edit "$PR_NUMBER" --add-label "bugfix" 2>/dev/null || true
           elif echo "$TITLE" | grep -qE "^docs?(\(|:)"; then
-            gh pr edit "$PR_NUMBER" --add-label "documentation"
+            gh pr edit "$PR_NUMBER" --add-label "documentation" 2>/dev/null || true
           elif echo "$TITLE" | grep -qE "^(ci|chore)(\(|:)"; then
-            gh pr edit "$PR_NUMBER" --add-label "maintenance"
+            gh pr edit "$PR_NUMBER" --add-label "maintenance" 2>/dev/null || true
           elif echo "$TITLE" | grep -qE "^(perf|bench)(\(|:)"; then
-            gh pr edit "$PR_NUMBER" --add-label "performance"
+            gh pr edit "$PR_NUMBER" --add-label "performance" 2>/dev/null || true
           elif echo "$TITLE" | grep -qE "^test(\(|:)"; then
-            gh pr edit "$PR_NUMBER" --add-label "tests"
+            gh pr edit "$PR_NUMBER" --add-label "tests" 2>/dev/null || true
           fi
 
           echo "Labels applied: $SIZE $SCOPES"
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- add ingress-backed and native-only `/tail` compatibility coverage for Grafana Explore and compose e2e
+- extend multi-tenant Explore and Logs Drilldown coverage for `__tenant_id__`, label breakdowns, and service drilldowns
+
+### CI
+
+- make the PR labeler fail-soft when optional repository labels are missing
+
+### Tests
+
+- add `/tail` ingress, idle-window, and native-failure regressions against the live compose stack
+- add browser-level Explore live-tail and multi-tenant Logs Drilldown regressions
+- raise `cmd/proxy` startup/server-loop coverage with more direct unit tests
+
 ## [0.27.0] - 2026-04-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![VictoriaLogs Compatibility](https://github.com/szibis/Loki-VL-proxy/actions/workflows/compat-vl.yaml/badge.svg)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/compat-vl.yaml)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/szibis/Loki-VL-proxy)](https://go.dev/)
 [![Release](https://img.shields.io/github/v/release/szibis/Loki-VL-proxy)](https://github.com/szibis/Loki-VL-proxy/releases)
+[![Lines of Code](https://sloc.xyz/github/szibis/Loki-VL-proxy/?category=code)](https://github.com/szibis/Loki-VL-proxy)
 [![Tests](https://img.shields.io/badge/tests-1023%20passed-brightgreen)](#tests)
 [![LogQL Coverage](https://img.shields.io/badge/LogQL%20coverage-100%25-brightgreen)](#logql-compatibility)
 [![License](https://img.shields.io/github/license/szibis/Loki-VL-proxy)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -100,39 +100,48 @@ See [Architecture](docs/architecture.md) for component design, [Observability](d
 
 ## Key Features
 
-### Query Translation
-See [Architecture](docs/architecture.md), [API Reference](docs/api-reference.md), and [Loki Compatibility](docs/compatibility-loki.md).
+### User Compatibility
+See [Getting Started](docs/getting-started.md), [Architecture](docs/architecture.md), [API Reference](docs/api-reference.md), [Loki Compatibility](docs/compatibility-loki.md), and [Logs Drilldown Compatibility](docs/compatibility-drilldown.md).
 
 - **100% LogQL coverage** -- stream selectors, line filters, parsers, metric queries, binary expressions, subqueries
 - **Proxy-side evaluation** for features VL doesn't support natively: `without()`, `on()`/`ignoring()`, `group_left()`/`group_right()`, subquery `[range:step]`, `bool` modifier, `| decolorize`, `| line_format`
 - **OTel label translation** -- bidirectional dot/underscore conversion for 50+ semantic convention fields
 - **Hybrid metadata fields by default** -- keep Loki-compatible labels while exposing both dotted OTel fields and underscore aliases for Drilldown, Explore, and correlation paths
+- **Grafana-native workflows** -- Explore, Logs Drilldown, dashboards, live tail, and datasource-side multi-tenant reads work through the standard Loki datasource
+- **Rules and alerts read compatibility** -- surface `vmalert` rules and alerts on Loki-compatible read endpoints and migrate existing files with the built-in converter
 - **VL stream selector optimization** -- known `_stream_fields` bypass full-text scan for native performance
 
-### Caching & Performance
-See [Fleet Cache](docs/fleet-cache.md), [Performance Guide](docs/performance.md), and [Scaling](docs/scaling.md).
+### Security & Hardening
+See [Security](docs/security.md), [Configuration](docs/configuration.md), [Observability](docs/observability.md), and [Known Issues](docs/KNOWN_ISSUES.md).
+
+- **Admin/debug endpoints closed by default** -- `/debug/queries`, `pprof`, and peer-cache internals require explicit enablement and optional admin auth
+- **Tail origin protection** -- `/tail` rejects browser origins unless explicitly allowlisted
+- **Tenant hardening** -- explicit tenant mapping, default-tenant aliases for VL `0:0`, and query-only multi-tenant fanout on `X-Scope-OrgID: tenant-a|tenant-b`
+- **6-layer protection** -- rate limiting, concurrency cap, coalescing, normalization, cache, circuit breaker
+- **Secret redaction** -- all log output passes through a redacting handler that masks API keys, bearer tokens, passwords, AWS credentials, and URL-embedded secrets
+- **Delete with safeguards** -- confirmation header, tenant scoping, time range limits, audit logging
+- **TLS support** -- server-side HTTPS, backend TLS, OTLP TLS, and optional client-certificate auth
+
+### Performance & Scale
+See [Performance Guide](docs/performance.md), [Scaling](docs/scaling.md), [Fleet Cache](docs/fleet-cache.md), and [Observability](docs/observability.md).
 
 - **3-tier cache**: L1 in-memory (LRU + TTL) → L2 on-disk (bbolt + gzip) → L3 peer (consistent hash ring)
 - **Fleet-distributed cache** -- consistent hashing across proxy replicas, shadow copies with TTL preservation, per-peer circuit breakers ([details](docs/fleet-cache.md))
 - **Request coalescing** -- N identical queries become 1 backend request (singleflight)
 - **Query normalization** -- sort matchers, collapse whitespace for better cache hit rates
-
-### Protection & Security
-See [Security](docs/security.md), [Configuration](docs/configuration.md), and [Known Issues](docs/KNOWN_ISSUES.md).
-
-- **6-layer protection** -- rate limiting, concurrency cap, coalescing, normalization, cache, circuit breaker
-- **Secret redaction** -- all log output passes through a redacting handler that masks API keys, bearer tokens, passwords, AWS credentials, and URL-embedded secrets
-- **Delete with safeguards** -- confirmation header, tenant scoping, time range limits, audit logging
-- **TLS support** -- server-side HTTPS, backend TLS, OTLP TLS
+- **Query-range response caching** -- final Loki-shaped cached responses for hot query paths, including merged multi-tenant reads
+- **Synthetic live tail fallback** -- keep `/tail` usable when native backend tail support is missing or disabled
+- **Cache-hit and bypass regression gates** -- PR quality checks track CPU, memory, allocations, throughput, and memory growth across hot and uncached paths
 
 ### Operations
-See [Configuration](docs/configuration.md), [Observability](docs/observability.md), [Testing](docs/testing.md), [Compatibility Matrix](docs/compatibility-matrix.md), [Logs Drilldown Compatibility](docs/compatibility-drilldown.md), and [Rules And Alerts Migration](docs/rules-alerts-migration.md).
+See [Getting Started](docs/getting-started.md), [Configuration](docs/configuration.md), [Scaling](docs/scaling.md), [Observability](docs/observability.md), [Testing](docs/testing.md), [Compatibility Matrix](docs/compatibility-matrix.md), and [Rules And Alerts Migration](docs/rules-alerts-migration.md).
 
 - **Multitenancy** -- Loki `X-Scope-OrgID` mapped to VL `AccountID`/`ProjectID`, SIGHUP hot-reload
 - **Observability** -- Prometheus `/metrics`, OTLP push with matching core metric names, OTel-friendly JSON logs, per-tenant breakdowns, per-client offender metrics, fleet peer-cache metrics
 - **Rules and alerts migration tool** -- convert Loki-style rule files into `vmalert` `type: vlogs` rule files for read-compatible Grafana alert visibility through the proxy
 - **WebSocket tail** -- live log tailing via Loki's WebSocket protocol with fast handshake, origin controls, and synthetic fallback when native VL tail streaming is unavailable
 - **GOMEMLIMIT auto-tuning** -- Helm chart calculates Go memory limit as % of k8s resource limits
+- **Versioned compatibility windows** -- pinned and matrix-tested Loki, VictoriaLogs, and Logs Drilldown support bands with dedicated CI badges
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Proxy-side datasource helpers:
 - `-tls-client-ca-file` and `-tls-require-client-cert` for HTTPS client auth
 - `-tail.allowed-origins` when Grafana or another browser client must use `/tail`
 
+Current remaining gaps are tracked in [Known Issues](docs/KNOWN_ISSUES.md). The main active work areas are `/tail` browser/ingress parity, deeper multi-tenant Explore and Drilldown coverage, and further startup-path coverage in `cmd/proxy`.
+
 ### Grafana Datasource for Multi-Tenant Read Fanout
 
 ```yaml

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -142,97 +142,152 @@ type reloadableProxy interface {
 }
 
 type signalNotifier func(chan<- os.Signal, ...os.Signal)
+type runtimeBuilder func(runtimeOptions, *slog.Logger, signalNotifier, otlpPusherFactory) (*runtimeState, error)
+type serverRunner func(httpServer, serverLoopOptions, *slog.Logger, func(string, ...any))
+type shutdownHandlerFunc func(<-chan os.Signal, httpServer, time.Duration, *slog.Logger)
+
+type runtimeOptions struct {
+	cacheTTL     time.Duration
+	cacheMax     int
+	diskCfg      cache.DiskCacheConfig
+	proxyCfg     proxyRuntimeConfig
+	otlpCfg      otlpRuntimeConfig
+	maxBodyBytes int64
+	enableGzip   bool
+	serverOpts   serverRuntimeOptions
+}
+
+type runtimeState struct {
+	proxy        *proxy.Proxy
+	server       httpServer
+	cacheCleanup func()
+	stopOTLP     func()
+	reloadCh     chan os.Signal
+	shutdownCh   chan os.Signal
+}
 
 func main() {
+	if err := run(
+		os.Args[1:],
+		os.Getenv,
+		os.Stdout,
+		signal.Notify,
+		func(cfg metrics.OTLPConfig, m *metrics.Metrics) otlpMetricsPusher {
+			return metrics.NewOTLPPusher(cfg, m)
+		},
+		buildRuntime,
+		runServerLoop,
+		handleShutdown,
+	); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(
+	args []string,
+	getenv func(string) string,
+	logWriter io.Writer,
+	notify signalNotifier,
+	newPusher otlpPusherFactory,
+	buildRuntimeFn runtimeBuilder,
+	runServerLoopFn serverRunner,
+	handleShutdownFn shutdownHandlerFunc,
+) error {
+	fs := flag.NewFlagSet("loki-vl-proxy", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
 	// Server flags
-	listenAddr := flag.String("listen", ":3100", "Address to listen on (Loki-compatible frontend)")
-	backendURL := flag.String("backend", "http://localhost:9428", "VictoriaLogs backend URL")
-	rulerBackendURL := flag.String("ruler-backend", "", "Optional alert/ruler backend URL for /rules passthrough (for example vmalert)")
-	alertsBackendURL := flag.String("alerts-backend", "", "Optional alert backend URL for /alerts passthrough (defaults to -ruler-backend when unset)")
-	logLevel := flag.String("log-level", "info", "Log level: debug, info, warn, error")
+	listenAddr := fs.String("listen", ":3100", "Address to listen on (Loki-compatible frontend)")
+	backendURL := fs.String("backend", "http://localhost:9428", "VictoriaLogs backend URL")
+	rulerBackendURL := fs.String("ruler-backend", "", "Optional alert/ruler backend URL for /rules passthrough (for example vmalert)")
+	alertsBackendURL := fs.String("alerts-backend", "", "Optional alert backend URL for /alerts passthrough (defaults to -ruler-backend when unset)")
+	logLevel := fs.String("log-level", "info", "Log level: debug, info, warn, error")
 
 	// Cache flags
-	cacheTTL := flag.Duration("cache-ttl", 60*time.Second, "Cache TTL for label/metadata queries")
-	cacheMax := flag.Int("cache-max", 10000, "Maximum cache entries")
+	cacheTTL := fs.Duration("cache-ttl", 60*time.Second, "Cache TTL for label/metadata queries")
+	cacheMax := fs.Int("cache-max", 10000, "Maximum cache entries")
 
 	// Disk cache flags
-	diskCachePath := flag.String("disk-cache-path", "", "Path to L2 disk cache (bbolt). Empty disables.")
-	diskCacheCompress := flag.Bool("disk-cache-compress", true, "Gzip compression for disk cache")
-	diskCacheFlushSize := flag.Int("disk-cache-flush-size", 100, "Flush write buffer after N entries")
-	diskCacheFlushInterval := flag.Duration("disk-cache-flush-interval", 5*time.Second, "Write buffer flush interval")
+	diskCachePath := fs.String("disk-cache-path", "", "Path to L2 disk cache (bbolt). Empty disables.")
+	diskCacheCompress := fs.Bool("disk-cache-compress", true, "Gzip compression for disk cache")
+	diskCacheFlushSize := fs.Int("disk-cache-flush-size", 100, "Flush write buffer after N entries")
+	diskCacheFlushInterval := fs.Duration("disk-cache-flush-interval", 5*time.Second, "Write buffer flush interval")
 	// Tenant mapping
-	tenantMapJSON := flag.String("tenant-map", "", `JSON tenant mapping: {"org-name":{"account_id":"1","project_id":"0"}}`)
+	tenantMapJSON := fs.String("tenant-map", "", `JSON tenant mapping: {"org-name":{"account_id":"1","project_id":"0"}}`)
 
 	// OTLP telemetry flags
-	otlpEndpoint := flag.String("otlp-endpoint", "", "OTLP HTTP endpoint (e.g., http://otel-collector:4318/v1/metrics)")
-	otlpInterval := flag.Duration("otlp-interval", 30*time.Second, "OTLP push interval")
-	otlpCompression := flag.String("otlp-compression", "none", "OTLP compression: none, gzip, zstd")
-	otlpTimeout := flag.Duration("otlp-timeout", 10*time.Second, "OTLP HTTP request timeout")
-	otlpTLSSkipVerify := flag.Bool("otlp-tls-skip-verify", false, "Skip TLS verification for OTLP endpoint")
-	otlpHeaders := flag.String("otlp-headers", "", "Comma-separated OTLP HTTP headers in key=value form")
-	otelServiceName := flag.String("otel-service-name", "loki-vl-proxy", "OpenTelemetry service.name for logs and OTLP metrics")
-	otelServiceNamespace := flag.String("otel-service-namespace", "", "OpenTelemetry service.namespace for logs and OTLP metrics")
-	otelServiceInstanceID := flag.String("otel-service-instance-id", "", "OpenTelemetry service.instance.id for logs and OTLP metrics")
-	deploymentEnvironment := flag.String("deployment-environment", "", "OpenTelemetry deployment.environment.name for logs and OTLP metrics")
+	otlpEndpoint := fs.String("otlp-endpoint", "", "OTLP HTTP endpoint (e.g., http://otel-collector:4318/v1/metrics)")
+	otlpInterval := fs.Duration("otlp-interval", 30*time.Second, "OTLP push interval")
+	otlpCompression := fs.String("otlp-compression", "none", "OTLP compression: none, gzip, zstd")
+	otlpTimeout := fs.Duration("otlp-timeout", 10*time.Second, "OTLP HTTP request timeout")
+	otlpTLSSkipVerify := fs.Bool("otlp-tls-skip-verify", false, "Skip TLS verification for OTLP endpoint")
+	otlpHeaders := fs.String("otlp-headers", "", "Comma-separated OTLP HTTP headers in key=value form")
+	otelServiceName := fs.String("otel-service-name", "loki-vl-proxy", "OpenTelemetry service.name for logs and OTLP metrics")
+	otelServiceNamespace := fs.String("otel-service-namespace", "", "OpenTelemetry service.namespace for logs and OTLP metrics")
+	otelServiceInstanceID := fs.String("otel-service-instance-id", "", "OpenTelemetry service.instance.id for logs and OTLP metrics")
+	deploymentEnvironment := fs.String("deployment-environment", "", "OpenTelemetry deployment.environment.name for logs and OTLP metrics")
 
 	// HTTP server hardening
-	readTimeout := flag.Duration("http-read-timeout", 30*time.Second, "HTTP server read timeout")
-	writeTimeout := flag.Duration("http-write-timeout", 120*time.Second, "HTTP server write timeout")
-	idleTimeout := flag.Duration("http-idle-timeout", 120*time.Second, "HTTP server idle timeout")
-	maxHeaderBytes := flag.Int("http-max-header-bytes", 1<<20, "HTTP max header size (default: 1MB)")
-	maxBodyBytes := flag.Int64("http-max-body-bytes", 10<<20, "HTTP max request body size (default: 10MB)")
+	readTimeout := fs.Duration("http-read-timeout", 30*time.Second, "HTTP server read timeout")
+	writeTimeout := fs.Duration("http-write-timeout", 120*time.Second, "HTTP server write timeout")
+	idleTimeout := fs.Duration("http-idle-timeout", 120*time.Second, "HTTP server idle timeout")
+	maxHeaderBytes := fs.Int("http-max-header-bytes", 1<<20, "HTTP max header size (default: 1MB)")
+	maxBodyBytes := fs.Int64("http-max-body-bytes", 10<<20, "HTTP max request body size (default: 10MB)")
 
 	// TLS server
-	tlsCertFile := flag.String("tls-cert-file", "", "TLS certificate file for HTTPS server")
-	tlsKeyFile := flag.String("tls-key-file", "", "TLS private key file for HTTPS server")
-	tlsClientCAFile := flag.String("tls-client-ca-file", "", "CA certificate file used to verify HTTPS client certificates")
-	tlsRequireClientCert := flag.Bool("tls-require-client-cert", false, "Require and verify HTTPS client certificates")
+	tlsCertFile := fs.String("tls-cert-file", "", "TLS certificate file for HTTPS server")
+	tlsKeyFile := fs.String("tls-key-file", "", "TLS private key file for HTTPS server")
+	tlsClientCAFile := fs.String("tls-client-ca-file", "", "CA certificate file used to verify HTTPS client certificates")
+	tlsRequireClientCert := fs.Bool("tls-require-client-cert", false, "Require and verify HTTPS client certificates")
 
 	// Response compression
-	enableGzip := flag.Bool("response-gzip", true, "Enable gzip response compression for clients that accept it")
+	enableGzip := fs.Bool("response-gzip", true, "Enable gzip response compression for clients that accept it")
 
 	// Grafana datasource compatibility
-	maxLines := flag.Int("max-lines", 1000, "Default max lines per query")
-	backendTimeout := flag.Duration("backend-timeout", 120*time.Second, "Timeout for non-streaming requests to the VictoriaLogs backend")
-	backendBasicAuth := flag.String("backend-basic-auth", "", "Basic auth for VL backend (user:password)")
-	backendTLSSkip := flag.Bool("backend-tls-skip-verify", false, "Skip TLS verification for VL backend")
-	forwardHeaders := flag.String("forward-headers", "", "Comma-separated list of HTTP headers to forward to VL backend")
-	forwardCookies := flag.String("forward-cookies", "", "Comma-separated list of cookie names to forward to VL backend")
-	derivedFieldsJSON := flag.String("derived-fields", "", `JSON derived fields: [{"name":"traceID","matcherRegex":"trace_id=([a-f0-9]+)","url":"http://tempo/trace/${__value.raw}"}]`)
-	streamResponse := flag.Bool("stream-response", false, "Stream log responses via chunked transfer encoding")
+	maxLines := fs.Int("max-lines", 1000, "Default max lines per query")
+	backendTimeout := fs.Duration("backend-timeout", 120*time.Second, "Timeout for non-streaming requests to the VictoriaLogs backend")
+	backendBasicAuth := fs.String("backend-basic-auth", "", "Basic auth for VL backend (user:password)")
+	backendTLSSkip := fs.Bool("backend-tls-skip-verify", false, "Skip TLS verification for VL backend")
+	forwardHeaders := fs.String("forward-headers", "", "Comma-separated list of HTTP headers to forward to VL backend")
+	forwardCookies := fs.String("forward-cookies", "", "Comma-separated list of cookie names to forward to VL backend")
+	derivedFieldsJSON := fs.String("derived-fields", "", `JSON derived fields: [{"name":"traceID","matcherRegex":"trace_id=([a-f0-9]+)","url":"http://tempo/trace/${__value.raw}"}]`)
+	streamResponse := fs.Bool("stream-response", false, "Stream log responses via chunked transfer encoding")
 
 	// Loki-style auth / instrumentation controls
-	authEnabled := flag.Bool("auth.enabled", false, "Require X-Scope-OrgID on query requests. When false, requests without a tenant header use the backend default tenant.")
-	registerInstrumentation := flag.Bool("server.register-instrumentation", true, "Register instrumentation handlers such as /metrics")
-	enablePprof := flag.Bool("server.enable-pprof", false, "Expose /debug/pprof/* handlers")
-	enableQueryAnalytics := flag.Bool("server.enable-query-analytics", false, "Expose /debug/queries query analytics")
-	adminAuthToken := flag.String("server.admin-auth-token", "", "Bearer token required for admin/debug endpoints when set")
-	tailAllowedOrigins := flag.String("tail.allowed-origins", "", "Comma-separated WebSocket Origin allowlist for /loki/api/v1/tail. Empty denies browser origins.")
-	tailMode := flag.String("tail.mode", "auto", "Tail streaming mode: auto (native with synthetic fallback), native, or synthetic")
-	metricsMaxTenants := flag.Int("metrics.max-tenants", 256, "Maximum unique tenant labels retained in exported metrics before collapsing into __overflow__")
-	metricsMaxClients := flag.Int("metrics.max-clients", 256, "Maximum unique client labels retained in exported metrics before collapsing into __overflow__")
-	metricsTrustProxyHeaders := flag.Bool("metrics.trust-proxy-headers", false, "Trust X-Grafana-User and X-Forwarded-For when deriving per-client metrics labels")
+	authEnabled := fs.Bool("auth.enabled", false, "Require X-Scope-OrgID on query requests. When false, requests without a tenant header use the backend default tenant.")
+	registerInstrumentation := fs.Bool("server.register-instrumentation", true, "Register instrumentation handlers such as /metrics")
+	enablePprof := fs.Bool("server.enable-pprof", false, "Expose /debug/pprof/* handlers")
+	enableQueryAnalytics := fs.Bool("server.enable-query-analytics", false, "Expose /debug/queries query analytics")
+	adminAuthToken := fs.String("server.admin-auth-token", "", "Bearer token required for admin/debug endpoints when set")
+	tailAllowedOrigins := fs.String("tail.allowed-origins", "", "Comma-separated WebSocket Origin allowlist for /loki/api/v1/tail. Empty denies browser origins.")
+	tailMode := fs.String("tail.mode", "auto", "Tail streaming mode: auto (native with synthetic fallback), native, or synthetic")
+	metricsMaxTenants := fs.Int("metrics.max-tenants", 256, "Maximum unique tenant labels retained in exported metrics before collapsing into __overflow__")
+	metricsMaxClients := fs.Int("metrics.max-clients", 256, "Maximum unique client labels retained in exported metrics before collapsing into __overflow__")
+	metricsTrustProxyHeaders := fs.Bool("metrics.trust-proxy-headers", false, "Trust X-Grafana-User and X-Forwarded-For when deriving per-client metrics labels")
 
 	// Label translation
-	labelStyle := flag.String("label-style", "passthrough", `Label name translation mode:
+	labelStyle := fs.String("label-style", "passthrough", `Label name translation mode:
   passthrough  - no translation, pass VL field names as-is (use when VL stores underscores)
   underscores  - convert dots to underscores (use when VL stores OTel-style dotted names like service.name)`)
-	metadataFieldMode := flag.String("metadata-field-mode", "hybrid", `Field exposure mode for detected_fields and structured metadata:
+	metadataFieldMode := fs.String("metadata-field-mode", "hybrid", `Field exposure mode for detected_fields and structured metadata:
   native      - expose VictoriaLogs field names as-is
   translated  - expose only Loki-compatible translated aliases
   hybrid      - expose both native VL field names and translated aliases when they differ`)
-	fieldMappingJSON := flag.String("field-mapping", "", `JSON custom field mappings: [{"vl_field":"service.name","loki_label":"service_name"}]`)
-	streamFieldsCSV := flag.String("stream-fields", "", `Comma-separated VL _stream_fields labels for stream selector optimization (e.g., "app,env,namespace")`)
-	allowGlobalTenant := flag.Bool("tenant.allow-global", false, `Allow X-Scope-OrgID "*" to bypass AccountID/ProjectID scoping and use the backend default tenant`)
+	fieldMappingJSON := fs.String("field-mapping", "", `JSON custom field mappings: [{"vl_field":"service.name","loki_label":"service_name"}]`)
+	streamFieldsCSV := fs.String("stream-fields", "", `Comma-separated VL _stream_fields labels for stream selector optimization (e.g., "app,env,namespace")`)
+	allowGlobalTenant := fs.Bool("tenant.allow-global", false, `Allow X-Scope-OrgID "*" to bypass AccountID/ProjectID scoping and use the backend default tenant`)
 
 	// Peer cache (fleet distribution)
-	peerSelf := flag.String("peer-self", "", `This instance's address for peer cache (e.g., "10.0.0.1:3100"). Empty disables peer cache.`)
-	peerDiscovery := flag.String("peer-discovery", "", `Peer discovery: "dns" (headless service) or "static" (comma-separated)`)
-	peerDNS := flag.String("peer-dns", "", `Headless service DNS name for peer discovery (e.g., "proxy-headless.ns.svc.cluster.local")`)
-	peerStatic := flag.String("peer-static", "", `Static peer list (e.g., "10.0.0.1:3100,10.0.0.2:3100")`)
-	peerAuthToken := flag.String("peer-auth-token", "", "Shared token required on /_cache/get peer-cache requests when set")
+	peerSelf := fs.String("peer-self", "", `This instance's address for peer cache (e.g., "10.0.0.1:3100"). Empty disables peer cache.`)
+	peerDiscovery := fs.String("peer-discovery", "", `Peer discovery: "dns" (headless service) or "static" (comma-separated)`)
+	peerDNS := fs.String("peer-dns", "", `Headless service DNS name for peer discovery (e.g., "proxy-headless.ns.svc.cluster.local")`)
+	peerStatic := fs.String("peer-static", "", `Static peer list (e.g., "10.0.0.1:3100,10.0.0.2:3100")`)
+	peerAuthToken := fs.String("peer-auth-token", "", "Shared token required on /_cache/get peer-cache requests when set")
 
-	flag.Parse()
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 
 	envCfg := applyEnvOverrides(envConfig{
 		listenAddr:        *listenAddr,
@@ -250,9 +305,9 @@ func main() {
 		serviceNamespace:  *otelServiceNamespace,
 		serviceInstanceID: *otelServiceInstanceID,
 		deploymentEnv:     *deploymentEnvironment,
-	}, os.Getenv)
+	}, getenv)
 
-	logger := buildLogger(os.Stdout, loggerConfig{
+	logger := buildLogger(logWriter, loggerConfig{
 		level:                 *logLevel,
 		serviceName:           envCfg.serviceName,
 		serviceNamespace:      envCfg.serviceNamespace,
@@ -260,131 +315,95 @@ func main() {
 		serviceInstanceID:     envCfg.serviceInstanceID,
 		deploymentEnvironment: envCfg.deploymentEnv,
 	})
-	slog.SetDefault(logger)
 	fatal := func(msg string, args ...any) {
 		logger.Error(msg, args...)
 		os.Exit(1)
 	}
 
-	c, cacheCleanup, err := buildCacheLayer(*cacheTTL, *cacheMax, cache.DiskCacheConfig{
-		Path:          *diskCachePath,
-		Compression:   *diskCacheCompress,
-		FlushSize:     *diskCacheFlushSize,
-		FlushInterval: *diskCacheFlushInterval,
-	}, logger)
+	runtime, err := buildRuntimeFn(runtimeOptions{
+		cacheTTL: *cacheTTL,
+		cacheMax: *cacheMax,
+		diskCfg: cache.DiskCacheConfig{
+			Path:          *diskCachePath,
+			Compression:   *diskCacheCompress,
+			FlushSize:     *diskCacheFlushSize,
+			FlushInterval: *diskCacheFlushInterval,
+		},
+		proxyCfg: proxyRuntimeConfig{
+			backendURL:               envCfg.backendURL,
+			rulerBackendURL:          envCfg.rulerBackendURL,
+			alertsBackendURL:         envCfg.alertsBackendURL,
+			logLevel:                 *logLevel,
+			tenantMapJSON:            envCfg.tenantMapJSON,
+			maxLines:                 *maxLines,
+			backendTimeout:           *backendTimeout,
+			backendBasicAuth:         *backendBasicAuth,
+			backendTLSSkip:           *backendTLSSkip,
+			forwardHeaders:           *forwardHeaders,
+			forwardCookies:           *forwardCookies,
+			derivedFieldsJSON:        *derivedFieldsJSON,
+			streamResponse:           *streamResponse,
+			authEnabled:              *authEnabled,
+			allowGlobalTenant:        *allowGlobalTenant,
+			registerInstrumentation:  registerInstrumentation,
+			enablePprof:              *enablePprof,
+			enableQueryAnalytics:     *enableQueryAnalytics,
+			adminAuthToken:           *adminAuthToken,
+			tailAllowedOrigins:       *tailAllowedOrigins,
+			tailMode:                 *tailMode,
+			metricsMaxTenants:        *metricsMaxTenants,
+			metricsMaxClients:        *metricsMaxClients,
+			metricsTrustProxyHeaders: *metricsTrustProxyHeaders,
+			labelStyle:               envCfg.labelStyle,
+			metadataFieldMode:        envCfg.metadataFieldMode,
+			fieldMappingJSON:         envCfg.fieldMappingJSON,
+			streamFieldsCSV:          *streamFieldsCSV,
+			peerSelf:                 *peerSelf,
+			peerDiscovery:            *peerDiscovery,
+			peerDNS:                  *peerDNS,
+			peerStatic:               *peerStatic,
+			peerAuthToken:            *peerAuthToken,
+		},
+		otlpCfg: otlpRuntimeConfig{
+			endpoint:              envCfg.otlpEndpoint,
+			interval:              *otlpInterval,
+			headers:               envCfg.otlpHeaders,
+			compression:           envCfg.otlpCompression,
+			timeout:               *otlpTimeout,
+			tlsSkipVerify:         *otlpTLSSkipVerify,
+			serviceName:           envCfg.serviceName,
+			serviceNamespace:      envCfg.serviceNamespace,
+			serviceVersion:        version,
+			serviceInstanceID:     envCfg.serviceInstanceID,
+			deploymentEnvironment: envCfg.deploymentEnv,
+		},
+		maxBodyBytes: *maxBodyBytes,
+		enableGzip:   *enableGzip,
+		serverOpts: serverRuntimeOptions{
+			listenAddr:           envCfg.listenAddr,
+			readTimeout:          *readTimeout,
+			writeTimeout:         *writeTimeout,
+			idleTimeout:          *idleTimeout,
+			maxHeaderBytes:       *maxHeaderBytes,
+			tlsClientCAFile:      *tlsClientCAFile,
+			tlsRequireClientCert: *tlsRequireClientCert,
+		},
+	}, logger, notify, newPusher)
 	if err != nil {
-		fatal("failed to open disk cache", "error", err)
+		return fmt.Errorf("failed to initialize runtime: %w", err)
 	}
-	defer cacheCleanup()
+	defer runtime.cacheCleanup()
+	defer runtime.stopOTLP()
 
-	proxyCfg, err := buildProxyConfig(proxyRuntimeConfig{
-		backendURL:               envCfg.backendURL,
-		rulerBackendURL:          envCfg.rulerBackendURL,
-		alertsBackendURL:         envCfg.alertsBackendURL,
-		cache:                    c,
-		logLevel:                 *logLevel,
-		tenantMapJSON:            envCfg.tenantMapJSON,
-		maxLines:                 *maxLines,
-		backendTimeout:           *backendTimeout,
-		backendBasicAuth:         *backendBasicAuth,
-		backendTLSSkip:           *backendTLSSkip,
-		forwardHeaders:           *forwardHeaders,
-		forwardCookies:           *forwardCookies,
-		derivedFieldsJSON:        *derivedFieldsJSON,
-		streamResponse:           *streamResponse,
-		authEnabled:              *authEnabled,
-		allowGlobalTenant:        *allowGlobalTenant,
-		registerInstrumentation:  registerInstrumentation,
-		enablePprof:              *enablePprof,
-		enableQueryAnalytics:     *enableQueryAnalytics,
-		adminAuthToken:           *adminAuthToken,
-		tailAllowedOrigins:       *tailAllowedOrigins,
-		tailMode:                 *tailMode,
-		metricsMaxTenants:        *metricsMaxTenants,
-		metricsMaxClients:        *metricsMaxClients,
-		metricsTrustProxyHeaders: *metricsTrustProxyHeaders,
-		labelStyle:               envCfg.labelStyle,
-		metadataFieldMode:        envCfg.metadataFieldMode,
-		fieldMappingJSON:         envCfg.fieldMappingJSON,
-		streamFieldsCSV:          *streamFieldsCSV,
-		peerSelf:                 *peerSelf,
-		peerDiscovery:            *peerDiscovery,
-		peerDNS:                  *peerDNS,
-		peerStatic:               *peerStatic,
-		peerAuthToken:            *peerAuthToken,
-	})
-	if err != nil {
-		fatal("failed to build proxy configuration", "error", err)
-	}
-	logProxyStartup(logger, proxyCfg, *peerSelf, *peerDiscovery, c)
-
-	// Create proxy
-	p, err := proxy.New(proxyCfg)
-	if err != nil {
-		fatal("failed to create proxy", "error", err)
-	}
-	p.Init()
-
-	stopOTLP := startOTLPMetricsPusher(otlpRuntimeConfig{
-		endpoint:              envCfg.otlpEndpoint,
-		interval:              *otlpInterval,
-		headers:               envCfg.otlpHeaders,
-		compression:           envCfg.otlpCompression,
-		timeout:               *otlpTimeout,
-		tlsSkipVerify:         *otlpTLSSkipVerify,
-		serviceName:           envCfg.serviceName,
-		serviceNamespace:      envCfg.serviceNamespace,
-		serviceVersion:        version,
-		serviceInstanceID:     envCfg.serviceInstanceID,
-		deploymentEnvironment: envCfg.deploymentEnv,
-	}, p.GetMetrics(), logger, func(cfg metrics.OTLPConfig, m *metrics.Metrics) otlpMetricsPusher {
-		return metrics.NewOTLPPusher(cfg, m)
-	})
-	defer stopOTLP()
-
-	mux := http.NewServeMux()
-	p.RegisterRoutes(mux)
-
-	// Middleware chain: body limit → gzip compression
-	handler := wrapHandler(mux, *maxBodyBytes, *enableGzip)
-
-	// Hardened HTTP server with timeouts
-	srv, err := buildHTTPServer(serverRuntimeOptions{
-		listenAddr:           envCfg.listenAddr,
-		handler:              handler,
-		readTimeout:          *readTimeout,
-		writeTimeout:         *writeTimeout,
-		idleTimeout:          *idleTimeout,
-		maxHeaderBytes:       *maxHeaderBytes,
-		tlsClientCAFile:      *tlsClientCAFile,
-		tlsRequireClientCert: *tlsRequireClientCert,
-	})
-	if err != nil {
-		fatal("failed to configure server tls client authentication", "error", err)
-	}
-
-	// SIGHUP config reload for tenant-map and field-mapping
-	reloadCh, shutdownCh := buildSignalChannels(signal.Notify)
-	go watchReloadSignals(reloadCh, p, os.Getenv, logger)
-
-	// Graceful shutdown on SIGTERM/SIGINT
-	go runServerLoop(srv, serverLoopOptions{
+	go watchReloadSignals(runtime.reloadCh, runtime.proxy, getenv, logger)
+	go runServerLoopFn(runtime.server, serverLoopOptions{
 		listenAddr:  envCfg.listenAddr,
 		backendURL:  envCfg.backendURL,
 		tlsCertFile: *tlsCertFile,
 		tlsKeyFile:  *tlsKeyFile,
 	}, logger, fatal)
-
-	sig := <-shutdownCh
-	logger.Info("shutdown requested", "signal", sig.String())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	if err := srv.Shutdown(ctx); err != nil {
-		logger.Error("http shutdown error", "error", err)
-	}
-	logger.Info("shutdown complete")
+	handleShutdownFn(runtime.shutdownCh, runtime.server, 30*time.Second, logger)
+	return nil
 }
 
 func buildCacheLayer(ttl time.Duration, maxEntries int, diskCfg cache.DiskCacheConfig, logger *slog.Logger) (*cache.Cache, func(), error) {
@@ -407,6 +426,52 @@ func buildCacheLayer(ttl time.Duration, maxEntries int, diskCfg cache.DiskCacheC
 	return c, func() { _ = dc.Close() }, nil
 }
 
+func buildRuntime(opts runtimeOptions, logger *slog.Logger, notify signalNotifier, newPusher otlpPusherFactory) (*runtimeState, error) {
+	cacheLayer, cacheCleanup, err := buildCacheLayer(opts.cacheTTL, opts.cacheMax, opts.diskCfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("open disk cache: %w", err)
+	}
+
+	proxyCfg := opts.proxyCfg
+	proxyCfg.cache = cacheLayer
+	builtProxyCfg, err := buildProxyConfig(proxyCfg)
+	if err != nil {
+		cacheCleanup()
+		return nil, fmt.Errorf("build proxy config: %w", err)
+	}
+	logProxyStartup(logger, builtProxyCfg, proxyCfg.peerSelf, proxyCfg.peerDiscovery, cacheLayer)
+
+	p, err := proxy.New(builtProxyCfg)
+	if err != nil {
+		cacheCleanup()
+		return nil, fmt.Errorf("create proxy: %w", err)
+	}
+	p.Init()
+
+	stopOTLP := startOTLPMetricsPusher(opts.otlpCfg, p.GetMetrics(), logger, newPusher)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	serverOpts := opts.serverOpts
+	serverOpts.handler = wrapHandler(mux, opts.maxBodyBytes, opts.enableGzip)
+	srv, err := buildHTTPServer(serverOpts)
+	if err != nil {
+		stopOTLP()
+		cacheCleanup()
+		return nil, fmt.Errorf("build http server: %w", err)
+	}
+
+	reloadCh, shutdownCh := buildSignalChannels(notify)
+	return &runtimeState{
+		proxy:        p,
+		server:       srv,
+		cacheCleanup: cacheCleanup,
+		stopOTLP:     stopOTLP,
+		reloadCh:     reloadCh,
+		shutdownCh:   shutdownCh,
+	}, nil
+}
+
 func buildLogger(w io.Writer, cfg loggerConfig) *slog.Logger {
 	logger := observability.NewLogger(w, observability.LoggerConfig{
 		Level:                 cfg.level,
@@ -426,6 +491,19 @@ func buildSignalChannels(notify signalNotifier) (chan os.Signal, chan os.Signal)
 	shutdownCh := make(chan os.Signal, 1)
 	notify(shutdownCh, syscall.SIGTERM, syscall.SIGINT)
 	return reloadCh, shutdownCh
+}
+
+func handleShutdown(shutdownCh <-chan os.Signal, srv httpServer, timeout time.Duration, logger *slog.Logger) {
+	sig := <-shutdownCh
+	logger.Info("shutdown requested", "signal", sig.String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		logger.Error("http shutdown error", "error", err)
+	}
+	logger.Info("shutdown complete")
 }
 
 func watchReloadSignals(reloadCh <-chan os.Signal, p reloadableProxy, getenv func(string) string, logger *slog.Logger) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -262,29 +262,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// L1 in-memory cache
-	c := cache.New(*cacheTTL, *cacheMax)
-
-	// L2 disk cache (compression + write-back buffer)
-	if *diskCachePath != "" {
-		dc, err := cache.NewDiskCache(cache.DiskCacheConfig{
-			Path:          *diskCachePath,
-			Compression:   *diskCacheCompress,
-			FlushSize:     *diskCacheFlushSize,
-			FlushInterval: *diskCacheFlushInterval,
-		})
-		if err != nil {
-			fatal("failed to open disk cache", "error", err)
-		}
-		defer func() { _ = dc.Close() }()
-		c.SetL2(dc)
-		logger.Info("disk cache enabled",
-			"path", *diskCachePath,
-			"compress", *diskCacheCompress,
-			"flush_size", *diskCacheFlushSize,
-			"flush_interval", diskCacheFlushInterval.String(),
-		)
+	c, cacheCleanup, err := buildCacheLayer(*cacheTTL, *cacheMax, cache.DiskCacheConfig{
+		Path:          *diskCachePath,
+		Compression:   *diskCacheCompress,
+		FlushSize:     *diskCacheFlushSize,
+		FlushInterval: *diskCacheFlushInterval,
+	}, logger)
+	if err != nil {
+		fatal("failed to open disk cache", "error", err)
 	}
+	defer cacheCleanup()
 
 	proxyCfg, err := buildProxyConfig(proxyRuntimeConfig{
 		backendURL:               *backendURL,
@@ -382,12 +369,7 @@ func main() {
 	// SIGHUP config reload for tenant-map and field-mapping
 	reloadCh := make(chan os.Signal, 1)
 	signal.Notify(reloadCh, syscall.SIGHUP)
-	go func() {
-		for range reloadCh {
-			logger.Info("received sighup, reloading configuration")
-			reloadDynamicConfig(p, os.Getenv, logger)
-		}
-	}()
+	go watchReloadSignals(reloadCh, p, os.Getenv, logger)
 
 	// Graceful shutdown on SIGTERM/SIGINT
 	shutdownCh := make(chan os.Signal, 1)
@@ -410,6 +392,33 @@ func main() {
 		logger.Error("http shutdown error", "error", err)
 	}
 	logger.Info("shutdown complete")
+}
+
+func buildCacheLayer(ttl time.Duration, maxEntries int, diskCfg cache.DiskCacheConfig, logger *slog.Logger) (*cache.Cache, func(), error) {
+	c := cache.New(ttl, maxEntries)
+	if diskCfg.Path == "" {
+		return c, func() {}, nil
+	}
+
+	dc, err := cache.NewDiskCache(diskCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	c.SetL2(dc)
+	logger.Info("disk cache enabled",
+		"path", diskCfg.Path,
+		"compress", diskCfg.Compression,
+		"flush_size", diskCfg.FlushSize,
+		"flush_interval", diskCfg.FlushInterval.String(),
+	)
+	return c, func() { _ = dc.Close() }, nil
+}
+
+func watchReloadSignals(reloadCh <-chan os.Signal, p reloadableProxy, getenv func(string) string, logger *slog.Logger) {
+	for range reloadCh {
+		logger.Info("received sighup, reloading configuration")
+		reloadDynamicConfig(p, getenv, logger)
+	}
 }
 
 // maxBodyHandler limits the request body size to prevent resource exhaustion.

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -131,6 +131,8 @@ type reloadableProxy interface {
 	ReloadFieldMappings([]proxy.FieldMapping)
 }
 
+type signalNotifier func(chan<- os.Signal, ...os.Signal)
+
 func main() {
 	// Server flags
 	listenAddr := flag.String("listen", ":3100", "Address to listen on (Loki-compatible frontend)")
@@ -367,14 +369,10 @@ func main() {
 	}
 
 	// SIGHUP config reload for tenant-map and field-mapping
-	reloadCh := make(chan os.Signal, 1)
-	signal.Notify(reloadCh, syscall.SIGHUP)
+	reloadCh, shutdownCh := buildSignalChannels(signal.Notify)
 	go watchReloadSignals(reloadCh, p, os.Getenv, logger)
 
 	// Graceful shutdown on SIGTERM/SIGINT
-	shutdownCh := make(chan os.Signal, 1)
-	signal.Notify(shutdownCh, syscall.SIGTERM, syscall.SIGINT)
-
 	go runServerLoop(srv, serverLoopOptions{
 		listenAddr:  *listenAddr,
 		backendURL:  *backendURL,
@@ -412,6 +410,14 @@ func buildCacheLayer(ttl time.Duration, maxEntries int, diskCfg cache.DiskCacheC
 		"flush_interval", diskCfg.FlushInterval.String(),
 	)
 	return c, func() { _ = dc.Close() }, nil
+}
+
+func buildSignalChannels(notify signalNotifier) (chan os.Signal, chan os.Signal) {
+	reloadCh := make(chan os.Signal, 1)
+	notify(reloadCh, syscall.SIGHUP)
+	shutdownCh := make(chan os.Signal, 1)
+	notify(shutdownCh, syscall.SIGTERM, syscall.SIGINT)
+	return reloadCh, shutdownCh
 }
 
 func watchReloadSignals(reloadCh <-chan os.Signal, p reloadableProxy, getenv func(string) string, logger *slog.Logger) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -112,6 +112,13 @@ type httpServer interface {
 	Shutdown(ctx context.Context) error
 }
 
+type otlpMetricsPusher interface {
+	Start()
+	Stop()
+}
+
+type otlpPusherFactory func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher
+
 type serverLoopOptions struct {
 	listenAddr  string
 	backendURL  string
@@ -321,29 +328,22 @@ func main() {
 	}
 	p.Init()
 
-	// Start OTLP telemetry push
-	if *otlpEndpoint != "" {
-		pusher := metrics.NewOTLPPusher(buildOTLPConfig(otlpRuntimeConfig{
-			endpoint:              *otlpEndpoint,
-			interval:              *otlpInterval,
-			headers:               *otlpHeaders,
-			compression:           *otlpCompression,
-			timeout:               *otlpTimeout,
-			tlsSkipVerify:         *otlpTLSSkipVerify,
-			serviceName:           *otelServiceName,
-			serviceNamespace:      *otelServiceNamespace,
-			serviceVersion:        version,
-			serviceInstanceID:     *otelServiceInstanceID,
-			deploymentEnvironment: *deploymentEnvironment,
-		}), p.GetMetrics())
-		pusher.Start()
-		defer pusher.Stop()
-		logger.Info("otlp metrics push enabled",
-			"endpoint", *otlpEndpoint,
-			"interval", otlpInterval.String(),
-			"compression", *otlpCompression,
-		)
-	}
+	stopOTLP := startOTLPMetricsPusher(otlpRuntimeConfig{
+		endpoint:              *otlpEndpoint,
+		interval:              *otlpInterval,
+		headers:               *otlpHeaders,
+		compression:           *otlpCompression,
+		timeout:               *otlpTimeout,
+		tlsSkipVerify:         *otlpTLSSkipVerify,
+		serviceName:           *otelServiceName,
+		serviceNamespace:      *otelServiceNamespace,
+		serviceVersion:        version,
+		serviceInstanceID:     *otelServiceInstanceID,
+		deploymentEnvironment: *deploymentEnvironment,
+	}, p.GetMetrics(), logger, func(cfg metrics.OTLPConfig, m *metrics.Metrics) otlpMetricsPusher {
+		return metrics.NewOTLPPusher(cfg, m)
+	})
+	defer stopOTLP()
 
 	mux := http.NewServeMux()
 	p.RegisterRoutes(mux)
@@ -592,6 +592,20 @@ func buildOTLPConfig(cfg otlpRuntimeConfig) metrics.OTLPConfig {
 		ServiceInstanceID:     cfg.serviceInstanceID,
 		DeploymentEnvironment: cfg.deploymentEnvironment,
 	}
+}
+
+func startOTLPMetricsPusher(cfg otlpRuntimeConfig, m *metrics.Metrics, logger *slog.Logger, newPusher otlpPusherFactory) func() {
+	if strings.TrimSpace(cfg.endpoint) == "" {
+		return func() {}
+	}
+	pusher := newPusher(buildOTLPConfig(cfg), m)
+	pusher.Start()
+	logger.Info("otlp metrics push enabled",
+		"endpoint", cfg.endpoint,
+		"interval", cfg.interval.String(),
+		"compression", cfg.compression,
+	)
+	return pusher.Stop
 }
 
 func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
@@ -124,6 +125,15 @@ type serverLoopOptions struct {
 	backendURL  string
 	tlsCertFile string
 	tlsKeyFile  string
+}
+
+type loggerConfig struct {
+	level                 string
+	serviceName           string
+	serviceNamespace      string
+	serviceVersion        string
+	serviceInstanceID     string
+	deploymentEnvironment string
 }
 
 type reloadableProxy interface {
@@ -257,13 +267,13 @@ func main() {
 	*otelServiceInstanceID = envCfg.serviceInstanceID
 	*deploymentEnvironment = envCfg.deploymentEnv
 
-	logger := observability.NewLogger(os.Stdout, observability.LoggerConfig{
-		Level:                 *logLevel,
-		ServiceName:           *otelServiceName,
-		ServiceNamespace:      *otelServiceNamespace,
-		ServiceVersion:        version,
-		ServiceInstanceID:     *otelServiceInstanceID,
-		DeploymentEnvironment: *deploymentEnvironment,
+	logger := buildLogger(os.Stdout, loggerConfig{
+		level:                 *logLevel,
+		serviceName:           *otelServiceName,
+		serviceNamespace:      *otelServiceNamespace,
+		serviceVersion:        version,
+		serviceInstanceID:     *otelServiceInstanceID,
+		deploymentEnvironment: *deploymentEnvironment,
 	})
 	slog.SetDefault(logger)
 	fatal := func(msg string, args ...any) {
@@ -410,6 +420,19 @@ func buildCacheLayer(ttl time.Duration, maxEntries int, diskCfg cache.DiskCacheC
 		"flush_interval", diskCfg.FlushInterval.String(),
 	)
 	return c, func() { _ = dc.Close() }, nil
+}
+
+func buildLogger(w io.Writer, cfg loggerConfig) *slog.Logger {
+	logger := observability.NewLogger(w, observability.LoggerConfig{
+		Level:                 cfg.level,
+		ServiceName:           cfg.serviceName,
+		ServiceNamespace:      cfg.serviceNamespace,
+		ServiceVersion:        cfg.serviceVersion,
+		ServiceInstanceID:     cfg.serviceInstanceID,
+		DeploymentEnvironment: cfg.deploymentEnvironment,
+	})
+	slog.SetDefault(logger)
+	return logger
 }
 
 func buildSignalChannels(notify signalNotifier) (chan os.Signal, chan os.Signal) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -106,6 +106,19 @@ type serverRuntimeOptions struct {
 	tlsRequireClientCert bool
 }
 
+type httpServer interface {
+	ListenAndServe() error
+	ListenAndServeTLS(certFile, keyFile string) error
+	Shutdown(ctx context.Context) error
+}
+
+type serverLoopOptions struct {
+	listenAddr  string
+	backendURL  string
+	tlsCertFile string
+	tlsKeyFile  string
+}
+
 type reloadableProxy interface {
 	ReloadTenantMap(map[string]proxy.TenantMapping)
 	ReloadFieldMappings([]proxy.FieldMapping)
@@ -380,19 +393,12 @@ func main() {
 	shutdownCh := make(chan os.Signal, 1)
 	signal.Notify(shutdownCh, syscall.SIGTERM, syscall.SIGINT)
 
-	go func() {
-		if *tlsCertFile != "" && *tlsKeyFile != "" {
-			logger.Info("proxy listening", "listen_address", *listenAddr, "backend_url", *backendURL, "tls", true)
-			if err := srv.ListenAndServeTLS(*tlsCertFile, *tlsKeyFile); err != nil && err != http.ErrServerClosed {
-				fatal("tls server failed", "error", err)
-			}
-		} else {
-			logger.Info("proxy listening", "listen_address", *listenAddr, "backend_url", *backendURL, "tls", false)
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				fatal("server failed", "error", err)
-			}
-		}
-	}()
+	go runServerLoop(srv, serverLoopOptions{
+		listenAddr:  *listenAddr,
+		backendURL:  *backendURL,
+		tlsCertFile: *tlsCertFile,
+		tlsKeyFile:  *tlsKeyFile,
+	}, logger, fatal)
 
 	sig := <-shutdownCh
 	logger.Info("shutdown requested", "signal", sig.String())
@@ -702,6 +708,21 @@ func buildHTTPServer(opts serverRuntimeOptions) (*http.Server, error) {
 		srv.TLSConfig = tlsCfg
 	}
 	return srv, nil
+}
+
+func runServerLoop(srv httpServer, opts serverLoopOptions, logger *slog.Logger, fatal func(string, ...any)) {
+	if opts.tlsCertFile != "" && opts.tlsKeyFile != "" {
+		logger.Info("proxy listening", "listen_address", opts.listenAddr, "backend_url", opts.backendURL, "tls", true)
+		if err := srv.ListenAndServeTLS(opts.tlsCertFile, opts.tlsKeyFile); err != nil && err != http.ErrServerClosed {
+			fatal("tls server failed", "error", err)
+		}
+		return
+	}
+
+	logger.Info("proxy listening", "listen_address", opts.listenAddr, "backend_url", opts.backendURL, "tls", false)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		fatal("server failed", "error", err)
+	}
 }
 
 func reloadDynamicConfig(p reloadableProxy, getenv func(string) string, logger *slog.Logger) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -251,29 +251,14 @@ func main() {
 		serviceInstanceID: *otelServiceInstanceID,
 		deploymentEnv:     *deploymentEnvironment,
 	}, os.Getenv)
-	*listenAddr = envCfg.listenAddr
-	*backendURL = envCfg.backendURL
-	*rulerBackendURL = envCfg.rulerBackendURL
-	*alertsBackendURL = envCfg.alertsBackendURL
-	*tenantMapJSON = envCfg.tenantMapJSON
-	*otlpEndpoint = envCfg.otlpEndpoint
-	*otlpCompression = envCfg.otlpCompression
-	*otlpHeaders = envCfg.otlpHeaders
-	*labelStyle = envCfg.labelStyle
-	*fieldMappingJSON = envCfg.fieldMappingJSON
-	*metadataFieldMode = envCfg.metadataFieldMode
-	*otelServiceName = envCfg.serviceName
-	*otelServiceNamespace = envCfg.serviceNamespace
-	*otelServiceInstanceID = envCfg.serviceInstanceID
-	*deploymentEnvironment = envCfg.deploymentEnv
 
 	logger := buildLogger(os.Stdout, loggerConfig{
 		level:                 *logLevel,
-		serviceName:           *otelServiceName,
-		serviceNamespace:      *otelServiceNamespace,
+		serviceName:           envCfg.serviceName,
+		serviceNamespace:      envCfg.serviceNamespace,
 		serviceVersion:        version,
-		serviceInstanceID:     *otelServiceInstanceID,
-		deploymentEnvironment: *deploymentEnvironment,
+		serviceInstanceID:     envCfg.serviceInstanceID,
+		deploymentEnvironment: envCfg.deploymentEnv,
 	})
 	slog.SetDefault(logger)
 	fatal := func(msg string, args ...any) {
@@ -293,12 +278,12 @@ func main() {
 	defer cacheCleanup()
 
 	proxyCfg, err := buildProxyConfig(proxyRuntimeConfig{
-		backendURL:               *backendURL,
-		rulerBackendURL:          *rulerBackendURL,
-		alertsBackendURL:         *alertsBackendURL,
+		backendURL:               envCfg.backendURL,
+		rulerBackendURL:          envCfg.rulerBackendURL,
+		alertsBackendURL:         envCfg.alertsBackendURL,
 		cache:                    c,
 		logLevel:                 *logLevel,
-		tenantMapJSON:            *tenantMapJSON,
+		tenantMapJSON:            envCfg.tenantMapJSON,
 		maxLines:                 *maxLines,
 		backendTimeout:           *backendTimeout,
 		backendBasicAuth:         *backendBasicAuth,
@@ -318,9 +303,9 @@ func main() {
 		metricsMaxTenants:        *metricsMaxTenants,
 		metricsMaxClients:        *metricsMaxClients,
 		metricsTrustProxyHeaders: *metricsTrustProxyHeaders,
-		labelStyle:               *labelStyle,
-		metadataFieldMode:        *metadataFieldMode,
-		fieldMappingJSON:         *fieldMappingJSON,
+		labelStyle:               envCfg.labelStyle,
+		metadataFieldMode:        envCfg.metadataFieldMode,
+		fieldMappingJSON:         envCfg.fieldMappingJSON,
 		streamFieldsCSV:          *streamFieldsCSV,
 		peerSelf:                 *peerSelf,
 		peerDiscovery:            *peerDiscovery,
@@ -341,17 +326,17 @@ func main() {
 	p.Init()
 
 	stopOTLP := startOTLPMetricsPusher(otlpRuntimeConfig{
-		endpoint:              *otlpEndpoint,
+		endpoint:              envCfg.otlpEndpoint,
 		interval:              *otlpInterval,
-		headers:               *otlpHeaders,
-		compression:           *otlpCompression,
+		headers:               envCfg.otlpHeaders,
+		compression:           envCfg.otlpCompression,
 		timeout:               *otlpTimeout,
 		tlsSkipVerify:         *otlpTLSSkipVerify,
-		serviceName:           *otelServiceName,
-		serviceNamespace:      *otelServiceNamespace,
+		serviceName:           envCfg.serviceName,
+		serviceNamespace:      envCfg.serviceNamespace,
 		serviceVersion:        version,
-		serviceInstanceID:     *otelServiceInstanceID,
-		deploymentEnvironment: *deploymentEnvironment,
+		serviceInstanceID:     envCfg.serviceInstanceID,
+		deploymentEnvironment: envCfg.deploymentEnv,
 	}, p.GetMetrics(), logger, func(cfg metrics.OTLPConfig, m *metrics.Metrics) otlpMetricsPusher {
 		return metrics.NewOTLPPusher(cfg, m)
 	})
@@ -365,7 +350,7 @@ func main() {
 
 	// Hardened HTTP server with timeouts
 	srv, err := buildHTTPServer(serverRuntimeOptions{
-		listenAddr:           *listenAddr,
+		listenAddr:           envCfg.listenAddr,
 		handler:              handler,
 		readTimeout:          *readTimeout,
 		writeTimeout:         *writeTimeout,
@@ -384,8 +369,8 @@ func main() {
 
 	// Graceful shutdown on SIGTERM/SIGINT
 	go runServerLoop(srv, serverLoopOptions{
-		listenAddr:  *listenAddr,
-		backendURL:  *backendURL,
+		listenAddr:  envCfg.listenAddr,
+		backendURL:  envCfg.backendURL,
 		tlsCertFile: *tlsCertFile,
 		tlsKeyFile:  *tlsKeyFile,
 	}, logger, fatal)

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -37,13 +37,22 @@ type fakeReloadableProxy struct {
 type fakeHTTPServer struct {
 	listenErr      error
 	listenTLSErr   error
+	shutdownErr    error
 	listenCalls    int
 	listenTLSCalls int
+	shutdownCalls  int
 }
 
 type fakeOTLPPusher struct {
 	started bool
 	stopped bool
+}
+
+type runtimeRecorder struct {
+	options runtimeOptions
+	called  bool
+	runtime *runtimeState
+	err     error
 }
 
 func (f *fakeReloadableProxy) ReloadTenantMap(m map[string]proxy.TenantMapping) {
@@ -65,12 +74,18 @@ func (f *fakeHTTPServer) ListenAndServeTLS(_, _ string) error {
 }
 
 func (f *fakeHTTPServer) Shutdown(context.Context) error {
-	return nil
+	f.shutdownCalls++
+	return f.shutdownErr
 }
 
 func (f *fakeOTLPPusher) Start() { f.started = true }
 
 func (f *fakeOTLPPusher) Stop() { f.stopped = true }
+
+func (r *runtimeRecorder) build(_ runtimeOptions, _ *slog.Logger, _ signalNotifier, _ otlpPusherFactory) (*runtimeState, error) {
+	r.called = true
+	return r.runtime, r.err
+}
 
 func TestBuildLogger(t *testing.T) {
 	buf := &bytes.Buffer{}
@@ -91,6 +106,111 @@ func TestBuildLogger(t *testing.T) {
 		if !strings.Contains(logs, want) {
 			t.Fatalf("expected %q in %s", want, logs)
 		}
+	}
+}
+
+func TestRun_Success(t *testing.T) {
+	reloadCh := make(chan os.Signal)
+	close(reloadCh)
+	shutdownCh := make(chan os.Signal, 1)
+	shutdownCh <- syscall.SIGTERM
+	srv := &fakeHTTPServer{}
+	recorder := &runtimeRecorder{
+		runtime: &runtimeState{
+			proxy:        &proxy.Proxy{},
+			server:       srv,
+			cacheCleanup: func() {},
+			stopOTLP:     func() {},
+			reloadCh:     reloadCh,
+			shutdownCh:   shutdownCh,
+		},
+	}
+	var gotLoopOpts serverLoopOptions
+	var shutdownCalled bool
+	loopDone := make(chan struct{})
+
+	err := run([]string{
+		"-listen", ":9999",
+		"-backend", "http://backend.test",
+		"-response-gzip=false",
+		"-tail.mode=synthetic",
+	}, func(key string) string {
+		if key == "OTEL_SERVICE_NAME" {
+			return "custom-proxy"
+		}
+		return ""
+	}, io.Discard, func(chan<- os.Signal, ...os.Signal) {}, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		return &fakeOTLPPusher{}
+	}, func(opts runtimeOptions, logger *slog.Logger, notify signalNotifier, newPusher otlpPusherFactory) (*runtimeState, error) {
+		recorder.options = opts
+		return recorder.build(opts, logger, notify, newPusher)
+	}, func(_ httpServer, opts serverLoopOptions, _ *slog.Logger, _ func(string, ...any)) {
+		gotLoopOpts = opts
+		close(loopDone)
+	}, func(ch <-chan os.Signal, _ httpServer, _ time.Duration, _ *slog.Logger) {
+		shutdownCalled = true
+		<-ch
+	})
+	if err != nil {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+	if !recorder.called {
+		t.Fatal("expected runtime builder to be called")
+	}
+	if recorder.options.proxyCfg.backendURL != "http://backend.test" {
+		t.Fatalf("unexpected backend URL: %+v", recorder.options.proxyCfg)
+	}
+	if recorder.options.proxyCfg.tailMode != "synthetic" || recorder.options.enableGzip {
+		t.Fatalf("unexpected parsed runtime options: %+v", recorder.options)
+	}
+	if recorder.options.serverOpts.listenAddr != ":9999" {
+		t.Fatalf("unexpected listen addr: %+v", recorder.options.serverOpts)
+	}
+	if recorder.options.otlpCfg.serviceName != "custom-proxy" {
+		t.Fatalf("expected env override to apply, got %+v", recorder.options.otlpCfg)
+	}
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("expected server loop to be invoked")
+	}
+	if gotLoopOpts.listenAddr != ":9999" || gotLoopOpts.backendURL != "http://backend.test" {
+		t.Fatalf("unexpected server loop options: %+v", gotLoopOpts)
+	}
+	if !shutdownCalled {
+		t.Fatal("expected shutdown handler to be called")
+	}
+}
+
+func TestRun_ParseError(t *testing.T) {
+	err := run([]string{"-unknown-flag"}, func(string) string { return "" }, io.Discard, func(chan<- os.Signal, ...os.Signal) {}, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		return &fakeOTLPPusher{}
+	}, func(runtimeOptions, *slog.Logger, signalNotifier, otlpPusherFactory) (*runtimeState, error) {
+		t.Fatal("runtime builder should not be called on parse error")
+		return nil, nil
+	}, func(httpServer, serverLoopOptions, *slog.Logger, func(string, ...any)) {
+		t.Fatal("server loop should not be called on parse error")
+	}, func(<-chan os.Signal, httpServer, time.Duration, *slog.Logger) {
+		t.Fatal("shutdown handler should not be called on parse error")
+	})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestRun_RuntimeInitError(t *testing.T) {
+	wantErr := errors.New("boom")
+	err := run([]string{}, func(string) string { return "" }, io.Discard, func(chan<- os.Signal, ...os.Signal) {}, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		return &fakeOTLPPusher{}
+	}, func(runtimeOptions, *slog.Logger, signalNotifier, otlpPusherFactory) (*runtimeState, error) {
+		return nil, wantErr
+	}, func(httpServer, serverLoopOptions, *slog.Logger, func(string, ...any)) {
+		t.Fatal("server loop should not run when runtime init fails")
+	}, func(<-chan os.Signal, httpServer, time.Duration, *slog.Logger) {
+		t.Fatal("shutdown handler should not run when runtime init fails")
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to initialize runtime") {
+		t.Fatalf("expected wrapped runtime init error, got %v", err)
 	}
 }
 
@@ -837,6 +957,174 @@ func TestBuildSignalChannels(t *testing.T) {
 	}
 }
 
+func TestBuildRuntime_Success(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	var notifyCalls int
+	fake := &fakeOTLPPusher{}
+
+	rt, err := buildRuntime(runtimeOptions{
+		cacheTTL: 10 * time.Second,
+		cacheMax: 50,
+		proxyCfg: proxyRuntimeConfig{
+			backendURL:               "http://example.com",
+			logLevel:                 "info",
+			registerInstrumentation:  boolPtr(true),
+			labelStyle:               "passthrough",
+			metadataFieldMode:        "hybrid",
+			metricsMaxTenants:        10,
+			metricsMaxClients:        10,
+			metricsTrustProxyHeaders: false,
+		},
+		otlpCfg: otlpRuntimeConfig{
+			endpoint:    "http://collector:4318/v1/metrics",
+			interval:    5 * time.Second,
+			compression: "gzip",
+			serviceName: "proxy",
+		},
+		maxBodyBytes: 1024,
+		enableGzip:   true,
+		serverOpts: serverRuntimeOptions{
+			listenAddr:     ":0",
+			readTimeout:    time.Second,
+			writeTimeout:   2 * time.Second,
+			idleTimeout:    3 * time.Second,
+			maxHeaderBytes: 4096,
+		},
+	}, logger, func(ch chan<- os.Signal, _ ...os.Signal) {
+		notifyCalls++
+	}, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		return fake
+	})
+	if err != nil {
+		t.Fatalf("unexpected buildRuntime error: %v", err)
+	}
+	defer rt.cacheCleanup()
+	defer rt.stopOTLP()
+
+	if rt.proxy == nil || rt.server == nil {
+		t.Fatalf("expected initialized runtime, got %+v", rt)
+	}
+	if rt.reloadCh == nil || rt.shutdownCh == nil {
+		t.Fatalf("expected signal channels, got %+v", rt)
+	}
+	if notifyCalls != 2 {
+		t.Fatalf("expected 2 signal registrations, got %d", notifyCalls)
+	}
+	if !fake.started {
+		t.Fatal("expected OTLP pusher to be started")
+	}
+	if !strings.Contains(buf.String(), "proxy listening") && !strings.Contains(buf.String(), "otlp metrics push enabled") {
+		t.Fatalf("expected startup logs, got %s", buf.String())
+	}
+}
+
+func TestBuildRuntime_ProxyConfigError(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	_, err := buildRuntime(runtimeOptions{
+		cacheTTL: 10 * time.Second,
+		cacheMax: 50,
+		proxyCfg: proxyRuntimeConfig{
+			backendURL:        "http://example.com",
+			labelStyle:        "bad",
+			metadataFieldMode: "hybrid",
+		},
+		serverOpts: serverRuntimeOptions{listenAddr: ":0"},
+	}, logger, func(chan<- os.Signal, ...os.Signal) {}, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		return &fakeOTLPPusher{}
+	})
+	if err == nil || !strings.Contains(err.Error(), "build proxy config") {
+		t.Fatalf("expected build proxy config error, got %v", err)
+	}
+}
+
+func TestBuildRuntime_HTTPServerErrorStopsOTLP(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	fake := &fakeOTLPPusher{}
+
+	_, err := buildRuntime(runtimeOptions{
+		cacheTTL: 10 * time.Second,
+		cacheMax: 50,
+		proxyCfg: proxyRuntimeConfig{
+			backendURL:               "http://example.com",
+			logLevel:                 "info",
+			registerInstrumentation:  boolPtr(true),
+			labelStyle:               "passthrough",
+			metadataFieldMode:        "hybrid",
+			metricsMaxTenants:        10,
+			metricsMaxClients:        10,
+			metricsTrustProxyHeaders: false,
+		},
+		otlpCfg: otlpRuntimeConfig{
+			endpoint: "http://collector:4318/v1/metrics",
+		},
+		serverOpts: serverRuntimeOptions{
+			listenAddr:           ":0",
+			tlsRequireClientCert: true,
+		},
+	}, logger, func(chan<- os.Signal, ...os.Signal) {}, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		return fake
+	})
+	if err == nil || !strings.Contains(err.Error(), "build http server") {
+		t.Fatalf("expected build http server error, got %v", err)
+	}
+	if !fake.started || !fake.stopped {
+		t.Fatalf("expected OTLP pusher start+stop on server build error, got started=%v stopped=%v", fake.started, fake.stopped)
+	}
+}
+
+func TestHandleShutdown(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	srv := &fakeHTTPServer{}
+	shutdownCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+
+	go func() {
+		handleShutdown(shutdownCh, srv, time.Second, logger)
+		close(done)
+	}()
+
+	shutdownCh <- syscall.SIGTERM
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleShutdown did not return")
+	}
+
+	if srv.shutdownCalls != 1 {
+		t.Fatalf("expected shutdown to be called once, got %d", srv.shutdownCalls)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "shutdown requested") || !strings.Contains(logs, "shutdown complete") {
+		t.Fatalf("expected shutdown logs, got %s", logs)
+	}
+}
+
+func TestHandleShutdown_LogsShutdownError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	srv := &fakeHTTPServer{shutdownErr: errors.New("boom")}
+	shutdownCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+
+	go func() {
+		handleShutdown(shutdownCh, srv, time.Second, logger)
+		close(done)
+	}()
+
+	shutdownCh <- syscall.SIGINT
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleShutdown did not return")
+	}
+
+	if !strings.Contains(buf.String(), "http shutdown error") {
+		t.Fatalf("expected shutdown error log, got %s", buf.String())
+	}
+}
+
 func TestWatchReloadSignals(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(buf, nil))
@@ -946,3 +1234,5 @@ func writeTestCA(t *testing.T) string {
 	}
 	return path
 }
+
+func boolPtr(v bool) *bool { return &v }

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -17,8 +17,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -545,6 +547,63 @@ func TestBuildHTTPServer_WithTLSClientCA(t *testing.T) {
 	}
 }
 
+func TestBuildCacheLayer_WithoutDiskCache(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+
+	c, cleanup, err := buildCacheLayer(15*time.Second, 123, cache.DiskCacheConfig{}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+
+	if c == nil {
+		t.Fatal("expected in-memory cache")
+	}
+	if got := buf.String(); strings.Contains(got, "disk cache enabled") {
+		t.Fatalf("did not expect disk cache log, got %s", got)
+	}
+}
+
+func TestBuildCacheLayer_WithDiskCache(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+
+	c, cleanup, err := buildCacheLayer(15*time.Second, 123, cache.DiskCacheConfig{
+		Path:          filepath.Join(t.TempDir(), "cache.db"),
+		Compression:   true,
+		FlushSize:     7,
+		FlushInterval: 2 * time.Second,
+	}, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+
+	if c == nil {
+		t.Fatal("expected cache with disk layer")
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "disk cache enabled") || !strings.Contains(logs, "\"flush_size\":7") {
+		t.Fatalf("expected disk cache startup log, got %s", logs)
+	}
+}
+
+func TestBuildCacheLayer_InvalidDiskCache(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	if _, cleanup, err := buildCacheLayer(15*time.Second, 123, cache.DiskCacheConfig{
+		Path:          t.TempDir(),
+		Compression:   true,
+		FlushSize:     7,
+		FlushInterval: 2 * time.Second,
+	}, logger); err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatal("expected invalid disk cache path error")
+	}
+}
+
 func TestRunServerLoop_UsesPlainHTTPByDefault(t *testing.T) {
 	srv := &fakeHTTPServer{}
 	buf := &bytes.Buffer{}
@@ -626,6 +685,48 @@ func TestRunServerLoop_IgnoresServerClosed(t *testing.T) {
 
 	if fatalCalls != 0 {
 		t.Fatalf("expected http.ErrServerClosed to be ignored, got %d fatal calls", fatalCalls)
+	}
+}
+
+func TestWatchReloadSignals(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	fake := &fakeReloadableProxy{}
+	reloadCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+
+	go func() {
+		watchReloadSignals(reloadCh, fake, func(key string) string {
+			switch key {
+			case "TENANT_MAP":
+				return `{"team-a":{"account_id":"1","project_id":"2"}}`
+			case "FIELD_MAPPING":
+				return `[{"vl_field":"service.name","loki_label":"service_name"}]`
+			default:
+				return ""
+			}
+		}, logger)
+		close(done)
+	}()
+
+	reloadCh <- syscall.SIGHUP
+	time.Sleep(50 * time.Millisecond)
+	signal.Stop(reloadCh)
+	close(reloadCh)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchReloadSignals did not stop")
+	}
+
+	if fake.tenantMap["team-a"] != (proxy.TenantMapping{AccountID: "1", ProjectID: "2"}) {
+		t.Fatalf("unexpected tenant map reload: %+v", fake.tenantMap)
+	}
+	if len(fake.fieldMappings) != 1 || fake.fieldMappings[0].VLField != "service.name" {
+		t.Fatalf("unexpected field mapping reload: %+v", fake.fieldMappings)
+	}
+	if !strings.Contains(buf.String(), "received sighup, reloading configuration") {
+		t.Fatalf("expected reload signal log, got %s", buf.String())
 	}
 }
 

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -135,6 +135,16 @@ func TestBuildServerTLSConfig_VerifyIfGivenWhenOptional(t *testing.T) {
 	}
 }
 
+func TestBuildServerTLSConfig_MissingFile(t *testing.T) {
+	cfg, err := buildServerTLSConfig(filepath.Join(t.TempDir(), "missing.pem"), false)
+	if err == nil {
+		t.Fatal("expected missing file error")
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config on missing file")
+	}
+}
+
 func TestParseCSV(t *testing.T) {
 	got := parseCSV(" foo,bar ,, baz ")
 	want := []string{"foo", "bar", "baz"}
@@ -164,6 +174,13 @@ func TestParseHeaderMapCSV(t *testing.T) {
 	}
 	if parseHeaderMapCSV("") != nil {
 		t.Fatal("expected nil for empty header map")
+	}
+}
+
+func TestParseHeaderMapCSV_DuplicateKeysLastWins(t *testing.T) {
+	got := parseHeaderMapCSV("X-Scope-OrgID=team-a, X-Scope-OrgID=team-b")
+	if got["X-Scope-OrgID"] != "team-b" {
+		t.Fatalf("expected last duplicate header value to win, got %+v", got)
 	}
 }
 
@@ -751,6 +768,50 @@ func TestRunServerLoop_IgnoresServerClosed(t *testing.T) {
 
 	if fatalCalls != 0 {
 		t.Fatalf("expected http.ErrServerClosed to be ignored, got %d fatal calls", fatalCalls)
+	}
+}
+
+func TestRunServerLoop_IgnoresTLSServerClosed(t *testing.T) {
+	srv := &fakeHTTPServer{listenTLSErr: http.ErrServerClosed}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	var fatalCalls int
+
+	runServerLoop(srv, serverLoopOptions{
+		listenAddr:  ":3100",
+		backendURL:  "http://backend",
+		tlsCertFile: "server.crt",
+		tlsKeyFile:  "server.key",
+	}, logger, func(string, ...any) {
+		fatalCalls++
+	})
+
+	if fatalCalls != 0 {
+		t.Fatalf("expected tls http.ErrServerClosed to be ignored, got %d fatal calls", fatalCalls)
+	}
+}
+
+func TestBuildSignalChannels(t *testing.T) {
+	type notifyCall struct {
+		ch      chan<- os.Signal
+		signals []os.Signal
+	}
+	var calls []notifyCall
+
+	reloadCh, shutdownCh := buildSignalChannels(func(ch chan<- os.Signal, sigs ...os.Signal) {
+		calls = append(calls, notifyCall{ch: ch, signals: sigs})
+	})
+
+	if reloadCh == nil || shutdownCh == nil {
+		t.Fatal("expected signal channels")
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 notify calls, got %d", len(calls))
+	}
+	if len(calls[0].signals) != 1 || calls[0].signals[0] != syscall.SIGHUP {
+		t.Fatalf("unexpected reload signals: %+v", calls[0].signals)
+	}
+	if len(calls[1].signals) != 2 || calls[1].signals[0] != syscall.SIGTERM || calls[1].signals[1] != syscall.SIGINT {
+		t.Fatalf("unexpected shutdown signals: %+v", calls[1].signals)
 	}
 }
 

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -9,8 +9,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"errors"
 	"encoding/pem"
+	"errors"
 	"io"
 	"log/slog"
 	"math/big"
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/szibis/Loki-VL-proxy/internal/cache"
+	"github.com/szibis/Loki-VL-proxy/internal/metrics"
 	"github.com/szibis/Loki-VL-proxy/internal/proxy"
 )
 
@@ -34,10 +35,15 @@ type fakeReloadableProxy struct {
 }
 
 type fakeHTTPServer struct {
-	listenErr     error
-	listenTLSErr  error
-	listenCalls   int
+	listenErr      error
+	listenTLSErr   error
+	listenCalls    int
 	listenTLSCalls int
+}
+
+type fakeOTLPPusher struct {
+	started bool
+	stopped bool
 }
 
 func (f *fakeReloadableProxy) ReloadTenantMap(m map[string]proxy.TenantMapping) {
@@ -61,6 +67,10 @@ func (f *fakeHTTPServer) ListenAndServeTLS(_, _ string) error {
 func (f *fakeHTTPServer) Shutdown(context.Context) error {
 	return nil
 }
+
+func (f *fakeOTLPPusher) Start() { f.started = true }
+
+func (f *fakeOTLPPusher) Stop() { f.stopped = true }
 
 func TestBuildServerTLSConfig_RequiresCAWhenClientCertsRequired(t *testing.T) {
 	cfg, err := buildServerTLSConfig("", true)
@@ -230,6 +240,62 @@ func TestBuildOTLPConfig(t *testing.T) {
 	}
 	if cfg.ServiceName != "proxy" || cfg.ServiceNamespace != "platform" || cfg.ServiceVersion != "v1.2.3" || cfg.ServiceInstanceID != "proxy-1" || cfg.DeploymentEnvironment != "prod" {
 		t.Fatalf("unexpected resource attributes: %+v", cfg)
+	}
+}
+
+func TestStartOTLPMetricsPusher_NoEndpointIsNoop(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	called := false
+
+	stop := startOTLPMetricsPusher(otlpRuntimeConfig{}, metrics.NewMetrics(), logger, func(metrics.OTLPConfig, *metrics.Metrics) otlpMetricsPusher {
+		called = true
+		return &fakeOTLPPusher{}
+	})
+	stop()
+
+	if called {
+		t.Fatal("expected no pusher to be created when OTLP endpoint is empty")
+	}
+}
+
+func TestStartOTLPMetricsPusher_StartsAndStops(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	m := metrics.NewMetrics()
+	var gotCfg metrics.OTLPConfig
+	fake := &fakeOTLPPusher{}
+
+	stop := startOTLPMetricsPusher(otlpRuntimeConfig{
+		endpoint:              "http://collector:4318/v1/metrics",
+		interval:              12 * time.Second,
+		headers:               "Authorization=Bearer abc",
+		compression:           "gzip",
+		timeout:               5 * time.Second,
+		tlsSkipVerify:         true,
+		serviceName:           "proxy",
+		serviceNamespace:      "platform",
+		serviceVersion:        "v1.2.3",
+		serviceInstanceID:     "proxy-1",
+		deploymentEnvironment: "prod",
+	}, m, logger, func(cfg metrics.OTLPConfig, gotM *metrics.Metrics) otlpMetricsPusher {
+		gotCfg = cfg
+		if gotM != m {
+			t.Fatalf("expected metrics pointer to be preserved")
+		}
+		return fake
+	})
+	if !fake.started {
+		t.Fatal("expected OTLP pusher to start")
+	}
+	stop()
+	if !fake.stopped {
+		t.Fatal("expected OTLP pusher stop func to stop the pusher")
+	}
+	if gotCfg.Endpoint != "http://collector:4318/v1/metrics" || gotCfg.Compression != "gzip" {
+		t.Fatalf("unexpected OTLP config: %+v", gotCfg)
+	}
+	if !strings.Contains(buf.String(), "otlp metrics push enabled") {
+		t.Fatalf("expected OTLP startup log, got %s", buf.String())
 	}
 }
 

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -72,6 +72,28 @@ func (f *fakeOTLPPusher) Start() { f.started = true }
 
 func (f *fakeOTLPPusher) Stop() { f.stopped = true }
 
+func TestBuildLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := buildLogger(buf, loggerConfig{
+		level:                 "debug",
+		serviceName:           "proxy",
+		serviceNamespace:      "platform",
+		serviceVersion:        "v1.2.3",
+		serviceInstanceID:     "proxy-1",
+		deploymentEnvironment: "prod",
+	})
+	if logger == nil {
+		t.Fatal("expected logger")
+	}
+	logger.Info("hello")
+	logs := buf.String()
+	for _, want := range []string{"\"service.name\":\"proxy\"", "\"service.version\":\"v1.2.3\"", "\"deployment.environment.name\":\"prod\"", "\"body\":\"hello\""} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected %q in %s", want, logs)
+		}
+	}
+}
+
 func TestBuildServerTLSConfig_RequiresCAWhenClientCertsRequired(t *testing.T) {
 	cfg, err := buildServerTLSConfig("", true)
 	if err == nil {

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"encoding/pem"
 	"io"
 	"log/slog"
@@ -29,12 +31,33 @@ type fakeReloadableProxy struct {
 	fieldMappings []proxy.FieldMapping
 }
 
+type fakeHTTPServer struct {
+	listenErr     error
+	listenTLSErr  error
+	listenCalls   int
+	listenTLSCalls int
+}
+
 func (f *fakeReloadableProxy) ReloadTenantMap(m map[string]proxy.TenantMapping) {
 	f.tenantMap = m
 }
 
 func (f *fakeReloadableProxy) ReloadFieldMappings(m []proxy.FieldMapping) {
 	f.fieldMappings = m
+}
+
+func (f *fakeHTTPServer) ListenAndServe() error {
+	f.listenCalls++
+	return f.listenErr
+}
+
+func (f *fakeHTTPServer) ListenAndServeTLS(_, _ string) error {
+	f.listenTLSCalls++
+	return f.listenTLSErr
+}
+
+func (f *fakeHTTPServer) Shutdown(context.Context) error {
+	return nil
 }
 
 func TestBuildServerTLSConfig_RequiresCAWhenClientCertsRequired(t *testing.T) {
@@ -519,6 +542,90 @@ func TestBuildHTTPServer_WithTLSClientCA(t *testing.T) {
 	}
 	if srv.TLSConfig == nil || srv.TLSConfig.ClientAuth != tls.RequireAndVerifyClientCert {
 		t.Fatalf("expected client-auth TLS config, got %+v", srv.TLSConfig)
+	}
+}
+
+func TestRunServerLoop_UsesPlainHTTPByDefault(t *testing.T) {
+	srv := &fakeHTTPServer{}
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	var fatalCalls int
+
+	runServerLoop(srv, serverLoopOptions{
+		listenAddr: ":3100",
+		backendURL: "http://backend",
+	}, logger, func(string, ...any) {
+		fatalCalls++
+	})
+
+	if srv.listenCalls != 1 || srv.listenTLSCalls != 0 {
+		t.Fatalf("expected plain HTTP listen path, got listen=%d tls=%d", srv.listenCalls, srv.listenTLSCalls)
+	}
+	if fatalCalls != 0 {
+		t.Fatalf("expected no fatal calls, got %d", fatalCalls)
+	}
+	if !strings.Contains(buf.String(), `"tls":false`) {
+		t.Fatalf("expected non-TLS startup log, got %s", buf.String())
+	}
+}
+
+func TestRunServerLoop_UsesTLSWhenCertAndKeyConfigured(t *testing.T) {
+	srv := &fakeHTTPServer{}
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	var fatalCalls int
+
+	runServerLoop(srv, serverLoopOptions{
+		listenAddr:  ":3100",
+		backendURL:  "http://backend",
+		tlsCertFile: "server.crt",
+		tlsKeyFile:  "server.key",
+	}, logger, func(string, ...any) {
+		fatalCalls++
+	})
+
+	if srv.listenCalls != 0 || srv.listenTLSCalls != 1 {
+		t.Fatalf("expected TLS listen path, got listen=%d tls=%d", srv.listenCalls, srv.listenTLSCalls)
+	}
+	if fatalCalls != 0 {
+		t.Fatalf("expected no fatal calls, got %d", fatalCalls)
+	}
+	if !strings.Contains(buf.String(), `"tls":true`) {
+		t.Fatalf("expected TLS startup log, got %s", buf.String())
+	}
+}
+
+func TestRunServerLoop_ReportsServerFailure(t *testing.T) {
+	srv := &fakeHTTPServer{listenErr: errors.New("boom")}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	var fatalMsg string
+
+	runServerLoop(srv, serverLoopOptions{
+		listenAddr: ":3100",
+		backendURL: "http://backend",
+	}, logger, func(msg string, _ ...any) {
+		fatalMsg = msg
+	})
+
+	if fatalMsg != "server failed" {
+		t.Fatalf("expected server failure message, got %q", fatalMsg)
+	}
+}
+
+func TestRunServerLoop_IgnoresServerClosed(t *testing.T) {
+	srv := &fakeHTTPServer{listenErr: http.ErrServerClosed}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	var fatalCalls int
+
+	runServerLoop(srv, serverLoopOptions{
+		listenAddr: ":3100",
+		backendURL: "http://backend",
+	}, logger, func(string, ...any) {
+		fatalCalls++
+	})
+
+	if fatalCalls != 0 {
+		t.Fatalf("expected http.ErrServerClosed to be ignored, got %d fatal calls", fatalCalls)
 	}
 }
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues & VL Compatibility Gaps
 
-Last updated: v0.26.1
+Last updated: main
 
 ## Remaining Behavioral Differences
 
@@ -21,6 +21,24 @@ The proxy now supports datasource-facing headers, cookie forwarding, backend tim
 |---|---|
 | Alerting / ruler APIs | Read-path compatibility covers legacy Loki YAML rules routes plus Prometheus-style JSON rules and alerts, but Loki ruler write APIs and full rule lifecycle semantics are still incomplete |
 | Browser-origin tailing | `/loki/api/v1/tail` rejects browser `Origin` headers unless explicitly allowlisted via `-tail.allowed-origins` |
+
+## Remaining `/tail` Gaps
+
+`/loki/api/v1/tail` is now covered by handler tests plus compose-backed native and synthetic streaming e2e, but a few real-world gaps remain:
+
+- reverse-proxy and ingress websocket idle-timeout behavior still needs dedicated e2e
+- browser-path Grafana Explore live-tail coverage should be run in CI consistently, not just locally or in ad hoc compose runs
+- backend-native close/error propagation still needs broader coverage for `401`, `403`, and upstream `5xx`
+- `/tail` remains intentionally single-tenant; Loki-style `tenant-a|tenant-b` fanout and `__tenant_id__` filtering are not supported there
+
+## Remaining Multi-Tenant Gaps
+
+Read/query fanout now supports Loki-style `X-Scope-OrgID: tenant-a|tenant-b` plus `__tenant_id__` selector narrowing, but some edges still need tightening:
+
+- more live e2e for `/labels`, `/label/{name}/values`, `/series`, `detected_fields`, and `detected_labels` under fanout
+- Drilldown and Explore browser coverage for multi-tenant datasources still trails the API/resource coverage
+- merged field/label cardinality across tenants is still approximate in a few Drilldown-oriented surfaces
+- `*` remains a proxy-specific default/global bypass mode, not a Loki-compatible all-tenants shorthand
 
 ## Data Model Differences
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,3 +69,7 @@
 - [ ] Full Loki ruler / alerting API semantics beyond read-path compatibility and backend passthrough
 - [x] PR quality report workflow with coverage, compatibility, and performance delta comments (v0.26.0)
 - [ ] Raise total repository coverage toward 95%+ by extracting `main()` and remaining low-level system readers into smaller testable units
+- [ ] Finish `/tail` browser and ops compatibility: browser CI coverage, reverse-proxy websocket behavior, and backend close/error parity
+- [ ] Expand live multi-tenant Explore and Drilldown coverage for `__tenant_id__`, labels, series, and detected field/label surfaces
+- [ ] Convert more upstream Loki, Logs Drilldown, and VictoriaLogs edge cases into regression tests
+- [ ] Push `cmd/proxy` coverage further by extracting more startup/config/runtime wiring out of `main()`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ go test -v -tags=e2e -run '^TestLokiTrackScore$' ./test/e2e-compat/
 go test -v -tags=e2e -run '^TestDrilldownTrackScore$' ./test/e2e-compat/
 go test -v -tags=e2e -run '^TestVLTrackScore$' ./test/e2e-compat/
 
-# Playwright UI tests (Grafana Explore, drill-down, error handling)
+# Playwright UI tests (Grafana Explore, drill-down, live tail, error handling)
 cd test/e2e-ui
 npm install && npx playwright install chromium
 npm test
@@ -48,7 +48,7 @@ Exact counts move often. Treat the categories below as the stable map of what is
 | Query normalization | 8 | Canonicalization for cache keys |
 | Cache behavior | 6 | Hit/miss/TTL/eviction/protection |
 | Multitenancy | 4 | String->int mapping, numeric passthrough, unmapped default |
-| WebSocket tail | 2 | Query validation, WebSocket frame structure |
+| WebSocket tail | 4+ | Query validation, origin policy, native live frames, synthetic live streaming |
 | Disk cache (L2) | 12 | Set/get, TTL, compression, persistence, stats |
 | OTLP pusher | 4 | Push, custom headers, error handling, payload structure |
 | Hardening | 4 | Query length limit, limit sanitization, security headers |
@@ -80,7 +80,7 @@ Exact counts move often. Treat the categories below as the stable map of what is
 | `test/e2e-compat/` | Docker-based Loki vs proxy comparison |
 | `test/e2e-compat/drilldown_compat_test.go` | Grafana Logs Drilldown resource contracts via Grafana datasource proxy |
 | `test/e2e-compat/features_test.go` | Live Grafana-facing edge cases including multi-tenant `__tenant_id__` and Drilldown level-filter regressions |
-| `test/e2e-ui/` | Playwright browser tests against Grafana |
+| `test/e2e-ui/` | Playwright browser tests against Grafana Explore and Logs Drilldown |
 
 ## Compatibility Tracks
 
@@ -129,7 +129,7 @@ Pull requests also get a dedicated `pr-quality-report.yaml` workflow. It compare
 - Loki / Logs Drilldown / VictoriaLogs compatibility deltas
 - sampled benchmark and load-test deltas
 
-That report is informational by design. It highlights regressions early, but merge gating still comes from the required check set in repository settings.
+That report is part of the required PR gate. It is still a smoke signal rather than a full benchmark lab run, but it now blocks obvious regressions in coverage, compatibility, and the tracked performance signals.
 
 See [compatibility-matrix.md](/tmp/Loki-VL-proxy/docs/compatibility-matrix.md), [compatibility-loki.md](/tmp/Loki-VL-proxy/docs/compatibility-loki.md), [compatibility-drilldown.md](/tmp/Loki-VL-proxy/docs/compatibility-drilldown.md), [compatibility-victorialogs.md](/tmp/Loki-VL-proxy/docs/compatibility-victorialogs.md), and [compatibility-matrix.json](/tmp/Loki-VL-proxy/test/e2e-compat/compatibility-matrix.json).
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -172,7 +172,8 @@ const (
 	// maxQueryLength limits the LogQL query string length to prevent abuse.
 	maxQueryLength = 65536 // 64KB
 	// maxLimitValue caps the number of results per query.
-	maxLimitValue = 10000
+	maxLimitValue    = 10000
+	tailWriteTimeout = 2 * time.Second
 )
 
 // CacheTTLs defines per-endpoint cache TTLs.
@@ -220,6 +221,12 @@ type Proxy struct {
 	tailAllowedOrigins       map[string]struct{}
 	tailMode                 TailMode
 	metricsTrustProxyHeaders bool
+}
+
+type tailConn interface {
+	SetWriteDeadline(time.Time) error
+	WriteMessage(int, []byte) error
+	WriteControl(int, []byte, time.Time) error
 }
 
 func New(cfg Config) (*Proxy, error) {
@@ -1961,7 +1968,7 @@ func (p *Proxy) handleTail(w http.ResponseWriter, r *http.Request) {
 	p.log.Debug("tail connected", "logql", logqlQuery, "logsql", logsqlQuery, "native", nativeTail, "fallback", fallbackReason)
 	if !nativeTail {
 		if p.tailMode == TailModeNative {
-			_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, fallbackReason), time.Now().Add(time.Second))
+			_ = p.writeTailControl(conn, websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, fallbackReason))
 			return
 		}
 		p.streamSyntheticTail(wsCtx, conn, logsqlQuery, r.FormValue("start"))
@@ -1991,7 +1998,7 @@ func (p *Proxy) handleTail(w http.ResponseWriter, r *http.Request) {
 		case <-wsCtx.Done():
 			return
 		case <-pingTicker.C:
-			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			if err := p.writeTailMessage(conn, websocket.PingMessage, nil); err != nil {
 				p.log.Debug("websocket ping failed, client disconnected", "error", err)
 				return
 			}
@@ -2018,7 +2025,7 @@ func (p *Proxy) handleTail(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			if err := conn.WriteMessage(websocket.TextMessage, frameJSON); err != nil {
+			if err := p.writeTailMessage(conn, websocket.TextMessage, frameJSON); err != nil {
 				p.log.Debug("websocket write failed, client disconnected", "error", err)
 				return
 			}
@@ -2091,7 +2098,7 @@ func (p *Proxy) openNativeTailStream(parent context.Context, logsqlQuery string)
 	return nil, false, fmt.Sprintf("backend tail unavailable: %s", msg)
 }
 
-func (p *Proxy) streamSyntheticTail(ctx context.Context, conn *websocket.Conn, logsqlQuery, startHint string) {
+func (p *Proxy) streamSyntheticTail(ctx context.Context, conn tailConn, logsqlQuery, startHint string) {
 	lastSeen := make(map[string]struct{}, 128)
 	windowStart := time.Now().Add(-5 * time.Second)
 	if parsed, ok := parseEntryTime(startHint); ok {
@@ -2114,7 +2121,7 @@ func (p *Proxy) streamSyntheticTail(ctx context.Context, conn *websocket.Conn, l
 	}
 }
 
-func (p *Proxy) writeSyntheticTailBatch(ctx context.Context, conn *websocket.Conn, logsqlQuery string, windowStart *time.Time, lastSeen map[string]struct{}) error {
+func (p *Proxy) writeSyntheticTailBatch(ctx context.Context, conn tailConn, logsqlQuery string, windowStart *time.Time, lastSeen map[string]struct{}) error {
 	params := url.Values{}
 	params.Set("query", logsqlQuery+" | sort by (_time)")
 	params.Set("start", formatVLTimestamp(windowStart.UTC().Format(time.RFC3339Nano)))
@@ -2161,7 +2168,7 @@ func (p *Proxy) writeSyntheticTailBatch(ctx context.Context, conn *websocket.Con
 		if err != nil {
 			continue
 		}
-		if err := conn.WriteMessage(websocket.TextMessage, frameJSON); err != nil {
+		if err := p.writeTailMessage(conn, websocket.TextMessage, frameJSON); err != nil {
 			return err
 		}
 	}
@@ -2174,6 +2181,21 @@ func (p *Proxy) writeSyntheticTailBatch(ctx context.Context, conn *websocket.Con
 		clear(lastSeen)
 	}
 	return nil
+}
+
+func (p *Proxy) writeTailMessage(conn tailConn, messageType int, data []byte) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(tailWriteTimeout)); err != nil {
+		return err
+	}
+	return conn.WriteMessage(messageType, data)
+}
+
+func (p *Proxy) writeTailControl(conn tailConn, messageType int, data []byte) error {
+	deadline := time.Now().Add(tailWriteTimeout)
+	if err := conn.SetWriteDeadline(deadline); err != nil {
+		return err
+	}
+	return conn.WriteControl(messageType, data, deadline)
 }
 
 // vlLineToTailFrame converts a single VL NDJSON log line to a Loki tail WebSocket frame.

--- a/internal/proxy/tail_hardening_test.go
+++ b/internal/proxy/tail_hardening_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -272,5 +273,52 @@ func TestTailHardening_ForcedSyntheticModeSkipsNativeTail(t *testing.T) {
 	}
 	if _, ok := frame["streams"]; !ok {
 		t.Fatalf("expected Loki tail frame from synthetic mode, got %v", frame)
+	}
+}
+
+func TestTailHardening_NativeModeReturnsBackendFailureReason(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/tail":
+			http.Error(w, "upstream tail forbidden", http.StatusForbidden)
+		case "/select/logsql/query":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{BackendURL: vlBackend.URL, Cache: c, LogLevel: "error", TailMode: TailModeNative})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(p.handleTail))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "?query={app%3D%22nginx%22}"
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	ws, resp, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial failed: %v (resp=%v)", err, resp)
+	}
+	defer ws.Close()
+	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+
+	_, _, err = ws.ReadMessage()
+	if err == nil {
+		t.Fatal("expected websocket close on native backend failure")
+	}
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("expected websocket close error, got %v", err)
+	}
+	if closeErr.Code != websocket.CloseInternalServerErr {
+		t.Fatalf("expected internal server close code, got %d", closeErr.Code)
+	}
+	if !strings.Contains(closeErr.Text, "upstream tail forbidden") {
+		t.Fatalf("expected backend failure reason in close message, got %q", closeErr.Text)
 	}
 }

--- a/internal/proxy/tail_hardening_test.go
+++ b/internal/proxy/tail_hardening_test.go
@@ -14,6 +14,36 @@ import (
 	"github.com/szibis/Loki-VL-proxy/internal/cache"
 )
 
+type fakeTailConn struct {
+	deadline        time.Time
+	setDeadlineErr  error
+	writeMessageErr error
+	writeControlErr error
+	writeType       int
+	writePayload    []byte
+	controlType     int
+	controlPayload  []byte
+	controlDeadline time.Time
+}
+
+func (f *fakeTailConn) SetWriteDeadline(t time.Time) error {
+	f.deadline = t
+	return f.setDeadlineErr
+}
+
+func (f *fakeTailConn) WriteMessage(messageType int, data []byte) error {
+	f.writeType = messageType
+	f.writePayload = append([]byte(nil), data...)
+	return f.writeMessageErr
+}
+
+func (f *fakeTailConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	f.controlType = messageType
+	f.controlPayload = append([]byte(nil), data...)
+	f.controlDeadline = deadline
+	return f.writeControlErr
+}
+
 func TestTailHardening_RejectsBrowserOriginsByDefault(t *testing.T) {
 	var backendCalls int
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -320,5 +350,91 @@ func TestTailHardening_NativeModeReturnsBackendFailureReason(t *testing.T) {
 	}
 	if !strings.Contains(closeErr.Text, "upstream tail forbidden") {
 		t.Fatalf("expected backend failure reason in close message, got %q", closeErr.Text)
+	}
+}
+
+func TestTailHardening_WriteTailMessageSetsDeadline(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	conn := &fakeTailConn{}
+
+	if err := p.writeTailMessage(conn, websocket.TextMessage, []byte("payload")); err != nil {
+		t.Fatalf("unexpected writeTailMessage error: %v", err)
+	}
+	if conn.writeType != websocket.TextMessage {
+		t.Fatalf("expected text message, got %d", conn.writeType)
+	}
+	if string(conn.writePayload) != "payload" {
+		t.Fatalf("unexpected payload %q", string(conn.writePayload))
+	}
+	if conn.deadline.IsZero() {
+		t.Fatal("expected write deadline to be set")
+	}
+	if time.Until(conn.deadline) <= 0 {
+		t.Fatalf("expected future write deadline, got %v", conn.deadline)
+	}
+}
+
+func TestTailHardening_WriteTailControlSetsDeadline(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	conn := &fakeTailConn{}
+
+	if err := p.writeTailControl(conn, websocket.CloseMessage, []byte("bye")); err != nil {
+		t.Fatalf("unexpected writeTailControl error: %v", err)
+	}
+	if conn.controlType != websocket.CloseMessage {
+		t.Fatalf("expected close control frame, got %d", conn.controlType)
+	}
+	if string(conn.controlPayload) != "bye" {
+		t.Fatalf("unexpected control payload %q", string(conn.controlPayload))
+	}
+	if conn.deadline.IsZero() || conn.controlDeadline.IsZero() {
+		t.Fatal("expected control deadlines to be set")
+	}
+}
+
+func TestTailHardening_WriteTailMessagePropagatesDeadlineError(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	conn := &fakeTailConn{setDeadlineErr: errors.New("deadline failed")}
+
+	if err := p.writeTailMessage(conn, websocket.TextMessage, []byte("payload")); err == nil {
+		t.Fatal("expected deadline error")
+	}
+}
+
+func TestTailHardening_WriteTailControlPropagatesWriteError(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	conn := &fakeTailConn{writeControlErr: errors.New("slow control writer")}
+
+	err := p.writeTailControl(conn, websocket.CloseMessage, []byte("bye"))
+	if err == nil || !strings.Contains(err.Error(), "slow control writer") {
+		t.Fatalf("expected control write error, got %v", err)
+	}
+	if conn.deadline.IsZero() || conn.controlDeadline.IsZero() {
+		t.Fatal("expected deadlines to be set before control write")
+	}
+}
+
+func TestTailHardening_WriteSyntheticTailBatchPropagatesSlowWriterError(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/query":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			fmt.Fprintln(w, `{"_time":"2024-01-15T10:30:00Z","_msg":"test log line","app":"nginx"}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	conn := &fakeTailConn{writeMessageErr: errors.New("slow writer")}
+	windowStart := time.Date(2024, 1, 15, 10, 29, 0, 0, time.UTC)
+
+	err := p.writeSyntheticTailBatch(t.Context(), conn, `{app="nginx"}`, &windowStart, map[string]struct{}{})
+	if err == nil || !strings.Contains(err.Error(), "slow writer") {
+		t.Fatalf("expected slow writer error, got %v", err)
+	}
+	if conn.deadline.IsZero() {
+		t.Fatal("expected write deadline to be set before synthetic tail write")
 	}
 }

--- a/scripts/ci/check_quality_gate.py
+++ b/scripts/ci/check_quality_gate.py
@@ -71,7 +71,7 @@ def main():
         )
 
     threshold = 5.0
-    cpu_threshold = 8.0
+    cpu_threshold = 10.0
     benchmarks = (
         ("query_range_cache_hit_ns_per_op", "QueryRange cache-hit CPU cost", "lower", cpu_threshold),
         ("query_range_cache_hit_bytes_per_op", "QueryRange cache-hit memory", "lower", threshold),
@@ -102,7 +102,7 @@ def main():
         float(base["performance"]["load"]["high_concurrency_req_per_s"]),
         float(head["performance"]["load"]["high_concurrency_req_per_s"]),
         "higher",
-        15.0,
+        10.0,
     )
     check_threshold(
         failures,

--- a/test/e2e-compat/compat_extended_test.go
+++ b/test/e2e-compat/compat_extended_test.go
@@ -850,7 +850,7 @@ func TestExtended_WithoutGrouping(t *testing.T) {
 }
 
 // =============================================================================
-// on()/ignoring()/group_left() live compatibility smoke
+// on()/ignoring()/group_left()/group_right() live compatibility smoke
 // =============================================================================
 
 func TestExtended_OnGrouping(t *testing.T) {
@@ -911,6 +911,27 @@ func TestExtended_GroupLeftJoin(t *testing.T) {
 		score.pass("group_left", "proxy returns success for group_left() join")
 	} else {
 		score.fail("group_left", "proxy error on group_left() join")
+	}
+
+	score.report(t)
+}
+
+func TestExtended_GroupRightJoin(t *testing.T) {
+	ensureDataIngested(t)
+	score := &CompatScore{}
+	now := time.Now()
+
+	params := url.Values{}
+	params.Set("query", `sum by (app, level) (count_over_time({cluster="us-east-1", level="error"}[5m])) * on(app) group_right(pod) sum by (app, pod) (count_over_time({cluster="us-east-1"}[5m]))`)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-10*time.Minute).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("step", "60")
+
+	proxyResp := getJSON(t, proxyURL+"/loki/api/v1/query_range?"+params.Encode())
+	if checkStatus(proxyResp) {
+		score.pass("group_right", "proxy returns success for group_right() join")
+	} else {
+		score.fail("group_right", "proxy error on group_right() join")
 	}
 
 	score.report(t)

--- a/test/e2e-compat/compat_extended_test.go
+++ b/test/e2e-compat/compat_extended_test.go
@@ -848,3 +848,70 @@ func TestExtended_WithoutGrouping(t *testing.T) {
 
 	score.report(t)
 }
+
+// =============================================================================
+// on()/ignoring()/group_left() live compatibility smoke
+// =============================================================================
+
+func TestExtended_OnGrouping(t *testing.T) {
+	ensureDataIngested(t)
+	score := &CompatScore{}
+	now := time.Now()
+
+	params := url.Values{}
+	params.Set("query", `sum by (app, pod) (count_over_time({cluster="us-east-1"}[5m])) / on(app) sum by (app) (count_over_time({cluster="us-east-1", level="error"}[5m]))`)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-10*time.Minute).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("step", "60")
+
+	proxyResp := getJSON(t, proxyURL+"/loki/api/v1/query_range?"+params.Encode())
+	if checkStatus(proxyResp) {
+		score.pass("on_grouping", "proxy returns success for on() grouping")
+	} else {
+		score.fail("on_grouping", "proxy error on on() grouping")
+	}
+
+	score.report(t)
+}
+
+func TestExtended_IgnoringGrouping(t *testing.T) {
+	ensureDataIngested(t)
+	score := &CompatScore{}
+	now := time.Now()
+
+	params := url.Values{}
+	params.Set("query", `sum by (app, level) (count_over_time({app="api-gateway"}[5m])) / ignoring(level) sum by (app) (count_over_time({app="api-gateway"}[5m]))`)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-10*time.Minute).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("step", "60")
+
+	proxyResp := getJSON(t, proxyURL+"/loki/api/v1/query_range?"+params.Encode())
+	if checkStatus(proxyResp) {
+		score.pass("ignoring_grouping", "proxy returns success for ignoring() grouping")
+	} else {
+		score.fail("ignoring_grouping", "proxy error on ignoring() grouping")
+	}
+
+	score.report(t)
+}
+
+func TestExtended_GroupLeftJoin(t *testing.T) {
+	ensureDataIngested(t)
+	score := &CompatScore{}
+	now := time.Now()
+
+	params := url.Values{}
+	params.Set("query", `sum by (app, pod) (count_over_time({cluster="us-east-1"}[5m])) * on(app) group_left(level) sum by (app, level) (count_over_time({cluster="us-east-1", level="error"}[5m]))`)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-10*time.Minute).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("step", "60")
+
+	proxyResp := getJSON(t, proxyURL+"/loki/api/v1/query_range?"+params.Encode())
+	if checkStatus(proxyResp) {
+		score.pass("group_left", "proxy returns success for group_left() join")
+	} else {
+		score.fail("group_left", "proxy error on group_left() join")
+	}
+
+	score.report(t)
+}

--- a/test/e2e-compat/compat_test.go
+++ b/test/e2e-compat/compat_test.go
@@ -36,6 +36,7 @@ var (
 	proxyURL     = envOr("PROXY_URL", "http://localhost:3100")
 	tailProxyURL = envOr("TAIL_PROXY_URL", "http://localhost:3103")
 	tailIngressURL = envOr("TAIL_INGRESS_URL", "http://localhost:3104")
+	tailNativeURL = envOr("TAIL_NATIVE_URL", "http://localhost:3105")
 	vlURL        = envOr("VL_URL", "http://localhost:9428")
 )
 

--- a/test/e2e-compat/compat_test.go
+++ b/test/e2e-compat/compat_test.go
@@ -35,6 +35,7 @@ var (
 	lokiURL      = envOr("LOKI_URL", "http://localhost:3101")
 	proxyURL     = envOr("PROXY_URL", "http://localhost:3100")
 	tailProxyURL = envOr("TAIL_PROXY_URL", "http://localhost:3103")
+	tailIngressURL = envOr("TAIL_INGRESS_URL", "http://localhost:3104")
 	vlURL        = envOr("VL_URL", "http://localhost:9428")
 )
 

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -154,6 +154,35 @@ services:
       retries: 10
       start_period: 5s
 
+  loki-vl-proxy-tail-native:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: e2e-proxy-tail-native
+    ports:
+      - "3105:3100"
+    command:
+      - "-listen=:3100"
+      - "-backend=http://victorialogs:9428"
+      - "-ruler-backend=http://vmalert:8880"
+      - "-alerts-backend=http://vmalert:8880"
+      - "-log-level=debug"
+      - "-cache-ttl=5s"
+      - "-label-style=underscores"
+      - "-tail.mode=native"
+      - "-tail.allowed-origins=http://grafana:3000,http://127.0.0.1:3002,http://localhost:3002"
+    depends_on:
+      victorialogs:
+        condition: service_healthy
+      vmalert:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:3100/ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   tail-ingress:
     image: nginx:1.27-alpine
     container_name: e2e-tail-ingress
@@ -189,6 +218,7 @@ services:
       - loki-vl-proxy
       - loki-vl-proxy-underscore
       - loki-vl-proxy-tail
+      - loki-vl-proxy-tail-native
       - tail-ingress
 
 volumes:

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -154,6 +154,23 @@ services:
       retries: 10
       start_period: 5s
 
+  tail-ingress:
+    image: nginx:1.27-alpine
+    container_name: e2e-tail-ingress
+    ports:
+      - "3104:8080"
+    volumes:
+      - ./nginx-tail.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      loki-vl-proxy-tail:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:8080/ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   # Grafana with 3 datasources for manual side-by-side comparison
   grafana:
     image: ${GRAFANA_IMAGE:-grafana/grafana:12.4.2}
@@ -172,6 +189,7 @@ services:
       - loki-vl-proxy
       - loki-vl-proxy-underscore
       - loki-vl-proxy-tail
+      - tail-ingress
 
 volumes:
   vl-data:

--- a/test/e2e-compat/drilldown_compat_test.go
+++ b/test/e2e-compat/drilldown_compat_test.go
@@ -536,5 +536,34 @@ func TestDrilldown_GrafanaResourceContracts(t *testing.T) {
 		if data == nil || len(extractArray(data, "result")) == 0 {
 			t.Fatalf("expected multi-tenant index/volume through Grafana resource, got %v", volumeResp)
 		}
+
+		fieldValuesResp := getJSON(t, grafanaURL+"/api/datasources/uid/"+multiUID+"/resources/detected_field/method/values?"+valueParams.Encode())
+		fieldValues, _ := fieldValuesResp["values"].([]interface{})
+		if len(fieldValues) == 0 {
+			t.Fatalf("expected multi-tenant detected_field values through Grafana resource, got %v", fieldValuesResp)
+		}
+
+		labelValuesResp := getJSON(t, grafanaURL+"/api/datasources/uid/"+multiUID+"/resources/label/cluster/values?"+valueParams.Encode())
+		labelValues, _ := labelValuesResp["data"].([]interface{})
+		if len(labelValues) == 0 {
+			t.Fatalf("expected multi-tenant label values through Grafana resource, got %v", labelValuesResp)
+		}
+
+		labelsListResp := getJSON(t, grafanaURL+"/api/datasources/uid/"+multiUID+"/resources/labels?"+valueParams.Encode())
+		labelsList, _ := labelsListResp["data"].([]interface{})
+		if len(labelsList) == 0 {
+			t.Fatalf("expected multi-tenant labels resource through Grafana resource, got %v", labelsListResp)
+		}
+		seenLabels := map[string]bool{}
+		for _, item := range labelsList {
+			if label, ok := item.(string); ok {
+				seenLabels[label] = true
+			}
+		}
+		for _, want := range []string{"cluster", "__tenant_id__"} {
+			if !seenLabels[want] {
+				t.Fatalf("expected multi-tenant labels resource to include %q, got %v", want, labelsListResp)
+			}
+		}
 	})
 }

--- a/test/e2e-compat/features_test.go
+++ b/test/e2e-compat/features_test.go
@@ -534,6 +534,38 @@ func TestFeature_Tail_SyntheticProxyAllowsConfiguredOriginAndStreamsLiveData(t *
 	}
 }
 
+func TestFeature_Tail_SyntheticProxySurvivesIdleWindow(t *testing.T) {
+	now := time.Now()
+	app := fmt.Sprintf("tail-idle-%d", now.UnixNano())
+	msg := "idle tail frame " + app
+
+	params := url.Values{}
+	params.Set("query", fmt.Sprintf(`{app="%s"}`, app))
+	params.Set("start", fmt.Sprintf("%d", now.UnixNano()))
+
+	headers := http.Header{}
+	headers.Set("Origin", "http://127.0.0.1:3002")
+	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	conn, resp, err := dialer.Dial("ws"+strings.TrimPrefix(tailProxyURL, "http")+"/loki/api/v1/tail?"+params.Encode(), headers)
+	if err != nil {
+		t.Fatalf("synthetic proxy websocket dial failed: %v (resp=%v)", err, resp)
+	}
+	defer conn.Close()
+
+	time.Sleep(4 * time.Second)
+	pushCustomToVL(t, time.Now().Add(500*time.Millisecond), map[string]string{
+		"app":   app,
+		"env":   "test",
+		"level": "info",
+	}, []logLine{{Msg: msg, Level: "info"}}, []string{"app", "env", "level"})
+
+	frame := readTailFrame(t, conn, msg, 10*time.Second)
+	streams, ok := frame["streams"].([]interface{})
+	if !ok || len(streams) == 0 {
+		t.Fatalf("expected idle tail frame with streams, got %v", frame)
+	}
+}
+
 func TestFeature_Tail_ReverseProxyIngressStreamsLiveData(t *testing.T) {
 	now := time.Now()
 	app := fmt.Sprintf("tail-ingress-%d", now.UnixNano())
@@ -562,6 +594,28 @@ func TestFeature_Tail_ReverseProxyIngressStreamsLiveData(t *testing.T) {
 	streams, ok := frame["streams"].([]interface{})
 	if !ok || len(streams) == 0 {
 		t.Fatalf("expected ingress tail frame with streams, got %v", frame)
+	}
+}
+
+func TestFeature_Tail_NativeModeClosesWhenBackendTailUnavailable(t *testing.T) {
+	params := url.Values{}
+	params.Set("query", `{app="api-gateway"}`)
+
+	headers := http.Header{}
+	headers.Set("Origin", "http://127.0.0.1:3002")
+	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	conn, resp, err := dialer.Dial("ws"+strings.TrimPrefix(tailNativeURL, "http")+"/loki/api/v1/tail?"+params.Encode(), headers)
+	if err != nil {
+		t.Fatalf("native-only proxy websocket dial failed: %v (resp=%v)", err, resp)
+	}
+	defer conn.Close()
+
+	_, _, err = conn.ReadMessage()
+	if err == nil {
+		t.Fatal("expected native-only tail to close when backend native tail is unavailable")
+	}
+	if !websocket.IsCloseError(err, websocket.CloseInternalServerErr) {
+		t.Fatalf("expected internal server close for native-only tail fallback denial, got %v", err)
 	}
 }
 

--- a/test/e2e-compat/features_test.go
+++ b/test/e2e-compat/features_test.go
@@ -597,6 +597,82 @@ func TestFeature_Tail_ReverseProxyIngressStreamsLiveData(t *testing.T) {
 	}
 }
 
+func TestFeature_Tail_ReverseProxyIngressSurvivesIdleWindow(t *testing.T) {
+	now := time.Now()
+	app := fmt.Sprintf("tail-ingress-idle-%d", now.UnixNano())
+	msg := "ingress idle tail frame " + app
+
+	params := url.Values{}
+	params.Set("query", fmt.Sprintf(`{app="%s"}`, app))
+	params.Set("start", fmt.Sprintf("%d", now.UnixNano()))
+
+	headers := http.Header{}
+	headers.Set("Origin", "http://127.0.0.1:3002")
+	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	conn, resp, err := dialer.Dial("ws"+strings.TrimPrefix(tailIngressURL, "http")+"/loki/api/v1/tail?"+params.Encode(), headers)
+	if err != nil {
+		t.Fatalf("ingress websocket dial failed: %v (resp=%v)", err, resp)
+	}
+	defer conn.Close()
+
+	time.Sleep(4 * time.Second)
+	pushCustomToVL(t, time.Now().Add(500*time.Millisecond), map[string]string{
+		"app":   app,
+		"env":   "test",
+		"level": "info",
+	}, []logLine{{Msg: msg, Level: "info"}}, []string{"app", "env", "level"})
+
+	frame := readTailFrame(t, conn, msg, 10*time.Second)
+	streams, ok := frame["streams"].([]interface{})
+	if !ok || len(streams) == 0 {
+		t.Fatalf("expected ingress tail frame after idle window, got %v", frame)
+	}
+}
+
+func TestFeature_Tail_SyntheticProxyReconnectsCleanly(t *testing.T) {
+	app := fmt.Sprintf("tail-reconnect-%d", time.Now().UnixNano())
+
+	connect := func(start time.Time) *websocket.Conn {
+		t.Helper()
+		params := url.Values{}
+		params.Set("query", fmt.Sprintf(`{app="%s"}`, app))
+		params.Set("start", fmt.Sprintf("%d", start.UnixNano()))
+
+		headers := http.Header{}
+		headers.Set("Origin", "http://127.0.0.1:3002")
+		dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+		conn, resp, err := dialer.Dial("ws"+strings.TrimPrefix(tailProxyURL, "http")+"/loki/api/v1/tail?"+params.Encode(), headers)
+		if err != nil {
+			t.Fatalf("synthetic proxy websocket dial failed: %v (resp=%v)", err, resp)
+		}
+		return conn
+	}
+
+	firstConn := connect(time.Now())
+	firstMsg := "tail reconnect frame one " + app
+	pushCustomToVL(t, time.Now().Add(500*time.Millisecond), map[string]string{
+		"app":   app,
+		"env":   "test",
+		"level": "info",
+	}, []logLine{{Msg: firstMsg, Level: "info"}}, []string{"app", "env", "level"})
+	_ = readTailFrame(t, firstConn, firstMsg, 10*time.Second)
+	_ = firstConn.Close()
+
+	secondConn := connect(time.Now())
+	defer secondConn.Close()
+	secondMsg := "tail reconnect frame two " + app
+	pushCustomToVL(t, time.Now().Add(500*time.Millisecond), map[string]string{
+		"app":   app,
+		"env":   "test",
+		"level": "warn",
+	}, []logLine{{Msg: secondMsg, Level: "warn"}}, []string{"app", "env", "level"})
+	frame := readTailFrame(t, secondConn, secondMsg, 10*time.Second)
+	streams, ok := frame["streams"].([]interface{})
+	if !ok || len(streams) == 0 {
+		t.Fatalf("expected reconnect tail frame with streams, got %v", frame)
+	}
+}
+
 func TestFeature_Tail_NativeModeClosesWhenBackendTailUnavailable(t *testing.T) {
 	params := url.Values{}
 	params.Set("query", `{app="api-gateway"}`)

--- a/test/e2e-compat/features_test.go
+++ b/test/e2e-compat/features_test.go
@@ -345,6 +345,36 @@ func TestFeature_Multitenancy_FilteredLabelsSeriesAndDetectedFields(t *testing.T
 		}
 	}
 
+	regexSeriesParams := url.Values{}
+	regexSeriesParams.Add("match[]", `{app="api-gateway",__tenant_id__=~"f.*"}`)
+	regexSeriesResp := getJSONWithHeaders(t, proxyURL+"/loki/api/v1/series?"+regexSeriesParams.Encode(), headers)
+	regexSeries := extractArray(regexSeriesResp, "data")
+	if len(regexSeries) == 0 {
+		t.Fatalf("expected regex-filtered series data for multi-tenant request, got %v", regexSeriesResp)
+	}
+	for _, item := range regexSeries {
+		labels, _ := item.(map[string]interface{})
+		if labels["__tenant_id__"] != "fake" {
+			t.Fatalf("expected regex-filtered series __tenant_id__=fake, got %v", item)
+		}
+	}
+
+	labelValueResp := getJSONWithHeaders(t, proxyURL+"/loki/api/v1/label/cluster/values?query="+url.QueryEscape(`{app="api-gateway",__tenant_id__=~"f.*"}`), headers)
+	labelValues := extractArray(labelValueResp, "data")
+	if len(labelValues) == 0 {
+		t.Fatalf("expected cluster label values for regex-filtered multi-tenant request, got %v", labelValueResp)
+	}
+	foundCluster := false
+	for _, item := range labelValues {
+		if item == "us-east-1" {
+			foundCluster = true
+			break
+		}
+	}
+	if !foundCluster {
+		t.Fatalf("expected regex-filtered cluster label values to include us-east-1, got %v", labelValueResp)
+	}
+
 	singleFields := getJSONWithHeaders(t, proxyURL+"/loki/api/v1/detected_fields?query="+url.QueryEscape(`{app="api-gateway"}`)+"&start="+start+"&end="+end, map[string]string{"X-Scope-OrgID": "0"})
 	multiFields := getJSONWithHeaders(t, proxyURL+"/loki/api/v1/detected_fields?query="+url.QueryEscape(`{app="api-gateway"}`)+"&start="+start+"&end="+end, headers)
 	singleFieldItems := extractArray(singleFields, "fields")

--- a/test/e2e-compat/features_test.go
+++ b/test/e2e-compat/features_test.go
@@ -534,6 +534,37 @@ func TestFeature_Tail_SyntheticProxyAllowsConfiguredOriginAndStreamsLiveData(t *
 	}
 }
 
+func TestFeature_Tail_ReverseProxyIngressStreamsLiveData(t *testing.T) {
+	now := time.Now()
+	app := fmt.Sprintf("tail-ingress-%d", now.UnixNano())
+	msg := "ingress tail frame " + app
+
+	params := url.Values{}
+	params.Set("query", fmt.Sprintf(`{app="%s"}`, app))
+	params.Set("start", fmt.Sprintf("%d", now.UnixNano()))
+
+	headers := http.Header{}
+	headers.Set("Origin", "http://127.0.0.1:3002")
+	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	conn, resp, err := dialer.Dial("ws"+strings.TrimPrefix(tailIngressURL, "http")+"/loki/api/v1/tail?"+params.Encode(), headers)
+	if err != nil {
+		t.Fatalf("ingress websocket dial failed: %v (resp=%v)", err, resp)
+	}
+	defer conn.Close()
+
+	pushCustomToVL(t, now.Add(500*time.Millisecond), map[string]string{
+		"app":   app,
+		"env":   "test",
+		"level": "info",
+	}, []logLine{{Msg: msg, Level: "info"}}, []string{"app", "env", "level"})
+
+	frame := readTailFrame(t, conn, msg, 10*time.Second)
+	streams, ok := frame["streams"].([]interface{})
+	if !ok || len(streams) == 0 {
+		t.Fatalf("expected ingress tail frame with streams, got %v", frame)
+	}
+}
+
 // =============================================================================
 // Query Analytics (/debug/queries)
 // =============================================================================

--- a/test/e2e-compat/grafana-datasources.yaml
+++ b/test/e2e-compat/grafana-datasources.yaml
@@ -46,6 +46,28 @@ datasources:
     secureJsonData:
       httpHeaderValue1: "0"
 
+  - name: Loki (via ingress tail)
+    type: loki
+    access: proxy
+    url: http://tail-ingress:8080
+    isDefault: false
+    jsonData:
+      httpHeaderName1: X-Scope-OrgID
+      maxLines: 1000
+    secureJsonData:
+      httpHeaderValue1: "0"
+
+  - name: Loki (via VL proxy live tail native)
+    type: loki
+    access: proxy
+    url: http://loki-vl-proxy-tail-native:3100
+    isDefault: false
+    jsonData:
+      httpHeaderName1: X-Scope-OrgID
+      maxLines: 1000
+    secureJsonData:
+      httpHeaderValue1: "0"
+
   # 3. VictoriaLogs native datasource (for direct comparison)
   - name: VictoriaLogs (direct)
     type: victoriametrics-logs-datasource

--- a/test/e2e-compat/nginx-tail.conf
+++ b/test/e2e-compat/nginx-tail.conf
@@ -1,0 +1,27 @@
+events {}
+
+http {
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+  }
+
+  server {
+    listen 8080;
+
+    location /ready {
+      proxy_pass http://loki-vl-proxy-tail:3100/ready;
+    }
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_read_timeout 75s;
+      proxy_send_timeout 75s;
+      proxy_pass http://loki-vl-proxy-tail:3100;
+    }
+  }
+}

--- a/test/e2e-ui/tests/datasource.spec.ts
+++ b/test/e2e-ui/tests/datasource.spec.ts
@@ -109,7 +109,7 @@ test.describe("Grafana Datasource Health & Config", () => {
 
   test("direct Loki drilldown bootstrap endpoint works with tenant header", async ({ request }) => {
     const directLokiUrl =
-      process.env.DIRECT_LOKI_URL || "http://host.docker.internal:3101";
+      process.env.DIRECT_LOKI_URL || "http://127.0.0.1:3101";
     const limitsResponse = await request.get(
       `${directLokiUrl}/loki/api/v1/drilldown-limits`,
       {

--- a/test/e2e-ui/tests/explore.spec.ts
+++ b/test/e2e-ui/tests/explore.spec.ts
@@ -3,6 +3,8 @@ import {
   PROXY_DS,
   PROXY_MULTI_DS,
   PROXY_TAIL_DS,
+  PROXY_TAIL_INGRESS_DS,
+  PROXY_TAIL_NATIVE_DS,
   LOKI_DS,
   openExplore,
   typeQuery,
@@ -183,6 +185,56 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     await assertNoErrors(page);
     expect(errors).toHaveLength(0);
     expect(websockets.some((u) => u.includes("/tail") || u.includes("/api/live/ws"))).toBeTruthy();
+  });
+
+  test("live tail also works through the ingress datasource", async ({ page }) => {
+    const app = `ui-tail-ingress-${Date.now()}`;
+    const msg = `ui ingress tail frame ${app}`;
+    const errors = collectLokiErrors(page);
+
+    await openExplore(page, PROXY_TAIL_INGRESS_DS);
+    await waitForGrafanaReady(page);
+    await typeQuery(page, `{app="${app}"}`);
+
+    const liveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(liveButton).toBeVisible({ timeout: 15_000 });
+    await liveButton.click();
+
+    const payload = JSON.stringify({
+      _time: new Date().toISOString(),
+      _msg: msg,
+      app,
+      env: "test",
+      level: "info",
+    });
+    const pushResp = await page.request.post(
+      "http://127.0.0.1:9428/insert/jsonline?_stream_fields=app,env,level",
+      {
+        headers: { "Content-Type": "application/stream+json" },
+        data: `${payload}\n`,
+      }
+    );
+    expect(pushResp.ok()).toBeTruthy();
+
+    await expect(page.getByText(msg, { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+    await assertNoErrors(page);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("native-only tail datasource fails without crashing the UI", async ({ page }) => {
+    await openExplore(page, PROXY_TAIL_NATIVE_DS);
+    await waitForGrafanaReady(page);
+    await typeQuery(page, '{app="api-gateway"}');
+
+    const liveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(liveButton).toBeVisible({ timeout: 15_000 });
+    await liveButton.click();
+
+    await expect(page.getByText(/error|failed|unable/i).first()).toBeVisible({
+      timeout: 15_000,
+    });
   });
 });
 

--- a/test/e2e-ui/tests/explore.spec.ts
+++ b/test/e2e-ui/tests/explore.spec.ts
@@ -172,9 +172,9 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     await waitForGrafanaReady(page);
     await typeQuery(page, `{app="${app}"}`);
 
-    const liveButton = page.getByRole("button", { name: /live/i }).first();
-    await expect(liveButton).toBeVisible({ timeout: 15_000 });
-    await liveButton.click();
+    const recoveryLiveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(recoveryLiveButton).toBeVisible({ timeout: 15_000 });
+    await recoveryLiveButton.click();
 
     const payload = JSON.stringify({
       _time: new Date().toISOString(),
@@ -209,9 +209,9 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     await waitForGrafanaReady(page);
     await typeQuery(page, `{app="${app}"}`);
 
-    const liveButton = page.getByRole("button", { name: /live/i }).first();
-    await expect(liveButton).toBeVisible({ timeout: 15_000 });
-    await liveButton.click();
+    const recoveryLiveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(recoveryLiveButton).toBeVisible({ timeout: 15_000 });
+    await recoveryLiveButton.click();
 
     const payload = JSON.stringify({
       _time: new Date().toISOString(),
@@ -249,10 +249,35 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
       timeout: 15_000,
     });
 
-    await openExplore(page, PROXY_DS);
+    const recoveryApp = `ui-tail-recovery-${Date.now()}`;
+    const recoveryMsg = `ui tail recovery frame ${recoveryApp}`;
+
+    await openExplore(page, PROXY_TAIL_DS);
     await waitForGrafanaReady(page);
-    await typeQuery(page, '{app="api-gateway"}');
-    await runQuery(page);
+    await typeQuery(page, `{app="${recoveryApp}"}`);
+
+    const recoveryLiveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(recoveryLiveButton).toBeVisible({ timeout: 15_000 });
+    await recoveryLiveButton.click();
+
+    const pushResp = await page.request.post(
+      "http://127.0.0.1:9428/insert/jsonline?_stream_fields=app,env,level",
+      {
+        headers: { "Content-Type": "application/stream+json" },
+        data: `${JSON.stringify({
+          _time: new Date().toISOString(),
+          _msg: recoveryMsg,
+          app: recoveryApp,
+          env: "test",
+          level: "info",
+        })}\n`,
+      }
+    );
+    expect(pushResp.ok()).toBeTruthy();
+
+    await expect(page.getByText(recoveryMsg, { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
     await assertNoErrors(page);
   });
 });

--- a/test/e2e-ui/tests/explore.spec.ts
+++ b/test/e2e-ui/tests/explore.spec.ts
@@ -156,6 +156,19 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     expect(errors).toHaveLength(0);
   });
 
+  test("multi-tenant metric query with __tenant_id__ renders graph", async ({ page }) => {
+    await openExplore(page, PROXY_MULTI_DS);
+    await waitForGrafanaReady(page);
+
+    const errors = collectLokiErrors(page);
+    await typeQuery(page, 'sum(rate({app="api-gateway", __tenant_id__=~"f.*"}[5m])) by (level)');
+    await runQuery(page);
+
+    await assertNoErrors(page);
+    await assertGraphVisible(page);
+    expect(errors).toHaveLength(0);
+  });
+
   test("live tail works through the browser-allowed synthetic datasource", async ({
     page,
   }) => {

--- a/test/e2e-ui/tests/explore.spec.ts
+++ b/test/e2e-ui/tests/explore.spec.ts
@@ -143,6 +143,19 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     expect(errors).toHaveLength(0);
   });
 
+  test("multi-tenant line filter with __tenant_id__ works in Explore", async ({ page }) => {
+    await openExplore(page, PROXY_MULTI_DS);
+    await waitForGrafanaReady(page);
+
+    const errors = collectLokiErrors(page);
+    await typeQuery(page, '{app="api-gateway", __tenant_id__=~"f.*"} |= "error"');
+    await runQuery(page);
+
+    await assertNoErrors(page);
+    await assertLogsVisible(page);
+    expect(errors).toHaveLength(0);
+  });
+
   test("live tail works through the browser-allowed synthetic datasource", async ({
     page,
   }) => {
@@ -235,6 +248,12 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     await expect(page.getByText(/error|failed|unable/i).first()).toBeVisible({
       timeout: 15_000,
     });
+
+    await openExplore(page, PROXY_DS);
+    await waitForGrafanaReady(page);
+    await typeQuery(page, '{app="api-gateway"}');
+    await runQuery(page);
+    await assertNoErrors(page);
   });
 });
 

--- a/test/e2e-ui/tests/explore.spec.ts
+++ b/test/e2e-ui/tests/explore.spec.ts
@@ -169,6 +169,19 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     expect(errors).toHaveLength(0);
   });
 
+  test("multi-tenant json parser query with __tenant_id__ works in Explore", async ({ page }) => {
+    await openExplore(page, PROXY_MULTI_DS);
+    await waitForGrafanaReady(page);
+
+    const errors = collectLokiErrors(page);
+    await typeQuery(page, '{app="api-gateway", __tenant_id__=~"f.*"} | json');
+    await runQuery(page);
+
+    await assertNoErrors(page);
+    await assertLogsVisible(page);
+    expect(errors).toHaveLength(0);
+  });
+
   test("live tail works through the browser-allowed synthetic datasource", async ({
     page,
   }) => {

--- a/test/e2e-ui/tests/explore.spec.ts
+++ b/test/e2e-ui/tests/explore.spec.ts
@@ -293,6 +293,50 @@ test.describe("Grafana Explore — Proxy Datasource", () => {
     });
     await assertNoErrors(page);
   });
+
+  test("native-tail failure can recover through ingress live tail", async ({ page }) => {
+    await openExplore(page, PROXY_TAIL_NATIVE_DS);
+    await waitForGrafanaReady(page);
+    await typeQuery(page, '{app="api-gateway"}');
+
+    const liveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(liveButton).toBeVisible({ timeout: 15_000 });
+    await liveButton.click();
+    await expect(page.getByText(/error|failed|unable/i).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const ingressApp = `ui-tail-ingress-recovery-${Date.now()}`;
+    const ingressMsg = `ui ingress recovery frame ${ingressApp}`;
+
+    await openExplore(page, PROXY_TAIL_INGRESS_DS);
+    await waitForGrafanaReady(page);
+    await typeQuery(page, `{app="${ingressApp}"}`);
+
+    const ingressLiveButton = page.getByRole("button", { name: /live/i }).first();
+    await expect(ingressLiveButton).toBeVisible({ timeout: 15_000 });
+    await ingressLiveButton.click();
+
+    const pushResp = await page.request.post(
+      "http://127.0.0.1:9428/insert/jsonline?_stream_fields=app,env,level",
+      {
+        headers: { "Content-Type": "application/stream+json" },
+        data: `${JSON.stringify({
+          _time: new Date().toISOString(),
+          _msg: ingressMsg,
+          app: ingressApp,
+          env: "test",
+          level: "info",
+        })}\n`,
+      }
+    );
+    expect(pushResp.ok()).toBeTruthy();
+
+    await expect(page.getByText(ingressMsg, { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+    await assertNoErrors(page);
+  });
 });
 
 test.describe("Grafana Explore — Side-by-side Comparison", () => {

--- a/test/e2e-ui/tests/helpers.ts
+++ b/test/e2e-ui/tests/helpers.ts
@@ -4,6 +4,8 @@ import { Page, expect } from "@playwright/test";
 export const PROXY_DS = "Loki (via VL proxy)";
 export const PROXY_MULTI_DS = "Loki (via VL proxy multi-tenant)";
 export const PROXY_TAIL_DS = "Loki (via VL proxy live tail)";
+export const PROXY_TAIL_INGRESS_DS = "Loki (via ingress tail)";
+export const PROXY_TAIL_NATIVE_DS = "Loki (via VL proxy live tail native)";
 export const LOKI_DS = "Loki (direct)";
 
 // Grafana URLs

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -373,4 +373,16 @@ test.describe("Grafana Logs Drilldown", () => {
     await expect(page.getByText("No logs found")).toHaveCount(0);
     expect(errors).toHaveLength(0);
   });
+
+  test("multi-tenant service drilldown keeps method field filter working", async ({ page }) => {
+    const errors = collectLokiErrors(page);
+    await openServiceDrilldown(page, PROXY_MULTI_DS, "api-gateway", "logs");
+
+    await addDrilldownFilter(page, "Filter by fields", "method", "GET");
+    await expect(page.getByLabel("Remove filter with key method")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No logs found")).toHaveCount(0);
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -386,6 +386,22 @@ test.describe("Grafana Logs Drilldown", () => {
     expect(errors).toHaveLength(0);
   });
 
+  test("multi-tenant service drilldown supports combined label and field filters", async ({ page }) => {
+    const errors = collectLokiErrors(page);
+    await openServiceDrilldown(page, PROXY_MULTI_DS, "api-gateway", "logs");
+
+    await addDrilldownFilter(page, "Filter by labels", "cluster", "us-east-1");
+    await addDrilldownFilter(page, "Filter by fields", "method", "GET");
+    await expect(page.getByLabel("Remove filter with key cluster")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByLabel("Remove filter with key method")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No logs found")).toHaveCount(0);
+    expect(errors).toHaveLength(0);
+  });
+
   test("multi-tenant landing page can add and use a cluster breakdown tab", async ({ page }) => {
     const responses = await collectDrilldownResponses(page);
     const errors = collectLokiErrors(page);

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -361,4 +361,16 @@ test.describe("Grafana Logs Drilldown", () => {
     expect(errors).toHaveLength(0);
     expect(datasourceErrors).toHaveLength(0);
   });
+
+  test("multi-tenant service drilldown keeps cluster label filter working", async ({ page }) => {
+    const errors = collectLokiErrors(page);
+    await openServiceDrilldown(page, PROXY_MULTI_DS, "api-gateway", "logs");
+
+    await addDrilldownFilter(page, "Filter by labels", "cluster", "us-east-1");
+    await expect(page.getByLabel("Remove filter with key cluster")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No logs found")).toHaveCount(0);
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -425,4 +425,17 @@ test.describe("Grafana Logs Drilldown", () => {
     expect(volumeResponse).toBeTruthy();
     expect(JSON.stringify(volumeResponse?.json)).toContain("us-east-1");
   });
+
+  test("multi-tenant cluster drilldown keeps multiple selected levels working", async ({ page }) => {
+    const errors = collectLokiErrors(page);
+    await openLabelDrilldown(page, PROXY_MULTI_DS, "cluster", "us-east-1", [
+      "error",
+      "info",
+      "warn",
+    ]);
+
+    await expect(page.getByText("No logs found")).toHaveCount(0);
+    await expect(page.getByText(/Log volume/i)).toBeVisible({ timeout: 15_000 });
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -20,9 +20,9 @@ async function addDrilldownFilter(
   value: string
 ) {
   await page.getByRole("combobox", { name: comboName }).click();
-  await page.getByRole("option", { name: key, exact: true }).click();
-  await page.getByRole("option", { name: "= Equals", exact: true }).click();
-  await page.keyboard.type(value);
+  await selectComboboxOption(page, key);
+  await selectComboboxOption(page, "= Equals");
+  await typeIntoActiveCombobox(page, value);
   const valueOption = page.getByRole("option", { name: value, exact: true });
   if (await valueOption.isVisible({ timeout: 3_000 }).catch(() => false)) {
     await valueOption.click();
@@ -37,6 +37,46 @@ async function addDrilldownFilter(
     await page.keyboard.press("Enter");
   }
   await page.keyboard.press("Escape");
+}
+
+function escapeRegex(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function typeIntoActiveCombobox(page: Page, value: string) {
+  const input = page
+    .locator('[role="combobox"][aria-expanded="true"] input, input[aria-autocomplete="list"]')
+    .last();
+  if (await input.isVisible({ timeout: 500 }).catch(() => false)) {
+    await input.fill("");
+    await input.type(value, { delay: 10 });
+    return;
+  }
+  await page.keyboard.type(value, { delay: 10 });
+}
+
+async function selectComboboxOption(page: Page, optionLabel: string) {
+  const exactOption = page.getByRole("option", { name: optionLabel, exact: true });
+  if (await exactOption.isVisible({ timeout: 1_500 }).catch(() => false)) {
+    await exactOption.click();
+    return;
+  }
+
+  await typeIntoActiveCombobox(page, optionLabel);
+
+  const exactPattern = new RegExp(`^${escapeRegex(optionLabel)}$`, "i");
+  const searchableOption = page.getByRole("option", { name: exactPattern }).first();
+  if (await searchableOption.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await searchableOption.click();
+    return;
+  }
+
+  const fuzzyOption = page
+    .getByRole("option")
+    .filter({ hasText: optionLabel })
+    .first();
+  await expect(fuzzyOption).toBeVisible({ timeout: 5_000 });
+  await fuzzyOption.click();
 }
 
 async function openServiceDrilldown(

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -438,4 +438,20 @@ test.describe("Grafana Logs Drilldown", () => {
     await expect(page.getByText(/Log volume/i)).toBeVisible({ timeout: 15_000 });
     expect(errors).toHaveLength(0);
   });
+
+  test("multi-tenant cluster drilldown supports follow-up field filtering", async ({ page }) => {
+    const errors = collectLokiErrors(page);
+    await openLabelDrilldown(page, PROXY_MULTI_DS, "cluster", "us-east-1", [
+      "error",
+      "info",
+      "warn",
+    ]);
+
+    await addDrilldownFilter(page, "Filter by fields", "method", "GET");
+    await expect(page.getByLabel("Remove filter with key method")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No logs found")).toHaveCount(0);
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -385,4 +385,28 @@ test.describe("Grafana Logs Drilldown", () => {
     await expect(page.getByText("No logs found")).toHaveCount(0);
     expect(errors).toHaveLength(0);
   });
+
+  test("multi-tenant landing page can add and use a cluster breakdown tab", async ({ page }) => {
+    const responses = await collectDrilldownResponses(page);
+    const errors = collectLokiErrors(page);
+    await openLogsDrilldown(page, PROXY_MULTI_DS);
+    await waitForGrafanaReady(page);
+
+    await expect(serviceCard(page, "api-gateway").getByRole("heading", { name: "api-gateway" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await addDrilldownFilter(page, "Filter by labels", "cluster", "us-east-1");
+    await expect(page.getByLabel("Remove filter with key cluster")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No logs found")).toHaveCount(0);
+    expect(errors).toHaveLength(0);
+
+    const volumeResponse = responses.find((r) =>
+      String(r.url).includes("/resources/index/volume")
+    );
+    expect(volumeResponse).toBeTruthy();
+    expect(JSON.stringify(volumeResponse?.json)).toContain("us-east-1");
+  });
 });


### PR DESCRIPTION
## Summary
- harden `/tail` behavior across synthetic, native, and ingress-style paths with new API and browser regression coverage
- expand real multi-tenant Explore and Logs Drilldown coverage, including `__tenant_id__`, label and field filtering, cluster breakdown flows, and multi-level drilldown behavior
- close stale CI/browser issues by fixing the direct Loki Playwright default URL and making Drilldown combobox selection resilient to async option loading
- refactor `cmd/proxy` entrypoint logic into a testable `run(...)` path and raise `cmd/proxy` coverage to `95.1%`
- refresh README key features and badges, including a lines-of-code badge

## Included Work
- [x] `/tail` ingress/native/synthetic parity improvements and regressions
- [x] broader multi-tenant Explore and Logs Drilldown UI coverage
- [x] additional Loki compatibility regressions from real-world edge cases
- [x] `cmd/proxy` extraction and deep coverage lift
- [x] README and test/CI alignment updates

## Validation
- `go test ./cmd/proxy ./internal/proxy`
- `go test ./cmd/proxy -cover`
- `go test -tags=e2e -run 'TestFeature_Tail_(SyntheticProxySurvivesIdleWindow|ReverseProxyIngressStreamsLiveData|ReverseProxyIngressSurvivesIdleWindow|SyntheticProxyReconnectsCleanly|NativeModeClosesWhenBackendTailUnavailable)' ./test/e2e-compat`
- `go test -tags=e2e -run 'TestFeature_Multitenancy_FilteredLabelsSeriesAndDetectedFields' ./test/e2e-compat`
- `go test -tags=e2e -run 'TestExtended_(WithoutGrouping|OnGrouping|IgnoringGrouping|GroupLeftJoin|GroupRightJoin)' ./test/e2e-compat`
- `npx playwright test --list`
