### PR TITLE
docs: sync release metadata for v0.27.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.8] - 2026-04-08
+
 ### CI
 
 - stabilize PR performance smoke by running benchmarks/load in an isolated phase after functional checks, increasing benchmark sample depth (`-benchtime=2s`, `-count=7`), and tightening perf regression thresholds to better flag real cache-bypass regressions

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Release](https://img.shields.io/github/v/release/ReliablyObserve/Loki-VL-proxy)](https://github.com/ReliablyObserve/Loki-VL-proxy/releases)
 [![Lines of Code](https://img.shields.io/badge/go%20loc-45.5k-blue)](https://github.com/ReliablyObserve/Loki-VL-proxy)
 [![Tests](https://img.shields.io/badge/tests-1294%20passed-brightgreen)](#tests)
-[![Coverage](https://img.shields.io/badge/coverage-90.8%25-brightgreen)](#tests)
+[![Coverage](https://img.shields.io/badge/coverage-91.0%25-brightgreen)](#tests)
 [![LogQL Coverage](https://img.shields.io/badge/LogQL%20coverage-100%25-brightgreen)](#logql-compatibility)
 [![License](https://img.shields.io/github/license/ReliablyObserve/Loki-VL-proxy)](LICENSE)
 [![CodeQL](https://github.com/ReliablyObserve/Loki-VL-proxy/actions/workflows/codeql.yaml/badge.svg?branch=main&event=push)](https://github.com/ReliablyObserve/Loki-VL-proxy/actions/workflows/codeql.yaml)

--- a/charts/loki-vl-proxy/Chart.yaml
+++ b/charts/loki-vl-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-vl-proxy
 description: HTTP proxy translating Loki API to VictoriaLogs
 type: application
-version: 0.27.7
-appVersion: "0.27.7"
+version: 0.27.8
+appVersion: "0.27.8"
 home: https://github.com/ReliablyObserve/Loki-VL-proxy
 sources:
   - https://github.com/ReliablyObserve/Loki-VL-proxy

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -48,7 +48,7 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
   },
   "body": "request",
   "service.name": "loki-vl-proxy",
-  "service.version": "0.27.7",
+  "service.version": "0.27.8",
   "service.instance.id": "proxy-1",
   "deployment.environment.name": "prod",
   "component": "proxy",


### PR DESCRIPTION
## Summary
- sync release metadata files for v0.27.8 after automated release publish
- update CHANGELOG materialization, Helm chart version/appVersion, observability service.version, and README release badges

## Why
- branch protection blocks direct pushes to main
- this PR preserves required checks and signed merge flow while keeping metadata sync automated