### PR TITLE
Sync release metadata automatically

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - "CHANGELOG.md"
+      - "docs/observability.md"
+      - "charts/loki-vl-proxy/Chart.yaml"
       - "README.md"
   workflow_dispatch:
 
@@ -256,3 +259,23 @@ jobs:
             dist/loki-vl-proxy-*
             dist/checksums.txt
             dist/loki-vl-proxy-*.tgz
+
+      - name: Sync release metadata back to main
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          TEST_COUNT: ${{ needs.validate-release.outputs.test_count }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/sync_release_metadata.sh
+          scripts/ci/sync_release_metadata.sh "${VERSION}" "$(date +%Y-%m-%d)" "${TEST_COUNT}" .
+
+          if git diff --quiet --exit-code -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml; then
+            echo "release metadata already synced"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
+          git commit -m "docs: sync release metadata for v${VERSION} [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "docs/observability.md"
+      - "charts/loki-vl-proxy/Chart.yaml"
+      - "README.md"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,6 +3,11 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "docs/observability.md"
+      - "charts/loki-vl-proxy/Chart.yaml"
+      - "README.md"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/compat-drilldown.yaml
+++ b/.github/workflows/compat-drilldown.yaml
@@ -3,6 +3,11 @@ name: Logs Drilldown Compatibility
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "docs/observability.md"
+      - "charts/loki-vl-proxy/Chart.yaml"
+      - "README.md"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/compat-loki.yaml
+++ b/.github/workflows/compat-loki.yaml
@@ -3,6 +3,11 @@ name: Loki Compatibility
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "docs/observability.md"
+      - "charts/loki-vl-proxy/Chart.yaml"
+      - "README.md"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/compat-vl.yaml
+++ b/.github/workflows/compat-vl.yaml
@@ -3,6 +3,11 @@ name: VictoriaLogs Compatibility
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "docs/observability.md"
+      - "charts/loki-vl-proxy/Chart.yaml"
+      - "README.md"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/scripts/ci/sync_release_metadata.sh
+++ b/scripts/ci/sync_release_metadata.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "usage: $0 <version> <release-date> <tests-count> [repo-root]" >&2
+  exit 1
+fi
+
+VERSION="${1#v}"
+RELEASE_DATE="$2"
+TEST_COUNT="$3"
+REPO_ROOT="${4:-.}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$REPO_ROOT"
+
+CHANGELOG_FILE="CHANGELOG.md"
+CHART_FILE="charts/loki-vl-proxy/Chart.yaml"
+README_FILE="README.md"
+OBSERVABILITY_FILE="docs/observability.md"
+
+for path in "$CHANGELOG_FILE" "$CHART_FILE" "$README_FILE" "$OBSERVABILITY_FILE"; do
+  if [ ! -f "$path" ]; then
+    echo "required file not found: $path" >&2
+    exit 1
+  fi
+done
+
+"$SCRIPT_DIR/materialize_unreleased.sh" "$VERSION" "$RELEASE_DATE" "$CHANGELOG_FILE"
+
+awk -v version="$VERSION" '
+  /^version:/ { print "version: " version; next }
+  /^appVersion:/ { print "appVersion: \"" version "\""; next }
+  { print }
+' "$CHART_FILE" > "$CHART_FILE.tmp"
+mv "$CHART_FILE.tmp" "$CHART_FILE"
+
+perl -0pi -e 's/"service\.version":\s*"[^"]+"/"service.version": "'"$VERSION"'"/' "$OBSERVABILITY_FILE"
+
+if [ -n "$TEST_COUNT" ]; then
+  TESTS_BADGE="https://img.shields.io/badge/tests-${TEST_COUNT}%20passed-brightgreen"
+  awk -v badge="$TESTS_BADGE" '
+    /^\[!\[Tests\]\(/ { print "[![Tests](" badge ")](#tests)"; next }
+    { print }
+  ' "$README_FILE" > "$README_FILE.tmp"
+  mv "$README_FILE.tmp" "$README_FILE"
+fi


### PR DESCRIPTION
## What changed

This updates the release automation so release metadata is synced back into `main` automatically after a release is published.

- add `scripts/ci/sync_release_metadata.sh` to materialize `CHANGELOG.md` and update `README.md`, `docs/observability.md`, and `charts/loki-vl-proxy/Chart.yaml`
- run that sync step from `auto-release.yaml` after the GitHub release is created
- ignore metadata-only push-backs in push-triggered workflows so the sync commit does not fan out into another full CI / compatibility cycle

## Why

The current auto-release flow generates a materialized changelog section only for release notes and then discards the file. As a result, `main` keeps stale release metadata even though checks pass and a GitHub release is published.

This keeps the release flow tokenless from the repo perspective: it uses the default workflow credentials only, with no extra PAT or manual follow-up.

## Impact

After a successful auto release, `main` should reflect the released version in the changelog, Helm chart metadata, observability example, and README tests badge without manual edits.

## Validation

- `bash -n scripts/ci/sync_release_metadata.sh`
- `git diff --check -- .github/workflows/auto-release.yaml .github/workflows/ci.yaml .github/workflows/codeql.yaml .github/workflows/compat-drilldown.yaml .github/workflows/compat-loki.yaml .github/workflows/compat-vl.yaml scripts/ci/sync_release_metadata.sh`
- dry-run `scripts/ci/sync_release_metadata.sh` against copied repo files
