### PR TITLE
Harden Grafana Explore/Drilldown tuple compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- restore Grafana-safe tuple defaults when `-emit-structured-metadata=true`: Explore/Drilldown requests now stay on canonical `[timestamp, line]` unless explicitly opted into `structured_metadata=true` (or `X-Loki-Response-Encoding-Flags: structured-metadata`), preventing `ReadArray` decode regressions
+
+### Tests
+
+- add strict query-range regression coverage that decodes Grafana responses as `[2]string` tuples and fails on any metadata-object tuple shape leak
+
 ## [0.27.17] - 2026-04-10
 
 ### Bug Fixes

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,8 +25,8 @@
 For Grafana Logs Drilldown and Explore compatibility:
 
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default.
-- With `-emit-structured-metadata=true`, callers (including Grafana Explore/Drilldown) receive Loki 3-tuples `[timestamp, line, metadata]` by default.
-- Callers can explicitly force canonical 2-tuples with `structured_metadata=false`.
+- With `-emit-structured-metadata=true`, non-Grafana callers receive Loki 3-tuples `[timestamp, line, metadata]` by default.
+- Grafana Explore/Drilldown callers stay on canonical 2-tuples unless they explicitly opt in with `structured_metadata=true` or `X-Loki-Response-Encoding-Flags: structured-metadata`.
 - When emitted, tuple metadata is always a flat key/value object for broad client/parser compatibility, including requests that carry `X-Loki-Response-Encoding-Flags: categorize-labels`.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ All flags follow VictoriaMetrics naming conventions (`-flagName=value`).
 |---|---|---|---|
 | `-label-style` | `LABEL_STYLE` | `passthrough` | `passthrough` or `underscores` |
 | `-metadata-field-mode` | `METADATA_FIELD_MODE` | `hybrid` | `native`, `translated`, or `hybrid` for `detected_fields` and structured metadata exposure |
-| `-emit-structured-metadata` | — | `false` | Enable 3-tuple support. Callers (including Grafana) get `[timestamp, line, metadata]` by default; set `structured_metadata=false` per request to force canonical `[timestamp, line]` tuples |
+| `-emit-structured-metadata` | — | `false` | Enable 3-tuple support. Non-Grafana callers get `[timestamp, line, metadata]` by default; Grafana callers stay on `[timestamp, line]` unless they explicitly opt in (`structured_metadata=true` or `X-Loki-Response-Encoding-Flags: structured-metadata`) |
 | `-field-mapping` | `FIELD_MAPPING` | — | JSON custom field mappings |
 
 ### Label Style Modes

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4186,6 +4186,16 @@ func requestStructuredMetadataOverride(r *http.Request) (bool, bool) {
 	return false, false
 }
 
+func requestLooksLikeGrafana(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if strings.TrimSpace(r.Header.Get("X-Grafana-User")) != "" || strings.TrimSpace(r.Header.Get("X-Grafana-Org-Id")) != "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(r.Header.Get("User-Agent"))), "grafana")
+}
+
 func (p *Proxy) shouldEmitStructuredMetadata(r *http.Request) bool {
 	if !p.emitStructuredMetadata {
 		return false
@@ -4195,6 +4205,11 @@ func (p *Proxy) shouldEmitStructuredMetadata(r *http.Request) bool {
 	// - X-Loki-Response-Encoding-Flags: structured-metadata
 	if enabled, ok := requestStructuredMetadataOverride(r); ok {
 		return enabled
+	}
+	// Keep Grafana clients on canonical [ts, line] tuples unless they opt in.
+	// This avoids ReadArray/decode regressions across Explore/Drilldown versions.
+	if requestLooksLikeGrafana(r) {
+		return false
 	}
 	return true
 }

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -199,13 +199,13 @@ func TestRequestWantsCategorizedLabels(t *testing.T) {
 	}
 }
 
-func TestShouldEmitStructuredMetadata_EnablesForGrafanaByDefault(t *testing.T) {
+func TestShouldEmitStructuredMetadata_DisablesForGrafanaByDefault(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, true)
 	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
 	req.Header.Set("X-Grafana-User", "admin")
 
-	if !p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata enabled for Grafana callers by default")
+	if p.shouldEmitStructuredMetadata(req) {
+		t.Fatal("expected structured metadata disabled for Grafana callers by default")
 	}
 }
 
@@ -237,5 +237,63 @@ func TestShouldEmitStructuredMetadata_AllowsQueryParamOptOut(t *testing.T) {
 
 	if p.shouldEmitStructuredMetadata(req) {
 		t.Fatal("expected structured metadata disabled when structured_metadata=false query param is set")
+	}
+}
+
+func TestShouldEmitStructuredMetadata_NonGrafanaDefaultsToEnabled(t *testing.T) {
+	p := newStreamMetadataTestProxy(t, true)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+
+	if !p.shouldEmitStructuredMetadata(req) {
+		t.Fatal("expected structured metadata enabled by default for non-Grafana callers")
+	}
+}
+
+func TestQueryRange_GrafanaDefaultStaysTwoTupleForStrictDecoders(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"_time":"2026-04-10T12:00:00Z","_msg":"iptables policy update: \"Drop if no profiles matched\" -j DROP","_stream":"{deployment_environment=\"dev\"}","chain.link.env":"dev","deployment_environment":"dev","service.name":"calico","level":"error"}` + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL:             vlBackend.URL,
+		Cache:                  cache.New(30*time.Second, 100),
+		LogLevel:               "error",
+		EmitStructuredMetadata: true,
+		MetadataFieldMode:      MetadataFieldModeHybrid,
+		LabelStyle:             LabelStylePassthrough,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", `/loki/api/v1/query_range?query={deployment_environment="dev"}&start=1&end=2&limit=10`, nil)
+	req.Header.Set("X-Grafana-User", "admin")
+	p.handleQueryRange(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Strict decoder: Grafana compatibility path expects [ts, line] tuples.
+	var strict struct {
+		Data struct {
+			Result []struct {
+				Values [][2]string `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &strict); err != nil {
+		t.Fatalf("strict tuple decode failed (possible ReadArray regression): %v\nbody=%s", err, rec.Body.String())
+	}
+	if len(strict.Data.Result) != 1 || len(strict.Data.Result[0].Values) != 1 {
+		t.Fatalf("unexpected strict decode shape: %+v", strict.Data.Result)
+	}
+	if strict.Data.Result[0].Values[0][1] == "" {
+		t.Fatalf("expected non-empty log line in strict decode tuple, got %+v", strict.Data.Result[0].Values[0])
 	}
 }


### PR DESCRIPTION
## Summary
- restore Grafana-safe structured metadata behavior: keep canonical `[timestamp, line]` tuples by default for Grafana callers even when `-emit-structured-metadata=true`
- preserve explicit opt-in/override support via `structured_metadata=true|false` and `X-Loki-Response-Encoding-Flags: structured-metadata`
- add strict regression coverage that fails when Grafana query responses leak metadata objects into tuple slot 3
- update API/config docs to reflect Grafana default tuple behavior

## Validation
- `go test ./internal/proxy -count=1`
- `go test -v -tags=e2e -timeout=240s -count=1 -run "^(TestExplore_HTTPQueryRangeContracts|TestDrilldown_.*)$" ./test/e2e-compat/`
- `npx playwright test --grep @explore-core`
- `npx playwright test --grep @drilldown-core`
- `npx playwright test --grep @drilldown-mt`

## Changelog
- `Unreleased / Bug Fixes`: restore Grafana-safe tuple defaults to prevent `ReadArray` decode regressions
- `Unreleased / Tests`: add strict tuple decode regression test for Grafana query_range responses