### PR TITLE
ci: fix auto-release tag auth fallback

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -224,18 +224,30 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Create release tag
         env:
+          RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           WORKFLOW_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           TAG="${{ steps.meta.outputs.tag }}"
+          PRIMARY_TOKEN="${RELEASE_PR_TOKEN:-$WORKFLOW_TOKEN}"
+          PRIMARY_ACTOR="RELEASE_PR_TOKEN"
+          if [ -z "${RELEASE_PR_TOKEN:-}" ]; then
+            PRIMARY_ACTOR="GITHUB_TOKEN"
+          fi
           git fetch --tags origin
           if git rev-parse "${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists"
           else
             git tag "${TAG}" "${GITHUB_SHA}"
-            if ! git push origin "${TAG}"; then
-              echo "::warning::Primary tag push failed; retrying with workflow token"
-              git push "https://x-access-token:${WORKFLOW_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${TAG}"
+            PRIMARY_URL="https://x-access-token:${PRIMARY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            if ! git push "${PRIMARY_URL}" "${TAG}"; then
+              if [ "${PRIMARY_ACTOR}" = "RELEASE_PR_TOKEN" ]; then
+                echo "::warning::Tag push with RELEASE_PR_TOKEN failed; retrying with GITHUB_TOKEN"
+                git push "https://x-access-token:${WORKFLOW_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${TAG}"
+              else
+                echo "::error::Tag push failed with GITHUB_TOKEN and no RELEASE_PR_TOKEN fallback is available"
+                exit 1
+              fi
             fi
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - enforce canonical dashboard/alert asset sync in CI and support syncing multiple dashboard JSON files into chart assets
 - add auto-release tag push fallback to retry with the workflow token when checkout credentials cannot create tags
+- make auto-release tag creation prefer `RELEASE_PR_TOKEN` when configured and fall back to `GITHUB_TOKEN` only if needed
 
 ## [0.27.8] - 2026-04-08
 


### PR DESCRIPTION
## Summary
- make auto-release tag creation explicitly prefer `RELEASE_PR_TOKEN` when present
- keep fallback retry to `GITHUB_TOKEN`
- add changelog note for the CI hotfix

## Why
The latest auto-release run still failed at `Create release tag` with 403 even after URL fallback, because the effective token lacked write access for tags. This change ensures the step uses the same release token channel intended for release automation before falling back.

## Validation
- inspected failed job logs for run 24192159858 / job 70612346216
- confirmed failure point was tag push auth in `Create release tag`
