### PR TITLE
chart: wire GOMEMLIMIT from memory limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ helm install loki-vl-proxy ./charts/loki-vl-proxy \
   --set extraArgs.backend=http://victorialogs:9428
 ```
 
+For autoscaled installs, use the chart-native HPA block and let the chart derive `GOMEMLIMIT` from the pod memory limit:
+
+```bash
+helm install loki-vl-proxy ./charts/loki-vl-proxy \
+  --set extraArgs.backend=http://victorialogs:9428 \
+  --set resources.requests.cpu=250m \
+  --set resources.requests.memory=256Mi \
+  --set resources.limits.cpu=1 \
+  --set resources.limits.memory=512Mi \
+  --set horizontalPodAutoscaling.enabled=true \
+  --set horizontalPodAutoscaling.minReplicas=2 \
+  --set horizontalPodAutoscaling.maxReplicas=6 \
+  --set goMemLimitPercent=80
+```
+
+This renders `GOMEMLIMIT` into the pod env automatically. If you need an exact value instead of a percentage, set `goMemLimit` directly.
+
 ### Fleet Cache (Multi-Replica)
 
 ```bash

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -87,3 +87,57 @@ Default disk cache path when persistence is enabled.
 {{- define "loki-vl-proxy.diskCachePath" -}}
 {{- printf "%s/%s" (trimSuffix "/" .Values.persistence.mountPath) .Values.persistence.fileName -}}
 {{- end }}
+
+{{/*
+Convert a Kubernetes memory quantity to bytes.
+Supports plain integers plus decimal/binary suffixes commonly used in charts.
+*/}}
+{{- define "loki-vl-proxy.memoryQuantityToBytes" -}}
+{{- $raw := toString . | trim -}}
+{{- if not $raw -}}
+{{- "" -}}
+{{- else -}}
+{{- $num := mustRegexFind "^[0-9]+" $raw | int64 -}}
+{{- $unit := "" -}}
+{{- if regexMatch "[A-Za-z]+$" $raw -}}
+{{- $unit = mustRegexFind "[A-Za-z]+$" $raw -}}
+{{- end -}}
+{{- if eq $unit "" -}}
+{{- $num -}}
+{{- else if eq $unit "Ki" -}}
+{{- mul $num 1024 -}}
+{{- else if eq $unit "Mi" -}}
+{{- mul $num 1048576 -}}
+{{- else if eq $unit "Gi" -}}
+{{- mul $num 1073741824 -}}
+{{- else if eq $unit "Ti" -}}
+{{- mul $num 1099511627776 -}}
+{{- else if eq $unit "K" -}}
+{{- mul $num 1000 -}}
+{{- else if eq $unit "M" -}}
+{{- mul $num 1000000 -}}
+{{- else if eq $unit "G" -}}
+{{- mul $num 1000000000 -}}
+{{- else if eq $unit "T" -}}
+{{- mul $num 1000000000000 -}}
+{{- else -}}
+{{- fail (printf "unsupported memory unit for goMemLimitPercent: %q" $raw) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the runtime GOMEMLIMIT value.
+Explicit goMemLimit wins; otherwise derive bytes from resources.limits.memory.
+*/}}
+{{- define "loki-vl-proxy.goMemLimit" -}}
+{{- if .Values.goMemLimit -}}
+{{- .Values.goMemLimit -}}
+{{- else -}}
+{{- $memoryLimit := dig "limits" "memory" "" .Values.resources -}}
+{{- if $memoryLimit -}}
+{{- $limitBytes := include "loki-vl-proxy.memoryQuantityToBytes" $memoryLimit | int64 -}}
+{{- div (mul $limitBytes (.Values.goMemLimitPercent | int64)) 100 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "loki-vl-proxy.labels" . | nindent 4 }}
 spec:
+  {{- $goMemLimit := include "loki-vl-proxy.goMemLimit" . | trim }}
   {{- if eq (include "loki-vl-proxy.workloadKind" .) "StatefulSet" }}
   serviceName: {{ include "loki-vl-proxy.peerServiceName" . }}
   podManagementPolicy: {{ .Values.workload.statefulSet.podManagementPolicy }}
@@ -92,8 +93,14 @@ spec:
             - "-peer-static={{ join "," .Values.peerCache.peers }}"
             {{- end }}
             {{- end }}
-          {{- if or .Values.peerCache.enabled .Values.env }}
+          {{- if or .Values.peerCache.enabled .Values.env $goMemLimit }}
           env:
+            # Keep the runtime memory budget aligned with the chart memory limit.
+            # Explicit goMemLimit wins; otherwise we derive bytes from limits.memory.
+            {{- if $goMemLimit }}
+            - name: GOMEMLIMIT
+              value: {{ $goMemLimit | quote }}
+            {{- end }}
             {{- if .Values.peerCache.enabled }}
             - name: POD_IP
               valueFrom:

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -86,11 +86,12 @@ extraArgs:
   # Stream selector optimization — list VL _stream_fields labels for fast index path
   # stream-fields: "app,env,namespace"
 
-# Go runtime tuning — set GOMEMLIMIT to ~90% of memory limit for optimal GC
+# Go runtime tuning — set GOMEMLIMIT to a bounded share of the pod memory limit
 # This prevents OOM while minimizing GC overhead. See docs/performance.md.
-# Go runtime tuning:
-# GOMEMLIMIT is auto-calculated as goMemLimitPercent% of resources.limits.memory.
+# The chart injects GOMEMLIMIT automatically into the container env.
+# GOMEMLIMIT is calculated as goMemLimitPercent% of resources.limits.memory.
 # Override with goMemLimit to set an explicit value (e.g., "500MiB").
+# Prefer goMemLimit/goMemLimitPercent over setting env.GOMEMLIMIT directly.
 goMemLimitPercent: 70  # percentage of resources.limits.memory
 goMemLimit: ""         # explicit override; if set, goMemLimitPercent is ignored
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -166,8 +166,8 @@ go tool pprof mem.prof
 The Helm chart auto-calculates `GOMEMLIMIT` as a percentage of `resources.limits.memory`:
 
 ```yaml
-# Default: 70% of memory limit
-goMemLimitPercent: 70   # 256Mi * 70% = 179MiB
+# Default: 70% of memory limit, injected as GOMEMLIMIT
+goMemLimitPercent: 70   # 256Mi -> 187904819 bytes
 
 # Override with explicit value
 goMemLimit: "500MiB"    # ignores goMemLimitPercent

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -163,7 +163,10 @@ horizontalPodAutoscaling:
         target:
           type: Utilization
           averageUtilization: 70
+goMemLimitPercent: 80
 ```
+
+With the chart defaults, this also injects `GOMEMLIMIT` into the pod env based on `resources.limits.memory`, so GC pressure tracks the memory envelope used by the HPA target.
 
 ### Large (1,000-10,000 req/s)
 
@@ -205,6 +208,7 @@ horizontalPodAutoscaling:
         target:
           type: Utilization
           averageUtilization: 60
+goMemLimitPercent: 80
 podDisruptionBudget:
   minAvailable: 2
 ```


### PR DESCRIPTION
## Summary
- wire chart-managed `GOMEMLIMIT` into the pod env from `resources.limits.memory`
- keep `goMemLimit` as the explicit override and document the behavior in chart docs
- add HPA + memory tuning examples in the README and scaling docs

## Root Cause
The chart advertised `goMemLimitPercent` as an auto-calculated setting, but `0.27.6` never rendered that value into the deployment. In practice, operators could set `goMemLimitPercent` and get no runtime effect unless they also hand-managed `env.GOMEMLIMIT` outside the chart.

## Validation
- `helm template loki-vl-proxy ./charts/loki-vl-proxy --set resources.limits.memory=512Mi --set goMemLimitPercent=80 --set horizontalPodAutoscaling.enabled=true --set horizontalPodAutoscaling.minReplicas=2 --set horizontalPodAutoscaling.maxReplicas=6`
- verified rendered deployment contains `env: GOMEMLIMIT=429496729`
- verified rendered HPA remains valid with chart-native `horizontalPodAutoscaling`
