### PR TITLE
docs: sync release metadata for v0.27.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.6] - 2026-04-07
+
 ### CI
 
 - require `100%` Loki compatibility on PR quality and dedicated Loki compatibility workflow checks

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Release](https://img.shields.io/github/v/release/szibis/Loki-VL-proxy)](https://github.com/szibis/Loki-VL-proxy/releases)
 [![Lines of Code](https://img.shields.io/badge/go%20loc-43.3k-blue)](https://github.com/szibis/Loki-VL-proxy)
 [![Tests](https://img.shields.io/badge/tests-1227%20passed-brightgreen)](#tests)
-[![Coverage](https://img.shields.io/badge/coverage-90.1%25-brightgreen)](#tests)
+[![Coverage](https://img.shields.io/badge/coverage-90.0%25-brightgreen)](#tests)
 [![LogQL Coverage](https://img.shields.io/badge/LogQL%20coverage-100%25-brightgreen)](#logql-compatibility)
 [![License](https://img.shields.io/github/license/szibis/Loki-VL-proxy)](LICENSE)
 [![CodeQL](https://github.com/szibis/Loki-VL-proxy/actions/workflows/codeql.yaml/badge.svg)](https://github.com/szibis/Loki-VL-proxy/actions/workflows/codeql.yaml)

--- a/charts/loki-vl-proxy/Chart.yaml
+++ b/charts/loki-vl-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-vl-proxy
 description: HTTP proxy translating Loki API to VictoriaLogs
 type: application
-version: 0.27.5
-appVersion: "0.27.5"
+version: 0.27.6
+appVersion: "0.27.6"
 home: https://github.com/szibis/Loki-VL-proxy
 sources:
   - https://github.com/szibis/Loki-VL-proxy

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -39,7 +39,7 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
   },
   "body": "request",
   "service.name": "loki-vl-proxy",
-  "service.version": "0.27.5",
+  "service.version": "0.27.6",
   "service.instance.id": "proxy-1",
   "deployment.environment.name": "prod",
   "component": "proxy",


### PR DESCRIPTION
## Summary
- sync release metadata files for v0.27.6 after automated release publish
- update CHANGELOG materialization, Helm chart version/appVersion, observability service.version, and README release badges

## Why
- branch protection blocks direct pushes to main
- this PR preserves required checks and signed merge flow while keeping metadata sync automated