### PR TITLE
ci: harden release metadata and PR quality reporting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+- describe the user-visible and operator-visible change
+
+## Changelog (Required)
+
+- add at least one `- ...` bullet under `## [Unreleased]` in `CHANGELOG.md`
+- this text is promoted into the release section and used for GitHub release notes
+
+## Validation
+
+- list checks/tests you ran locally or in CI

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -334,6 +334,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
+          git add -f -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
           git commit -m "docs: sync release metadata for v${VERSION} [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -134,7 +134,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       test_count: ${{ steps.metrics.outputs.tests }}
-      coverage: ${{ steps.metrics.outputs.coverage }}
+      coverage_pct: ${{ steps.metrics.outputs.coverage_pct }}
+      code_lines: ${{ steps.metrics.outputs.code_lines }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -168,9 +169,11 @@ jobs:
           set -euo pipefail
           TESTS=$(go test ./... -count=1 -json 2>/dev/null | jq -r 'select(.Action=="pass" and .Test != null) | .Test' | wc -l | tr -d ' ')
           go test ./... -coverprofile=coverage.out -count=1 >/dev/null 2>&1
-          COV=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
+          COV=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}' | tr -d '%')
+          CODE_LINES=$(git ls-files '*.go' | xargs wc -l | tail -1 | awk '{print $1}')
           echo "tests=${TESTS}" >> "$GITHUB_OUTPUT"
-          echo "coverage=${COV}" >> "$GITHUB_OUTPUT"
+          echo "coverage_pct=${COV}" >> "$GITHUB_OUTPUT"
+          echo "code_lines=${CODE_LINES}" >> "$GITHUB_OUTPUT"
 
       - name: Helm lint
         run: helm lint charts/loki-vl-proxy/
@@ -194,6 +197,9 @@ jobs:
 
       - name: Extract release metadata
         id: meta
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.prepare-release.outputs.next_version }}"
@@ -212,13 +218,19 @@ jobs:
             echo "### Release Validation"
             echo ""
             echo "- Tests: ${{ needs.validate-release.outputs.test_count }}"
-            echo "- Coverage: ${{ needs.validate-release.outputs.coverage }}"
+            echo "- Coverage: ${{ needs.validate-release.outputs.coverage_pct }}%"
+            echo "- Go LOC: ${{ needs.validate-release.outputs.code_lines }}"
             echo ""
             echo "### Installation"
             echo ""
             echo '```bash'
-            echo "# Docker"
+            echo "# Docker (GHCR)"
             echo "docker pull ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${VERSION}"
+            if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+              echo ""
+              echo "# Docker (Docker Hub)"
+              echo "docker pull docker.io/${DOCKERHUB_USERNAME}/loki-vl-proxy:${VERSION}"
+            fi
             echo ""
             echo "# Helm (OCI)"
             echo "helm install loki-vl-proxy oci://ghcr.io/${{ github.repository_owner }}/charts/loki-vl-proxy \\"
@@ -232,6 +244,9 @@ jobs:
             echo "- SHA256 checksums"
             echo "- Versioned Helm chart package"
             echo "- Multi-arch GHCR image"
+            if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+              echo "- Multi-arch Docker Hub image"
+            fi
           } >> "$NOTES_FILE"
           {
             echo "tag=${TAG}"
@@ -290,14 +305,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve Docker image tags
+        id: image-tags
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${VERSION}"
+            if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+              echo "docker.io/${DOCKERHUB_USERNAME}/loki-vl-proxy:${VERSION}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${{ steps.meta.outputs.version }}
+          tags: ${{ steps.image-tags.outputs.tags }}
           labels: |
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
@@ -322,10 +361,12 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           TEST_COUNT: ${{ needs.validate-release.outputs.test_count }}
+          COVERAGE_PCT: ${{ needs.validate-release.outputs.coverage_pct }}
+          CODE_LINES: ${{ needs.validate-release.outputs.code_lines }}
         run: |
           set -euo pipefail
           chmod +x scripts/ci/sync_release_metadata.sh
-          scripts/ci/sync_release_metadata.sh "${VERSION}" "$(date +%Y-%m-%d)" "${TEST_COUNT}" .
+          scripts/ci/sync_release_metadata.sh "${VERSION}" "$(date +%Y-%m-%d)" "${TEST_COUNT}" "${COVERAGE_PCT}" "${CODE_LINES}" .
 
           if git diff --quiet --exit-code -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml; then
             echo "release metadata already synced"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
+          git add -f -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
           git commit -m "docs: sync release metadata for v${VERSION} [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,22 +47,7 @@ jobs:
           chmod +x scripts/ci/extract_changelog_section.sh
           VERSION="${{ steps.version.outputs.version }}"
           NOTES_FILE="$(mktemp)"
-          if scripts/ci/extract_changelog_section.sh "${VERSION}" CHANGELOG.md > "$NOTES_FILE" 2>/dev/null; then
-            :
-          else
-            PREV_TAG="${{ steps.version.outputs.prev_tag }}"
-            {
-              echo "## [${VERSION}]"
-              echo ""
-              echo "### Changes"
-              echo ""
-              if [ -n "$PREV_TAG" ]; then
-                git log "${PREV_TAG}..${{ steps.version.outputs.tag }}" --pretty=format:'- %s'
-              else
-                git log "${{ steps.version.outputs.tag }}" --pretty=format:'- %s'
-              fi
-            } > "$NOTES_FILE"
-          fi
+          scripts/ci/extract_changelog_section.sh "${VERSION}" CHANGELOG.md > "$NOTES_FILE"
           echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Build release binaries
@@ -104,14 +89,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve Docker image tags
+        id: image-tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${VERSION}"
+            if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+              echo "docker.io/${DOCKERHUB_USERNAME}/loki-vl-proxy:${VERSION}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/loki-vl-proxy:${{ steps.version.outputs.version }}
+          tags: ${{ steps.image-tags.outputs.tags }}
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
@@ -141,7 +150,7 @@ jobs:
           git checkout -B main origin/main
 
           chmod +x scripts/ci/sync_release_metadata.sh
-          scripts/ci/sync_release_metadata.sh "${VERSION}" "$(date +%Y-%m-%d)" "" .
+          scripts/ci/sync_release_metadata.sh "${VERSION}" "$(date +%Y-%m-%d)" "" "" "" .
 
           if git diff --quiet --exit-code -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml; then
             echo "release metadata already synced"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 [![VictoriaLogs Compatibility](https://github.com/szibis/Loki-VL-proxy/actions/workflows/compat-vl.yaml/badge.svg)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/compat-vl.yaml)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/szibis/Loki-VL-proxy)](https://go.dev/)
 [![Release](https://img.shields.io/github/v/release/szibis/Loki-VL-proxy)](https://github.com/szibis/Loki-VL-proxy/releases)
-[![Lines of Code](https://sloc.xyz/github/szibis/Loki-VL-proxy/?category=code)](https://github.com/szibis/Loki-VL-proxy)
-[![Tests](https://img.shields.io/github/actions/workflow/status/szibis/Loki-VL-proxy/ci.yaml?label=tests)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/ci.yaml)
+[![Lines of Code](https://img.shields.io/badge/go%20loc-updating-lightgrey)](https://github.com/szibis/Loki-VL-proxy)
+[![Tests](https://img.shields.io/badge/tests-updating-lightgrey)](#tests)
+[![Coverage](https://img.shields.io/badge/coverage-updating-lightgrey)](#tests)
 [![LogQL Coverage](https://img.shields.io/badge/LogQL%20coverage-100%25-brightgreen)](#logql-compatibility)
 [![License](https://img.shields.io/github/license/szibis/Loki-VL-proxy)](LICENSE)
 [![CodeQL](https://github.com/szibis/Loki-VL-proxy/actions/workflows/codeql.yaml/badge.svg)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/codeql.yaml)
@@ -137,6 +138,7 @@ See [Performance Guide](docs/performance.md), [Scaling](docs/scaling.md), [Fleet
 - **Cache-hit and bypass regression gates** -- PR quality checks track CPU, memory, allocations, throughput, and memory growth across hot and uncached paths
 - **Faster PR quality snapshots** -- base/head quality metrics are collected in parallel with bounded per-metric timeouts so required report gating stays informative without stalling whole PR checks
 - **CI noise-tolerant report gate** -- base/head quality comparisons use relative plus absolute thresholds with low-baseline guards, so small runner jitter does not block PRs
+- **Release metadata sync** -- release automation promotes `Unreleased` changelog notes into the version section and refreshes README tests/coverage/Go LOC badges on `main`
 
 ### Operations
 See [Getting Started](docs/getting-started.md), [Configuration](docs/configuration.md), [Scaling](docs/scaling.md), [Observability](docs/observability.md), [Testing](docs/testing.md), [Compatibility Matrix](docs/compatibility-matrix.md), and [Rules And Alerts Migration](docs/rules-alerts-migration.md).
@@ -158,6 +160,10 @@ go build -o loki-vl-proxy ./cmd/proxy
 # Docker
 docker build -t loki-vl-proxy .
 docker run -p 3100:3100 loki-vl-proxy -backend=http://victorialogs:9428
+
+# Pull published release images
+docker pull ghcr.io/szibis/loki-vl-proxy:<release>
+docker pull docker.io/<dockerhub-user>/loki-vl-proxy:<release>
 
 # Docker Compose (dev/test with Grafana)
 docker-compose up -d

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -237,6 +237,7 @@ The report job now collects test count and coverage from the same Go test pass, 
 The collector runs test/coverage, compatibility scores, benchmark medians, and load metrics in parallel with bounded fallbacks so a single slow signal does not block the whole report gate.
 The quality gate compares base/head with relative and absolute regression thresholds and ignores low-baseline noise, so tiny shared-runner jitter does not fail required checks.
 The high-concurrency load threshold remains strict locally (`>10k req/s`) and uses a CI floor (`>5k req/s`) on shared race-enabled runners to avoid flaky non-regression failures.
+Release automation also materializes `CHANGELOG.md` `Unreleased` into the new version section and uses that same section as the GitHub release notes body, then syncs README tests/coverage/Go LOC badges on `main`.
 
 Required-check note:
 

--- a/scripts/ci/check_changelog_pr.py
+++ b/scripts/ci/check_changelog_pr.py
@@ -35,9 +35,6 @@ IMPACTFUL_FILES = {
 
 NON_RELEASE_PATH_PREFIXES = (
     "docs/",
-    ".github/",
-    "scripts/",
-    "test/",
 )
 
 NON_RELEASE_FILES = {

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -141,7 +141,7 @@ collect_compat() {
 
 collect_benchmarks() {
   local out="$TMP_DIR/bench.txt"
-  go test ./internal/proxy -run '^$' -bench 'BenchmarkProxy_(QueryRange|Labels)_(CacheHit|CacheBypass)$' -benchmem -benchtime=1s -count=3 >"$out"
+  GOMAXPROCS=1 go test ./internal/proxy -run '^$' -bench 'BenchmarkProxy_(QueryRange|Labels)_(CacheHit|CacheBypass)$' -benchmem -benchtime=1s -count=3 -cpu=1 >"$out"
   python3 - "$out" <<'PY'
 import json
 import re

--- a/scripts/ci/render_pr_report.sh
+++ b/scripts/ci/render_pr_report.sh
@@ -20,25 +20,34 @@ format_delta() {
   local current="$1"
   local base="$2"
   local better="$3"
-  python3 - "$current" "$base" "$better" <<'PY'
+  local pct_threshold="$4"
+  local abs_threshold="$5"
+  local min_base="$6"
+  python3 - "$current" "$base" "$better" "$pct_threshold" "$abs_threshold" "$min_base" <<'PY'
 import sys
 current=float(sys.argv[1])
 base=float(sys.argv[2])
 better=sys.argv[3]
+pct_threshold=float(sys.argv[4])
+abs_threshold=float(sys.argv[5])
+min_base=float(sys.argv[6])
 if base == 0:
     print("n/a")
     raise SystemExit
 delta=((current-base)/base)*100.0
+absolute_delta=abs(current-base)
 state="stable"
-if better == "higher":
-    if delta >= 5:
+if base < min_base:
+    state="stable"
+elif better == "higher":
+    if delta >= pct_threshold and absolute_delta >= abs_threshold:
         state="improved"
-    elif delta <= -5:
+    elif delta <= -pct_threshold and absolute_delta >= abs_threshold:
         state="regressed"
 elif better == "lower":
-    if delta <= -5:
+    if delta <= -pct_threshold and absolute_delta >= abs_threshold:
         state="improved"
-    elif delta >= 5:
+    elif delta >= pct_threshold and absolute_delta >= abs_threshold:
         state="regressed"
 sign="+" if delta > 0 else ""
 print(f"{sign}{delta:.1f}% ({state})")
@@ -94,24 +103,24 @@ BASE_THROUGHPUT="$(json_field "$BASE_JSON" '.performance.load.high_concurrency_r
 HEAD_MEM_GROWTH="$(json_field "$HEAD_JSON" '.performance.load.high_concurrency_memory_growth_mb')"
 BASE_MEM_GROWTH="$(json_field "$BASE_JSON" '.performance.load.high_concurrency_memory_growth_mb')"
 
-COVERAGE_DELTA="$(format_delta "$HEAD_COVERAGE" "$BASE_COVERAGE" higher)"
-LOKI_DELTA="$(format_delta "$HEAD_LOKI_PCT" "$BASE_LOKI_PCT" higher)"
-DRILL_DELTA="$(format_delta "$HEAD_DRILL_PCT" "$BASE_DRILL_PCT" higher)"
-VL_DELTA="$(format_delta "$HEAD_VL_PCT" "$BASE_VL_PCT" higher)"
-QUERY_DELTA="$(format_delta "$HEAD_QUERY_NS" "$BASE_QUERY_NS" lower)"
-QUERY_BYTES_DELTA="$(format_delta "$HEAD_QUERY_BYTES" "$BASE_QUERY_BYTES" lower)"
-QUERY_ALLOCS_DELTA="$(format_delta "$HEAD_QUERY_ALLOCS" "$BASE_QUERY_ALLOCS" lower)"
-QUERY_BYPASS_DELTA="$(format_delta "$HEAD_QUERY_BYPASS_NS" "$BASE_QUERY_BYPASS_NS" lower)"
-QUERY_BYPASS_BYTES_DELTA="$(format_delta "$HEAD_QUERY_BYPASS_BYTES" "$BASE_QUERY_BYPASS_BYTES" lower)"
-QUERY_BYPASS_ALLOCS_DELTA="$(format_delta "$HEAD_QUERY_BYPASS_ALLOCS" "$BASE_QUERY_BYPASS_ALLOCS" lower)"
-LABELS_DELTA="$(format_delta "$HEAD_LABELS_NS" "$BASE_LABELS_NS" lower)"
-LABELS_BYTES_DELTA="$(format_delta "$HEAD_LABELS_BYTES" "$BASE_LABELS_BYTES" lower)"
-LABELS_ALLOCS_DELTA="$(format_delta "$HEAD_LABELS_ALLOCS" "$BASE_LABELS_ALLOCS" lower)"
-LABELS_BYPASS_DELTA="$(format_delta "$HEAD_LABELS_BYPASS_NS" "$BASE_LABELS_BYPASS_NS" lower)"
-LABELS_BYPASS_BYTES_DELTA="$(format_delta "$HEAD_LABELS_BYPASS_BYTES" "$BASE_LABELS_BYPASS_BYTES" lower)"
-LABELS_BYPASS_ALLOCS_DELTA="$(format_delta "$HEAD_LABELS_BYPASS_ALLOCS" "$BASE_LABELS_BYPASS_ALLOCS" lower)"
-THROUGHPUT_DELTA="$(format_delta "$HEAD_THROUGHPUT" "$BASE_THROUGHPUT" higher)"
-MEMORY_DELTA="$(format_delta "$HEAD_MEM_GROWTH" "$BASE_MEM_GROWTH" lower)"
+COVERAGE_DELTA="$(format_delta "$HEAD_COVERAGE" "$BASE_COVERAGE" higher 0.1 0.1 1)"
+LOKI_DELTA="$(format_delta "$HEAD_LOKI_PCT" "$BASE_LOKI_PCT" higher 0.1 0.1 1)"
+DRILL_DELTA="$(format_delta "$HEAD_DRILL_PCT" "$BASE_DRILL_PCT" higher 0.1 0.1 1)"
+VL_DELTA="$(format_delta "$HEAD_VL_PCT" "$BASE_VL_PCT" higher 0.1 0.1 1)"
+QUERY_DELTA="$(format_delta "$HEAD_QUERY_NS" "$BASE_QUERY_NS" lower 15 300 1000)"
+QUERY_BYTES_DELTA="$(format_delta "$HEAD_QUERY_BYTES" "$BASE_QUERY_BYTES" lower 20 32 64)"
+QUERY_ALLOCS_DELTA="$(format_delta "$HEAD_QUERY_ALLOCS" "$BASE_QUERY_ALLOCS" lower 15 1 1)"
+QUERY_BYPASS_DELTA="$(format_delta "$HEAD_QUERY_BYPASS_NS" "$BASE_QUERY_BYPASS_NS" lower 15 400 1000)"
+QUERY_BYPASS_BYTES_DELTA="$(format_delta "$HEAD_QUERY_BYPASS_BYTES" "$BASE_QUERY_BYPASS_BYTES" lower 20 32 64)"
+QUERY_BYPASS_ALLOCS_DELTA="$(format_delta "$HEAD_QUERY_BYPASS_ALLOCS" "$BASE_QUERY_BYPASS_ALLOCS" lower 15 1 1)"
+LABELS_DELTA="$(format_delta "$HEAD_LABELS_NS" "$BASE_LABELS_NS" lower 15 250 1000)"
+LABELS_BYTES_DELTA="$(format_delta "$HEAD_LABELS_BYTES" "$BASE_LABELS_BYTES" lower 20 32 64)"
+LABELS_ALLOCS_DELTA="$(format_delta "$HEAD_LABELS_ALLOCS" "$BASE_LABELS_ALLOCS" lower 15 1 1)"
+LABELS_BYPASS_DELTA="$(format_delta "$HEAD_LABELS_BYPASS_NS" "$BASE_LABELS_BYPASS_NS" lower 15 300 1000)"
+LABELS_BYPASS_BYTES_DELTA="$(format_delta "$HEAD_LABELS_BYPASS_BYTES" "$BASE_LABELS_BYPASS_BYTES" lower 20 32 64)"
+LABELS_BYPASS_ALLOCS_DELTA="$(format_delta "$HEAD_LABELS_BYPASS_ALLOCS" "$BASE_LABELS_BYPASS_ALLOCS" lower 15 1 1)"
+THROUGHPUT_DELTA="$(format_delta "$HEAD_THROUGHPUT" "$BASE_THROUGHPUT" higher 8 1000 5000)"
+MEMORY_DELTA="$(format_delta "$HEAD_MEM_GROWTH" "$BASE_MEM_GROWTH" lower 20 0.5 1)"
 
 cat >"$OUTPUT_MD" <<EOF
 <!-- pr-quality-report -->
@@ -160,4 +169,5 @@ Lower CPU cost (\`ns/op\`) is better. Lower benchmark memory cost (\`B/op\`, \`a
 - Coverage, compatibility, and sampled performance are reported here from the same PR workflow.
 - This is a delta report, not a release gate by itself. Required checks still decide merge safety.
 - Performance is a smoke comparison, not a full benchmark lab run.
+- Delta states apply noise guards (percent and absolute thresholds), so small runner jitter is reported as \`stable\`.
 EOF

--- a/scripts/ci/sync_release_metadata.sh
+++ b/scripts/ci/sync_release_metadata.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
-  echo "usage: $0 <version> <release-date> <tests-count> [repo-root]" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 6 ]; then
+  echo "usage: $0 <version> <release-date> <tests-count> [coverage-pct] [go-lines] [repo-root]" >&2
   exit 1
 fi
 
 VERSION="${1#v}"
 RELEASE_DATE="$2"
 TEST_COUNT="$3"
-REPO_ROOT="${4:-.}"
+COVERAGE_PCT="${4:-}"
+GO_LINES="${5:-}"
+REPO_ROOT="${6:-.}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 cd "$REPO_ROOT"
@@ -37,10 +39,69 @@ mv "$CHART_FILE.tmp" "$CHART_FILE"
 
 perl -0pi -e 's/"service\.version":\s*"[^"]+"/"service.version": "'"$VERSION"'"/' "$OBSERVABILITY_FILE"
 
+badge_message() {
+  local value="$1"
+  python3 - "$value" <<'PY'
+import sys
+import urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+}
+
+coverage_color() {
+  local cov="$1"
+  python3 - "$cov" <<'PY'
+import sys
+try:
+    value = float(sys.argv[1])
+except ValueError:
+    print("lightgrey")
+    raise SystemExit
+if value >= 90:
+    print("brightgreen")
+elif value >= 80:
+    print("green")
+elif value >= 70:
+    print("yellow")
+else:
+    print("red")
+PY
+}
+
 if [ -n "$TEST_COUNT" ]; then
-  TESTS_BADGE="https://img.shields.io/badge/tests-${TEST_COUNT}%20passed-brightgreen"
+  TESTS_MESSAGE="$(badge_message "${TEST_COUNT} passed")"
+  TESTS_BADGE="https://img.shields.io/badge/tests-${TESTS_MESSAGE}-brightgreen"
   awk -v badge="$TESTS_BADGE" '
     /^\[!\[Tests\]\(/ { print "[![Tests](" badge ")](#tests)"; next }
+    { print }
+  ' "$README_FILE" > "$README_FILE.tmp"
+  mv "$README_FILE.tmp" "$README_FILE"
+fi
+
+if [ -n "$COVERAGE_PCT" ]; then
+  COVERAGE_NUM="${COVERAGE_PCT%\%}"
+  COVERAGE_COLOR="$(coverage_color "$COVERAGE_NUM")"
+  COVERAGE_MESSAGE="$(badge_message "${COVERAGE_NUM}%")"
+  COVERAGE_BADGE="https://img.shields.io/badge/coverage-${COVERAGE_MESSAGE}-${COVERAGE_COLOR}"
+  if grep -Fq '[![Coverage](' "$README_FILE"; then
+    awk -v badge="$COVERAGE_BADGE" '
+      /^\[!\[Coverage\]\(/ { print "[![Coverage](" badge ")](#tests)"; next }
+      { print }
+    ' "$README_FILE" > "$README_FILE.tmp"
+  else
+    awk -v badge="$COVERAGE_BADGE" '
+      /^\[!\[Tests\]\(/ { print; print "[![Coverage](" badge ")](#tests)"; next }
+      { print }
+    ' "$README_FILE" > "$README_FILE.tmp"
+  fi
+  mv "$README_FILE.tmp" "$README_FILE"
+fi
+
+if [ -n "$GO_LINES" ]; then
+  LINES_MESSAGE="$(badge_message "${GO_LINES}")"
+  LOC_BADGE="https://img.shields.io/badge/go%20loc-${LINES_MESSAGE}-blue"
+  awk -v badge="$LOC_BADGE" '
+    /^\[!\[Lines of Code\]\(/ { print "[![Lines of Code](" badge ")](https://github.com/szibis/Loki-VL-proxy)"; next }
     { print }
   ' "$README_FILE" > "$README_FILE.tmp"
   mv "$README_FILE.tmp" "$README_FILE"

--- a/scripts/ci/tests/test_check_changelog_pr.py
+++ b/scripts/ci/tests/test_check_changelog_pr.py
@@ -37,10 +37,12 @@ class CheckChangelogPRTests(unittest.TestCase):
         self.assertTrue(should_require_changelog(["test: add coverage"], ["internal/proxy/proxy.go"]))
         self.assertTrue(should_require_changelog(["docs: mention thing"], ["go.mod"]))
 
-    def test_should_skip_for_docs_ci_and_tests_only(self):
+    def test_should_skip_for_docs_only(self):
         self.assertFalse(should_require_changelog(["docs: update guide"], ["docs/getting-started.md"]))
-        self.assertFalse(should_require_changelog(["ci: tune workflow"], [".github/workflows/ci.yaml"]))
-        self.assertFalse(should_require_changelog(["test: add coverage"], ["test/e2e-compat/features_test.go"]))
+
+    def test_should_require_for_ci_and_tests_changes(self):
+        self.assertTrue(should_require_changelog(["ci: tune workflow"], [".github/workflows/ci.yaml"]))
+        self.assertTrue(should_require_changelog(["test: add coverage"], ["test/e2e-compat/features_test.go"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- harden release metadata sync so changelog -> release notes -> main metadata stays consistent and deterministic
- stabilize PR quality performance smoke reporting by applying noise guards (percent + absolute thresholds) and single-CPU benchmark sampling
- add optional Docker Hub image publish in both auto and manual release workflows (alongside GHCR)
- auto-refresh README release badges (tests passed, coverage, Go LOC) during metadata sync to main
- add PR template guidance and stricter changelog gate behavior so CI/test workflow changes also require CHANGELOG.md updates

## Why
- PR quality summary was over-labeling small benchmark jitter as regressions
- release automation needed explicit support for Docker Hub credentials and tighter changelog/release-note coupling
- README release badges were drifting from actual release state
- changelog discipline needed to be enforced consistently at PR time