### PR TITLE
Fix ReadArray compatibility and add system metrics startup diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- harden startup diagnostics and /proc-host mount guidance for system resource metrics so missing CPU/memory/disk/network/PSI families are surfaced explicitly at boot
+
+### Tests
+
+- add coverage for `PROC_ROOT` env override behavior and startup diagnostics branches (`passed`/`incomplete`) to prevent regressions in release quality checks
+
 ## [0.27.15] - 2026-04-10
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.15] - 2026-04-10
+
+### Bug Fixes
+
+- keep Grafana Explore/Drilldown on canonical 2-tuples even when `-emit-structured-metadata=true`, and require explicit caller opt-in (`X-Loki-Response-Encoding-Flags: structured-metadata` or `structured_metadata=true`) for 3-tuples to prevent `ReadArray` client decode failures
+
+### Observability
+
+- add startup diagnostics for `/proc`-backed system metrics so missing CPU/memory/disk/network/PSI families are logged with concrete remediation instead of failing silently
+
+### Helm
+
+- add chart support for host `/proc` mounting (`systemMetrics.hostProc.enabled`) and auto-wire `-proc-root` so node-level system metrics can be enabled explicitly in Kubernetes
+
 ## [0.27.14] - 2026-04-10
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Observability
 
 - add startup diagnostics for `/proc`-backed system metrics so missing CPU/memory/disk/network/PSI families are logged with concrete remediation instead of failing silently
+- expand the main operations dashboard with system resource drilldown panels (memory, CPU modes, PSI pressure, disk/network throughput, process RSS, open FDs)
+- add actionable system resource alerts for missing system metrics, high memory usage, and sustained CPU/IO PSI pressure
 
 ### Helm
 
 - add chart support for host `/proc` mounting (`systemMetrics.hostProc.enabled`) and auto-wire `-proc-root` so node-level system metrics can be enabled explicitly in Kubernetes
+
+### Documentation
+
+- add a dedicated system-resources runbook and include it in the alert runbook index for faster incident handling
 
 ## [0.27.14] - 2026-04-10
 

--- a/alerting/loki-vl-proxy-prometheusrule.yaml
+++ b/alerting/loki-vl-proxy-prometheusrule.yaml
@@ -183,3 +183,79 @@ rules:
       impact: "Clients experience hard failures and retry storms can increase platform load."
       action: "Identify top offending clients and inspect rejected query patterns."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-client-bad-request-burst.md'
+
+  - alert: LokiVLProxySystemMetricsMissing
+    expr: absent(node_memory_usage_ratio{job="{{ include "loki-vl-proxy.fullname" . }}"})
+    for: 15m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-metrics
+      category: observability
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "System resource metrics missing"
+      description: "node_memory_usage_ratio is missing for loki-vl-proxy for 15 minutes."
+      impact: "CPU/memory/disk/network/pressure visibility is degraded and related alerts cannot fire."
+      action: "Check startup diagnostics, ensure /metrics exposure, and if running in Kubernetes enable host /proc mount plus -proc-root=/host/proc."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'
+
+  - alert: LokiVLProxySystemMemoryHigh
+    expr: max_over_time(node_memory_usage_ratio{job="{{ include "loki-vl-proxy.fullname" . }}"}[10m]) > 0.90
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-memory
+      category: capacity
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "System memory usage > 90%"
+      description: "node_memory_usage_ratio stayed above 90% for 10 minutes."
+      impact: "Query latency and backend request failures may increase under memory pressure."
+      action: "Correlate with process RSS/open FDs and node pressure, then reduce query load or increase pod/node capacity."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'
+
+  - alert: LokiVLProxySystemCPUPressureHigh
+    expr: max_over_time(node_pressure_cpu_some_ratio{job="{{ include "loki-vl-proxy.fullname" . }}",window="60s"}[10m]) > 0.30
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-cpu
+      category: performance
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "CPU pressure elevated"
+      description: "CPU PSI some ratio (60s window) stayed above 30% for 10 minutes."
+      impact: "Scheduler contention can cause request tail latency and timeout amplification."
+      action: "Check CPU mode split, top endpoints/tenants, and scale replicas or tune expensive queries."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'
+
+  - alert: LokiVLProxySystemIOPressureHigh
+    expr: max_over_time(node_pressure_io_some_ratio{job="{{ include "loki-vl-proxy.fullname" . }}",window="60s"}[10m]) > 0.20
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-io
+      category: performance
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "I/O pressure elevated"
+      description: "I/O PSI some ratio (60s window) stayed above 20% for 10 minutes."
+      impact: "Disk/network stalls can slow backend and cache operations, increasing user-facing latency."
+      action: "Check disk and network throughput trends, cache path storage performance, and backend saturation."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'

--- a/charts/loki-vl-proxy/Chart.yaml
+++ b/charts/loki-vl-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-vl-proxy
 description: HTTP proxy translating Loki API to VictoriaLogs
 type: application
-version: 0.27.14
-appVersion: "0.27.14"
+version: 0.27.15
+appVersion: "0.27.15"
 home: https://github.com/ReliablyObserve/Loki-VL-proxy
 sources:
   - https://github.com/ReliablyObserve/Loki-VL-proxy

--- a/charts/loki-vl-proxy/alerting/loki-vl-proxy-prometheusrule.yaml
+++ b/charts/loki-vl-proxy/alerting/loki-vl-proxy-prometheusrule.yaml
@@ -183,3 +183,79 @@ rules:
       impact: "Clients experience hard failures and retry storms can increase platform load."
       action: "Identify top offending clients and inspect rejected query patterns."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-client-bad-request-burst.md'
+
+  - alert: LokiVLProxySystemMetricsMissing
+    expr: absent(node_memory_usage_ratio{job="{{ include "loki-vl-proxy.fullname" . }}"})
+    for: 15m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-metrics
+      category: observability
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "System resource metrics missing"
+      description: "node_memory_usage_ratio is missing for loki-vl-proxy for 15 minutes."
+      impact: "CPU/memory/disk/network/pressure visibility is degraded and related alerts cannot fire."
+      action: "Check startup diagnostics, ensure /metrics exposure, and if running in Kubernetes enable host /proc mount plus -proc-root=/host/proc."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'
+
+  - alert: LokiVLProxySystemMemoryHigh
+    expr: max_over_time(node_memory_usage_ratio{job="{{ include "loki-vl-proxy.fullname" . }}"}[10m]) > 0.90
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-memory
+      category: capacity
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "System memory usage > 90%"
+      description: "node_memory_usage_ratio stayed above 90% for 10 minutes."
+      impact: "Query latency and backend request failures may increase under memory pressure."
+      action: "Correlate with process RSS/open FDs and node pressure, then reduce query load or increase pod/node capacity."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'
+
+  - alert: LokiVLProxySystemCPUPressureHigh
+    expr: max_over_time(node_pressure_cpu_some_ratio{job="{{ include "loki-vl-proxy.fullname" . }}",window="60s"}[10m]) > 0.30
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-cpu
+      category: performance
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "CPU pressure elevated"
+      description: "CPU PSI some ratio (60s window) stayed above 30% for 10 minutes."
+      impact: "Scheduler contention can cause request tail latency and timeout amplification."
+      action: "Check CPU mode split, top endpoints/tenants, and scale replicas or tune expensive queries."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'
+
+  - alert: LokiVLProxySystemIOPressureHigh
+    expr: max_over_time(node_pressure_io_some_ratio{job="{{ include "loki-vl-proxy.fullname" . }}",window="60s"}[10m]) > 0.20
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: system-io
+      category: performance
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "I/O pressure elevated"
+      description: "I/O PSI some ratio (60s window) stayed above 20% for 10 minutes."
+      impact: "Disk/network stalls can slow backend and cache operations, increasing user-facing latency."
+      action: "Check disk and network throughput trends, cache path storage performance, and backend saturation."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-system-resources.md'

--- a/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
+++ b/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
@@ -322,6 +322,150 @@
       "fieldConfig": {
         "defaults": {"unit": "s"}
       }
+    },
+    {
+      "title": "System Resources",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 61},
+      "collapsed": false
+    },
+    {
+      "title": "Memory Usage %",
+      "type": "gauge",
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 62},
+      "targets": [
+        {
+          "expr": "100 * max(node_memory_usage_ratio{job=\"$job\"})",
+          "legendFormat": "memory usage"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 75},
+              {"color": "red", "value": 90}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "CPU Usage Ratio by Mode",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 9, "x": 6, "y": 62},
+      "targets": [
+        {
+          "expr": "max(node_cpu_usage_ratio{job=\"$job\"}) by (mode)",
+          "legendFormat": "{{mode}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {"fillOpacity": 10}
+        }
+      }
+    },
+    {
+      "title": "PSI Pressure (60s Window)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 9, "x": 15, "y": 62},
+      "targets": [
+        {
+          "expr": "max(node_pressure_cpu_some_ratio{job=\"$job\",window=\"60s\"})",
+          "legendFormat": "cpu some"
+        },
+        {
+          "expr": "max(node_pressure_memory_some_ratio{job=\"$job\",window=\"60s\"})",
+          "legendFormat": "memory some"
+        },
+        {
+          "expr": "max(node_pressure_io_some_ratio{job=\"$job\",window=\"60s\"})",
+          "legendFormat": "io some"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {"fillOpacity": 10},
+          "thresholds": {
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.1},
+              {"color": "red", "value": 0.2}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Disk Throughput",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 70},
+      "targets": [
+        {
+          "expr": "sum(rate(node_disk_read_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "read"
+        },
+        {
+          "expr": "sum(rate(node_disk_written_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "write"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "Bps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Network Throughput",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 70},
+      "targets": [
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "rx"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "tx"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "Bps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Process RSS",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 78},
+      "targets": [
+        {
+          "expr": "max(process_resident_memory_bytes{job=\"$job\"})",
+          "legendFormat": "rss"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "bytes"}
+      }
+    },
+    {
+      "title": "Open File Descriptors",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 78},
+      "targets": [
+        {
+          "expr": "max(process_open_fds{job=\"$job\"})",
+          "legendFormat": "fds"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "none"}
+      }
     }
   ],
   "schemaVersion": 39,

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -70,9 +70,21 @@ spec:
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $hostProcEnabled := false }}
+      {{- $hostProcMountPath := "/host/proc" }}
+      {{- if and (hasKey .Values "systemMetrics") (hasKey .Values.systemMetrics "hostProc") }}
+      {{- $hostProcEnabled = .Values.systemMetrics.hostProc.enabled }}
+      {{- if .Values.systemMetrics.hostProc.mountPath }}
+      {{- $hostProcMountPath = .Values.systemMetrics.hostProc.mountPath }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: loki-vl-proxy
           {{- $goMemLimitValue := (include "loki-vl-proxy.goMemLimitValue" . | trim) }}
+          {{- $injectOTELFromPod := true }}
+          {{- if and (hasKey .Values "otelResourceAttributes") (hasKey .Values.otelResourceAttributes "injectFromPod") }}
+          {{- $injectOTELFromPod = .Values.otelResourceAttributes.injectFromPod }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
@@ -80,6 +92,9 @@ spec:
           args:
             {{- range $key, $value := .Values.extraArgs }}
             - "-{{ $key }}={{ $value }}"
+            {{- end }}
+            {{- if and $hostProcEnabled (not (hasKey .Values.extraArgs "proc-root")) }}
+            - "-proc-root={{ $hostProcMountPath }}"
             {{- end }}
             {{- if and .Values.persistence.enabled (not (hasKey .Values.extraArgs "disk-cache-path")) }}
             - "-disk-cache-path={{ include "loki-vl-proxy.diskCachePath" . }}"
@@ -93,11 +108,21 @@ spec:
             - "-peer-static={{ join "," .Values.peerCache.peers }}"
             {{- end }}
             {{- end }}
-          {{- if or .Values.peerCache.enabled .Values.env $goMemLimitValue }}
+          {{- if or .Values.peerCache.enabled .Values.env $goMemLimitValue $injectOTELFromPod }}
           env:
             {{- if $goMemLimitValue }}
             - name: GOMEMLIMIT
               value: {{ $goMemLimitValue | quote }}
+            {{- end }}
+            {{- if $injectOTELFromPod }}
+            - name: OTEL_SERVICE_INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- end }}
             {{- if .Values.peerCache.enabled }}
             - name: POD_IP
@@ -155,11 +180,16 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts }}
+          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts $hostProcEnabled }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: cache-data
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            {{- if $hostProcEnabled }}
+            - name: host-proc
+              mountPath: {{ $hostProcMountPath }}
+              readOnly: true
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -168,12 +198,18 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.extraVolumes (and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet"))) }}
+      {{- if or .Values.extraVolumes $hostProcEnabled (and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet"))) }}
       volumes:
         {{- if and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet")) }}
         - name: cache-data
           persistentVolumeClaim:
             claimName: {{ include "loki-vl-proxy.persistenceClaimName" . }}
+        {{- end }}
+        {{- if $hostProcEnabled }}
+        - name: host-proc
+          hostPath:
+            path: /proc
+            type: Directory
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -123,6 +123,14 @@ env: []
   #       name: loki-vl-proxy-config
   #       key: field-mapping
 
+# OpenTelemetry resource attribute defaults for Kubernetes.
+# When enabled, the chart injects:
+# - OTEL_SERVICE_INSTANCE_ID from pod name
+# - OTEL_SERVICE_NAMESPACE from pod namespace
+# This improves per-pod metric visibility in OTLP pipelines without extra RBAC.
+otelResourceAttributes:
+  injectFromPod: true
+
 envFrom: []
   # - secretRef:
   #     name: loki-vl-proxy-env
@@ -379,6 +387,14 @@ initContainers: []
 extraContainers: []
 extraVolumes: []
 extraVolumeMounts: []
+
+# --- System metrics (/proc) ---
+# When enabled, mount host /proc read-only and point the proxy at that mount
+# so CPU/memory/disk/network/PSI metrics reflect node-level context.
+systemMetrics:
+  hostProc:
+    enabled: false
+    mountPath: /host/proc
 
 # --- Gateway API HTTPRoute (traffic distribution) ---
 # Optional Gateway API exposure instead of Ingress.

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -32,6 +32,7 @@ type envConfig struct {
 	backendURL        string
 	rulerBackendURL   string
 	alertsBackendURL  string
+	procRoot          string
 	tenantMapJSON     string
 	otlpEndpoint      string
 	otlpCompression   string
@@ -260,6 +261,7 @@ func run(
 	otelServiceNamespace := fs.String("otel-service-namespace", "", "OpenTelemetry service.namespace for logs and OTLP metrics")
 	otelServiceInstanceID := fs.String("otel-service-instance-id", "", "OpenTelemetry service.instance.id for logs and OTLP metrics")
 	deploymentEnvironment := fs.String("deployment-environment", "", "OpenTelemetry deployment.environment.name for logs and OTLP metrics")
+	procRoot := fs.String("proc-root", "/proc", "Proc filesystem root for system metrics (/proc for container scope, /host/proc for host scope)")
 
 	// HTTP server hardening
 	readTimeout := fs.Duration("http-read-timeout", 30*time.Second, "HTTP server read timeout")
@@ -329,6 +331,7 @@ func run(
 		backendURL:        *backendURL,
 		rulerBackendURL:   *rulerBackendURL,
 		alertsBackendURL:  *alertsBackendURL,
+		procRoot:          *procRoot,
 		tenantMapJSON:     *tenantMapJSON,
 		otlpEndpoint:      *otlpEndpoint,
 		otlpCompression:   *otlpCompression,
@@ -350,6 +353,9 @@ func run(
 		serviceInstanceID:     envCfg.serviceInstanceID,
 		deploymentEnvironment: envCfg.deploymentEnv,
 	})
+	metrics.SetProcRoot(envCfg.procRoot)
+	logSystemMetricsStartup(logger)
+
 	fatal := func(msg string, args ...any) {
 		logger.Error(msg, args...)
 		os.Exit(1)
@@ -682,6 +688,9 @@ func applyEnvOverrides(cfg envConfig, getenv func(string) string) envConfig {
 	if v := getenv("ALERTS_BACKEND_URL"); v != "" && cfg.alertsBackendURL == "" {
 		cfg.alertsBackendURL = v
 	}
+	if v := getenv("PROC_ROOT"); v != "" && cfg.procRoot == "/proc" {
+		cfg.procRoot = v
+	}
 	if v := getenv("TENANT_MAP"); v != "" && cfg.tenantMapJSON == "" {
 		cfg.tenantMapJSON = v
 	}
@@ -1006,5 +1015,36 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 	}
 	if compat != nil {
 		logger.Info("compatibility edge cache active", "tier", "tier0")
+	}
+}
+
+func logSystemMetricsStartup(logger *slog.Logger) {
+	check := metrics.InspectSystemStartup()
+	if check.GOOS != "linux" {
+		logger.Info("system metrics startup check",
+			"goos", check.GOOS,
+			"proc_root", check.ProcRoot,
+			"scope", check.Scope,
+			"note", "linux /proc metric families are unavailable on this platform",
+		)
+		return
+	}
+
+	missing := check.MissingFamilies()
+	if len(missing) == 0 {
+		logger.Info("system metrics startup check passed",
+			"proc_root", check.ProcRoot,
+			"scope", check.Scope,
+		)
+	} else {
+		logger.Warn("system metrics startup check incomplete",
+			"proc_root", check.ProcRoot,
+			"scope", check.Scope,
+			"missing_families", strings.Join(missing, ","),
+			"issues", strings.Join(check.IssueList(), "; "),
+		)
+	}
+	for _, rec := range check.Recommendations {
+		logger.Info("system metrics startup recommendation", "message", rec)
 	}
 }

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -95,6 +96,28 @@ func (r *runtimeRecorder) build(_ runtimeOptions, _ *slog.Logger, _ signalNotifi
 func (r *exitRecorder) exit(code int) {
 	r.calls++
 	r.code = code
+}
+
+func writeSyntheticProcFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+
+	for rel, content := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+}
+
+func withSyntheticProcRoot(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	writeSyntheticProcFiles(t, root, files)
+	return root
 }
 
 func TestBuildLogger(t *testing.T) {
@@ -600,6 +623,21 @@ func TestApplyEnvOverrides_PreservesExplicitFlags(t *testing.T) {
 	got := applyEnvOverrides(cfg, func(key string) string { return env[key] })
 	if got != cfg {
 		t.Fatalf("expected explicit values to win, got %+v", got)
+	}
+}
+
+func TestApplyEnvOverrides_ProcRoot(t *testing.T) {
+	cfg := envConfig{procRoot: "/proc"}
+	env := map[string]string{"PROC_ROOT": "/host/proc"}
+	got := applyEnvOverrides(cfg, func(key string) string { return env[key] })
+	if got.procRoot != "/host/proc" {
+		t.Fatalf("expected PROC_ROOT override when default procRoot is used, got %+v", got)
+	}
+
+	cfg.procRoot = "/custom/proc"
+	got = applyEnvOverrides(cfg, func(key string) string { return env[key] })
+	if got.procRoot != "/custom/proc" {
+		t.Fatalf("expected explicit procRoot to win over PROC_ROOT env var, got %+v", got)
 	}
 }
 
@@ -1303,6 +1341,76 @@ func TestLogProxyStartup(t *testing.T) {
 		if !strings.Contains(logs, want) {
 			t.Fatalf("expected log %q in %s", want, logs)
 		}
+	}
+}
+
+func TestLogSystemMetricsStartup_Passed(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only startup check path")
+	}
+
+	root := withSyntheticProcRoot(t, map[string]string{
+		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
+		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
+		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
+		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
+		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
+		"pressure/memory": "some avg10=0.50 avg60=1.00 avg300=1.50 total=10\nfull avg10=2.00 avg60=2.50 avg300=3.00 total=20\n",
+		"pressure/io":     "some avg10=0.25 avg60=0.50 avg300=0.75 total=10\nfull avg10=1.00 avg60=1.25 avg300=1.50 total=20\n",
+		"self/fd/0":       "",
+	})
+	prevProcRoot := metrics.ProcRoot()
+	metrics.SetProcRoot(root)
+	t.Cleanup(func() { metrics.SetProcRoot(prevProcRoot) })
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	logSystemMetricsStartup(logger)
+
+	logs := buf.String()
+	if !strings.Contains(logs, "system metrics startup check passed") {
+		t.Fatalf("expected startup pass log, got: %s", logs)
+	}
+	if strings.Contains(logs, "system metrics startup check incomplete") {
+		t.Fatalf("did not expect startup incomplete log, got: %s", logs)
+	}
+	if !strings.Contains(logs, "system metrics startup recommendation") {
+		t.Fatalf("expected startup recommendation log for non-host proc scope, got: %s", logs)
+	}
+}
+
+func TestLogSystemMetricsStartup_Incomplete(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only startup check path")
+	}
+
+	root := withSyntheticProcRoot(t, map[string]string{
+		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
+		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
+		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
+		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
+		"pressure/memory": "some avg10=0.50 avg60=1.00 avg300=1.50 total=10\nfull avg10=2.00 avg60=2.50 avg300=3.00 total=20\n",
+		"self/fd/0":       "",
+	})
+	prevProcRoot := metrics.ProcRoot()
+	metrics.SetProcRoot(root)
+	t.Cleanup(func() { metrics.SetProcRoot(prevProcRoot) })
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	logSystemMetricsStartup(logger)
+
+	logs := buf.String()
+	if !strings.Contains(logs, "system metrics startup check incomplete") {
+		t.Fatalf("expected startup incomplete log, got: %s", logs)
+	}
+	if !strings.Contains(logs, "missing_families") {
+		t.Fatalf("expected missing families in startup log, got: %s", logs)
+	}
+	if !strings.Contains(logs, "system metrics startup recommendation") {
+		t.Fatalf("expected startup recommendation log, got: %s", logs)
 	}
 }
 

--- a/dashboard/loki-vl-proxy.json
+++ b/dashboard/loki-vl-proxy.json
@@ -322,6 +322,150 @@
       "fieldConfig": {
         "defaults": {"unit": "s"}
       }
+    },
+    {
+      "title": "System Resources",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 61},
+      "collapsed": false
+    },
+    {
+      "title": "Memory Usage %",
+      "type": "gauge",
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 62},
+      "targets": [
+        {
+          "expr": "100 * max(node_memory_usage_ratio{job=\"$job\"})",
+          "legendFormat": "memory usage"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 75},
+              {"color": "red", "value": 90}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "CPU Usage Ratio by Mode",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 9, "x": 6, "y": 62},
+      "targets": [
+        {
+          "expr": "max(node_cpu_usage_ratio{job=\"$job\"}) by (mode)",
+          "legendFormat": "{{mode}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {"fillOpacity": 10}
+        }
+      }
+    },
+    {
+      "title": "PSI Pressure (60s Window)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 9, "x": 15, "y": 62},
+      "targets": [
+        {
+          "expr": "max(node_pressure_cpu_some_ratio{job=\"$job\",window=\"60s\"})",
+          "legendFormat": "cpu some"
+        },
+        {
+          "expr": "max(node_pressure_memory_some_ratio{job=\"$job\",window=\"60s\"})",
+          "legendFormat": "memory some"
+        },
+        {
+          "expr": "max(node_pressure_io_some_ratio{job=\"$job\",window=\"60s\"})",
+          "legendFormat": "io some"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {"fillOpacity": 10},
+          "thresholds": {
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.1},
+              {"color": "red", "value": 0.2}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Disk Throughput",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 70},
+      "targets": [
+        {
+          "expr": "sum(rate(node_disk_read_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "read"
+        },
+        {
+          "expr": "sum(rate(node_disk_written_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "write"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "Bps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Network Throughput",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 70},
+      "targets": [
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "rx"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "tx"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "Bps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Process RSS",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 78},
+      "targets": [
+        {
+          "expr": "max(process_resident_memory_bytes{job=\"$job\"})",
+          "legendFormat": "rss"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "bytes"}
+      }
+    },
+    {
+      "title": "Open File Descriptors",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 78},
+      "targets": [
+        {
+          "expr": "max(process_open_fds{job=\"$job\"})",
+          "legendFormat": "fds"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "none"}
+      }
     }
   ],
   "schemaVersion": 39,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -24,7 +24,9 @@
 
 For Grafana Logs Drilldown and Explore compatibility:
 
-- Query results use canonical Loki 2-tuples `[timestamp, line]` by default. Set `-emit-structured-metadata=true` to emit Loki 3-tuples `[timestamp, line, metadata]`.
+- Query results use canonical Loki 2-tuples `[timestamp, line]` by default.
+- With `-emit-structured-metadata=true`, non-Grafana callers receive Loki 3-tuples `[timestamp, line, metadata]`.
+- Grafana callers stay on 2-tuples unless they explicitly opt in with `X-Loki-Response-Encoding-Flags: structured-metadata` or `structured_metadata=true`.
 - When emitted, tuple metadata is always a flat key/value object for broad client/parser compatibility, including requests that carry `X-Loki-Response-Encoding-Flags: categorize-labels`.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ All flags follow VictoriaMetrics naming conventions (`-flagName=value`).
 |---|---|---|---|
 | `-listen` | `LISTEN_ADDR` | `:3100` | Listen address |
 | `-backend` | `VL_BACKEND_URL` | `http://localhost:9428` | VictoriaLogs backend URL |
+| `-proc-root` | `PROC_ROOT` | `/proc` | Proc filesystem root used for CPU/memory/disk/network/PSI metrics (`/proc` for container scope, `/host/proc` for host scope) |
 | `-ruler-backend` | `RULER_BACKEND_URL` | — | Optional rules backend for legacy Loki YAML rules routes and Prometheus-style `/prometheus/api/v1/rules` passthrough |
 | `-alerts-backend` | `ALERTS_BACKEND_URL` | — | Optional alerts backend for Loki and Prometheus-style alerts endpoints (defaults to `-ruler-backend`) |
 | `-log-level` | — | `info` | Log level: debug, info, warn, error |
@@ -22,7 +23,7 @@ All flags follow VictoriaMetrics naming conventions (`-flagName=value`).
 |---|---|---|---|
 | `-label-style` | `LABEL_STYLE` | `passthrough` | `passthrough` or `underscores` |
 | `-metadata-field-mode` | `METADATA_FIELD_MODE` | `hybrid` | `native`, `translated`, or `hybrid` for `detected_fields` and structured metadata exposure |
-| `-emit-structured-metadata` | — | `false` | Emit Loki 3-tuple stream values `[timestamp, line, metadata]` instead of canonical 2-tuples |
+| `-emit-structured-metadata` | — | `false` | Enable 3-tuple support. Non-Grafana callers get `[timestamp, line, metadata]`; Grafana callers stay on `[timestamp, line]` unless they explicitly opt in (`X-Loki-Response-Encoding-Flags: structured-metadata` or `structured_metadata=true`) |
 | `-field-mapping` | `FIELD_MAPPING` | — | JSON custom field mappings |
 
 ### Label Style Modes

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -48,7 +48,7 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
   },
   "body": "request",
   "service.name": "loki-vl-proxy",
-  "service.version": "0.27.14",
+  "service.version": "0.27.15",
   "service.instance.id": "proxy-1",
   "deployment.environment.name": "prod",
   "component": "proxy",
@@ -196,6 +196,13 @@ The proxy also exports a lightweight built-in set of runtime and host health met
 | `node_disk_*_bytes_total` | disk I/O counters |
 | `node_network_*_bytes_total` | network I/O counters |
 | `node_pressure_*` | Linux PSI gauges when available |
+
+Kubernetes notes:
+- These runtime/system metrics are read from `/proc` and do not require Kubernetes RBAC permissions.
+- PSI metrics (`node_pressure_*`) depend on kernel support and may be absent on nodes without `/proc/pressure/*`.
+- On startup, the proxy logs a system-metrics readiness check with missing families and remediation hints instead of failing silently.
+- For node-level metrics in Kubernetes, mount host `/proc` and set `-proc-root=/host/proc` (the upstream chart supports this via `systemMetrics.hostProc.enabled: true`).
+- For per-pod attribution in OTLP backends, set `OTEL_SERVICE_INSTANCE_ID` from pod name and `OTEL_SERVICE_NAMESPACE` from pod namespace (the upstream chart now injects these by default).
 
 ### PromQL Drilldowns For Slowness And Client Errors
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -219,6 +219,14 @@ Use these queries to quickly isolate backend slowness vs proxy/client-side failu
 
 For latency histograms, keep dashboards on `p50`, `p95`, and `p99` rather than averages. Averages hide tail latency incidents.
 
+The packaged `Loki-VL-Proxy` dashboard also includes a `System Resources` section with:
+
+- memory usage ratio
+- CPU usage split by mode
+- PSI pressure (cpu/memory/io)
+- disk and network throughput
+- process RSS and open file descriptors
+
 ### Active Backend E2E Healthchecks
 
 `/ready` confirms backend reachability, but production health should also include synthetic end-to-end probes with real query traffic shape.

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -24,3 +24,4 @@ Alert runbooks are split per alert under this directory so each alert annotation
 - [LokiVLProxyTenantHighErrorRate](loki-vl-proxy-tenant-high-error-rate.md)
 - [LokiVLProxyRateLimiting](loki-vl-proxy-rate-limiting.md)
 - [LokiVLProxyClientBadRequestBurst](loki-vl-proxy-client-bad-request-burst.md)
+- [LokiVLProxySystemResources](loki-vl-proxy-system-resources.md)

--- a/docs/runbooks/loki-vl-proxy-system-resources.md
+++ b/docs/runbooks/loki-vl-proxy-system-resources.md
@@ -1,0 +1,50 @@
+# LokiVLProxy System Resources
+
+## Alerts Covered
+
+- `LokiVLProxySystemMetricsMissing`
+- `LokiVLProxySystemMemoryHigh`
+- `LokiVLProxySystemCPUPressureHigh`
+- `LokiVLProxySystemIOPressureHigh`
+
+## Symptoms
+
+- System metrics disappear from `/metrics` or dashboards.
+- Memory usage ratio remains above `90%`.
+- PSI `cpu` or `io` pressure (60s window) remains elevated for 10+ minutes.
+- User-facing query latency and timeout/error rates increase during pressure windows.
+
+## Immediate Checks
+
+1. Confirm proxy health:
+   - `curl -fsS http://<proxy>:3100/ready`
+2. Confirm metrics endpoint includes system families:
+   - `curl -fsS http://<proxy>:3100/metrics | rg "node_memory_usage_ratio|node_cpu_usage_ratio|node_pressure_"`
+3. Inspect startup diagnostics in proxy logs for system-metrics check output.
+4. Check dashboard section `System Resources` for memory, PSI, disk, and network trends.
+
+## Kubernetes-Specific Checks
+
+1. Ensure host `/proc` is mounted when node-level visibility is expected:
+   - `systemMetrics.hostProc.enabled: true`
+   - chart auto-sets `-proc-root=/host/proc`
+2. Verify container has read access to mounted proc path.
+3. If scraping is disabled (`server.register-instrumentation=false`), ensure OTLP pipeline is healthy and metrics are queryable in your backend.
+
+## Mitigation
+
+1. Reduce expensive query pressure:
+   - identify top endpoints/tenants/clients from proxy metrics dashboards
+   - temporarily tighten query ranges or concurrency
+2. Scale capacity:
+   - increase proxy replicas for CPU-bound contention
+   - move to nodes with higher memory/IO capacity when sustained pressure persists
+3. Validate backend health:
+   - correlate with VictoriaLogs latency and error metrics
+   - inspect backend disk/network saturation
+
+## Recovery Criteria
+
+- `node_memory_usage_ratio < 0.85` sustained.
+- PSI `cpu` and `io` some-ratio drops below alert thresholds.
+- Query latency/error alerts recover and remain stable for at least one alert interval.

--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,6 +30,167 @@ var (
 	procReadDir  = os.ReadDir
 	systemGOOS   = runtime.GOOS
 )
+
+// SystemStartupCheck describes startup-time availability of /proc-backed metric families.
+type SystemStartupCheck struct {
+	GOOS            string
+	ProcRoot        string
+	Scope           string
+	Availability    map[string]bool
+	Issues          map[string]string
+	Recommendations []string
+}
+
+// MissingFamilies returns a stable list of unavailable metric families.
+func (c SystemStartupCheck) MissingFamilies() []string {
+	missing := make([]string, 0, len(c.Availability))
+	for family, ok := range c.Availability {
+		if !ok {
+			missing = append(missing, family)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+// IssueList returns issue strings in stable key order.
+func (c SystemStartupCheck) IssueList() []string {
+	keys := make([]string, 0, len(c.Issues))
+	for k := range c.Issues {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf("%s: %s", k, c.Issues[k]))
+	}
+	return out
+}
+
+// SetProcRoot overrides the root used for /proc-backed system metrics.
+func SetProcRoot(root string) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		procRoot = "/proc"
+		return
+	}
+	procRoot = filepath.Clean(root)
+}
+
+// ProcRoot returns the configured /proc root path.
+func ProcRoot() string {
+	return procRoot
+}
+
+func detectProcScope(root string) string {
+	clean := filepath.Clean(strings.TrimSpace(root))
+	switch clean {
+	case "/proc":
+		return "container"
+	case "/host/proc", "/rootfs/proc":
+		return "host"
+	default:
+		if strings.Contains(clean, "host") && strings.HasSuffix(clean, "/proc") {
+			return "host"
+		}
+		return "custom"
+	}
+}
+
+// InspectSystemStartup validates startup prerequisites for /proc-backed metric families.
+func InspectSystemStartup() SystemStartupCheck {
+	check := SystemStartupCheck{
+		GOOS:         systemGOOS,
+		ProcRoot:     procRoot,
+		Scope:        detectProcScope(procRoot),
+		Availability: map[string]bool{},
+		Issues:       map[string]string{},
+	}
+
+	if systemGOOS != "linux" {
+		check.Recommendations = append(check.Recommendations, "System CPU/memory/disk/network/PSI metrics are exported only on Linux; non-Linux builds expose runtime/process metrics only.")
+		return check
+	}
+
+	if _, err := readCPUStat(); err != nil {
+		check.Availability["cpu"] = false
+		check.Issues["cpu"] = fmt.Sprintf("failed to read %s: %v", procPath("stat"), err)
+	} else {
+		check.Availability["cpu"] = true
+	}
+
+	if data, err := procReadFile(procPath("meminfo")); err != nil {
+		check.Availability["memory"] = false
+		check.Issues["memory"] = fmt.Sprintf("failed to read %s: %v", procPath("meminfo"), err)
+	} else {
+		memTotal, _, _ := parseMemInfoData(string(data))
+		if memTotal <= 0 {
+			check.Availability["memory"] = false
+			check.Issues["memory"] = fmt.Sprintf("parsed MemTotal=0 from %s", procPath("meminfo"))
+		} else {
+			check.Availability["memory"] = true
+		}
+	}
+
+	if data, err := procReadFile(procPath("self", "status")); err != nil {
+		check.Availability["process_rss"] = false
+		check.Issues["process_rss"] = fmt.Sprintf("failed to read %s: %v", procPath("self", "status"), err)
+	} else {
+		if parseProcessRSSData(string(data)) <= 0 {
+			check.Availability["process_rss"] = false
+			check.Issues["process_rss"] = fmt.Sprintf("unable to parse VmRSS from %s", procPath("self", "status"))
+		} else {
+			check.Availability["process_rss"] = true
+		}
+	}
+
+	if _, err := procReadFile(procPath("diskstats")); err != nil {
+		check.Availability["disk_io"] = false
+		check.Issues["disk_io"] = fmt.Sprintf("failed to read %s: %v", procPath("diskstats"), err)
+	} else {
+		check.Availability["disk_io"] = true
+	}
+
+	if _, err := procReadFile(procPath("net", "dev")); err != nil {
+		check.Availability["network_io"] = false
+		check.Issues["network_io"] = fmt.Sprintf("failed to read %s: %v", procPath("net", "dev"), err)
+	} else {
+		check.Availability["network_io"] = true
+	}
+
+	for _, resource := range []string{"cpu", "memory", "io"} {
+		family := "pressure_" + resource
+		path := procPath("pressure", resource)
+		data, err := procReadFile(path)
+		if err != nil {
+			check.Availability[family] = false
+			check.Issues[family] = fmt.Sprintf("failed to read %s: %v", path, err)
+			continue
+		}
+		some10, some60, some300, full10, full60, full300 := parsePSIData(string(data))
+		if some10 < 0 && some60 < 0 && some300 < 0 && full10 < 0 && full60 < 0 && full300 < 0 {
+			check.Availability[family] = false
+			check.Issues[family] = fmt.Sprintf("unable to parse PSI data from %s", path)
+			continue
+		}
+		check.Availability[family] = true
+	}
+
+	if _, err := procReadDir(procPath("self", "fd")); err != nil {
+		check.Availability["open_fds"] = false
+		check.Issues["open_fds"] = fmt.Sprintf("failed to read %s: %v", procPath("self", "fd"), err)
+	} else {
+		check.Availability["open_fds"] = true
+	}
+
+	if check.Scope != "host" {
+		check.Recommendations = append(check.Recommendations, "For node-level CPU/memory/disk/network/PSI metrics in Kubernetes, mount host /proc read-only and set -proc-root=/host/proc (or PROC_ROOT=/host/proc).")
+	}
+	if len(check.MissingFamilies()) > 0 {
+		check.Recommendations = append(check.Recommendations, "Verify container permissions and mount path for proc files; inaccessible /proc paths result in missing system metric families.")
+	}
+	return check
+}
 
 func procPath(parts ...string) string {
 	all := append([]string{procRoot}, parts...)

--- a/internal/metrics/system_test.go
+++ b/internal/metrics/system_test.go
@@ -59,6 +59,48 @@ func TestSetProcRoot(t *testing.T) {
 	}
 }
 
+func TestDetectProcScope(t *testing.T) {
+	cases := []struct {
+		root string
+		want string
+	}{
+		{root: "/proc", want: "container"},
+		{root: "/host/proc", want: "host"},
+		{root: "/rootfs/proc", want: "host"},
+		{root: " /tmp/mounted-host/proc ", want: "host"},
+		{root: "/tmp/custom/proc", want: "custom"},
+	}
+
+	for _, tc := range cases {
+		got := detectProcScope(tc.root)
+		if got != tc.want {
+			t.Fatalf("detectProcScope(%q)=%q, want %q", tc.root, got, tc.want)
+		}
+	}
+}
+
+func TestInspectSystemStartup_NonLinux(t *testing.T) {
+	oldGOOS := systemGOOS
+	oldRoot := procRoot
+	systemGOOS = "darwin"
+	procRoot = "/proc"
+	t.Cleanup(func() {
+		systemGOOS = oldGOOS
+		procRoot = oldRoot
+	})
+
+	check := InspectSystemStartup()
+	if check.GOOS != "darwin" {
+		t.Fatalf("unexpected GOOS in check: %q", check.GOOS)
+	}
+	if len(check.Availability) != 0 {
+		t.Fatalf("expected no linux /proc availability map on non-linux, got %+v", check.Availability)
+	}
+	if len(check.Recommendations) == 0 || !strings.Contains(check.Recommendations[0], "only on Linux") {
+		t.Fatalf("expected non-linux recommendation, got %+v", check.Recommendations)
+	}
+}
+
 func TestInspectSystemStartup_WithSyntheticHostProc(t *testing.T) {
 	root := withSyntheticProcFS(t, map[string]string{
 		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
@@ -110,6 +152,57 @@ func TestInspectSystemStartup_ReportsMissingFamilies(t *testing.T) {
 	issues := check.IssueList()
 	if len(issues) == 0 {
 		t.Fatalf("expected startup issues, got none")
+	}
+}
+
+func TestInspectSystemStartup_HostScope_NoHostMountRecommendation(t *testing.T) {
+	base := withSyntheticProcFS(t, map[string]string{
+		"host/proc/stat":            "cpu  100 5 20 300 7 0 1 2\n",
+		"host/proc/meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
+		"host/proc/self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"host/proc/diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
+		"host/proc/net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
+		"host/proc/pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
+		"host/proc/pressure/memory": "some avg10=0.50 avg60=1.00 avg300=1.50 total=10\nfull avg10=2.00 avg60=2.50 avg300=3.00 total=20\n",
+		"host/proc/pressure/io":     "some avg10=0.25 avg60=0.50 avg300=0.75 total=10\nfull avg10=1.00 avg60=1.25 avg300=1.50 total=20\n",
+		"host/proc/self/fd/0":       "",
+	})
+	setSyntheticProcEnv(t, filepath.Join(base, "host", "proc"))
+
+	check := InspectSystemStartup()
+	if check.Scope != "host" {
+		t.Fatalf("expected host scope, got %q", check.Scope)
+	}
+	if len(check.MissingFamilies()) != 0 {
+		t.Fatalf("expected no missing families, got %v", check.MissingFamilies())
+	}
+	for _, rec := range check.Recommendations {
+		if strings.Contains(rec, "mount host /proc") {
+			t.Fatalf("unexpected host /proc recommendation when already in host scope: %+v", check.Recommendations)
+		}
+	}
+}
+
+func TestInspectSystemStartup_ReportsPSIParseFailure(t *testing.T) {
+	root := withSyntheticProcFS(t, map[string]string{
+		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
+		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
+		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
+		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
+		"pressure/cpu":    "invalid",
+		"pressure/memory": "some avg10=0.50 avg60=1.00 avg300=1.50 total=10\nfull avg10=2.00 avg60=2.50 avg300=3.00 total=20\n",
+		"pressure/io":     "some avg10=0.25 avg60=0.50 avg300=0.75 total=10\nfull avg10=1.00 avg60=1.25 avg300=1.50 total=20\n",
+		"self/fd/0":       "",
+	})
+	setSyntheticProcEnv(t, root)
+
+	check := InspectSystemStartup()
+	if check.Availability["pressure_cpu"] {
+		t.Fatalf("expected pressure_cpu to be unavailable, got %+v", check.Availability)
+	}
+	if !strings.Contains(check.Issues["pressure_cpu"], "unable to parse PSI data") {
+		t.Fatalf("expected parse failure issue for pressure_cpu, got %+v", check.Issues)
 	}
 }
 

--- a/internal/metrics/system_test.go
+++ b/internal/metrics/system_test.go
@@ -44,6 +44,75 @@ func setSyntheticProcEnv(t *testing.T, root string) {
 	})
 }
 
+func TestSetProcRoot(t *testing.T) {
+	oldRoot := procRoot
+	t.Cleanup(func() { procRoot = oldRoot })
+
+	SetProcRoot("/host/proc/../proc")
+	if got := ProcRoot(); got != "/host/proc" {
+		t.Fatalf("expected cleaned proc root, got %q", got)
+	}
+
+	SetProcRoot("   ")
+	if got := ProcRoot(); got != "/proc" {
+		t.Fatalf("expected default proc root, got %q", got)
+	}
+}
+
+func TestInspectSystemStartup_WithSyntheticHostProc(t *testing.T) {
+	root := withSyntheticProcFS(t, map[string]string{
+		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
+		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
+		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
+		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
+		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
+		"pressure/memory": "some avg10=0.50 avg60=1.00 avg300=1.50 total=10\nfull avg10=2.00 avg60=2.50 avg300=3.00 total=20\n",
+		"pressure/io":     "some avg10=0.25 avg60=0.50 avg300=0.75 total=10\nfull avg10=1.00 avg60=1.25 avg300=1.50 total=20\n",
+		"self/fd/0":       "",
+		"self/fd/1":       "",
+		"self/fd/2":       "",
+	})
+	setSyntheticProcEnv(t, root)
+
+	check := InspectSystemStartup()
+	if check.Scope != "custom" {
+		t.Fatalf("expected custom scope for synthetic path, got %q", check.Scope)
+	}
+	if len(check.MissingFamilies()) != 0 {
+		t.Fatalf("expected no missing families, got %v (%v)", check.MissingFamilies(), check.Issues)
+	}
+}
+
+func TestInspectSystemStartup_ReportsMissingFamilies(t *testing.T) {
+	root := withSyntheticProcFS(t, map[string]string{
+		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
+		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
+		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
+		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
+		"pressure/memory": "some avg10=0.50 avg60=1.00 avg300=1.50 total=10\nfull avg10=2.00 avg60=2.50 avg300=3.00 total=20\n",
+		"self/fd/0":       "",
+	})
+	setSyntheticProcEnv(t, root)
+
+	check := InspectSystemStartup()
+	missing := check.MissingFamilies()
+	wantSubset := []string{"memory", "pressure_io"}
+	for _, family := range wantSubset {
+		if check.Availability[family] {
+			t.Fatalf("expected %s to be unavailable, got available map=%v", family, check.Availability)
+		}
+	}
+	if len(missing) == 0 {
+		t.Fatalf("expected missing families, got none")
+	}
+	issues := check.IssueList()
+	if len(issues) == 0 {
+		t.Fatalf("expected startup issues, got none")
+	}
+}
+
 func TestSystemMetrics_WritePrometheus_NoPanic(t *testing.T) {
 	sm := NewSystemMetrics()
 	var sb strings.Builder

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3423,8 +3423,9 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 
 	// Chunked streaming: flush partial results as they arrive from VL
 	categorizedLabels := requestWantsCategorizedLabels(r)
+	emitStructuredMetadata := p.shouldEmitStructuredMetadata(r)
 	if p.streamResponse {
-		p.streamLogQuery(w, resp, r.FormValue("query"), categorizedLabels)
+		p.streamLogQuery(w, resp, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
 		return
 	}
 
@@ -3432,7 +3433,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 
 	// VL returns newline-delimited JSON, each line is a log entry.
 	// Loki expects: {"status":"success","data":{"resultType":"streams","result":[...]}}
-	streams := p.vlLogsToLokiStreams(body, r.FormValue("query"), categorizedLabels)
+	streams := p.vlLogsToLokiStreams(body, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
 
 	// Apply derived fields (extract trace_id etc. from log lines)
 	if len(p.derivedFields) > 0 {
@@ -3466,7 +3467,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 }
 
 // streamLogQuery streams VL NDJSON response as chunked Loki-compatible JSON.
-func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, originalQuery string, categorizedLabels bool) {
+func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, originalQuery string, categorizedLabels bool, emitStructuredMetadata bool) {
 	flusher, canFlush := w.(http.Flusher)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -3514,7 +3515,7 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, origi
 
 		stream := map[string]interface{}{
 			"stream": translatedLabels,
-			"values": buildStreamValues(tsNanos, msg, structuredMetadata, parsedFields, p.emitStructuredMetadata, categorizedLabels),
+			"values": buildStreamValues(tsNanos, msg, structuredMetadata, parsedFields, emitStructuredMetadata, categorizedLabels),
 		}
 
 		chunk, _ := json.Marshal(stream)
@@ -3707,7 +3708,7 @@ func vlLogsToLokiStreams(body []byte) []map[string]interface{} {
 	return result
 }
 
-func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string, categorizedLabels bool) []map[string]interface{} {
+func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string, categorizedLabels bool, emitStructuredMetadata bool) []map[string]interface{} {
 	type streamEntry struct {
 		Labels map[string]string
 		Values []interface{}
@@ -3770,7 +3771,7 @@ func (p *Proxy) vlLogsToLokiStreams(body []byte, originalQuery string, categoriz
 			}
 			streamMap[streamKey] = se
 		}
-		se.Values = append(se.Values, buildStreamValue(tsNanos, msg, structuredMetadata, parsedFields, p.emitStructuredMetadata, categorizedLabels))
+		se.Values = append(se.Values, buildStreamValue(tsNanos, msg, structuredMetadata, parsedFields, emitStructuredMetadata, categorizedLabels))
 		vlEntryPool.Put(entry)
 	}
 
@@ -4164,6 +4165,52 @@ func requestWantsCategorizedLabels(r *http.Request) bool {
 		}
 	}
 	return false
+}
+
+func requestWantsStructuredMetadata(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if raw := strings.TrimSpace(r.FormValue("structured_metadata")); raw != "" {
+		if enabled, err := strconv.ParseBool(raw); err == nil {
+			return enabled
+		}
+	}
+	raw := strings.TrimSpace(r.Header.Get("X-Loki-Response-Encoding-Flags"))
+	if raw == "" {
+		return false
+	}
+	for _, part := range strings.Split(raw, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), "structured-metadata") {
+			return true
+		}
+	}
+	return false
+}
+
+func requestLooksLikeGrafana(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if strings.TrimSpace(r.Header.Get("X-Grafana-User")) != "" || strings.TrimSpace(r.Header.Get("X-Grafana-Org-Id")) != "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(r.Header.Get("User-Agent"))), "grafana")
+}
+
+func (p *Proxy) shouldEmitStructuredMetadata(r *http.Request) bool {
+	if !p.emitStructuredMetadata {
+		return false
+	}
+	if requestWantsStructuredMetadata(r) {
+		return true
+	}
+	// Grafana Explore/Drilldown clients still expect canonical [ts, line] tuples.
+	// Keep 3-tuples opt-in for these callers even when global emission is enabled.
+	if requestLooksLikeGrafana(r) {
+		return false
+	}
+	return true
 }
 
 func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, endpoint string, single func(http.ResponseWriter, *http.Request)) bool {

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -32,7 +32,7 @@ func TestVLLogsToLokiStreams_DefaultValuesStayTwoTuple(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, false)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"ok","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","deployment.environment.name":"dev","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false, p.emitStructuredMetadata)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -53,7 +53,7 @@ func TestVLLogsToLokiStreams_EmitStructuredMetadataAddsFlatThirdTupleValueByDefa
 	p := newStreamMetadataTestProxy(t, true)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"ok","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","deployment.environment.name":"dev","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false, p.emitStructuredMetadata)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -87,7 +87,7 @@ func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserFlattensFieldsByDef
 	p := newStreamMetadataTestProxy(t, true)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","http.status_code":"200","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, false)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, false, p.emitStructuredMetadata)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -118,7 +118,7 @@ func TestVLLogsToLokiStreams_CategorizedLabelsStillEmitsFlatMetadataForParserSaf
 	p := newStreamMetadataTestProxy(t, true)
 	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","trace_id":"abc123","http.status_code":"200","level":"info"}` + "\n")
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, true)
+	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, true, p.emitStructuredMetadata)
 	if len(streams) != 1 {
 		t.Fatalf("expected 1 stream, got %d", len(streams))
 	}
@@ -152,7 +152,7 @@ func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
 		Body: io.NopCloser(strings.NewReader(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","http.status_code":"200","level":"info"}` + "\n")),
 	}
 
-	p.streamLogQuery(rec, resp, `{job="otel-proxy"} | json`, false)
+	p.streamLogQuery(rec, resp, `{job="otel-proxy"} | json`, false, p.emitStructuredMetadata)
 
 	var payload map[string]interface{}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -196,5 +196,36 @@ func TestRequestWantsCategorizedLabels(t *testing.T) {
 	req.Header.Set("X-Loki-Response-Encoding-Flags", "foo,categorize-labels,bar")
 	if !requestWantsCategorizedLabels(req) {
 		t.Fatal("expected true when categorize-labels flag is present")
+	}
+}
+
+func TestShouldEmitStructuredMetadata_DisablesForGrafanaByDefault(t *testing.T) {
+	p := newStreamMetadataTestProxy(t, true)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	req.Header.Set("X-Grafana-User", "admin")
+
+	if p.shouldEmitStructuredMetadata(req) {
+		t.Fatal("expected structured metadata disabled for Grafana callers by default")
+	}
+}
+
+func TestShouldEmitStructuredMetadata_AllowsGrafanaOptInViaEncodingFlag(t *testing.T) {
+	p := newStreamMetadataTestProxy(t, true)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	req.Header.Set("X-Grafana-User", "admin")
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "structured-metadata")
+
+	if !p.shouldEmitStructuredMetadata(req) {
+		t.Fatal("expected structured metadata when Grafana explicitly opts in via encoding flag")
+	}
+}
+
+func TestShouldEmitStructuredMetadata_AllowsQueryParamOptIn(t *testing.T) {
+	p := newStreamMetadataTestProxy(t, true)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?structured_metadata=true", nil)
+	req.Header.Set("X-Grafana-User", "admin")
+
+	if !p.shouldEmitStructuredMetadata(req) {
+		t.Fatal("expected structured metadata when structured_metadata=true query param is set")
 	}
 }


### PR DESCRIPTION
## Summary
- keep Grafana Explore/Drilldown responses on canonical 2-tuple stream values by default even when structured metadata is enabled, with explicit caller opt-in for 3-tuples
- add startup diagnostics for /proc-backed system metrics so missing CPU/memory/disk/network/PSI families are logged with actionable remediation
- add chart support for host /proc mount and auto-wire proc-root (`systemMetrics.hostProc.enabled`) for node-level system metric visibility in Kubernetes
- keep OTEL semantic field alignment and 0.27.15 metadata updates already included in this branch

## Validation
- go test ./... -count=1
- helm lint charts/loki-vl-proxy
