### PR TITLE
ci: avoid hard-fail when metadata PR push is forbidden

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -395,7 +395,12 @@ jobs:
           git checkout -B "${BRANCH}"
           git add -f -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
           git commit -m "docs: sync release metadata for v${VERSION}"
-          git push origin "${BRANCH}" --force
+          if ! git push origin "${BRANCH}" --force; then
+            echo "::warning::Unable to push release metadata branch ${BRANCH}. Skipping metadata PR automation for this release."
+            echo "::warning::Verify RELEASE_PR_TOKEN permissions (contents:write and pull_requests:write) to re-enable metadata sync automation."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
       - name: Create or update release metadata PR
         id: metadata-pr

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -361,6 +361,7 @@ jobs:
       - name: Prepare release metadata branch
         id: metadata
         env:
+          METADATA_PUSH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN != '' && secrets.RELEASE_PR_TOKEN || github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
           TEST_COUNT: ${{ needs.validate-release.outputs.test_count }}
           COVERAGE_PCT: ${{ needs.validate-release.outputs.coverage_pct }}
@@ -395,7 +396,8 @@ jobs:
           git checkout -B "${BRANCH}"
           git add -f -- CHANGELOG.md README.md docs/observability.md charts/loki-vl-proxy/Chart.yaml
           git commit -m "docs: sync release metadata for v${VERSION}"
-          if ! git push origin "${BRANCH}" --force; then
+          PUSH_URL="https://x-access-token:${METADATA_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if ! git push "${PUSH_URL}" "${BRANCH}" --force; then
             echo "::warning::Unable to push release metadata branch ${BRANCH}. Skipping metadata PR automation for this release."
             echo "::warning::Verify RELEASE_PR_TOKEN permissions (contents:write and pull_requests:write) to re-enable metadata sync automation."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enforce canonical dashboard/alert asset sync in CI and support syncing multiple dashboard JSON files into chart assets
 - add auto-release tag push fallback to retry with the workflow token when checkout credentials cannot create tags
 - make auto-release tag creation prefer `RELEASE_PR_TOKEN` when configured and fall back to `GITHUB_TOKEN` only if needed
+- avoid failing auto-release when metadata sync branch push is denied; emit warnings and skip metadata PR automation for that run
 
 ## [0.27.8] - 2026-04-08
 


### PR DESCRIPTION
## Summary
- make release metadata branch push non-fatal in auto-release
- emit explicit warnings when push is denied
- skip metadata PR automation for that run instead of failing a published release

## Context
The v0.27.9 release was published, but the workflow concluded as failed because metadata branch push returned 403.

## Behavior
When metadata branch push fails:
- warn about missing token permissions
- set has_changes=false
- exit metadata prep step cleanly so release job remains successful
