### PR TITLE
Fix 3-tuple stream merge reliability and OTEL request log semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- preserve Loki stream 3-tuples (`[ts,line,metadata]`) in multi-tenant query merge paths so metadata-bearing responses no longer fail tuple decode/sort logic
+
+### Observability
+
+- align request-log attributes closer to OTEL semantic conventions by adding `url.path`, `network.peer.address`, `user.id`, `user.name`, and `event.duration` while keeping existing compatibility fields
+
 ## [0.27.13] - 2026-04-10
 
 ### Features

--- a/internal/proxy/multitenant_merge_test.go
+++ b/internal/proxy/multitenant_merge_test.go
@@ -412,6 +412,34 @@ func TestMergeMultiTenantResponsesQueryInjectsTenantLabel(t *testing.T) {
 	}
 }
 
+func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
+	body, _, err := mergeMultiTenantResponses("query", []string{"tenant-a", "tenant-b"}, []*httptest.ResponseRecorder{
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["2","line-a",{"service.name":"orders"}]]}]}}`),
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"http.status_code":"200"}]]}]}}`),
+	})
+	if err != nil {
+		t.Fatalf("mergeMultiTenantResponses failed: %v", err)
+	}
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Result) != 2 {
+		t.Fatalf("expected 2 merged streams, got %#v", resp.Data.Result)
+	}
+	for _, item := range resp.Data.Result {
+		if len(item.Values) == 0 || len(item.Values[0]) != 3 {
+			t.Fatalf("expected merged stream values to preserve 3-tuple shape, got %#v", item.Values)
+		}
+	}
+}
+
 func TestMergeMultiTenantResponsesQueryVectorInjectsTenantLabel(t *testing.T) {
 	body, _, err := mergeMultiTenantResponses("query", []string{"tenant-a", "tenant-b"}, []*httptest.ResponseRecorder{
 		recorderWithJSON(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"app":"api"},"value":[1,"2"]}],"stats":{"summary":"ok"}}}`),
@@ -479,10 +507,10 @@ func TestLatestStreamTimestampStrings(t *testing.T) {
 	if got := latestStreamTimestampStrings(nil); got != "" {
 		t.Fatalf("expected empty timestamp for nil input, got %q", got)
 	}
-	if got := latestStreamTimestampStrings([][]string{{}}); got != "" {
+	if got := latestStreamTimestampStrings([][]interface{}{{}}); got != "" {
 		t.Fatalf("expected empty timestamp for empty pair, got %q", got)
 	}
-	if got := latestStreamTimestampStrings([][]string{{"42", "line"}}); got != "42" {
+	if got := latestStreamTimestampStrings([][]interface{}{{"42", "line"}}); got != "42" {
 		t.Fatalf("expected first timestamp, got %q", got)
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4285,7 +4285,7 @@ type lokiQueryResponse struct {
 
 type lokiStreamResult struct {
 	Stream map[string]string `json:"stream"`
-	Values [][]string        `json:"values"`
+	Values [][]interface{}   `json:"values"`
 }
 
 type lokiVectorResult struct {
@@ -4784,14 +4784,14 @@ func mergeLokiQueryResponses(tenantIDs []string, recorders []*httptest.ResponseR
 	return body, "application/json", err
 }
 
-func latestStreamTimestampStrings(values [][]string) string {
+func latestStreamTimestampStrings(values [][]interface{}) string {
 	if len(values) == 0 {
 		return ""
 	}
 	if len(values[0]) == 0 {
 		return ""
 	}
-	return values[0][0]
+	return fmt.Sprintf("%v", values[0][0])
 }
 
 func mergeIndexStatsResponses(recorders []*httptest.ResponseRecorder) ([]byte, string, error) {
@@ -5452,12 +5452,16 @@ func (p *Proxy) requestLogger(endpoint string, next http.HandlerFunc) http.Handl
 		}
 		logAttrs := []interface{}{
 			"http.route", endpoint,
+			"url.path", r.URL.Path,
 			"http.request.method", r.Method,
 			"http.response.status_code", sc.code,
+			"event.duration", elapsed.Nanoseconds(),
 			"event.duration_ms", elapsed.Milliseconds(),
 			"loki.tenant.id", tenant,
 			"loki.query", truncateQuery(query, 200),
 			"client.address", r.RemoteAddr,
+			"network.peer.address", r.RemoteAddr,
+			"user.id", clientID,
 			"enduser.id", clientID,
 			"loki.client.source", clientSource,
 			"cache.result", telemetry.cacheResult,
@@ -5470,6 +5474,7 @@ func (p *Proxy) requestLogger(endpoint string, next http.HandlerFunc) http.Handl
 		}
 		if authUser != "" {
 			logAttrs = append(logAttrs,
+				"user.name", authUser,
 				"auth.principal", authUser,
 				"auth.source", authSource,
 			)

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -1,7 +1,11 @@
 package proxy
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +142,48 @@ func TestVLLogsToLokiStreams_CategorizedLabelsStillEmitsFlatMetadataForParserSaf
 	}
 	if got := meta["http.status_code"]; got != "200" {
 		t.Fatalf("expected flattened parser field, got %v", meta)
+	}
+}
+
+func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
+	p := newStreamMetadataTestProxy(t, true)
+	rec := httptest.NewRecorder()
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","http.status_code":"200","level":"info"}` + "\n")),
+	}
+
+	p.streamLogQuery(rec, resp, `{job="otel-proxy"} | json`, false)
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode streamLogQuery response: %v", err)
+	}
+	data, ok := payload["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data object, got %T", payload["data"])
+	}
+	results, ok := data["result"].([]interface{})
+	if !ok || len(results) != 1 {
+		t.Fatalf("expected one stream result, got %v", data["result"])
+	}
+	stream0, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected stream object, got %T", results[0])
+	}
+	values, ok := stream0["values"].([]interface{})
+	if !ok || len(values) != 1 {
+		t.Fatalf("expected one stream value, got %v", stream0["values"])
+	}
+	tuple, ok := values[0].([]interface{})
+	if !ok || len(tuple) != 3 {
+		t.Fatalf("expected 3-tuple stream value, got %v", values[0])
+	}
+	meta, ok := tuple[2].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadata object in tuple[2], got %T", tuple[2])
+	}
+	if got, ok := meta["http.status_code"]; !ok || got != "200" {
+		t.Fatalf("expected parser metadata in tuple[2], got %v", meta)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix multi-tenant stream merge decoding for Loki 3-tuples by accepting `values` as `[][]interface{}` instead of `[][]string`
- preserve timestamp ordering for merged stream tuples via interface-safe timestamp extraction
- align request log fields with OTEL semantic naming by adding `url.path`, `network.peer.address`, `user.id`, `user.name`, and `event.duration` while keeping existing compatibility fields
- add regression tests for 3-tuple merge preservation and streaming tuple metadata shape
- update `CHANGELOG.md` under `Unreleased`

## Why
Grafana Explore/Drilldown paths can encounter metadata-bearing stream tuples (`[ts, line, metadata]`). Merge logic that assumes string-only tuples is brittle and can break response shaping. This patch makes tuple handling resilient and expands test coverage around those paths.

## Validation
- `go test ./internal/proxy -run "TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues|TestLatestStreamTimestampStrings|TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata" -count=1`
- `go test ./internal/proxy -count=1`
- `go test ./... -count=1`
