### PR TITLE
Harden Grafana tuple contract gates and universalize metrics dashboard templates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,20 @@ jobs:
           name: coverage
           path: coverage.out
 
+  tuple-contract:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+          cache: true
+
+      - name: Tuple contract gate (Grafana default must remain strict 2-tuple)
+        run: go test ./internal/proxy -run '^TestTupleContract_' -count=1
+
   bench:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - restore Grafana-safe tuple defaults when `-emit-structured-metadata=true`: Explore/Drilldown requests now stay on canonical `[timestamp, line]` unless explicitly opted into `structured_metadata=true` (or `X-Loki-Response-Encoding-Flags: structured-metadata`), preventing `ReadArray` decode regressions
+- harden Grafana sand metrics dashboard templating with universal regex-safe variables (`job`, `cluster`, `env`, `namespace`, `service`, `pod`) and default service scoping to reduce duplicated/noisy series
 
 ### Tests
 
-- add strict query-range regression coverage that decodes Grafana responses as `[2]string` tuples and fails on any metadata-object tuple shape leak
+- add strict tuple-shape regression coverage that decodes Grafana responses as `[2]string` tuples and fails on any metadata-object tuple shape leak
+- add explicit tuple-contract tests for `/query_range`, `/query`, stream-response mode, multi-tenant merge, and parser-chain brace-heavy logs
+
+### CI
+
+- add a dedicated tuple-shape contract gate in CI (`TestTupleContract_*`) so Grafana default stream responses fail fast on any 3-tuple regression
+
+### Observability
+
+- add tuple-mode regression alerts for unexpected `grafana_default_3tuple` emissions and missing `grafana_default_2tuple` emissions while Grafana tuple traffic is present
+
+### Documentation
+
+- add `scripts/smoke-test.sh` deploy canary to validate strict 2-tuple Grafana responses on `/query_range` and `/query`
+- add a dedicated Grafana tuple-contract runbook and include it in the alert runbook index
 
 ## [0.27.17] - 2026-04-10
 

--- a/alerting/loki-vl-proxy-prometheusrule.yaml
+++ b/alerting/loki-vl-proxy-prometheusrule.yaml
@@ -184,6 +184,47 @@ rules:
       action: "Identify top offending clients and inspect rejected query patterns."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-client-bad-request-burst.md'
 
+  - alert: LokiVLProxyGrafanaDefault3TupleUnexpected
+    expr: sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_3tuple"}[10m])) > 0
+    for: 5m
+    labels:
+      severity: critical
+      service: loki-vl-proxy
+      component: grafana-contract
+      category: compatibility
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "Grafana default request emitted 3-tuple response"
+      description: "Proxy observed grafana_default_3tuple emissions for 5 minutes."
+      impact: "Explore/Drilldown requests can fail with ReadArray tuple-shape decode errors."
+      action: "Validate tuple contract smoke script and inspect recent query path changes."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
+
+  - alert: LokiVLProxyGrafanaDefault2TupleMissing
+    expr: |
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode=~"grafana_default_2tuple|grafana_optin_3tuple|grafana_default_3tuple"}[10m])) > 0
+      and
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_2tuple"}[10m])) == 0
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: grafana-contract
+      category: compatibility
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "Grafana default 2-tuple emissions missing"
+      description: "Grafana tuple-mode traffic exists but grafana_default_2tuple stayed at zero for 10 minutes."
+      impact: "Tuple-shape drift is likely; Grafana decode failures may follow."
+      action: "Run tuple smoke canary and verify `structured_metadata` overrides are not being forced globally."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
+
   - alert: LokiVLProxySystemMetricsMissing
     expr: absent(node_memory_usage_ratio{job="{{ include "loki-vl-proxy.fullname" . }}"})
     for: 15m

--- a/charts/loki-vl-proxy/alerting/loki-vl-proxy-prometheusrule.yaml
+++ b/charts/loki-vl-proxy/alerting/loki-vl-proxy-prometheusrule.yaml
@@ -184,6 +184,47 @@ rules:
       action: "Identify top offending clients and inspect rejected query patterns."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-client-bad-request-burst.md'
 
+  - alert: LokiVLProxyGrafanaDefault3TupleUnexpected
+    expr: sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_3tuple"}[10m])) > 0
+    for: 5m
+    labels:
+      severity: critical
+      service: loki-vl-proxy
+      component: grafana-contract
+      category: compatibility
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "Grafana default request emitted 3-tuple response"
+      description: "Proxy observed grafana_default_3tuple emissions for 5 minutes."
+      impact: "Explore/Drilldown requests can fail with ReadArray tuple-shape decode errors."
+      action: "Validate tuple contract smoke script and inspect recent query path changes."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
+
+  - alert: LokiVLProxyGrafanaDefault2TupleMissing
+    expr: |
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode=~"grafana_default_2tuple|grafana_optin_3tuple|grafana_default_3tuple"}[10m])) > 0
+      and
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_2tuple"}[10m])) == 0
+    for: 10m
+    labels:
+      severity: warning
+      service: loki-vl-proxy
+      component: grafana-contract
+      category: compatibility
+      team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
+      owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
+      source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
+      managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
+    annotations:
+      summary: "Grafana default 2-tuple emissions missing"
+      description: "Grafana tuple-mode traffic exists but grafana_default_2tuple stayed at zero for 10 minutes."
+      impact: "Tuple-shape drift is likely; Grafana decode failures may follow."
+      action: "Run tuple smoke canary and verify `structured_metadata` overrides are not being forced globally."
+      runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
+
   - alert: LokiVLProxySystemMetricsMissing
     expr: absent(node_memory_usage_ratio{job="{{ include "loki-vl-proxy.fullname" . }}"})
     for: 15m

--- a/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
+++ b/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
@@ -31,7 +31,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 0, "y": 1},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_requests_total{job=\"$job\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -45,7 +45,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 1},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_requests_total{job=\"$job\",status=~\"4..|5..\"}[$__rate_interval])) by (endpoint, status)",
+          "expr": "sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"4..|5..\"}[$__rate_interval])) by (endpoint, status)",
           "legendFormat": "{{endpoint}} {{status}}"
         }
       ],
@@ -59,7 +59,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 16, "y": 1},
       "targets": [
         {
-          "expr": "100 * sum(rate(loki_vl_proxy_requests_total{job=\"$job\",status=~\"5..\"}[$__rate_interval])) / sum(rate(loki_vl_proxy_requests_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "100 * sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"5..\"}[$__rate_interval])) / sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "5xx %"
         }
       ],
@@ -73,7 +73,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 20, "y": 1},
       "targets": [
         {
-          "expr": "loki_vl_proxy_uptime_seconds{job=\"$job\"}",
+          "expr": "loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}",
           "legendFormat": "uptime"
         }
       ],
@@ -87,7 +87,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 16, "y": 5},
       "targets": [
         {
-          "expr": "100 * rate(loki_vl_proxy_cache_hits_total{job=\"$job\"}[$__rate_interval]) / (rate(loki_vl_proxy_cache_hits_total{job=\"$job\"}[$__rate_interval]) + rate(loki_vl_proxy_cache_misses_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "100 * rate(loki_vl_proxy_cache_hits_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]) / (rate(loki_vl_proxy_cache_hits_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]) + rate(loki_vl_proxy_cache_misses_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "hit %"
         }
       ],
@@ -102,7 +102,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 20, "y": 5},
       "targets": [
         {
-          "expr": "rate(loki_vl_proxy_translation_errors_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_translation_errors_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "errors/s"
         }
       ],
@@ -122,7 +122,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p50 {{endpoint}}"
         }
       ],
@@ -136,7 +136,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p99 {{endpoint}}"
         }
       ],
@@ -156,11 +156,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
       "targets": [
         {
-          "expr": "rate(loki_vl_proxy_cache_hits_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_cache_hits_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "hits/s"
         },
         {
-          "expr": "rate(loki_vl_proxy_cache_misses_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_cache_misses_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "misses/s"
         }
       ],
@@ -174,11 +174,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
       "targets": [
         {
-          "expr": "rate(loki_vl_proxy_translations_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_translations_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "translations/s"
         },
         {
-          "expr": "rate(loki_vl_proxy_translation_errors_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_translation_errors_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "errors/s"
         }
       ],
@@ -198,7 +198,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 0, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=\"$job\"}[$__range])) by (endpoint)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__range])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ]
@@ -209,7 +209,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=\"$job\"}[$__range])) by (status)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__range])) by (status)",
           "legendFormat": "{{status}}"
         }
       ]
@@ -220,7 +220,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 28},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{job=\"$job\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{job=\"$job\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -240,7 +240,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 37},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=\"$job\"}[$__rate_interval])) by (tenant)",
+          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant)",
           "legendFormat": "{{tenant}}"
         }
       ],
@@ -254,7 +254,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 37},
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])) by (tenant, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_bucket{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant, le))",
           "legendFormat": "p99 {{tenant}}"
         }
       ],
@@ -268,11 +268,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 45},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=\"$job\",status=~\"5..\"}[$__rate_interval])) by (tenant)",
+          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"5..\"}[$__rate_interval])) by (tenant)",
           "legendFormat": "5xx {{tenant}}"
         },
         {
-          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=\"$job\",status=~\"4..\"}[$__rate_interval])) by (tenant)",
+          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"4..\"}[$__rate_interval])) by (tenant)",
           "legendFormat": "4xx {{tenant}}"
         }
       ],
@@ -286,7 +286,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 45},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_client_errors_total{job=\"$job\"}[$__rate_interval])) by (endpoint, reason)",
+          "expr": "sum(rate(loki_vl_proxy_client_errors_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, reason)",
           "legendFormat": "{{endpoint}}/{{reason}}"
         }
       ],
@@ -300,7 +300,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 53},
       "targets": [
         {
-          "expr": "topk(10, sum(increase(loki_vl_proxy_tenant_requests_total{job=\"$job\"}[$__range])) by (tenant))",
+          "expr": "topk(10, sum(increase(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__range])) by (tenant))",
           "legendFormat": "{{tenant}}",
           "format": "table",
           "instant": true
@@ -313,7 +313,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 53},
       "targets": [
         {
-          "expr": "topk(10, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_sum{job=\"$job\"}[$__rate_interval])) by (tenant) / sum(rate(loki_vl_proxy_tenant_request_duration_seconds_count{job=\"$job\"}[$__rate_interval])) by (tenant))",
+          "expr": "topk(10, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_sum{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant) / sum(rate(loki_vl_proxy_tenant_request_duration_seconds_count{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant))",
           "legendFormat": "{{tenant}}",
           "format": "table",
           "instant": true
@@ -335,7 +335,7 @@
       "gridPos": {"h": 8, "w": 6, "x": 0, "y": 62},
       "targets": [
         {
-          "expr": "100 * max(node_memory_usage_ratio{job=\"$job\"})",
+          "expr": "100 * max(node_memory_usage_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"})",
           "legendFormat": "memory usage"
         }
       ],
@@ -360,7 +360,7 @@
       "gridPos": {"h": 8, "w": 9, "x": 6, "y": 62},
       "targets": [
         {
-          "expr": "max(node_cpu_usage_ratio{job=\"$job\"}) by (mode)",
+          "expr": "max(node_cpu_usage_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}) by (mode)",
           "legendFormat": "{{mode}}"
         }
       ],
@@ -377,15 +377,15 @@
       "gridPos": {"h": 8, "w": 9, "x": 15, "y": 62},
       "targets": [
         {
-          "expr": "max(node_pressure_cpu_some_ratio{job=\"$job\",window=\"60s\"})",
+          "expr": "max(node_pressure_cpu_some_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",window=\"60s\"})",
           "legendFormat": "cpu some"
         },
         {
-          "expr": "max(node_pressure_memory_some_ratio{job=\"$job\",window=\"60s\"})",
+          "expr": "max(node_pressure_memory_some_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",window=\"60s\"})",
           "legendFormat": "memory some"
         },
         {
-          "expr": "max(node_pressure_io_some_ratio{job=\"$job\",window=\"60s\"})",
+          "expr": "max(node_pressure_io_some_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",window=\"60s\"})",
           "legendFormat": "io some"
         }
       ],
@@ -409,11 +409,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 70},
       "targets": [
         {
-          "expr": "sum(rate(node_disk_read_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_read_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "read"
         },
         {
-          "expr": "sum(rate(node_disk_written_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_written_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "write"
         }
       ],
@@ -427,11 +427,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 70},
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_receive_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "rx"
         },
         {
-          "expr": "sum(rate(node_network_transmit_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_transmit_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "tx"
         }
       ],
@@ -445,7 +445,7 @@
       "gridPos": {"h": 6, "w": 12, "x": 0, "y": 78},
       "targets": [
         {
-          "expr": "max(process_resident_memory_bytes{job=\"$job\"})",
+          "expr": "max(process_resident_memory_bytes{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"})",
           "legendFormat": "rss"
         }
       ],
@@ -459,7 +459,7 @@
       "gridPos": {"h": 6, "w": 12, "x": 12, "y": 78},
       "targets": [
         {
-          "expr": "max(process_open_fds{job=\"$job\"})",
+          "expr": "max(process_open_fds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"})",
           "legendFormat": "fds"
         }
       ],
@@ -475,12 +475,73 @@
       {
         "name": "job",
         "type": "query",
-        "query": "label_values(loki_vl_proxy_requests_total, job)",
+        "query": "label_values(loki_vl_proxy_uptime_seconds, job)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "loki-vl-proxy/loki-vl-proxy", "value": "loki-vl-proxy/loki-vl-proxy"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "cluster",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\"}, cluster)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "env",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\"}, env)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\"}, namespace)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "service",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\"}, service)",
         "datasource": "${DS_PROMETHEUS}",
         "current": {"text": "loki-vl-proxy", "value": "loki-vl-proxy"},
+        "allValue": ".*",
         "refresh": 2,
-        "includeAll": false,
-        "multi": false,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\"}, pod)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
         "sort": 1
       }
     ]
@@ -488,7 +549,7 @@
   "time": {"from": "now-1h", "to": "now"},
   "timepicker": {},
   "timezone": "browser",
-  "title": "Loki-VL-Proxy",
-  "uid": "loki-vl-proxy",
-  "version": 1
+  "title": "Loki-VL-Proxy Metrics",
+  "uid": "loki-vl-proxy-metrics",
+  "version": 4
 }

--- a/dashboard/loki-vl-proxy.json
+++ b/dashboard/loki-vl-proxy.json
@@ -31,7 +31,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 0, "y": 1},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_requests_total{job=\"$job\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -45,7 +45,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 1},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_requests_total{job=\"$job\",status=~\"4..|5..\"}[$__rate_interval])) by (endpoint, status)",
+          "expr": "sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"4..|5..\"}[$__rate_interval])) by (endpoint, status)",
           "legendFormat": "{{endpoint}} {{status}}"
         }
       ],
@@ -59,7 +59,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 16, "y": 1},
       "targets": [
         {
-          "expr": "100 * sum(rate(loki_vl_proxy_requests_total{job=\"$job\",status=~\"5..\"}[$__rate_interval])) / sum(rate(loki_vl_proxy_requests_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "100 * sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"5..\"}[$__rate_interval])) / sum(rate(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "5xx %"
         }
       ],
@@ -73,7 +73,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 20, "y": 1},
       "targets": [
         {
-          "expr": "loki_vl_proxy_uptime_seconds{job=\"$job\"}",
+          "expr": "loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}",
           "legendFormat": "uptime"
         }
       ],
@@ -87,7 +87,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 16, "y": 5},
       "targets": [
         {
-          "expr": "100 * rate(loki_vl_proxy_cache_hits_total{job=\"$job\"}[$__rate_interval]) / (rate(loki_vl_proxy_cache_hits_total{job=\"$job\"}[$__rate_interval]) + rate(loki_vl_proxy_cache_misses_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "100 * rate(loki_vl_proxy_cache_hits_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]) / (rate(loki_vl_proxy_cache_hits_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]) + rate(loki_vl_proxy_cache_misses_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "hit %"
         }
       ],
@@ -102,7 +102,7 @@
       "gridPos": {"h": 4, "w": 4, "x": 20, "y": 5},
       "targets": [
         {
-          "expr": "rate(loki_vl_proxy_translation_errors_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_translation_errors_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "errors/s"
         }
       ],
@@ -122,7 +122,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p50 {{endpoint}}"
         }
       ],
@@ -136,7 +136,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p99 {{endpoint}}"
         }
       ],
@@ -156,11 +156,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
       "targets": [
         {
-          "expr": "rate(loki_vl_proxy_cache_hits_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_cache_hits_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "hits/s"
         },
         {
-          "expr": "rate(loki_vl_proxy_cache_misses_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_cache_misses_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "misses/s"
         }
       ],
@@ -174,11 +174,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
       "targets": [
         {
-          "expr": "rate(loki_vl_proxy_translations_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_translations_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "translations/s"
         },
         {
-          "expr": "rate(loki_vl_proxy_translation_errors_total{job=\"$job\"}[$__rate_interval])",
+          "expr": "rate(loki_vl_proxy_translation_errors_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])",
           "legendFormat": "errors/s"
         }
       ],
@@ -198,7 +198,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 0, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=\"$job\"}[$__range])) by (endpoint)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__range])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ]
@@ -209,7 +209,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=\"$job\"}[$__range])) by (status)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__range])) by (status)",
           "legendFormat": "{{status}}"
         }
       ]
@@ -220,7 +220,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 28},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{job=\"$job\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{job=\"$job\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -240,7 +240,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 37},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=\"$job\"}[$__rate_interval])) by (tenant)",
+          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant)",
           "legendFormat": "{{tenant}}"
         }
       ],
@@ -254,7 +254,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 37},
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])) by (tenant, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_bucket{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant, le))",
           "legendFormat": "p99 {{tenant}}"
         }
       ],
@@ -268,11 +268,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 45},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=\"$job\",status=~\"5..\"}[$__rate_interval])) by (tenant)",
+          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"5..\"}[$__rate_interval])) by (tenant)",
           "legendFormat": "5xx {{tenant}}"
         },
         {
-          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=\"$job\",status=~\"4..\"}[$__rate_interval])) by (tenant)",
+          "expr": "sum(rate(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",status=~\"4..\"}[$__rate_interval])) by (tenant)",
           "legendFormat": "4xx {{tenant}}"
         }
       ],
@@ -286,7 +286,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 45},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_client_errors_total{job=\"$job\"}[$__rate_interval])) by (endpoint, reason)",
+          "expr": "sum(rate(loki_vl_proxy_client_errors_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, reason)",
           "legendFormat": "{{endpoint}}/{{reason}}"
         }
       ],
@@ -300,7 +300,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 53},
       "targets": [
         {
-          "expr": "topk(10, sum(increase(loki_vl_proxy_tenant_requests_total{job=\"$job\"}[$__range])) by (tenant))",
+          "expr": "topk(10, sum(increase(loki_vl_proxy_tenant_requests_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__range])) by (tenant))",
           "legendFormat": "{{tenant}}",
           "format": "table",
           "instant": true
@@ -313,7 +313,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 53},
       "targets": [
         {
-          "expr": "topk(10, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_sum{job=\"$job\"}[$__rate_interval])) by (tenant) / sum(rate(loki_vl_proxy_tenant_request_duration_seconds_count{job=\"$job\"}[$__rate_interval])) by (tenant))",
+          "expr": "topk(10, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_sum{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant) / sum(rate(loki_vl_proxy_tenant_request_duration_seconds_count{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (tenant))",
           "legendFormat": "{{tenant}}",
           "format": "table",
           "instant": true
@@ -335,7 +335,7 @@
       "gridPos": {"h": 8, "w": 6, "x": 0, "y": 62},
       "targets": [
         {
-          "expr": "100 * max(node_memory_usage_ratio{job=\"$job\"})",
+          "expr": "100 * max(node_memory_usage_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"})",
           "legendFormat": "memory usage"
         }
       ],
@@ -360,7 +360,7 @@
       "gridPos": {"h": 8, "w": 9, "x": 6, "y": 62},
       "targets": [
         {
-          "expr": "max(node_cpu_usage_ratio{job=\"$job\"}) by (mode)",
+          "expr": "max(node_cpu_usage_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}) by (mode)",
           "legendFormat": "{{mode}}"
         }
       ],
@@ -377,15 +377,15 @@
       "gridPos": {"h": 8, "w": 9, "x": 15, "y": 62},
       "targets": [
         {
-          "expr": "max(node_pressure_cpu_some_ratio{job=\"$job\",window=\"60s\"})",
+          "expr": "max(node_pressure_cpu_some_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",window=\"60s\"})",
           "legendFormat": "cpu some"
         },
         {
-          "expr": "max(node_pressure_memory_some_ratio{job=\"$job\",window=\"60s\"})",
+          "expr": "max(node_pressure_memory_some_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",window=\"60s\"})",
           "legendFormat": "memory some"
         },
         {
-          "expr": "max(node_pressure_io_some_ratio{job=\"$job\",window=\"60s\"})",
+          "expr": "max(node_pressure_io_some_ratio{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\",window=\"60s\"})",
           "legendFormat": "io some"
         }
       ],
@@ -409,11 +409,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 70},
       "targets": [
         {
-          "expr": "sum(rate(node_disk_read_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_read_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "read"
         },
         {
-          "expr": "sum(rate(node_disk_written_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_written_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "write"
         }
       ],
@@ -427,11 +427,11 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 70},
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_receive_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "rx"
         },
         {
-          "expr": "sum(rate(node_network_transmit_bytes_total{job=\"$job\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_transmit_bytes_total{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "tx"
         }
       ],
@@ -445,7 +445,7 @@
       "gridPos": {"h": 6, "w": 12, "x": 0, "y": 78},
       "targets": [
         {
-          "expr": "max(process_resident_memory_bytes{job=\"$job\"})",
+          "expr": "max(process_resident_memory_bytes{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"})",
           "legendFormat": "rss"
         }
       ],
@@ -459,7 +459,7 @@
       "gridPos": {"h": 6, "w": 12, "x": 12, "y": 78},
       "targets": [
         {
-          "expr": "max(process_open_fds{job=\"$job\"})",
+          "expr": "max(process_open_fds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\",pod=~\"${pod:regex}\"})",
           "legendFormat": "fds"
         }
       ],
@@ -475,12 +475,73 @@
       {
         "name": "job",
         "type": "query",
-        "query": "label_values(loki_vl_proxy_requests_total, job)",
+        "query": "label_values(loki_vl_proxy_uptime_seconds, job)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "loki-vl-proxy/loki-vl-proxy", "value": "loki-vl-proxy/loki-vl-proxy"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "cluster",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\"}, cluster)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "env",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\"}, env)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\"}, namespace)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "service",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\"}, service)",
         "datasource": "${DS_PROMETHEUS}",
         "current": {"text": "loki-vl-proxy", "value": "loki-vl-proxy"},
+        "allValue": ".*",
         "refresh": 2,
-        "includeAll": false,
-        "multi": false,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "query": "label_values(loki_vl_proxy_uptime_seconds{job=~\"${job:regex}\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}\",service=~\"${service:regex}\"}, pod)",
+        "datasource": "${DS_PROMETHEUS}",
+        "current": {"text": "All", "value": "$__all"},
+        "allValue": ".*",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
         "sort": 1
       }
     ]
@@ -488,7 +549,7 @@
   "time": {"from": "now-1h", "to": "now"},
   "timepicker": {},
   "timezone": "browser",
-  "title": "Loki-VL-Proxy",
-  "uid": "loki-vl-proxy",
-  "version": 1
+  "title": "Loki-VL-Proxy Metrics",
+  "uid": "loki-vl-proxy-metrics",
+  "version": 4
 }

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -24,4 +24,5 @@ Alert runbooks are split per alert under this directory so each alert annotation
 - [LokiVLProxyTenantHighErrorRate](loki-vl-proxy-tenant-high-error-rate.md)
 - [LokiVLProxyRateLimiting](loki-vl-proxy-rate-limiting.md)
 - [LokiVLProxyClientBadRequestBurst](loki-vl-proxy-client-bad-request-burst.md)
+- [LokiVLProxyGrafanaTupleContract](loki-vl-proxy-grafana-tuple-contract.md)
 - [LokiVLProxySystemResources](loki-vl-proxy-system-resources.md)

--- a/docs/runbooks/loki-vl-proxy-grafana-tuple-contract.md
+++ b/docs/runbooks/loki-vl-proxy-grafana-tuple-contract.md
@@ -1,0 +1,41 @@
+# LokiVLProxy Grafana Tuple Contract
+
+## Alerts Covered
+
+- `LokiVLProxyGrafanaDefault3TupleUnexpected`
+- `LokiVLProxyGrafanaDefault2TupleMissing`
+
+## Symptoms
+
+- Grafana Explore or Logs Drilldown shows tuple decode errors (for example `ReadArray`).
+- `loki_vl_proxy_response_tuple_mode_total` shows `grafana_default_3tuple` increments.
+- `grafana_default_2tuple` drops to zero while Grafana traffic still exists.
+
+## Immediate Checks
+
+1. Confirm proxy health:
+   - `curl -fsS http://<proxy>:3100/ready`
+2. Run tuple smoke canary with Grafana-style headers:
+   - `PROXY_URL=http://<proxy>:3100 ./scripts/smoke-test.sh`
+3. Check tuple mode counters:
+   - `curl -fsS http://<proxy>:3100/metrics | rg "loki_vl_proxy_response_tuple_mode_total"`
+
+## Typical Root Causes
+
+1. Response tuple shape regressed to 3-tuple for default Grafana callers.
+2. A global config or proxy path unintentionally forces structured metadata emission.
+3. Recent query-path changes bypassed strict tuple-shape handling in merge/stream code.
+
+## Mitigation
+
+1. Temporarily force canonical shape for Grafana callers:
+   - keep `-emit-structured-metadata=true` if needed for non-Grafana clients
+   - do not force `structured_metadata=true` globally for Grafana traffic
+2. Roll back to the previous known-good proxy version if smoke checks fail.
+3. Validate multi-tenant and stream-response paths with the tuple contract tests.
+
+## Recovery Criteria
+
+- `./scripts/smoke-test.sh` passes for both `/query_range` and `/query`.
+- `grafana_default_3tuple` rate returns to `0`.
+- `grafana_default_2tuple` resumes for active Grafana requests.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,9 @@
 # Unit tests
 go test ./...
 
+# Dedicated tuple-shape contract gate used in CI
+go test ./internal/proxy -run '^TestTupleContract_' -count=1
+
 # With race detector
 go test -race ./...
 
@@ -43,6 +46,9 @@ docker run --rm \
 
 # Build binary
 go build -o loki-vl-proxy ./cmd/proxy
+
+# Post-deploy Grafana tuple contract canary (expects recent log data)
+PROXY_URL=http://127.0.0.1:3100 ./scripts/smoke-test.sh
 ```
 
 ## Test Coverage by Category

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -43,6 +43,9 @@ type Metrics struct {
 	translationsTotal atomic.Int64
 	translationErrors atomic.Int64
 
+	// Tuple emission mode stats
+	tupleModes map[string]*atomic.Int64 // "mode" -> count
+
 	// Client error tracking
 	clientErrors map[string]*atomic.Int64 // "endpoint:reason" → count
 
@@ -128,6 +131,7 @@ func NewMetricsWithLimits(maxTenantLabels, maxClientLabels int) *Metrics {
 		endpointCacheHits:   make(map[string]*atomic.Int64),
 		endpointCacheMisses: make(map[string]*atomic.Int64),
 		backendDurations:    make(map[string]*histogram),
+		tupleModes:          make(map[string]*atomic.Int64),
 		clientRequests:      make(map[string]*atomic.Int64),
 		clientDurations:     make(map[string]*histogram),
 		clientBytes:         make(map[string]*atomic.Int64),
@@ -443,6 +447,27 @@ func (m *Metrics) RecordCacheMiss()        { m.cacheMisses.Add(1) }
 func (m *Metrics) RecordTranslation()      { m.translationsTotal.Add(1) }
 func (m *Metrics) RecordTranslationError() { m.translationErrors.Add(1) }
 
+// RecordTupleMode records the emitted tuple mode for a log query response.
+func (m *Metrics) RecordTupleMode(mode string) {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return
+	}
+	m.mu.RLock()
+	counter, ok := m.tupleModes[mode]
+	m.mu.RUnlock()
+	if !ok {
+		m.mu.Lock()
+		counter, ok = m.tupleModes[mode]
+		if !ok {
+			counter = &atomic.Int64{}
+			m.tupleModes[mode] = counter
+		}
+		m.mu.Unlock()
+	}
+	counter.Add(1)
+}
+
 // RecordEndpointCacheHit records a cache hit for a specific endpoint.
 func (m *Metrics) RecordEndpointCacheHit(endpoint string) {
 	m.cacheHits.Add(1)
@@ -557,6 +582,17 @@ func (m *Metrics) Handler(w http.ResponseWriter, r *http.Request) {
 	sb.WriteString("# HELP loki_vl_proxy_translation_errors_total Failed translations.\n")
 	sb.WriteString("# TYPE loki_vl_proxy_translation_errors_total counter\n")
 	fmt.Fprintf(&sb, "loki_vl_proxy_translation_errors_total %d\n", m.translationErrors.Load())
+
+	sb.WriteString("# HELP loki_vl_proxy_response_tuple_mode_total Log response tuple mode emissions by client behavior.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_response_tuple_mode_total counter\n")
+	tmKeys := make([]string, 0, len(m.tupleModes))
+	for mode := range m.tupleModes {
+		tmKeys = append(tmKeys, mode)
+	}
+	sort.Strings(tmKeys)
+	for _, mode := range tmKeys {
+		fmt.Fprintf(&sb, "loki_vl_proxy_response_tuple_mode_total{mode=%q} %d\n", mode, m.tupleModes[mode].Load())
+	}
 
 	sb.WriteString("# HELP loki_vl_proxy_uptime_seconds Proxy uptime.\n")
 	sb.WriteString("# TYPE loki_vl_proxy_uptime_seconds gauge\n")

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -257,6 +257,8 @@ func TestMetrics_RecordersAndHandler_ExposeAdditionalMetrics(t *testing.T) {
 	m.SetCircuitBreakerFunc(func() string { return "half-open" })
 	m.RecordTenantRequest("team-a", "query_range", 200, 15*time.Millisecond)
 	m.RecordClientError("query_range", "bad_query")
+	m.RecordTupleMode("grafana_default_2tuple")
+	m.RecordTupleMode("grafana_default_2tuple")
 	m.RecordEndpointCacheHit("labels")
 	m.RecordEndpointCacheMiss("labels")
 	m.RecordBackendDuration("query_range", 25*time.Millisecond)
@@ -276,6 +278,7 @@ func TestMetrics_RecordersAndHandler_ExposeAdditionalMetrics(t *testing.T) {
 		`loki_vl_proxy_backend_duration_seconds_count{endpoint="query_range"} 1`,
 		`loki_vl_proxy_coalesced_total 1`,
 		`loki_vl_proxy_coalesced_saved_total 1`,
+		`loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_2tuple"} 2`,
 		`loki_vl_proxy_circuit_breaker_state 2`,
 	} {
 		if !strings.Contains(body, snippet) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3424,6 +3424,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 	// Chunked streaming: flush partial results as they arrive from VL
 	categorizedLabels := requestWantsCategorizedLabels(r)
 	emitStructuredMetadata := p.shouldEmitStructuredMetadata(r)
+	p.metrics.RecordTupleMode(tupleModeForRequest(r, emitStructuredMetadata))
 	if p.streamResponse {
 		p.streamLogQuery(w, resp, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
 		return
@@ -4190,10 +4191,36 @@ func requestLooksLikeGrafana(r *http.Request) bool {
 	if r == nil {
 		return false
 	}
-	if strings.TrimSpace(r.Header.Get("X-Grafana-User")) != "" || strings.TrimSpace(r.Header.Get("X-Grafana-Org-Id")) != "" {
+	if strings.TrimSpace(r.Header.Get("X-Grafana-User")) != "" {
 		return true
 	}
-	return strings.Contains(strings.ToLower(strings.TrimSpace(r.Header.Get("User-Agent"))), "grafana")
+	if strings.TrimSpace(r.Header.Get("X-Grafana-Org-Id")) != "" {
+		return true
+	}
+	if strings.TrimSpace(r.Header.Get("X-Dashboard-Uid")) != "" {
+		return true
+	}
+	ua := strings.ToLower(strings.TrimSpace(r.Header.Get("User-Agent")))
+	return strings.Contains(ua, "grafana")
+}
+
+func tupleModeForRequest(r *http.Request, emitStructuredMetadata bool) string {
+	isGrafana := requestLooksLikeGrafana(r)
+	overrideEnabled, overrideSet := requestStructuredMetadataOverride(r)
+
+	if isGrafana {
+		if !emitStructuredMetadata {
+			return "grafana_default_2tuple"
+		}
+		if overrideSet && overrideEnabled {
+			return "grafana_optin_3tuple"
+		}
+		return "grafana_default_3tuple"
+	}
+	if emitStructuredMetadata {
+		return "nongrafana_3tuple"
+	}
+	return "nongrafana_2tuple"
 }
 
 func (p *Proxy) shouldEmitStructuredMetadata(r *http.Request) bool {
@@ -4206,8 +4233,7 @@ func (p *Proxy) shouldEmitStructuredMetadata(r *http.Request) bool {
 	if enabled, ok := requestStructuredMetadataOverride(r); ok {
 		return enabled
 	}
-	// Keep Grafana clients on canonical [ts, line] tuples unless they opt in.
-	// This avoids ReadArray/decode regressions across Explore/Drilldown versions.
+	// Keep Grafana default on canonical 2-tuples unless explicit opt-in is sent.
 	if requestLooksLikeGrafana(r) {
 		return false
 	}

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -240,12 +240,12 @@ func TestShouldEmitStructuredMetadata_AllowsQueryParamOptOut(t *testing.T) {
 	}
 }
 
-func TestShouldEmitStructuredMetadata_NonGrafanaDefaultsToEnabled(t *testing.T) {
+func TestShouldEmitStructuredMetadata_EnablesForNonGrafanaByDefault(t *testing.T) {
 	p := newStreamMetadataTestProxy(t, true)
 	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
 
 	if !p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata enabled by default for non-Grafana callers")
+		t.Fatal("expected structured metadata enabled for non-Grafana callers by default")
 	}
 }
 
@@ -295,5 +295,43 @@ func TestQueryRange_GrafanaDefaultStaysTwoTupleForStrictDecoders(t *testing.T) {
 	}
 	if strict.Data.Result[0].Values[0][1] == "" {
 		t.Fatalf("expected non-empty log line in strict decode tuple, got %+v", strict.Data.Result[0].Values[0])
+	}
+}
+
+func TestRequestLooksLikeGrafana(t *testing.T) {
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	if requestLooksLikeGrafana(req) {
+		t.Fatal("expected non-Grafana request by default")
+	}
+
+	req.Header.Set("X-Grafana-User", "admin")
+	if !requestLooksLikeGrafana(req) {
+		t.Fatal("expected Grafana detection from X-Grafana-User")
+	}
+
+	req = httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	req.Header.Set("User-Agent", "Grafana/12.4.2")
+	if !requestLooksLikeGrafana(req) {
+		t.Fatal("expected Grafana detection from User-Agent")
+	}
+}
+
+func TestTupleModeForRequest(t *testing.T) {
+	grafanaReq := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	grafanaReq.Header.Set("X-Grafana-User", "admin")
+	if got := tupleModeForRequest(grafanaReq, false); got != "grafana_default_2tuple" {
+		t.Fatalf("unexpected mode for Grafana default 2-tuple: %q", got)
+	}
+
+	grafanaOptInReq := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	grafanaOptInReq.Header.Set("X-Grafana-User", "admin")
+	grafanaOptInReq.Header.Set("X-Loki-Response-Encoding-Flags", "structured-metadata")
+	if got := tupleModeForRequest(grafanaOptInReq, true); got != "grafana_optin_3tuple" {
+		t.Fatalf("unexpected mode for Grafana opt-in 3-tuple: %q", got)
+	}
+
+	nonGrafanaReq := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	if got := tupleModeForRequest(nonGrafanaReq, true); got != "nongrafana_3tuple" {
+		t.Fatalf("unexpected mode for non-Grafana 3-tuple: %q", got)
 	}
 }

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -1,0 +1,175 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+)
+
+func newTupleContractProxy(t *testing.T, backendURL string, streamResponse bool) *Proxy {
+	t.Helper()
+	p, err := New(Config{
+		BackendURL:             backendURL,
+		Cache:                  cache.New(30*time.Second, 200),
+		LogLevel:               "error",
+		EmitStructuredMetadata: true,
+		StreamResponse:         streamResponse,
+		MetadataFieldMode:      MetadataFieldModeHybrid,
+		LabelStyle:             LabelStyleUnderscores,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	return p
+}
+
+func assertStrictTwoTupleContract(t *testing.T, body []byte) {
+	t.Helper()
+	var payload struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Values []json.RawMessage `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to decode response payload: %v\nbody=%s", err, string(body))
+	}
+	if payload.Status != "success" {
+		t.Fatalf("expected success status, got %q body=%s", payload.Status, string(body))
+	}
+
+	tupleCount := 0
+	for _, stream := range payload.Data.Result {
+		for _, rawTuple := range stream.Values {
+			tupleCount++
+			var tuple []json.RawMessage
+			if err := json.Unmarshal(rawTuple, &tuple); err != nil {
+				t.Fatalf("failed to decode tuple: %v\nraw=%s", err, string(rawTuple))
+			}
+			if len(tuple) != 2 {
+				t.Fatalf("expected strict 2-tuple [ts,line], got len=%d tuple=%s", len(tuple), string(rawTuple))
+			}
+			var ts string
+			if err := json.Unmarshal(tuple[0], &ts); err != nil {
+				t.Fatalf("expected tuple[0] string timestamp, got %s: %v", string(tuple[0]), err)
+			}
+			var line string
+			if err := json.Unmarshal(tuple[1], &line); err != nil {
+				t.Fatalf("expected tuple[1] string line, got %s: %v", string(tuple[1]), err)
+			}
+		}
+	}
+	if tupleCount == 0 {
+		t.Fatalf("expected at least one tuple in response body=%s", string(body))
+	}
+}
+
+func makeTupleContractBackend(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		tenant := r.Header.Get("X-Scope-OrgID")
+		switch tenant {
+		case "tenant-a":
+			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:00Z","_msg":"time=\"2026-04-10T10:00:00Z\" level=error msg=\"Drop if no profiles matched -j DROP\" chain.link.env=dev","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","chain.link.env":"dev"}` + "\n"))
+		case "tenant-b":
+			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:01Z","_msg":"time=\"2026-04-10T10:00:01Z\" level=error msg=\"fromYaml not defined\" app.label.component=notifications-controller","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","app.label.component":"notifications-controller"}` + "\n"))
+		default:
+			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:02Z","_msg":"time=\"2026-04-10T10:00:02Z\" level=error msg=\"api chain check\" resource=argocd/f5-nginx-external","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","resource":"argocd/f5-nginx-external"}` + "\n"))
+		}
+	}))
+}
+
+func TestTupleContract_GrafanaDefaultQueryRangeStrictTwoTuple(t *testing.T) {
+	backend := makeTupleContractBackend(t)
+	defer backend.Close()
+
+	p := newTupleContractProxy(t, backend.URL, false)
+	params := url.Values{}
+	params.Set("query", `{job="tuple-contract"} |= "DROP" | json | logfmt | drop __error__, __error_details__`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+	params.Set("limit", "50")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	req.Header.Set("X-Grafana-User", "admin")
+
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStrictTwoTupleContract(t, rec.Body.Bytes())
+}
+
+func TestTupleContract_GrafanaDefaultQueryStrictTwoTuple(t *testing.T) {
+	backend := makeTupleContractBackend(t)
+	defer backend.Close()
+
+	p := newTupleContractProxy(t, backend.URL, false)
+	params := url.Values{}
+	params.Set("query", `{job="tuple-contract"} |= "api" | json | logfmt | drop __error__, __error_details__`)
+	params.Set("time", "2")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query?"+params.Encode(), nil)
+	req.Header.Set("X-Grafana-User", "admin")
+
+	rec := httptest.NewRecorder()
+	p.handleQuery(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStrictTwoTupleContract(t, rec.Body.Bytes())
+}
+
+func TestTupleContract_StreamResponseModeStrictTwoTuple(t *testing.T) {
+	backend := makeTupleContractBackend(t)
+	defer backend.Close()
+
+	p := newTupleContractProxy(t, backend.URL, true)
+	params := url.Values{}
+	params.Set("query", `{job="tuple-contract"} |= "fromYaml" | json | logfmt | drop __error__, __error_details__`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+	params.Set("limit", "20")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	req.Header.Set("X-Grafana-User", "admin")
+
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStrictTwoTupleContract(t, rec.Body.Bytes())
+}
+
+func TestTupleContract_MultiTenantMergeStrictTwoTuple(t *testing.T) {
+	backend := makeTupleContractBackend(t)
+	defer backend.Close()
+
+	p := newTupleContractProxy(t, backend.URL, false)
+	params := url.Values{}
+	params.Set("query", `{job="tuple-contract"} |= "level=error" | json | logfmt | drop __error__, __error_details__`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+	params.Set("limit", "50")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	req.Header.Set("X-Grafana-User", "admin")
+	req.Header.Set("X-Scope-OrgID", "tenant-a|tenant-b")
+
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStrictTwoTupleContract(t, rec.Body.Bytes())
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROXY_URL="${PROXY_URL:-http://127.0.0.1:3100}"
+QUERY="${SMOKE_QUERY:-{job=~\".+\"}}"
+LIMIT="${SMOKE_LIMIT:-20}"
+LOOKBACK_SECONDS="${SMOKE_LOOKBACK_SECONDS:-900}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+now_ns="$(($(date +%s) * 1000000000))"
+start_ns="$((now_ns - LOOKBACK_SECONDS * 1000000000))"
+
+check_strict_two_tuple() {
+  local payload="$1"
+  local endpoint="$2"
+
+  echo "$payload" | jq -e '.status == "success"' >/dev/null
+
+  local tuple_count
+  tuple_count="$(echo "$payload" | jq '[.data.result[]?.values[]?] | length')"
+  if [[ "$tuple_count" -eq 0 ]]; then
+    echo "no log tuples returned for ${endpoint}; cannot validate tuple contract" >&2
+    return 1
+  fi
+
+  echo "$payload" | jq -e '
+    [.data.result[]?.values[]? | (type == "array" and length == 2 and (.[0] | type == "string") and (.[1] | type == "string"))]
+    | all
+  ' >/dev/null
+}
+
+fetch_query_range() {
+  curl -sS --get \
+    -H 'X-Grafana-User: smoke-canary' \
+    -H 'X-Grafana-Org-Id: 1' \
+    --data-urlencode "query=${QUERY}" \
+    --data-urlencode "start=${start_ns}" \
+    --data-urlencode "end=${now_ns}" \
+    --data-urlencode "limit=${LIMIT}" \
+    "${PROXY_URL}/loki/api/v1/query_range"
+}
+
+fetch_query() {
+  curl -sS --get \
+    -H 'X-Grafana-User: smoke-canary' \
+    -H 'X-Grafana-Org-Id: 1' \
+    --data-urlencode "query=${QUERY}" \
+    --data-urlencode "time=${now_ns}" \
+    --data-urlencode "limit=${LIMIT}" \
+    "${PROXY_URL}/loki/api/v1/query"
+}
+
+range_payload="$(fetch_query_range)"
+query_payload="$(fetch_query)"
+
+check_strict_two_tuple "$range_payload" "/query_range"
+check_strict_two_tuple "$query_payload" "/query"
+
+echo "tuple contract smoke check passed for /query_range and /query"


### PR DESCRIPTION
## Summary
- enforce Grafana default tuple safety with an explicit CI gate (`TestTupleContract_*`) and strict coverage for `/query_range`, `/query`, stream-response mode, multi-tenant merge, and parser-chain brace-heavy lines
- add tuple-mode observability (`loki_vl_proxy_response_tuple_mode_total`) plus alerts/runbook for unexpected `grafana_default_3tuple` or missing `grafana_default_2tuple`
- add post-deploy canary script (`scripts/smoke-test.sh`) validating strict 2-tuple contracts on both query endpoints with Grafana-style headers
- make metrics dashboard selectors universal and template-driven (`job`, `cluster`, `env`, `namespace`, `service`, `pod`) with regex-safe all-values and default `service=loki-vl-proxy`
- update docs/changelog and sync chart observability assets

## Validation
- `go test ./internal/proxy -run '^TestTupleContract_|TestShouldEmitStructuredMetadata|TestTupleModeForRequest|TestRequestLooksLikeGrafana' -count=1`
- `go test ./internal/metrics -run 'TestMetrics_RecordersAndHandler_ExposeAdditionalMetrics' -count=1`
- `go test ./... -count=1`
- pushed updated metrics dashboard to Grafana sand: `/d/loki-vl-proxy-metrics/loki-vl-proxy-metrics`
