### PR TITLE
Chart: add trafficDistribution and StatefulSet immutable guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- add Service `trafficDistribution` support across chart service resources (`service` and `peerService`), including configurable values for `PreferSameZone`, `PreferSameNode`, and deprecated alias `PreferClose`
+
+### Reliability
+
+- add a StatefulSet immutable-field upgrade guard in the Helm chart to fail early when live immutable fields drift from desired values (`serviceName`, `podManagementPolicy`, `volumeClaimTemplates`)
+
 ## [0.27.12] - 2026-04-09
 
 ### Documentation

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -75,10 +75,59 @@ Stateful/headless service name.
 {{- end }}
 
 {{/*
+Render Service trafficDistribution with strict enum validation.
+*/}}
+{{- define "loki-vl-proxy.renderTrafficDistribution" -}}
+{{- $value := default "" .value -}}
+{{- $allowed := list "" "PreferSameZone" "PreferSameNode" "PreferClose" -}}
+{{- if not (has $value $allowed) -}}
+{{- fail (printf "%s must be one of: PreferSameZone, PreferSameNode, PreferClose (deprecated), or empty" .field) -}}
+{{- end -}}
+{{- if ne $value "" -}}
+trafficDistribution: {{ $value | quote }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Persistence claim name for standalone PVC / existing claim mode.
 */}}
 {{- define "loki-vl-proxy.persistenceClaimName" -}}
 {{- default (printf "%s-cache" (include "loki-vl-proxy.fullname" .)) .Values.persistence.existingClaim }}
+{{- end }}
+
+{{/*
+Canonicalize volumeClaimTemplates to immutable-shape fields we care about.
+*/}}
+{{- define "loki-vl-proxy.canonicalizeVolumeClaimTemplates" -}}
+{{- $out := list -}}
+{{- range $tpl := default (list) .volumeClaimTemplates -}}
+{{- $meta := default (dict) $tpl.metadata -}}
+{{- $out = append $out (dict "name" (default "" $meta.name) "spec" (default (dict) $tpl.spec)) -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
+{{/*
+Desired canonical volumeClaimTemplates for StatefulSet mode.
+Must stay aligned with templates/deployment.yaml generation logic.
+*/}}
+{{- define "loki-vl-proxy.desiredVolumeClaimTemplates" -}}
+{{- $out := list -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- $spec := dict
+    "accessModes" (list .Values.persistence.accessMode)
+    "resources" (dict "requests" (dict "storage" .Values.persistence.size))
+-}}
+{{- if .Values.persistence.storageClass -}}
+{{- $_ := set $spec "storageClassName" .Values.persistence.storageClass -}}
+{{- end -}}
+{{- $out = append $out (dict "name" "cache-data" "spec" $spec) -}}
+{{- end -}}
+{{- range $tpl := default (list) .Values.persistence.extraVolumeClaimTemplates -}}
+{{- $meta := default (dict) $tpl.metadata -}}
+{{- $out = append $out (dict "name" (default "" $meta.name) "spec" (default (dict) $tpl.spec)) -}}
+{{- end -}}
+{{- toYaml $out -}}
 {{- end }}
 
 {{/*

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -185,7 +185,7 @@ spec:
     - metadata:
         name: cache-data
         labels:
-          {{- include "loki-vl-proxy.labels" . | nindent 10 }}
+          {{- include "loki-vl-proxy.selectorLabels" . | nindent 10 }}
         {{- with .Values.persistence.annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}

--- a/charts/loki-vl-proxy/templates/peer-service.yaml
+++ b/charts/loki-vl-proxy/templates/peer-service.yaml
@@ -5,9 +5,17 @@ metadata:
   name: {{ include "loki-vl-proxy.peerServiceName" . }}
   labels:
     {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+    {{- with .Values.peerService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.peerService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
+  {{- include "loki-vl-proxy.renderTrafficDistribution" (dict "field" ".Values.peerService.trafficDistribution" "value" .Values.peerService.trafficDistribution) | nindent 2 }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/loki-vl-proxy/templates/service.yaml
+++ b/charts/loki-vl-proxy/templates/service.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- include "loki-vl-proxy.renderTrafficDistribution" (dict "field" ".Values.service.trafficDistribution" "value" .Values.service.trafficDistribution) | nindent 2 }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/loki-vl-proxy/templates/statefulset-immutable-guard.yaml
+++ b/charts/loki-vl-proxy/templates/statefulset-immutable-guard.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.statefulSetImmutableGuard.enabled -}}
+{{- $name := include "loki-vl-proxy.fullname" . -}}
+{{- $kind := include "loki-vl-proxy.workloadKind" . -}}
+{{- $existing := lookup "apps/v1" "StatefulSet" .Release.Namespace $name -}}
+
+{{- if and $existing (ne $kind "StatefulSet") -}}
+{{- fail (printf "statefulSetImmutableGuard: release %q in namespace %q already has StatefulSet %q; switching workload.kind away from StatefulSet requires explicit migration/recreation" .Release.Name .Release.Namespace $name) -}}
+{{- end -}}
+
+{{- if and $existing (eq $kind "StatefulSet") -}}
+{{- $existingServiceName := default "" $existing.spec.serviceName -}}
+{{- $desiredServiceName := include "loki-vl-proxy.peerServiceName" . -}}
+{{- if ne $existingServiceName $desiredServiceName -}}
+{{- fail (printf "statefulSetImmutableGuard: immutable StatefulSet field change detected for %q: spec.serviceName current=%q desired=%q" $name $existingServiceName $desiredServiceName) -}}
+{{- end -}}
+
+{{- $existingPodManagementPolicy := default "" $existing.spec.podManagementPolicy -}}
+{{- $desiredPodManagementPolicy := default "" .Values.workload.statefulSet.podManagementPolicy -}}
+{{- if ne $existingPodManagementPolicy $desiredPodManagementPolicy -}}
+{{- fail (printf "statefulSetImmutableGuard: immutable StatefulSet field change detected for %q: spec.podManagementPolicy current=%q desired=%q" $name $existingPodManagementPolicy $desiredPodManagementPolicy) -}}
+{{- end -}}
+
+{{- $existingVCT := include "loki-vl-proxy.canonicalizeVolumeClaimTemplates" (dict "volumeClaimTemplates" (default (list) $existing.spec.volumeClaimTemplates)) | trim -}}
+{{- $desiredVCT := include "loki-vl-proxy.desiredVolumeClaimTemplates" . | trim -}}
+{{- if ne $existingVCT $desiredVCT -}}
+{{- fail (printf "statefulSetImmutableGuard: immutable StatefulSet field change detected for %q: spec.volumeClaimTemplates differs from live object; recreate/migrate StatefulSet or keep PVC template shape stable" $name) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -176,6 +176,23 @@ service:
   port: 3100
   annotations: {}
   labels: {}
+  # Service traffic preference (Kubernetes Service .spec.trafficDistribution).
+  # Supported values:
+  # - PreferSameZone
+  # - PreferSameNode
+  # - PreferClose (deprecated alias for PreferSameZone)
+  trafficDistribution: ""
+
+# Headless peer-discovery service used by StatefulSet / peerCache DNS mode.
+peerService:
+  annotations: {}
+  labels: {}
+  # Service traffic preference (Kubernetes Service .spec.trafficDistribution).
+  # Supported values:
+  # - PreferSameZone
+  # - PreferSameNode
+  # - PreferClose (deprecated alias for PreferSameZone)
+  trafficDistribution: ""
 
 # --- ServiceMonitor (Prometheus Operator) ---
 # Disabled by default to keep the chart generic outside Prometheus-Operator clusters.
@@ -416,3 +433,9 @@ persistence:
   # Extra claim templates appended only in StatefulSet mode.
   # Useful for separate WAL/buffer/storage volumes managed by the same chart.
   extraVolumeClaimTemplates: []
+
+# Guardrail for immutable StatefulSet fields.
+# Enabled by default to fail early during helm upgrade when live StatefulSet
+# immutable fields diverge from desired chart values.
+statefulSetImmutableGuard:
+  enabled: true


### PR DESCRIPTION
## Summary

This PR adds two chart-level safeguards for safer service routing and StatefulSet upgrades:

1. Service `trafficDistribution` support for all chart Service resources.
2. StatefulSet immutable-field guardrails to fail early during upgrade when immutable spec shape drifts.

## What Changed

- Added `service.trafficDistribution` and `peerService.trafficDistribution` values.
- Added `peerService.annotations` and `peerService.labels` values.
- Wired `trafficDistribution` rendering into:
  - `templates/service.yaml`
  - `templates/peer-service.yaml`
- Added strict enum validation for `trafficDistribution` values:
  - `PreferSameZone`
  - `PreferSameNode`
  - `PreferClose` (deprecated alias)
  - empty (unset)
- Added `statefulSetImmutableGuard.enabled` (default `true`).
- Added `templates/statefulset-immutable-guard.yaml` using `lookup` + `fail` to block unsafe upgrades when live StatefulSet immutable fields differ:
  - `spec.serviceName`
  - `spec.podManagementPolicy`
  - canonicalized `spec.volumeClaimTemplates`
- Reduced immutable churn risk by using stable selector labels (instead of dynamic chart/version labels) on generated StatefulSet `volumeClaimTemplates`.

## Why

StatefulSet upgrades can fail with immutable-field errors when PVC template shape changes (or when dynamic labels in immutable sections drift across chart versions). This guardrail surfaces that mismatch before apply, with explicit migration guidance.

At the same time, service-level `trafficDistribution` is now fully configurable for chart users across all Service manifests.

## Rollout / Behavior

```mermaid
flowchart TD
  V[values.yaml] --> SVC[service.yaml]
  V --> PSVC[peer-service.yaml]
  V --> GUARD[statefulset-immutable-guard.yaml]

  SVC --> K8S1[Service]
  PSVC --> K8S2[Headless Service]

  GUARD -->|lookup live StatefulSet| LIVE[apps/v1 StatefulSet]
  LIVE --> CMP[Immutable field comparison]
  CMP -->|match| APPLY[Render continues]
  CMP -->|drift| FAIL[Helm fail with migration message]
```

## Validation

```bash
helm lint charts/loki-vl-proxy
helm template lvp charts/loki-vl-proxy \
  --set service.trafficDistribution=PreferSameZone \
  --set peerService.trafficDistribution=PreferSameNode \
  --set workload.kind=StatefulSet \
  --set persistence.enabled=true
helm template lvp charts/loki-vl-proxy --set service.trafficDistribution=BadValue
```

Observed:
- `helm lint` passes.
- valid `trafficDistribution` values render on both services.
- invalid `trafficDistribution` fails fast with explicit error.


## Changelog

- Added under `## [Unreleased]` in `CHANGELOG.md`:
  - `Features`: service `trafficDistribution` support for chart services
  - `Reliability`: StatefulSet immutable-field guardrail for safer upgrades
