### PR TITLE
Complete helm chart and release distribution

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -173,9 +173,9 @@ jobs:
             echo "# Docker"
             echo "docker pull ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${VERSION}"
             echo ""
-            echo "# Helm"
-            echo "helm install loki-vl-proxy ./charts/loki-vl-proxy \\"
-            echo "  --set image.tag=${VERSION} \\"
+            echo "# Helm (OCI)"
+            echo "helm install loki-vl-proxy oci://ghcr.io/${{ github.repository_owner }}/charts/loki-vl-proxy \\"
+            echo "  --version ${VERSION} \\"
             echo "  --set extraArgs.backend=http://victorialogs:9428"
             echo '```'
             echo ""
@@ -227,6 +227,12 @@ jobs:
             --app-version "${VERSION}" \
             --destination dist
 
+      - name: Login Helm to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -248,6 +254,11 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Publish Helm chart to GHCR
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          helm push "dist/loki-vl-proxy-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,12 @@ jobs:
             --app-version "${VERSION}" \
             --destination dist
 
+      - name: Login Helm to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -109,6 +115,11 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Publish Helm chart to GHCR
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          helm push "dist/loki-vl-proxy-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - extend multi-tenant Explore and Logs Drilldown coverage for `__tenant_id__`, label breakdowns, and service drilldowns
 - prefer native VictoriaLogs field names, field values, and streams metadata for Drilldown discovery, with bounded fallback scanning for parsed and derived fields
 - complete the upstream Helm distribution surface with deployable runtime templates, peer-cache DNS service wiring, optional Gateway API routing, and OCI chart publication from release workflows
+- add chart-native StatefulSet support, PVC-backed disk-cache defaults, and extra claim templates for persistent cache deployments
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add ingress-backed and native-only `/tail` compatibility coverage for Grafana Explore and compose e2e
 - extend multi-tenant Explore and Logs Drilldown coverage for `__tenant_id__`, label breakdowns, and service drilldowns
 - prefer native VictoriaLogs field names, field values, and streams metadata for Drilldown discovery, with bounded fallback scanning for parsed and derived fields
+- complete the upstream Helm distribution surface with deployable runtime templates, peer-cache DNS service wiring, optional Gateway API routing, and OCI chart publication from release workflows
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set extraArgs.backend=http://victorialogs:9428
 ```
 
+For persistent cache, switch the workload to `StatefulSet` and enable `persistence`. The chart will mount the PVC and inject `-disk-cache-path` automatically unless you override it explicitly:
+
+```bash
+helm install loki-vl-proxy ./charts/loki-vl-proxy \
+  --set workload.kind=StatefulSet \
+  --set persistence.enabled=true \
+  --set persistence.size=10Gi \
+  --set extraArgs.backend=http://victorialogs:9428
+```
+
 ### Fleet Cache (Multi-Replica)
 
 ```bash
@@ -183,7 +193,7 @@ helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set peerCache.enabled=true
 ```
 
-When `peerCache.enabled=true`, the chart provisions a headless service and injects `-peer-self`, `-peer-discovery=dns`, and `-peer-dns` automatically. The proxy refreshes peers from DNS on a timer, so HPA-driven pod churn does not require a static replica list.
+When `peerCache.enabled=true`, the chart provisions a headless service and injects `-peer-self`, `-peer-discovery=dns`, and `-peer-dns` automatically. The proxy refreshes peers from DNS on a timer, so HPA-driven pod churn does not require a static replica list. The same headless service is also used automatically when `workload.kind=StatefulSet`.
 
 ### Grafana Datasource
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ docker-compose up -d
 ### Helm (Kubernetes)
 
 ```bash
+helm install loki-vl-proxy oci://ghcr.io/szibis/charts/loki-vl-proxy \
+  --version <release> \
+  --set extraArgs.backend=http://victorialogs:9428
+
+# Local chart (development)
 helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set extraArgs.backend=http://victorialogs:9428
 ```

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ helm install loki-vl-proxy ./charts/loki-vl-proxy \
 # Kubernetes (DNS discovery via headless service)
 helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set replicaCount=3 \
-  --set extraArgs.peer-self='$(POD_IP):3100' \
-  --set extraArgs.peer-discovery=dns \
-  --set extraArgs.peer-dns=loki-vl-proxy-headless.default.svc.cluster.local
+  --set peerCache.enabled=true
 ```
+
+When `peerCache.enabled=true`, the chart provisions a headless service and injects `-peer-self`, `-peer-discovery=dns`, and `-peer-dns` automatically. The proxy refreshes peers from DNS on a timer, so HPA-driven pod churn does not require a static replica list.
 
 ### Grafana Datasource
 

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -57,5 +57,33 @@ Create the name of the service account to use
 Peer-cache headless service name.
 */}}
 {{- define "loki-vl-proxy.peerServiceName" -}}
-{{- default (printf "%s-headless" (include "loki-vl-proxy.fullname" .)) .Values.peerCache.serviceName }}
+{{- default (include "loki-vl-proxy.headlessServiceName" .) .Values.peerCache.serviceName }}
+{{- end }}
+
+{{/*
+Resolved workload kind.
+*/}}
+{{- define "loki-vl-proxy.workloadKind" -}}
+{{- default "Deployment" .Values.workload.kind -}}
+{{- end }}
+
+{{/*
+Stateful/headless service name.
+*/}}
+{{- define "loki-vl-proxy.headlessServiceName" -}}
+{{- default (printf "%s-headless" (include "loki-vl-proxy.fullname" .)) .Values.workload.statefulSet.serviceName }}
+{{- end }}
+
+{{/*
+Persistence claim name for standalone PVC / existing claim mode.
+*/}}
+{{- define "loki-vl-proxy.persistenceClaimName" -}}
+{{- default (printf "%s-cache" (include "loki-vl-proxy.fullname" .)) .Values.persistence.existingClaim }}
+{{- end }}
+
+{{/*
+Default disk cache path when persistence is enabled.
+*/}}
+{{- define "loki-vl-proxy.diskCachePath" -}}
+{{- printf "%s/%s" (trimSuffix "/" .Values.persistence.mountPath) .Values.persistence.fileName -}}
 {{- end }}

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "loki-vl-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "loki-vl-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "loki-vl-proxy.labels" -}}
+helm.sh/chart: {{ include "loki-vl-proxy.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "loki-vl-proxy.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "loki-vl-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "loki-vl-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "loki-vl-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "loki-vl-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Peer-cache headless service name.
+*/}}
+{{- define "loki-vl-proxy.peerServiceName" -}}
+{{- default (printf "%s-headless" (include "loki-vl-proxy.fullname" .)) .Values.peerCache.serviceName }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -1,10 +1,25 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ include "loki-vl-proxy.workloadKind" . }}
 metadata:
   name: {{ include "loki-vl-proxy.fullname" . }}
   labels:
     {{- include "loki-vl-proxy.labels" . | nindent 4 }}
 spec:
+  {{- if eq (include "loki-vl-proxy.workloadKind" .) "StatefulSet" }}
+  serviceName: {{ include "loki-vl-proxy.peerServiceName" . }}
+  podManagementPolicy: {{ .Values.workload.statefulSet.podManagementPolicy }}
+  updateStrategy:
+    {{- toYaml .Values.workload.statefulSet.updateStrategy | nindent 4 }}
+  {{- with .Values.workload.statefulSet.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  {{- with .Values.workload.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- if not .Values.horizontalPodAutoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -64,6 +79,9 @@ spec:
           args:
             {{- range $key, $value := .Values.extraArgs }}
             - "-{{ $key }}={{ $value }}"
+            {{- end }}
+            {{- if and .Values.persistence.enabled (not (hasKey .Values.extraArgs "disk-cache-path")) }}
+            - "-disk-cache-path={{ include "loki-vl-proxy.diskCachePath" . }}"
             {{- end }}
             {{- if .Values.peerCache.enabled }}
             - "-peer-self=$(POD_IP):3100"
@@ -136,7 +154,7 @@ spec:
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: cache-data
-              mountPath: /cache
+              mountPath: {{ .Values.persistence.mountPath }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -145,14 +163,39 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.persistence.enabled .Values.extraVolumes }}
+      {{- if or .Values.extraVolumes (and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet"))) }}
       volumes:
-        {{- if .Values.persistence.enabled }}
+        {{- if and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet")) }}
         - name: cache-data
           persistentVolumeClaim:
-            claimName: {{ include "loki-vl-proxy.fullname" . }}-cache
+            claimName: {{ include "loki-vl-proxy.persistenceClaimName" . }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+  {{- if and (eq (include "loki-vl-proxy.workloadKind" .) "StatefulSet") (or (and .Values.persistence.enabled (not .Values.persistence.existingClaim)) .Values.persistence.extraVolumeClaimTemplates) }}
+  volumeClaimTemplates:
+    {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+    - metadata:
+        name: cache-data
+        labels:
+          {{- include "loki-vl-proxy.labels" . | nindent 10 }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+    {{- end }}
+    {{- with .Values.persistence.extraVolumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -1,0 +1,158 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.horizontalPodAutoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki-vl-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "loki-vl-proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "loki-vl-proxy.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: loki-vl-proxy
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          args:
+            {{- range $key, $value := .Values.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+            {{- if .Values.peerCache.enabled }}
+            - "-peer-self=$(POD_IP):3100"
+            - "-peer-discovery={{ .Values.peerCache.discovery }}"
+            {{- if eq .Values.peerCache.discovery "dns" }}
+            - "-peer-dns={{ include "loki-vl-proxy.peerServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+            {{- else if eq .Values.peerCache.discovery "static" }}
+            - "-peer-static={{ join "," .Values.peerCache.peers }}"
+            {{- end }}
+            {{- end }}
+          {{- if or .Values.peerCache.enabled .Values.env }}
+          env:
+            {{- if .Values.peerCache.enabled }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+          {{- if .Values.probe.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: {{ .Values.probe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probe.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probe.liveness.failureThreshold }}
+            successThreshold: {{ .Values.probe.liveness.successThreshold }}
+          {{- end }}
+          {{- if .Values.probe.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: {{ .Values.probe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probe.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probe.readiness.failureThreshold }}
+            successThreshold: {{ .Values.probe.readiness.successThreshold }}
+          {{- end }}
+          {{- if .Values.probe.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: {{ .Values.probe.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probe.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probe.startup.failureThreshold }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: cache-data
+              mountPath: /cache
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.persistence.enabled .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: cache-data
+          persistentVolumeClaim:
+            claimName: {{ include "loki-vl-proxy.fullname" . }}-cache
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}

--- a/charts/loki-vl-proxy/templates/hpa.yaml
+++ b/charts/loki-vl-proxy/templates/hpa.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ include "loki-vl-proxy.workloadKind" . }}
     name: {{ include "loki-vl-proxy.fullname" . }}
   minReplicas: {{ .Values.horizontalPodAutoscaling.minReplicas }}
   maxReplicas: {{ .Values.horizontalPodAutoscaling.maxReplicas }}

--- a/charts/loki-vl-proxy/templates/hpa.yaml
+++ b/charts/loki-vl-proxy/templates/hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.horizontalPodAutoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "loki-vl-proxy.fullname" . }}
+  minReplicas: {{ .Values.horizontalPodAutoscaling.minReplicas }}
+  maxReplicas: {{ .Values.horizontalPodAutoscaling.maxReplicas }}
+  {{- with .Values.horizontalPodAutoscaling.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/httproute.yaml
+++ b/charts/loki-vl-proxy/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "loki-vl-proxy.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: {{ .Values.httpRoute.weight }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/ingress.yaml
+++ b/charts/loki-vl-proxy/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "loki-vl-proxy.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/networkpolicy.yaml
+++ b/charts/loki-vl-proxy/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "loki-vl-proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/pdb.yaml
+++ b/charts/loki-vl-proxy/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki-vl-proxy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/peer-service.yaml
+++ b/charts/loki-vl-proxy/templates/peer-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.peerCache.enabled (eq .Values.peerCache.discovery "dns") }}
+{{- if or (eq (include "loki-vl-proxy.workloadKind" .) "StatefulSet") (and .Values.peerCache.enabled (eq .Values.peerCache.discovery "dns")) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/loki-vl-proxy/templates/peer-service.yaml
+++ b/charts/loki-vl-proxy/templates/peer-service.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.peerCache.enabled (eq .Values.peerCache.discovery "dns") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki-vl-proxy.peerServiceName" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "loki-vl-proxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/pvc.yaml
+++ b/charts/loki-vl-proxy/templates/pvc.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "loki-vl-proxy.fullname" . }}-cache
+  name: {{ include "loki-vl-proxy.persistenceClaimName" . }}
   labels:
     {{- include "loki-vl-proxy.labels" . | nindent 4 }}
   {{- with .Values.persistence.annotations }}

--- a/charts/loki-vl-proxy/templates/pvc.yaml
+++ b/charts/loki-vl-proxy/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}-cache
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/service.yaml
+++ b/charts/loki-vl-proxy/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "loki-vl-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/loki-vl-proxy/templates/serviceaccount.yaml
+++ b/charts/loki-vl-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "loki-vl-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/servicemonitor.yaml
+++ b/charts/loki-vl-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "loki-vl-proxy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/tests/test-connection.yaml
+++ b/charts/loki-vl-proxy/templates/tests/test-connection.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "loki-vl-proxy.fullname" . }}-test-connection
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: test-ready
+      image: busybox:1.36
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      command: ['wget']
+      args:
+        - '--spider'
+        - '--timeout=5'
+        - 'http://{{ include "loki-vl-proxy.fullname" . }}:{{ .Values.service.port }}/ready'
+    - name: test-labels
+      image: busybox:1.36
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      command: ['wget']
+      args:
+        - '-qO-'
+        - '--timeout=10'
+        - 'http://{{ include "loki-vl-proxy.fullname" . }}:{{ .Values.service.port }}/loki/api/v1/labels'
+    - name: test-metrics
+      image: busybox:1.36
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      command: ['wget']
+      args:
+        - '-qO-'
+        - '--timeout=5'
+        - 'http://{{ include "loki-vl-proxy.fullname" . }}:{{ .Values.service.port }}/metrics'

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -3,6 +3,16 @@
 
 replicaCount: 1
 
+workload:
+  kind: Deployment
+  deploymentStrategy: {}
+  statefulSet:
+    serviceName: ""
+    podManagementPolicy: Parallel
+    updateStrategy:
+      type: RollingUpdate
+    persistentVolumeClaimRetentionPolicy: {}
+
 image:
   repository: ghcr.io/szibis/loki-vl-proxy
   tag: ""  # defaults to Chart.appVersion
@@ -303,8 +313,11 @@ peerCache:
 # --- Disk cache persistent volume ---
 persistence:
   enabled: false
+  existingClaim: ""
   accessMode: ReadWriteOnce
   size: 10Gi
   storageClass: ""  # e.g., "gp3", "st1" for AWS
+  mountPath: /cache
+  fileName: proxy.db
   annotations: {}
-  # mountPath defaults to /cache, used with disk-cache-path=/cache/data.db
+  extraVolumeClaimTemplates: []

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -1,16 +1,35 @@
 # Loki-VL-proxy Helm values
 # VictoriaMetrics-style: all proxy flags exposed as extraArgs
+# Default install shape:
+# - 1 replica
+# - Deployment workload
+# - ClusterIP service on port 3100
+# - in-memory cache only
+# - no ingress / ServiceMonitor / HPA / persistence unless explicitly enabled
 
 replicaCount: 1
 
+# Workload controller for the proxy pods.
+# Default is Deployment for stateless installs.
+# Set workload.kind=StatefulSet when you want stable pod identity and per-pod PVCs
+# for the disk cache.
 workload:
   kind: Deployment
+  # Deployment-only rollout strategy. Leave empty to use the Kubernetes default.
   deploymentStrategy: {}
   statefulSet:
+    # Headless service name used by StatefulSet network identity.
+    # Empty = <release>-headless.
     serviceName: ""
+    # Parallel is usually fine for horizontally scaled proxy replicas.
     podManagementPolicy: Parallel
     updateStrategy:
       type: RollingUpdate
+    # Optional native StatefulSet PVC retention policy.
+    # Example:
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Retain
+    #   whenScaled: Delete
     persistentVolumeClaimRetentionPolicy: {}
 
 image:
@@ -24,6 +43,13 @@ fullnameOverride: ""
 
 # VictoriaMetrics-style: pass any CLI flag via extraArgs
 # These map directly to the binary's -flag arguments.
+# Defaults here are intentionally conservative:
+# - backend points at an in-cluster VictoriaLogs service
+# - memory cache is enabled
+# - HTTP hardening limits are enabled
+# If persistence.enabled=true and you do NOT set extraArgs.disk-cache-path,
+# the chart injects -disk-cache-path automatically as:
+#   <persistence.mountPath>/<persistence.fileName>
 extraArgs:
   listen: ":3100"
   backend: "http://victorialogs:9428"
@@ -69,6 +95,8 @@ goMemLimitPercent: 70  # percentage of resources.limits.memory
 goMemLimit: ""         # explicit override; if set, goMemLimitPercent is ignored
 
 # Environment variables (alternative to flags, also for secrets)
+# Use this for secrets or env-based integration config when you don't want
+# sensitive values embedded directly in extraArgs.
 env: []
   # - name: VL_BACKEND_URL
   #   value: "http://victorialogs:9428"
@@ -116,6 +144,8 @@ serviceAccount:
   automountServiceAccountToken: false
 
 # --- Service ---
+# Frontend service exposed to Grafana / clients.
+# The proxy itself always listens on container port 3100 by default.
 service:
   type: ClusterIP
   port: 3100
@@ -123,6 +153,7 @@ service:
   labels: {}
 
 # --- ServiceMonitor (Prometheus Operator) ---
+# Disabled by default to keep the chart generic outside Prometheus-Operator clusters.
 serviceMonitor:
   enabled: false
   namespace: ""
@@ -134,6 +165,9 @@ serviceMonitor:
   metricRelabelings: []
 
 # --- Ingress ---
+# Optional ingress for the Loki-compatible HTTP API.
+# Disabled by default because many fleets use internal service discovery,
+# Gateway API, or platform-specific ingress composition.
 ingress:
   enabled: false
   className: ""
@@ -151,6 +185,8 @@ ingress:
     #     - loki-vl-proxy.local
 
 # --- Resources ---
+# Defaults are small and intended for development or light shared use.
+# For production, raise both memory and cpu based on request rate and cache size.
 resources:
   requests:
     cpu: 50m
@@ -160,6 +196,9 @@ resources:
     memory: 256Mi
 
 # --- Probes ---
+# All probes hit /ready.
+# Startup probe is disabled by default because the proxy starts quickly in the
+# common in-memory-cache case; enable it for slower cold starts.
 probe:
   liveness:
     enabled: true
@@ -183,12 +222,16 @@ probe:
     failureThreshold: 30
 
 # --- Pod Disruption Budget ---
+# Recommended whenever replicaCount > 1 or HPA is enabled.
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
   # maxUnavailable: 1
 
 # --- Horizontal Pod Autoscaler ---
+# When enabled, the chart omits spec.replicas from the workload and HPA becomes
+# the source of truth for desired pod count.
+# Works with both Deployment and StatefulSet modes.
 horizontalPodAutoscaling:
   enabled: false
   minReplicas: 2
@@ -228,6 +271,8 @@ networkPolicy:
           protocol: TCP
 
 # --- Pod Security ---
+# Secure-by-default baseline.
+# Override only if your platform requires different UID/GID/fsGroup handling.
 securityContext:
   runAsNonRoot: true
   runAsUser: 65534
@@ -245,6 +290,8 @@ containerSecurityContext:
   runAsUser: 65534
 
 # --- Scheduling ---
+# Empty by default so the chart remains portable.
+# Fill these in from the platform repo when you need dedicated nodes or spread rules.
 nodeSelector: {}
 
 tolerations: []
@@ -270,6 +317,8 @@ topologySpreadConstraints: []
 priorityClassName: ""
 
 # --- Labels & Annotations ---
+# podAnnotations/podLabels apply to pods only.
+# extraLabels are chart-wide object labels added to most rendered resources.
 podAnnotations: {}
 podLabels: {}
 extraLabels: {}
@@ -282,12 +331,15 @@ lifecycle: {}
   #     command: ["/bin/sh", "-c", "sleep 5"]
 
 # --- Additional containers/volumes ---
+# Escape hatches for sidecars, init containers, extra config volumes, and
+# custom mounts. Keep these empty unless your platform needs them.
 initContainers: []
 extraContainers: []
 extraVolumes: []
 extraVolumeMounts: []
 
 # --- Gateway API HTTPRoute (traffic distribution) ---
+# Optional Gateway API exposure instead of Ingress.
 httpRoute:
   enabled: false
   annotations: {}
@@ -299,6 +351,10 @@ httpRoute:
   weight: 100  # for canary/weighted routing
 
 # --- Peer Cache (distributed L1.5 cache across replicas) ---
+# Disabled by default.
+# Enable this when you run multiple replicas and want cache sharing across pods.
+# With discovery=dns, the chart creates a headless service and injects the
+# peer-discovery flags automatically. This is the preferred mode for HPA.
 peerCache:
   enabled: false
   # Discovery: "dns" (headless service, recommended) or "static" (explicit peers list)
@@ -311,13 +367,27 @@ peerCache:
     # - "proxy-1.proxy-peers:3100"
 
 # --- Disk cache persistent volume ---
+# Persistence is off by default.
+# Behavior by mode:
+# - Deployment + persistence.enabled=true:
+#   creates one PVC (or mounts persistence.existingClaim if set)
+# - StatefulSet + persistence.enabled=true:
+#   creates volumeClaimTemplates for per-pod cache storage
+# If extraArgs.disk-cache-path is not set, the chart injects one automatically
+# using mountPath + fileName.
 persistence:
   enabled: false
+  # Existing PVC to mount instead of creating a new one.
+  # Primarily useful for Deployment mode.
   existingClaim: ""
   accessMode: ReadWriteOnce
   size: 10Gi
   storageClass: ""  # e.g., "gp3", "st1" for AWS
+  # Cache directory mounted into the container.
   mountPath: /cache
+  # File used for the proxy's bbolt disk cache inside mountPath.
   fileName: proxy.db
   annotations: {}
+  # Extra claim templates appended only in StatefulSet mode.
+  # Useful for separate WAL/buffer/storage volumes managed by the same chart.
   extraVolumeClaimTemplates: []

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -37,6 +37,10 @@ extraArgs:
   # otlp-interval: "30s"
   # otlp-compression: "gzip"
   # otlp-timeout: "10s"
+  # Backend auth to VictoriaLogs
+  # backend-basic-auth: "user:password"
+  # forward-headers: "Authorization"
+  # forward-cookies: "vmui_session"
   # Label translation (OTel compatibility)
   # label-style: "underscores"  # convert VL dotted fields (service.name) to Loki underscores (service_name)
   # field-mapping: '[{"vl_field":"custom.field","loki_label":"custom_label"}]'
@@ -112,6 +116,7 @@ service:
 serviceMonitor:
   enabled: false
   namespace: ""
+  annotations: {}
   interval: "30s"
   scrapeTimeout: "10s"
   labels: {}
@@ -288,16 +293,12 @@ peerCache:
   enabled: false
   # Discovery: "dns" (headless service, recommended) or "static" (explicit peers list)
   discovery: "dns"
-  # Headless service name (defaults to release-name + "-peers")
+  # Headless service name (defaults to release-name + "-headless")
   serviceName: ""
-  # Static peer URLs (if discovery=static)
+  # Static peer addresses in host:port form (if discovery=static)
   peers: []
-    # - "http://proxy-0.proxy-peers:3100"
-    # - "http://proxy-1.proxy-peers:3100"
-  # Timeout for peer cache fetch (must be << VL query time)
-  timeout: "5ms"
-  # Max peers to query on miss (0 = consistent hash to 1 peer)
-  maxPeerQueries: 1
+    # - "proxy-0.proxy-peers:3100"
+    # - "proxy-1.proxy-peers:3100"
 
 # --- Disk cache persistent volume ---
 persistence:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -26,6 +26,8 @@ helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set extraArgs.label-style=underscores
 ```
 
+For multi-replica fleets with HPA, prefer `peerCache.enabled=true` over static peer lists. The chart creates a headless service and the proxy refreshes DNS-discovered peers automatically, so scaling events do not require manual replica or peer updates.
+
 ### Required Configuration
 
 | Flag | Required | Description |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,6 +15,12 @@ The proxy is stateless (except optional disk cache). Scale horizontally without 
 ### Helm Deployment
 
 ```bash
+helm install loki-vl-proxy oci://ghcr.io/szibis/charts/loki-vl-proxy \
+  --version <release> \
+  --set extraArgs.backend=http://victorialogs:9428 \
+  --set extraArgs.label-style=underscores
+
+# Local chart (development)
 helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set extraArgs.backend=http://victorialogs:9428 \
   --set extraArgs.label-style=underscores

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -109,6 +109,8 @@ Bottleneck: Balanced CPU/memory/network
 
 ```yaml
 replicaCount: 1
+workload:
+  kind: StatefulSet
 resources:
   requests:
     cpu: 100m
@@ -130,6 +132,8 @@ persistence:
 
 ```yaml
 replicaCount: 3
+workload:
+  kind: StatefulSet
 resources:
   requests:
     cpu: 250m
@@ -148,17 +152,25 @@ extraArgs:
 persistence:
   enabled: true
   size: 5Gi
-autoscaling:
+horizontalPodAutoscaling:
   enabled: true
   minReplicas: 2
   maxReplicas: 6
-  targetCPUUtilizationPercentage: 70
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
 ```
 
 ### Large (1,000-10,000 req/s)
 
 ```yaml
 replicaCount: 8
+workload:
+  kind: StatefulSet
 resources:
   requests:
     cpu: 500m
@@ -182,11 +194,17 @@ persistence:
   enabled: true
   size: 10Gi
   storageClass: gp3  # high IOPS SSD
-autoscaling:
+horizontalPodAutoscaling:
   enabled: true
   minReplicas: 4
   maxReplicas: 20
-  targetCPUUtilizationPercentage: 60
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
 podDisruptionBudget:
   minAvailable: 2
 ```


### PR DESCRIPTION
## What changed
- restore the missing runtime Helm templates in `charts/loki-vl-proxy` so the upstream chart is actually deployable from the repo and release artifacts
- add optional `HTTPRoute` and peer-cache headless service templates for the chart features already advertised in values/docs
- align monitoring knobs with VictoriaMetrics chart patterns by honoring `serviceMonitor.annotations`, `relabelings`, and `metricRelabelings`
- honor `service.labels`, add peer-cache DNS wiring in the deployment, and document OCI chart install in README/operations docs
- publish the packaged Helm chart to GHCR OCI from both release workflows instead of only attaching the `.tgz` as a GitHub release asset

## Why
The `infra-k8s` integration exposed two upstream gaps:
- the Helm chart in `main` only packaged dashboard/rule fragments, not the deployment/service/ingress/runtime templates needed by consumers
- releases produced a chart archive but did not publish it to a consumable Helm/OCI location

That forced downstream vendoring for the first integration. This PR fixes the upstream distribution surface so internal consumers can reuse a consistent chart shape.

I also verified VictoriaLogs upstream auth support already exists in the binary via:
- `-backend-basic-auth`
- `-forward-headers`
- `-forward-cookies`

So no proxy auth feature gap was found; this PR only makes the chart/release surface match the existing runtime capabilities.

## Validation
- `helm lint charts/loki-vl-proxy`
- `helm template loki-vl-proxy charts/loki-vl-proxy --set serviceMonitor.enabled=true --set httpRoute.enabled=true --set 'httpRoute.parentRefs[0].name=internal-gw' --set 'httpRoute.hostnames[0]=loki-vl-proxy.example.com' --set peerCache.enabled=true --set extraArgs.backend=http://victorialogs:9428`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); YAML.load_file(ARGV[1])' .github/workflows/release.yaml .github/workflows/auto-release.yaml`
