### PR TITLE
Fix backtick line filter translation with logfmt pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- normalize backtick-quoted LogQL line filters (for example ``|= `api` ``) to literal substring matches so parser pipelines such as `| logfmt` no longer drop valid lines
+
+### Tests
+
+- add translator regression coverage for backtick raw-string line filters, including `|= ... | logfmt` and literals containing `|`
+
 ## [0.27.15] - 2026-04-10
 
 ### Bug Fixes

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -1022,18 +1022,22 @@ func normalizeByLabels(labels string, labelFn LabelTranslateFunc) string {
 
 func findMatchingBrace(s string) int {
 	depth := 0
-	inQuote := false
+	var inQuote rune
 	for i := 0; i < len(s); i++ {
 		c := rune(s[i])
 		// Handle backslash escapes inside quotes
-		if c == '\\' && inQuote && i+1 < len(s) {
+		if c == '\\' && inQuote == '"' && i+1 < len(s) {
 			i++ // skip escaped character
 			continue
 		}
-		if c == '"' {
-			inQuote = !inQuote
+		if (c == '"' || c == '`') && (inQuote == 0 || inQuote == c) {
+			if inQuote == 0 {
+				inQuote = c
+			} else {
+				inQuote = 0
+			}
 		}
-		if inQuote {
+		if inQuote != 0 {
 			continue
 		}
 		if c == '{' {
@@ -1051,12 +1055,20 @@ func findMatchingBrace(s string) int {
 
 func findLastMatchingParen(s string) int {
 	depth := 0
-	inQuote := false
+	var inQuote rune
 	for i, c := range s {
-		if c == '"' {
-			inQuote = !inQuote
+		if c == '\\' && inQuote == '"' && i+1 < len(s) {
+			i++
+			continue
 		}
-		if inQuote {
+		if (c == '"' || c == '`') && (inQuote == 0 || inQuote == c) {
+			if inQuote == 0 {
+				inQuote = c
+			} else {
+				inQuote = 0
+			}
+		}
+		if inQuote != 0 {
 			continue
 		}
 		if c == '(' {
@@ -1074,12 +1086,20 @@ func findLastMatchingParen(s string) int {
 
 func extractPipelineStage(s string) (stage, rest string) {
 	// A pipeline stage goes until the next unquoted |
-	inQuote := false
+	var inQuote rune
 	for i, c := range s {
-		if c == '"' {
-			inQuote = !inQuote
+		if c == '\\' && inQuote == '"' && i+1 < len(s) {
+			i++
+			continue
 		}
-		if inQuote {
+		if (c == '"' || c == '`') && (inQuote == 0 || inQuote == c) {
+			if inQuote == 0 {
+				inQuote = c
+			} else {
+				inQuote = 0
+			}
+		}
+		if inQuote != 0 {
 			continue
 		}
 		if c == '|' {
@@ -1101,6 +1121,13 @@ func extractQuotedValue(s string) (string, string) {
 		}
 		// No closing quote found — return everything
 		return s, ""
+	}
+	if strings.HasPrefix(s, "`") {
+		if i := strings.IndexByte(s[1:], '`'); i >= 0 {
+			// Raw strings should behave like regular quoted literals in the translated query.
+			return strconv.Quote(s[1 : i+1]), strings.TrimSpace(s[i+2:])
+		}
+		return strconv.Quote(s[1:]), ""
 	}
 	// Not quoted — take until next space or pipe
 	end := strings.IndexAny(s, " |")

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -32,6 +32,21 @@ func TestTranslateLogQL(t *testing.T) {
 			want:  `app:=nginx ~"error"`,
 		},
 		{
+			name:  "line contains filter with backtick raw string",
+			logql: "{app=\"nginx\"} |= `api`",
+			want:  `app:=nginx ~"api"`,
+		},
+		{
+			name:  "line contains backtick raw string with logfmt pipeline",
+			logql: "{app=\"nginx\"} |= `api` | logfmt",
+			want:  `app:=nginx ~"api" | unpack_logfmt`,
+		},
+		{
+			name:  "line contains backtick raw string containing pipe char",
+			logql: "{app=\"nginx\"} |= `api|v1` | logfmt",
+			want:  `app:=nginx ~"api|v1" | unpack_logfmt`,
+		},
+		{
 			name:  "line not contains filter — substring semantics",
 			logql: `{app="nginx"} != "debug"`,
 			want:  `app:=nginx NOT ~"debug"`,


### PR DESCRIPTION
## Summary
- fix LogQL translation for backtick-quoted line filters (raw-string form), so raw `|=` and `!=` filters behave as literal substring matches
- ensure parser chains still work after that filter, including `| logfmt`
- add regression tests for:
  - backtick `|=` filter
  - backtick `|=` followed by `| logfmt`
  - backtick literal containing `|`
- update changelog under `Unreleased`

## Why
Queries that use a backtick line-contains filter followed by parser stages were translated with the backticks included in the match token, which caused valid lines to be dropped.

## Validation
- `go test ./internal/translator -count=1`
