### PR TITLE
fix: separate datasource auth identity from client attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- separate datasource/basic-auth credentials from end-user attribution: `enduser.id` now resolves from trusted user headers/tenant/client IP, while auth principals are reported separately via `auth.*` logs and `X-Loki-VL-Auth-*` upstream headers
+- make emitted 3-tuple stream metadata parser-safe by default (flat key/value third element), and emit nested Loki categorized metadata (`structuredMetadata`/`parsed`) only when clients request `X-Loki-Response-Encoding-Flags: categorize-labels`
+- enrich request logs with proxy context diagnostics, including cache result (`hit|miss|bypass`), upstream call count/status/latency, and proxy-overhead timing
+
 ## [0.27.10] - 2026-04-09
 
 ### Features

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,7 +25,7 @@
 For Grafana Logs Drilldown and Explore compatibility:
 
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default. Set `-emit-structured-metadata=true` to emit Loki 3-tuples `[timestamp, line, metadata]`.
-- When emitted, tuple metadata keeps Loki-style `structuredMetadata` and also exposes a compatibility alias `structured_metadata` for clients that still read snake_case keys.
+- When emitted, tuple metadata defaults to a flat key/value object for broad client/parser compatibility. If the request carries `X-Loki-Response-Encoding-Flags: categorize-labels`, metadata is emitted in Loki's categorized shape with `structuredMetadata` and `parsed` objects.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,7 +250,7 @@ kill -HUP $(pidof loki-vl-proxy)
 | `-server.admin-auth-token` | — | — | Bearer token accepted on admin/debug endpoints |
 | `-metrics.max-tenants` | — | `256` | Max unique tenant labels retained in `/metrics` before using `__overflow__` |
 | `-metrics.max-clients` | — | `256` | Max unique client labels retained in `/metrics` before using `__overflow__` |
-| `-metrics.trust-proxy-headers` | — | `false` | Trust `X-Grafana-User` and `X-Forwarded-For` for client metrics, logs, and backend client-context forwarding |
+| `-metrics.trust-proxy-headers` | — | `false` | Trust user/proxy headers (`X-Grafana-User`, `X-Forwarded-User`, `X-Webauth-User`, `X-Auth-Request-User`, `X-Forwarded-*`) for client metrics/log attribution and backend context forwarding |
 
 ## Grafana Datasource Mapping
 
@@ -269,6 +269,8 @@ These Grafana Loki datasource settings now have a direct proxy-side mapping:
 | Timeout | `-backend-timeout` for proxy→VL, Grafana datasource timeout for Grafana→proxy |
 | Maximum lines | `-max-lines` |
 
-When `-metrics.trust-proxy-headers=true`, the proxy also forwards `X-Grafana-User` plus derived `X-Loki-VL-Client-ID` and `X-Loki-VL-Client-Source` headers to the backend so downstream logs and stats can attribute expensive queries to real Grafana users instead of only source IPs.
+When `-metrics.trust-proxy-headers=true`, the proxy forwards trusted user headers and proxy-chain headers to the backend, plus derived context headers `X-Loki-VL-Client-ID` / `X-Loki-VL-Client-Source`.
+
+Datasource auth credentials are forwarded separately as `X-Loki-VL-Auth-User` / `X-Loki-VL-Auth-Source` and are not used as `enduser.id` client identity.
 
 Alerting datasource integration is still partial: the proxy supports legacy Loki YAML rules reads and Prometheus-style JSON rules/alerts reads against a configured backend, but it does not yet implement the full Loki ruler write API surface.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,7 +60,12 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
   "loki.query": "{service_name=\"api\"} |= \"error\"",
   "client.address": "10.0.0.12:51884",
   "enduser.id": "grafana-user@example.com",
-  "loki.client.source": "x-grafana-user"
+  "loki.client.source": "grafana_user",
+  "cache.result": "miss",
+  "upstream.calls": 1,
+  "upstream.status_code": 200,
+  "upstream.duration_ms": 31,
+  "proxy.overhead_ms": 11
 }
 ```
 
@@ -93,6 +98,9 @@ The proxy writes structured logs for:
 | `http.*` | request semantics |
 | `client.address` | remote address |
 | `enduser.id` | trusted user/client identity when available |
+| `auth.*` | datasource/auth principal context (separate from `enduser.id`) |
+| `cache.result` | compatibility cache result (`hit`, `miss`, `bypass`) |
+| `upstream.*` | backend call count, status, and latency |
 | `loki.*` | Loki/proxy-specific attributes |
 
 ## Metrics
@@ -226,12 +234,13 @@ Per-client metrics and request logs can use trusted upstream identity instead of
 
 When enabled, the proxy prefers:
 
-1. `X-Grafana-User`
+1. Trusted user headers (`X-Grafana-User`, `X-Forwarded-User`, `X-Webauth-User`, `X-Auth-Request-User`)
 2. tenant
-3. basic-auth user
+3. trusted forwarded client IP (`X-Forwarded-For`)
 4. remote IP
 
-Only enable this when the proxy sits behind a trusted auth proxy or Grafana instance.
+Datasource/basic-auth credentials are reported separately under `auth.*` and are not used as end-user identity.
+Only enable trusted proxy headers when the proxy sits behind a trusted auth proxy or Grafana instance.
 
 ## Integration Examples
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -228,11 +228,12 @@ sum(rate(loki_vl_proxy_tenant_requests_total{status=~"4..|5.."}[5m])) by (tenant
 ### Per-Client (User Identity)
 
 Client identity is resolved from (priority order):
-1. `X-Grafana-User` header when `-metrics.trust-proxy-headers=true`
+1. Trusted user headers when `-metrics.trust-proxy-headers=true` (`X-Grafana-User`, `X-Forwarded-User`, `X-Webauth-User`, `X-Auth-Request-User`)
 2. `X-Scope-OrgID` header (tenant)
-3. Basic auth username
-4. `X-Forwarded-For` when `-metrics.trust-proxy-headers=true`
-5. Remote IP (fallback)
+3. `X-Forwarded-For` when `-metrics.trust-proxy-headers=true`
+4. Remote IP (fallback)
+
+Datasource/basic-auth credentials are tracked separately and are not used as client identity.
 
 ```promql
 # Request rate per client

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -215,7 +215,7 @@ func (m *Metrics) RecordTenantRequest(tenant, endpoint string, statusCode int, d
 }
 
 // RecordClientIdentity records a request for a specific client identity.
-// Client is identified by: X-Grafana-User > tenant > basic auth user > IP.
+// Client is identified by trusted user header > tenant > client IP.
 func (m *Metrics) RecordClientIdentity(clientID, endpoint string, duration time.Duration, responseBytes int64) {
 	clientID = m.canonicalClientLabel(clientID)
 
@@ -261,22 +261,32 @@ func (m *Metrics) RecordClientIdentity(clientID, endpoint string, duration time.
 }
 
 // ResolveClientContext extracts the client identity from an HTTP request and describes its source.
-// Priority with trusted proxy headers: X-Grafana-User > X-Scope-OrgID > basic auth user > X-Forwarded-For > remote IP.
-// Priority without trusted proxy headers: X-Scope-OrgID > basic auth user > remote IP.
+// Priority with trusted proxy headers: Grafana/auth-proxy user headers > X-Scope-OrgID > X-Forwarded-For > remote IP.
+// Priority without trusted proxy headers: X-Scope-OrgID > remote IP.
+//
+// Intentionally does not use datasource/basic-auth credentials as client identity.
+// Those credentials authenticate backend access and should not be attributed as the
+// end user in per-client telemetry.
 func ResolveClientContext(r *http.Request, trustProxyHeaders bool) (string, string) {
-	// Grafana sets this header when proxying datasource requests
 	if trustProxyHeaders {
-		if user := strings.TrimSpace(r.Header.Get("X-Grafana-User")); user != "" {
-			return user, "grafana_user"
+		type candidate struct {
+			header string
+			source string
+		}
+		for _, c := range []candidate{
+			{header: "X-Grafana-User", source: "grafana_user"},
+			{header: "X-Forwarded-User", source: "forwarded_user"},
+			{header: "X-Webauth-User", source: "webauth_user"},
+			{header: "X-Auth-Request-User", source: "auth_request_user"},
+		} {
+			if user := strings.TrimSpace(r.Header.Get(c.header)); user != "" {
+				return user, c.source
+			}
 		}
 	}
 	// Tenant ID (X-Scope-OrgID)
 	if tenant := strings.TrimSpace(r.Header.Get("X-Scope-OrgID")); tenant != "" {
 		return tenant, "tenant"
-	}
-	// Basic auth username
-	if user, _, ok := r.BasicAuth(); ok && user != "" {
-		return user, "basic_auth"
 	}
 	// Forwarded client IP
 	if trustProxyHeaders {
@@ -294,6 +304,15 @@ func ResolveClientContext(r *http.Request, trustProxyHeaders bool) (string, stri
 		return host, "remote_addr"
 	}
 	return strings.TrimSpace(r.RemoteAddr), "remote_addr"
+}
+
+// ResolveAuthContext extracts the request authentication principal (if available)
+// and describes its source. This is intentionally separate from ResolveClientContext.
+func ResolveAuthContext(r *http.Request) (string, string) {
+	if user, _, ok := r.BasicAuth(); ok && strings.TrimSpace(user) != "" {
+		return user, "basic_auth"
+	}
+	return "", ""
 }
 
 // ResolveClientID extracts the client identity from an HTTP request.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -104,8 +104,8 @@ func TestResolveClientID_IgnoresUntrustedProxyHeadersByDefault(t *testing.T) {
 	req.RemoteAddr = "198.51.100.20:1234"
 
 	got := ResolveClientID(req, false)
-	if got != "backend-user" {
-		t.Fatalf("expected basic auth user when proxy headers are untrusted, got %q", got)
+	if got != "198.51.100.20" {
+		t.Fatalf("expected remote client identity when proxy headers are untrusted, got %q", got)
 	}
 }
 
@@ -118,6 +118,18 @@ func TestResolveClientID_UsesTrustedGrafanaUser(t *testing.T) {
 	got := ResolveClientID(req, true)
 	if got != "grafana-user" {
 		t.Fatalf("expected trusted grafana user to win, got %q", got)
+	}
+}
+
+func TestResolveClientID_UsesTrustedForwardedUserHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.Header.Set("X-Forwarded-User", "idp-user@example.com")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("backend-user:secret")))
+	req.RemoteAddr = "198.51.100.20:1234"
+
+	got := ResolveClientID(req, true)
+	if got != "idp-user@example.com" {
+		t.Fatalf("expected trusted forwarded user header to win, got %q", got)
 	}
 }
 
@@ -215,6 +227,16 @@ func TestResolveClientContext_Branches(t *testing.T) {
 			t.Fatalf("unexpected context: %q %q", clientID, source)
 		}
 	})
+}
+
+func TestResolveAuthContext_BasicAuthUser(t *testing.T) {
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("backend-user:secret")))
+
+	authUser, authSource := ResolveAuthContext(req)
+	if authUser != "backend-user" || authSource != "basic_auth" {
+		t.Fatalf("unexpected auth context: %q %q", authUser, authSource)
+	}
 }
 
 func TestSanitizeMetricIdentity(t *testing.T) {

--- a/internal/proxy/datasource_compat_test.go
+++ b/internal/proxy/datasource_compat_test.go
@@ -100,3 +100,46 @@ func TestDatasourceCompat_ForwardsTrustedGrafanaUserContext(t *testing.T) {
 		t.Fatalf("expected client source to describe trusted grafana user, got %q", gotClientSource)
 	}
 }
+
+func TestDatasourceCompat_ForwardsTrustedUserAndProxyChainHeadersAndSeparatesAuthUser(t *testing.T) {
+	var gotForwardedUser, gotForwardedFor, gotAuthUser, gotAuthSource string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotForwardedUser = r.Header.Get("X-Forwarded-User")
+		gotForwardedFor = r.Header.Get("X-Forwarded-For")
+		gotAuthUser = r.Header.Get("X-Loki-VL-Auth-User")
+		gotAuthSource = r.Header.Get("X-Loki-VL-Auth-Source")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"values": []map[string]interface{}{},
+		})
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:               vlBackend.URL,
+		Cache:                    c,
+		LogLevel:                 "error",
+		MetricsTrustProxyHeaders: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/loki/api/v1/labels", nil)
+	req.Header.Set("X-Forwarded-User", "idp-user@example.com")
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.Header.Set("Authorization", "Basic ZGF0YXNvdXJjZS11c2VyOnNlY3JldA==")
+	req.RemoteAddr = "198.51.100.20:1234"
+	w := httptest.NewRecorder()
+	p.handleLabels(w, req)
+
+	if gotForwardedUser != "idp-user@example.com" {
+		t.Fatalf("expected trusted forwarded user header to be passed upstream, got %q", gotForwardedUser)
+	}
+	if gotForwardedFor != "203.0.113.10" {
+		t.Fatalf("expected trusted forwarded-for header to be passed upstream, got %q", gotForwardedFor)
+	}
+	if gotAuthUser != "datasource-user" || gotAuthSource != "basic_auth" {
+		t.Fatalf("expected datasource auth principal to be forwarded separately, got user=%q source=%q", gotAuthUser, gotAuthSource)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -25,11 +25,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/metrics"
 	mw "github.com/ReliablyObserve/Loki-VL-proxy/internal/middleware"
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/translator"
+	"github.com/gorilla/websocket"
 	"gopkg.in/yaml.v3"
 )
 
@@ -68,7 +68,74 @@ type ctxKey int
 const (
 	orgIDKey ctxKey = iota
 	origRequestKey
+	requestTelemetryKey
 )
+
+type requestTelemetry struct {
+	mu sync.Mutex
+
+	cacheResult       string
+	upstreamCalls     int
+	upstreamDuration  time.Duration
+	upstreamLastCode  int
+	upstreamErrorSeen bool
+}
+
+type requestTelemetrySnapshot struct {
+	cacheResult       string
+	upstreamCalls     int
+	upstreamDuration  time.Duration
+	upstreamLastCode  int
+	upstreamErrorSeen bool
+}
+
+func newRequestTelemetry() *requestTelemetry {
+	return &requestTelemetry{cacheResult: "bypass"}
+}
+
+func getRequestTelemetry(ctx context.Context) *requestTelemetry {
+	rt, _ := ctx.Value(requestTelemetryKey).(*requestTelemetry)
+	return rt
+}
+
+func setCacheResult(ctx context.Context, result string) {
+	rt := getRequestTelemetry(ctx)
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.cacheResult = result
+	rt.mu.Unlock()
+}
+
+func recordUpstreamCall(ctx context.Context, statusCode int, duration time.Duration, hadError bool) {
+	rt := getRequestTelemetry(ctx)
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.upstreamCalls++
+	rt.upstreamDuration += duration
+	rt.upstreamLastCode = statusCode
+	rt.upstreamErrorSeen = rt.upstreamErrorSeen || hadError
+	rt.mu.Unlock()
+}
+
+func snapshotTelemetry(ctx context.Context) requestTelemetrySnapshot {
+	rt := getRequestTelemetry(ctx)
+	if rt == nil {
+		return requestTelemetrySnapshot{cacheResult: "bypass"}
+	}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return requestTelemetrySnapshot{
+		cacheResult:       rt.cacheResult,
+		upstreamCalls:     rt.upstreamCalls,
+		upstreamDuration:  rt.upstreamDuration,
+		upstreamLastCode:  rt.upstreamLastCode,
+		upstreamErrorSeen: rt.upstreamErrorSeen,
+	}
+}
 
 // withOrgID stores the X-Scope-OrgID and original request in the request context (request-scoped, no shared state).
 func withOrgID(r *http.Request) *http.Request {
@@ -759,15 +826,18 @@ func (p *Proxy) compatCacheMiddleware(endpoint string, next http.HandlerFunc) ht
 		start := time.Now()
 		cacheKey, cacheable := p.compatCacheKey(endpoint, r)
 		if !cacheable {
+			setCacheResult(r.Context(), "bypass")
 			next(w, r)
 			return
 		}
 		ttl := CacheTTLs[endpoint]
 		if ttl <= 0 {
+			setCacheResult(r.Context(), "bypass")
 			next(w, r)
 			return
 		}
 		if cached, ok := p.compatCache.Get(cacheKey); ok {
+			setCacheResult(r.Context(), "hit")
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(cached)
 			elapsed := time.Since(start)
@@ -779,6 +849,7 @@ func (p *Proxy) compatCacheMiddleware(endpoint string, next http.HandlerFunc) ht
 			return
 		}
 
+		setCacheResult(r.Context(), "miss")
 		rec := httptest.NewRecorder()
 		next(rec, r)
 		copyHeaders(w.Header(), rec.Header())
@@ -2837,11 +2908,15 @@ func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*htt
 	}
 	p.forwardTenantHeaders(req)
 	p.applyBackendHeaders(req)
+	start := time.Now()
 	resp, err := p.client.Do(req)
+	duration := time.Since(start)
 	if err != nil {
+		recordUpstreamCall(ctx, 0, duration, true)
 		p.breaker.RecordFailure()
 		return nil, err
 	}
+	recordUpstreamCall(ctx, resp.StatusCode, duration, false)
 	if resp.StatusCode >= 500 {
 		p.breaker.RecordFailure()
 	} else {
@@ -2866,11 +2941,15 @@ func (p *Proxy) vlPost(ctx context.Context, path string, params url.Values) (*ht
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	p.forwardTenantHeaders(req)
 	p.applyBackendHeaders(req)
+	start := time.Now()
 	resp, err := p.client.Do(req)
+	duration := time.Since(start)
 	if err != nil {
+		recordUpstreamCall(ctx, 0, duration, true)
 		p.breaker.RecordFailure()
 		return nil, err
 	}
+	recordUpstreamCall(ctx, resp.StatusCode, duration, false)
 	if resp.StatusCode >= 500 {
 		p.breaker.RecordFailure()
 	} else {
@@ -3338,8 +3417,9 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 	}
 
 	// Chunked streaming: flush partial results as they arrive from VL
+	categorizedLabels := requestWantsCategorizedLabels(r)
 	if p.streamResponse {
-		p.streamLogQuery(w, resp)
+		p.streamLogQuery(w, resp, r.FormValue("query"), categorizedLabels)
 		return
 	}
 
@@ -3347,7 +3427,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 
 	// VL returns newline-delimited JSON, each line is a log entry.
 	// Loki expects: {"status":"success","data":{"resultType":"streams","result":[...]}}
-	streams := p.vlLogsToLokiStreams(body, r.FormValue("query"))
+	streams := p.vlLogsToLokiStreams(body, r.FormValue("query"), categorizedLabels)
 
 	// Apply derived fields (extract trace_id etc. from log lines)
 	if len(p.derivedFields) > 0 {
@@ -3381,7 +3461,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 }
 
 // streamLogQuery streams VL NDJSON response as chunked Loki-compatible JSON.
-func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response) {
+func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, originalQuery string, categorizedLabels bool) {
 	flusher, canFlush := w.(http.Flusher)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -3419,7 +3499,7 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response) {
 			continue
 		}
 
-		labels, metadata := p.classifyEntryFields(entry, "")
+		labels, structuredMetadata, parsedFields := p.classifyEntryFields(entry, originalQuery)
 		translatedLabels := labels
 		if !p.labelTranslator.IsPassthrough() {
 			translatedLabels = p.labelTranslator.TranslateLabelsMap(labels)
@@ -3429,7 +3509,7 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response) {
 
 		stream := map[string]interface{}{
 			"stream": translatedLabels,
-			"values": buildStreamValues(tsNanos, msg, metadata, p.emitStructuredMetadata),
+			"values": buildStreamValues(tsNanos, msg, structuredMetadata, parsedFields, p.emitStructuredMetadata, categorizedLabels),
 		}
 
 		chunk, _ := json.Marshal(stream)
@@ -3622,7 +3702,7 @@ func vlLogsToLokiStreams(body []byte) []map[string]interface{} {
 	return result
 }
 
-func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string) []map[string]interface{} {
+func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string, categorizedLabels bool) []map[string]interface{} {
 	type streamEntry struct {
 		Labels map[string]string
 		Values []interface{}
@@ -3668,7 +3748,7 @@ func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string) []map[str
 		}
 		msg, _ := stringifyEntryValue(entry["_msg"])
 
-		labels, metadata := p.classifyEntryFields(entry, originalQuery)
+		labels, structuredMetadata, parsedFields := p.classifyEntryFields(entry, originalQuery)
 		streamKey := canonicalLabelsKey(labels)
 		se, ok := streamMap[streamKey]
 		if !ok {
@@ -3685,7 +3765,7 @@ func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string) []map[str
 			}
 			streamMap[streamKey] = se
 		}
-		se.Values = append(se.Values, buildStreamValue(tsNanos, msg, metadata, p.emitStructuredMetadata))
+		se.Values = append(se.Values, buildStreamValue(tsNanos, msg, structuredMetadata, parsedFields, p.emitStructuredMetadata, categorizedLabels))
 		vlEntryPool.Put(entry)
 	}
 
@@ -3724,18 +3804,43 @@ func formatEntryTimestamp(timeStr string) (string, bool) {
 	return "", false
 }
 
-func buildStreamValues(ts, msg string, metadata map[string]interface{}, emitStructuredMetadata bool) []interface{} {
-	return []interface{}{buildStreamValue(ts, msg, metadata, emitStructuredMetadata)}
+func buildStreamValues(ts, msg string, structuredMetadata map[string]string, parsedFields map[string]string, emitStructuredMetadata bool, categorizedLabels bool) []interface{} {
+	return []interface{}{buildStreamValue(ts, msg, structuredMetadata, parsedFields, emitStructuredMetadata, categorizedLabels)}
 }
 
-func buildStreamValue(ts, msg string, metadata map[string]interface{}, emitStructuredMetadata bool) interface{} {
-	if emitStructuredMetadata && len(metadata) > 0 {
-		return []interface{}{ts, msg, metadata}
+func buildStreamValue(ts, msg string, structuredMetadata map[string]string, parsedFields map[string]string, emitStructuredMetadata bool, categorizedLabels bool) interface{} {
+	if !emitStructuredMetadata {
+		return []interface{}{ts, msg}
+	}
+	if categorizedLabels {
+		payload := make(map[string]interface{}, 2)
+		if len(structuredMetadata) > 0 {
+			payload["structuredMetadata"] = structuredMetadata
+		}
+		if len(parsedFields) > 0 {
+			payload["parsed"] = parsedFields
+		}
+		if len(payload) > 0 {
+			return []interface{}{ts, msg, payload}
+		}
+		return []interface{}{ts, msg}
+	}
+
+	// Legacy-safe fallback: flatten metadata into a simple map[string]string.
+	flat := make(map[string]string, len(structuredMetadata)+len(parsedFields))
+	for key, value := range structuredMetadata {
+		flat[key] = value
+	}
+	for key, value := range parsedFields {
+		flat[key] = value
+	}
+	if len(flat) > 0 {
+		return []interface{}{ts, msg, flat}
 	}
 	return []interface{}{ts, msg}
 }
 
-func (p *Proxy) classifyEntryFields(entry map[string]interface{}, originalQuery string) (map[string]string, map[string]interface{}) {
+func (p *Proxy) classifyEntryFields(entry map[string]interface{}, originalQuery string) (map[string]string, map[string]string, map[string]string) {
 	labels := parseStreamLabels(asString(entry["_stream"]))
 	if value, ok := stringifyEntryValue(entry["level"]); ok && strings.TrimSpace(value) != "" {
 		labels["level"] = value
@@ -3778,17 +3883,7 @@ func (p *Proxy) classifyEntryFields(entry map[string]interface{}, originalQuery 
 		}
 	}
 
-	metadata := map[string]interface{}{}
-	if len(structuredMetadataFields) > 0 {
-		// Keep canonical Loki query-response shape while exposing a snake_case alias
-		// for clients that still read structured metadata under that key.
-		metadata["structuredMetadata"] = structuredMetadataFields
-		metadata["structured_metadata"] = structuredMetadataFields
-	}
-	if len(parsedFields) > 0 {
-		metadata["parsed"] = parsedFields
-	}
-	return labels, metadata
+	return labels, structuredMetadataFields, parsedFields
 }
 
 // parseStreamLabels parses {key="value",key2="value2"} into a map.
@@ -4060,6 +4155,22 @@ func formatVLStep(step string) string {
 		return step + "s"
 	}
 	return step
+}
+
+func requestWantsCategorizedLabels(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	raw := strings.TrimSpace(r.Header.Get("X-Loki-Response-Encoding-Flags"))
+	if raw == "" {
+		return false
+	}
+	for _, part := range strings.Split(raw, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), "categorize-labels") {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, endpoint string, single func(http.ResponseWriter, *http.Request)) bool {
@@ -5173,6 +5284,21 @@ func copyHeaders(dst, src http.Header) {
 	}
 }
 
+var trustedIdentityHeaders = []string{
+	"X-Grafana-User",
+	"X-Forwarded-User",
+	"X-Webauth-User",
+	"X-Auth-Request-User",
+}
+
+var trustedProxyForwardHeaders = []string{
+	"X-Forwarded-For",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Host",
+	"X-Real-Ip",
+	"Forwarded",
+}
+
 // isVLInternalField returns true for VictoriaLogs internal field names
 // that should not be exposed in Loki-compatible label responses.
 func isVLInternalField(name string) bool {
@@ -5188,9 +5314,20 @@ func (p *Proxy) applyBackendHeaders(vlReq *http.Request) {
 		clientID, clientSource := metrics.ResolveClientContext(origReq, p.metricsTrustProxyHeaders)
 		vlReq.Header.Set("X-Loki-VL-Client-ID", clientID)
 		vlReq.Header.Set("X-Loki-VL-Client-Source", clientSource)
+		if authUser, authSource := metrics.ResolveAuthContext(origReq); authUser != "" {
+			vlReq.Header.Set("X-Loki-VL-Auth-User", authUser)
+			vlReq.Header.Set("X-Loki-VL-Auth-Source", authSource)
+		}
 		if p.metricsTrustProxyHeaders {
-			if grafanaUser := strings.TrimSpace(origReq.Header.Get("X-Grafana-User")); grafanaUser != "" {
-				vlReq.Header.Set("X-Grafana-User", grafanaUser)
+			for _, headerName := range trustedIdentityHeaders {
+				if value := strings.TrimSpace(origReq.Header.Get(headerName)); value != "" {
+					vlReq.Header.Set(headerName, value)
+				}
+			}
+			for _, headerName := range trustedProxyForwardHeaders {
+				if value := strings.TrimSpace(origReq.Header.Get(headerName)); value != "" {
+					vlReq.Header.Set(headerName, value)
+				}
 			}
 		}
 		// Forward configured client headers from the original request
@@ -5248,14 +5385,22 @@ func (p *Proxy) requestLogger(endpoint string, next http.HandlerFunc) http.Handl
 		start := time.Now()
 		tenant := r.Header.Get("X-Scope-OrgID")
 		query := r.FormValue("query")
+		authUser, authSource := metrics.ResolveAuthContext(r)
 		clientID, clientSource := metrics.ResolveClientContext(r, p.metricsTrustProxyHeaders)
 		p.metrics.RecordClientInflight(clientID, 1)
 		defer p.metrics.RecordClientInflight(clientID, -1)
 
+		rt := newRequestTelemetry()
+		reqWithTelemetry := r.WithContext(context.WithValue(r.Context(), requestTelemetryKey, rt))
 		sc := &statusCapture{ResponseWriter: w, code: 200}
-		next.ServeHTTP(sc, r)
+		next.ServeHTTP(sc, reqWithTelemetry)
 
 		elapsed := time.Since(start)
+		telemetry := snapshotTelemetry(reqWithTelemetry.Context())
+		proxyOverhead := elapsed - telemetry.upstreamDuration
+		if proxyOverhead < 0 {
+			proxyOverhead = 0
+		}
 
 		// Per-tenant metrics
 		p.metrics.RecordTenantRequest(tenant, endpoint, sc.code, elapsed)
@@ -5288,7 +5433,7 @@ func (p *Proxy) requestLogger(endpoint string, next http.HandlerFunc) http.Handl
 		} else if sc.code >= 400 {
 			logLevel = p.log.Warn
 		}
-		logLevel("request",
+		logAttrs := []interface{}{
 			"http.route", endpoint,
 			"http.request.method", r.Method,
 			"http.response.status_code", sc.code,
@@ -5298,7 +5443,21 @@ func (p *Proxy) requestLogger(endpoint string, next http.HandlerFunc) http.Handl
 			"client.address", r.RemoteAddr,
 			"enduser.id", clientID,
 			"loki.client.source", clientSource,
-		)
+			"cache.result", telemetry.cacheResult,
+			"proxy.duration_ms", elapsed.Milliseconds(),
+			"proxy.overhead_ms", proxyOverhead.Milliseconds(),
+			"upstream.calls", telemetry.upstreamCalls,
+			"upstream.duration_ms", telemetry.upstreamDuration.Milliseconds(),
+			"upstream.status_code", telemetry.upstreamLastCode,
+			"upstream.error", telemetry.upstreamErrorSeen,
+		}
+		if authUser != "" {
+			logAttrs = append(logAttrs,
+				"auth.principal", authUser,
+				"auth.source", authSource,
+			)
+		}
+		logLevel("request", logAttrs...)
 	})
 }
 

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -1,7 +1,7 @@
 package proxy
 
 import (
-	"reflect"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -28,7 +28,7 @@ func TestVLLogsToLokiStreams_DefaultValuesStayTwoTuple(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, false)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"ok","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","deployment.environment.name":"dev","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -45,11 +45,11 @@ func TestVLLogsToLokiStreams_DefaultValuesStayTwoTuple(t *testing.T) {
 	}
 }
 
-func TestVLLogsToLokiStreams_EmitStructuredMetadataAddsThirdTupleValue(t *testing.T) {
+func TestVLLogsToLokiStreams_EmitStructuredMetadataAddsFlatThirdTupleValueByDefault(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, true)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"ok","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","deployment.environment.name":"dev","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -64,28 +64,26 @@ func TestVLLogsToLokiStreams_EmitStructuredMetadataAddsThirdTupleValue(t *testin
 	if len(pair) != 3 {
 		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
 	}
-	meta, ok := pair[2].(map[string]interface{})
+	meta, ok := pair[2].(map[string]string)
 	if !ok {
 		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
 	}
-	canonical, ok := meta["structuredMetadata"]
-	if !ok {
-		t.Fatalf("expected structuredMetadata payload, got %v", meta)
+	if _, ok := meta["structuredMetadata"]; ok {
+		t.Fatalf("default tuple metadata must be flat for broad parser compatibility, got %v", meta)
 	}
-	snakeCase, ok := meta["structured_metadata"]
-	if !ok {
-		t.Fatalf("expected structured_metadata payload alias, got %v", meta)
+	if got := meta["service.name"]; got != "otel-app" {
+		t.Fatalf("expected flat structured metadata field service.name=otel-app, got %v", meta)
 	}
-	if !reflect.DeepEqual(canonical, snakeCase) {
-		t.Fatalf("expected structured metadata alias to mirror canonical value, got canonical=%v alias=%v", canonical, snakeCase)
+	if got := meta["deployment.environment.name"]; got != "dev" {
+		t.Fatalf("expected flat structured metadata field deployment.environment.name=dev, got %v", meta)
 	}
 }
 
-func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserPopulatesParsedPayload(t *testing.T) {
+func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserFlattensFieldsByDefault(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, true)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","http.status_code":"200","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, false)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -98,6 +96,34 @@ func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserPopulatesParsedPayl
 		t.Fatalf("expected stream value to be tuple, got %T", values[0])
 	}
 	if len(pair) != 3 {
+		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
+	}
+	meta, ok := pair[2].(map[string]string)
+	if !ok {
+		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
+	}
+	if _, ok := meta["parsed"]; ok {
+		t.Fatalf("default tuple metadata must avoid nested parsed payload for broad parser compatibility, got %v", meta)
+	}
+	if got := meta["http.status_code"]; got != "200" {
+		t.Fatalf("expected parser-derived field in flattened metadata, got %v", meta)
+	}
+}
+
+func TestVLLogsToLokiStreams_CategorizedLabelsKeepsNestedStructuredMetadataAndParsed(t *testing.T) {
+	p := newStreamMetadataTestProxy(t, true)
+	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","trace_id":"abc123","http.status_code":"200","level":"info"}` + "\n")
+
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, true)
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream, got %d", len(streams))
+	}
+	values, ok := streams[0]["values"].([]interface{})
+	if !ok || len(values) != 1 {
+		t.Fatalf("expected one stream value, got %#v", streams[0]["values"])
+	}
+	pair, ok := values[0].([]interface{})
+	if !ok || len(pair) != 3 {
 		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
 	}
 	meta, ok := pair[2].(map[string]interface{})
@@ -105,6 +131,18 @@ func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserPopulatesParsedPayl
 		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
 	}
 	if _, ok := meta["parsed"]; !ok {
-		t.Fatalf("expected parsed payload for parser query, got %v", meta)
+		t.Fatalf("expected nested parsed payload when categorize-labels is requested, got %v", meta)
+	}
+}
+
+func TestRequestWantsCategorizedLabels(t *testing.T) {
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	if requestWantsCategorizedLabels(req) {
+		t.Fatal("expected false when encoding flag header is absent")
+	}
+
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "foo,categorize-labels,bar")
+	if !requestWantsCategorizedLabels(req) {
+		t.Fatal("expected true when categorize-labels flag is present")
 	}
 }


### PR DESCRIPTION
## Summary
- stop using datasource/basic-auth usernames as `enduser.id` client identity
- carry datasource auth principal separately as `auth.*` in request logs and `X-Loki-VL-Auth-*` headers upstream
- support trusted forwarded user headers (`X-Forwarded-User`, `X-Webauth-User`, `X-Auth-Request-User`) plus trusted proxy-chain headers forwarding
- make emitted 3-tuple stream metadata parser-safe by default (flat third tuple object)
- emit categorized Loki metadata (`structuredMetadata` / `parsed`) only when request header `X-Loki-Response-Encoding-Flags: categorize-labels` is present
- enrich request logs with cache result and upstream vs proxy latency attribution (`cache.result`, `upstream.*`, `proxy.overhead_ms`)

## Why
- avoids attributing datasource service credentials as end-user client identity
- resolves client parser failures caused by always-emitted nested metadata objects in stream tuples
- improves operational debugging with full downstream/upstream timing and cache visibility per request

## Validation
- `go test ./...` (1302 passed)
- added/updated targeted tests in:
  - `internal/metrics/metrics_test.go`
  - `internal/proxy/datasource_compat_test.go`
  - `internal/proxy/stream_metadata_test.go`

## Notes
- docs updated (`configuration`, `observability`, `scaling`, `api-reference`) and changelog updated under `Unreleased`.
