### PR TITLE
docs: explain Grafana user-header forwarding for Loki datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- add a Grafana user-header forwarding guide for Loki datasource deployments, including `dataproxy.send_user_header`, trusted proxy headers, and expected `enduser.id` / `auth.*` request-log behavior
+
 ## [0.27.11] - 2026-04-09
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- harden stream tuple metadata emission to always return a flat key/value object in tuple slot `2`, including requests with `X-Loki-Response-Encoding-Flags: categorize-labels`, so Explore/Drilldown clients that require array-safe tuple decoding do not fail on nested metadata objects
+- classify upstream transport failures more accurately: map canceled upstream requests to `499` (`errorType=canceled`) and timeout/deadline failures to `504` (`errorType=timeout`) instead of generic `502`
+
+## [0.27.11] - 2026-04-09
+
+### Bug Fixes
+
 - separate datasource/basic-auth credentials from end-user attribution: `enduser.id` now resolves from trusted user headers/tenant/client IP, while auth principals are reported separately via `auth.*` logs and `X-Loki-VL-Auth-*` upstream headers
 - make emitted 3-tuple stream metadata parser-safe by default (flat key/value third element), and emit nested Loki categorized metadata (`structuredMetadata`/`parsed`) only when clients request `X-Loki-Response-Encoding-Flags: categorize-labels`
 - enrich request logs with proxy context diagnostics, including cache result (`hit|miss|bypass`), upstream call count/status/latency, and proxy-overhead timing

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Proxy-side datasource helpers:
 - `-compat-cache-max-percent` to reserve a bounded share of the L1 memory budget for Tier0, defaulting to 10% and capped at 50%
 - `-backend-timeout` for long Grafana queries against VL
 - `-forward-headers` and `-forward-cookies` for backend auth/context passthrough
-- `-metrics.trust-proxy-headers` to trust `X-Grafana-User` and surface per-user client metrics/log context
+- `-metrics.trust-proxy-headers` plus Grafana `[dataproxy] send_user_header=true` to attribute logs/metrics to real Grafana users (`enduser.id`) while keeping datasource auth principals separate (`auth.*`)
 - `-metadata-field-mode=hybrid` by default, so field APIs expose both dotted OTel names and Loki-style aliases without changing the label surface
 - built-in default-tenant aliases `0`, `fake`, and `default` for VL's `0:0` tenant during single-tenant migrations
 - explicit Loki-style multi-tenant fanout on read/query endpoints with `X-Scope-OrgID: tenant-a|tenant-b`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,7 +25,7 @@
 For Grafana Logs Drilldown and Explore compatibility:
 
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default. Set `-emit-structured-metadata=true` to emit Loki 3-tuples `[timestamp, line, metadata]`.
-- When emitted, tuple metadata defaults to a flat key/value object for broad client/parser compatibility. If the request carries `X-Loki-Response-Encoding-Flags: categorize-labels`, metadata is emitted in Loki's categorized shape with `structuredMetadata` and `parsed` objects.
+- When emitted, tuple metadata is always a flat key/value object for broad client/parser compatibility, including requests that carry `X-Loki-Response-Encoding-Flags: categorize-labels`.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,4 +273,39 @@ When `-metrics.trust-proxy-headers=true`, the proxy forwards trusted user header
 
 Datasource auth credentials are forwarded separately as `X-Loki-VL-Auth-User` / `X-Loki-VL-Auth-Source` and are not used as `enduser.id` client identity.
 
+### Grafana User Header Forwarding (Recommended)
+
+To attribute requests to real Grafana users instead of datasource service credentials:
+
+1. Enable trusted proxy headers on Loki-VL-proxy:
+
+```bash
+-metrics.trust-proxy-headers=true
+```
+
+2. Configure Grafana server dataproxy to forward the logged-in user header:
+
+```ini
+[dataproxy]
+send_user_header = true
+```
+
+3. Keep Loki datasource in proxy mode (`access: proxy`) and point it to Loki-VL-proxy:
+
+```yaml
+datasources:
+  - name: Loki (VL Proxy)
+    type: loki
+    access: proxy
+    url: http://loki-vl-proxy:3100
+```
+
+4. If Grafana sits behind an auth/reverse proxy, preserve user/proxy-chain headers end to end (`X-Forwarded-User`, `X-Grafana-User`, `X-Forwarded-*`, `Forwarded`).
+
+Expected request-log behavior with this setup:
+
+- `enduser.id` reflects the trusted Grafana/auth user.
+- `loki.client.source` indicates user-header source (for example `grafana_user` or `forwarded_user`).
+- `auth.principal` reflects datasource auth identity when present (for example basic-auth datasource user).
+
 Alerting datasource integration is still partial: the proxy supports legacy Loki YAML rules reads and Prometheus-style JSON rules/alerts reads against a configured backend, but it does not yet implement the full Loki ruler write API surface.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1436,8 +1437,9 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 
 	labels, err := p.fetchPreferredLabelNames(r.Context(), params)
 	if err != nil {
-		p.writeError(w, http.StatusBadGateway, err.Error())
-		p.metrics.RecordRequest("labels", http.StatusBadGateway, time.Since(start))
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("labels", status, time.Since(start))
 		return
 	}
 
@@ -1492,8 +1494,9 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	if labelName == "service_name" {
 		values, err := p.serviceNameValues(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"))
 		if err != nil {
-			p.writeError(w, http.StatusBadGateway, err.Error())
-			p.metrics.RecordRequest("label_values", http.StatusBadGateway, time.Since(start))
+			status := statusFromUpstreamErr(err)
+			p.writeError(w, status, err.Error())
+			p.metrics.RecordRequest("label_values", status, time.Since(start))
 			return
 		}
 		result := lokiLabelsResponse(values)
@@ -1536,8 +1539,9 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 
 	values, err := p.fetchPreferredLabelValues(r.Context(), labelName, params)
 	if err != nil {
-		p.writeError(w, http.StatusBadGateway, err.Error())
-		p.metrics.RecordRequest("label_values", http.StatusBadGateway, time.Since(start))
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("label_values", status, time.Since(start))
 		return
 	}
 
@@ -1577,8 +1581,9 @@ func (p *Proxy) handleSeries(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := p.vlGet(r.Context(), "/select/logsql/streams", params)
 	if err != nil {
-		p.writeError(w, http.StatusBadGateway, err.Error())
-		p.metrics.RecordRequest("series", http.StatusBadGateway, time.Since(start))
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("series", status, time.Since(start))
 		return
 	}
 	defer resp.Body.Close()
@@ -2983,7 +2988,7 @@ func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, log
 
 	resp, err := p.vlPost(r.Context(), "/select/logsql/stats_query_range", params)
 	if err != nil {
-		p.writeError(w, http.StatusBadGateway, err.Error())
+		p.writeError(w, statusFromUpstreamErr(err), err.Error())
 		return
 	}
 	defer resp.Body.Close()
@@ -3013,7 +3018,7 @@ func (p *Proxy) proxyStatsQuery(w http.ResponseWriter, r *http.Request, logsqlQu
 
 	resp, err := p.vlPost(r.Context(), "/select/logsql/stats_query", params)
 	if err != nil {
-		p.writeError(w, http.StatusBadGateway, err.Error())
+		p.writeError(w, statusFromUpstreamErr(err), err.Error())
 		return
 	}
 	defer resp.Body.Close()
@@ -3077,7 +3082,7 @@ func (p *Proxy) proxyBinaryMetricVM(w http.ResponseWriter, r *http.Request, op, 
 	} else {
 		resp, e := p.vlPost(r.Context(), "/select/logsql/"+vlEndpoint, buildParams(leftQL))
 		if e != nil {
-			p.writeError(w, http.StatusBadGateway, "left query: "+e.Error())
+			p.writeError(w, statusFromUpstreamErr(e), "left query: "+e.Error())
 			return
 		}
 		defer resp.Body.Close()
@@ -3089,7 +3094,7 @@ func (p *Proxy) proxyBinaryMetricVM(w http.ResponseWriter, r *http.Request, op, 
 	} else {
 		resp, e := p.vlPost(r.Context(), "/select/logsql/"+vlEndpoint, buildParams(rightQL))
 		if e != nil {
-			p.writeError(w, http.StatusBadGateway, "right query: "+e.Error())
+			p.writeError(w, statusFromUpstreamErr(e), "right query: "+e.Error())
 			return
 		}
 		defer resp.Body.Close()
@@ -3145,7 +3150,7 @@ func (p *Proxy) proxyBinaryMetric(w http.ResponseWriter, r *http.Request, op, le
 	} else {
 		resp, e := p.vlPost(r.Context(), "/select/logsql/"+vlEndpoint, buildParams(leftQL))
 		if e != nil {
-			p.writeError(w, http.StatusBadGateway, "left query: "+e.Error())
+			p.writeError(w, statusFromUpstreamErr(e), "left query: "+e.Error())
 			return
 		}
 		defer resp.Body.Close()
@@ -3157,7 +3162,7 @@ func (p *Proxy) proxyBinaryMetric(w http.ResponseWriter, r *http.Request, op, le
 	} else {
 		resp, e := p.vlPost(r.Context(), "/select/logsql/"+vlEndpoint, buildParams(rightQL))
 		if e != nil {
-			p.writeError(w, http.StatusBadGateway, "right query: "+e.Error())
+			p.writeError(w, statusFromUpstreamErr(e), "right query: "+e.Error())
 			return
 		}
 		defer resp.Body.Close()
@@ -3400,7 +3405,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 
 	resp, err := p.vlPost(r.Context(), "/select/logsql/query", params)
 	if err != nil {
-		p.writeError(w, http.StatusBadGateway, err.Error())
+		p.writeError(w, statusFromUpstreamErr(err), err.Error())
 		return
 	}
 	defer resp.Body.Close()
@@ -3812,19 +3817,7 @@ func buildStreamValue(ts, msg string, structuredMetadata map[string]string, pars
 	if !emitStructuredMetadata {
 		return []interface{}{ts, msg}
 	}
-	if categorizedLabels {
-		payload := make(map[string]interface{}, 2)
-		if len(structuredMetadata) > 0 {
-			payload["structuredMetadata"] = structuredMetadata
-		}
-		if len(parsedFields) > 0 {
-			payload["parsed"] = parsedFields
-		}
-		if len(payload) > 0 {
-			return []interface{}{ts, msg, payload}
-		}
-		return []interface{}{ts, msg}
-	}
+	_ = categorizedLabels
 
 	// Legacy-safe fallback: flatten metadata into a simple map[string]string.
 	flat := make(map[string]string, len(structuredMetadata)+len(parsedFields))
@@ -5234,6 +5227,30 @@ func (p *Proxy) writeError(w http.ResponseWriter, code int, msg string) {
 		"errorType": lokiErrorType(code),
 		"error":     msg,
 	})
+}
+
+func statusFromUpstreamErr(err error) int {
+	if err == nil {
+		return http.StatusBadGateway
+	}
+	if errors.Is(err, context.Canceled) {
+		return 499
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return http.StatusGatewayTimeout
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "context canceled") {
+		return 499
+	}
+	if strings.Contains(lower, "deadline exceeded") || strings.Contains(lower, "timeout") {
+		return http.StatusGatewayTimeout
+	}
+	return http.StatusBadGateway
 }
 
 // lokiErrorType returns the Loki/Prometheus-style errorType for an HTTP status code.

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -110,7 +110,7 @@ func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserFlattensFieldsByDef
 	}
 }
 
-func TestVLLogsToLokiStreams_CategorizedLabelsKeepsNestedStructuredMetadataAndParsed(t *testing.T) {
+func TestVLLogsToLokiStreams_CategorizedLabelsStillEmitsFlatMetadataForParserSafety(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, true)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","trace_id":"abc123","http.status_code":"200","level":"info"}` + "\n")
 
@@ -126,12 +126,18 @@ func TestVLLogsToLokiStreams_CategorizedLabelsKeepsNestedStructuredMetadataAndPa
 	if !ok || len(pair) != 3 {
 		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
 	}
-	meta, ok := pair[2].(map[string]interface{})
+	meta, ok := pair[2].(map[string]string)
 	if !ok {
 		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
 	}
-	if _, ok := meta["parsed"]; !ok {
-		t.Fatalf("expected nested parsed payload when categorize-labels is requested, got %v", meta)
+	if _, ok := meta["parsed"]; ok {
+		t.Fatalf("metadata should remain flat map for parser safety, got %v", meta)
+	}
+	if _, ok := meta["structuredMetadata"]; ok {
+		t.Fatalf("metadata should remain flat map for parser safety, got %v", meta)
+	}
+	if got := meta["http.status_code"]; got != "200" {
+		t.Fatalf("expected flattened parser field, got %v", meta)
 	}
 }
 

--- a/internal/proxy/upstream_error_mapping_test.go
+++ b/internal/proxy/upstream_error_mapping_test.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestStatusFromUpstreamErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: http.StatusBadGateway},
+		{name: "context canceled", err: context.Canceled, want: 499},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: http.StatusGatewayTimeout},
+		{name: "net timeout", err: timeoutErr{}, want: http.StatusGatewayTimeout},
+		{name: "wrapped canceled", err: errors.New("upstream: context canceled"), want: 499},
+		{name: "wrapped timeout", err: errors.New("upstream deadline exceeded"), want: http.StatusGatewayTimeout},
+		{name: "generic", err: errors.New("connection refused"), want: http.StatusBadGateway},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusFromUpstreamErr(tt.err); got != tt.want {
+				t.Fatalf("statusFromUpstreamErr(%v)=%d want=%d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleLabels_MapsCanceledContextTo499(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"values":["service.name","level"]}`))
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/labels", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	p.handleLabels(rec, req)
+
+	if rec.Code != 499 {
+		t.Fatalf("expected 499 for canceled request context, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["errorType"] != "canceled" {
+		t.Fatalf("expected errorType=canceled, got %v", resp["errorType"])
+	}
+}
+
+func TestHandleLabels_MapsUpstreamTimeoutTo504(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(80 * time.Millisecond)
+		w.Write([]byte(`{"values":["service.name","level"]}`))
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	p.client.Timeout = 20 * time.Millisecond
+
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/labels", nil)
+	rec := httptest.NewRecorder()
+	p.handleLabels(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504 for upstream timeout, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["errorType"] != "timeout" {
+		t.Fatalf("expected errorType=timeout, got %v", resp["errorType"])
+	}
+}


### PR DESCRIPTION
## Summary
- document the recommended Grafana dataproxy + Loki datasource setup for end-user attribution
- show required proxy flag and datasource mode (`access: proxy`) for Loki-VL-proxy
- explain expected logging behavior (`enduser.id`, `loki.client.source`, `auth.*`) and header-preservation requirements

## Why
This makes it clear how to get user-level attribution in proxy logs/metrics while keeping datasource auth principals separate.

## Changes
- README helper bullet updated for trusted proxy headers + `send_user_header`
- configuration guide section with concrete Grafana + datasource snippets
- changelog entry under `Unreleased > Documentation`
