### PR TITLE
Enforce strict Loki categorize-labels tuple contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- enforce strict Loki tuple behavior for query responses: default/no-flag requests return canonical 2-tuples, while `X-Loki-Response-Encoding-Flags: categorize-labels` returns Loki-style 3-tuples with `structuredMetadata` and/or `parsed`
+- remove proxy-side Grafana caller sniffing and `structured_metadata` request overrides from tuple-shape decisions, so response shape is controlled only by Loki header flags
+- remove non-Loki `structured_metadata` tuple key alias from query responses and keep only canonical Loki metadata keys
+
+### Tests
+
+- add strict `/query_range` and `/query` contract tests covering both default 2-tuple and `categorize-labels` 3-tuple paths
+- add parser-chain/brace-heavy stream-response regression coverage to prevent `ReadArray` tuple-shape regressions in Grafana Explore/Drilldown
+
+### Documentation
+
+- update API/config docs to describe strict `categorize-labels`-driven 3-tuple behavior and canonical Loki metadata keys
+
 ## [0.27.18] - 2026-04-10
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -23,14 +23,24 @@ This project is intentionally a **read/query proxy**. Ingestion stays on Victori
 
 ```mermaid
 flowchart LR
-    A["Ingest + Storage<br/>vlagent / OTLP / Loki-push / JSON -> VictoriaLogs"]
-    B["Compatibility Edge<br/>Loki API surface + auth/tenant guardrails + strict tuple contracts"]
-    C["Route + Processing Layer<br/>LogQL translation + compatibility execution + response shaping"]
-    D["Cache Fabric<br/>Tier0 edge cache + L1 memory + optional L2 disk + optional L3 peer"]
-    E["Consumers + Operations<br/>Grafana Explore/Drilldown/Dashboards + API/CLI/MCP + metrics/alerts/runbooks"]
+    A["Client Experience Layer<br/>Grafana Explore, Dashboards, Logs Drilldown app, Loki API tooling, LLM/MCP/API consumers"]
+    B["Compatibility Edge<br/>Loki read API contract, tenant guardrails, strict tuple compliance"]
+    C["Translation + Execution Core<br/>LogQL translation, compatibility processing, response shaping"]
+    D["Performance Fabric<br/>Tier0 edge cache, L1 memory, optional L2 disk, optional L3 peer cache"]
+    E["Observability + Operations<br/>Metrics, alerts, runbooks, and operational visibility"]
+    F["Source Systems<br/>VictoriaLogs (log data) + vmalert (rules/alerts state)"]
 
     A --> B --> C --> D --> B
+    C --> F
+    F --> C
     B --> E
+
+    style A fill:#fef3c7,stroke:#b45309,color:#111827,stroke-width:2px
+    style B fill:#dbeafe,stroke:#1d4ed8,color:#111827,stroke-width:2px
+    style C fill:#dcfce7,stroke:#15803d,color:#111827,stroke-width:2px
+    style D fill:#ede9fe,stroke:#6d28d9,color:#111827,stroke-width:2px
+    style E fill:#fee2e2,stroke:#b91c1c,color:#111827,stroke-width:2px
+    style F fill:#e0f2fe,stroke:#0369a1,color:#111827,stroke-width:2px
 ```
 
 ## Architecture (Detailed)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@ HTTP proxy that exposes a **Loki-compatible read API** on the frontend and trans
 
 This project is intentionally a **read/query proxy**. Ingestion stays on VictoriaLogs-side pipelines (`vlagent`, Loki-push ingestion to VictoriaLogs, OTLP, or native JSON/OTel log ingestion). Data written through those paths is then queryable through the proxy's Loki-compatible read endpoints.
 
-## Architecture
+## High-Level Architecture
+
+```mermaid
+flowchart LR
+    A["Ingest + Storage<br/>vlagent / OTLP / Loki-push / JSON -> VictoriaLogs"]
+    B["Compatibility Edge<br/>Loki API surface + auth/tenant guardrails + strict tuple contracts"]
+    C["Route + Processing Layer<br/>LogQL translation + compatibility execution + response shaping"]
+    D["Cache Fabric<br/>Tier0 edge cache + L1 memory + optional L2 disk + optional L3 peer"]
+    E["Consumers + Operations<br/>Grafana Explore/Drilldown/Dashboards + API/CLI/MCP + metrics/alerts/runbooks"]
+
+    A --> B --> C --> D --> B
+    B --> E
+```
+
+## Architecture (Detailed)
 
 ```mermaid
 flowchart TD
@@ -91,6 +105,7 @@ See [Getting Started](docs/getting-started.md), [Architecture](docs/architecture
 - **Loki-compatible frontend** -- use the standard Loki datasource, API shape, and WebSocket tail entrypoints against VictoriaLogs without a custom plugin
 - **Full LogQL execution surface** -- stream selectors, filters, parsers, metric queries, binary expressions, and subqueries are supported, with proxy-side evaluation for the parts VictoriaLogs does not natively provide
 - **Grafana-native workflows** -- Explore, Logs Drilldown, dashboards, live tail, and datasource-side multi-tenant reads work through the same datasource model operators already know
+- **Strict Loki tuple contract** -- default/no-flag responses stay canonical 2-tuples, while `X-Loki-Response-Encoding-Flags: categorize-labels` emits Loki 3-tuples with canonical metadata keys only
 - **OTel-aware label and metadata translation** -- bidirectional dot/underscore conversion plus hybrid field exposure keeps Loki labels usable while preserving dotted OTel-style metadata for field-oriented flows
 - **Read-path rules and alerts compatibility** -- surface `vmalert` rules and alerts on Loki-compatible read endpoints and migrate Loki-style rule files with the built-in converter
 - **Indexed fast path where possible** -- known VictoriaLogs `_stream_fields` can stay on native stream selectors instead of dropping to slower field scans
@@ -126,6 +141,7 @@ See [Getting Started](docs/getting-started.md), [Configuration](docs/configurati
 - **Rules migration support** -- convert Loki-style rule files into `vmalert` `type: vlogs` definitions for read-compatible Grafana alert visibility
 - **Production Helm support** -- OCI chart publishing, `Deployment` or `StatefulSet` modes, persistent disk cache, headless peer discovery, HPA support, and GOMEMLIMIT auto-tuning
 - **Versioned compatibility tracks** -- Loki, VictoriaLogs, and Logs Drilldown are validated as separate compatibility tracks with dedicated CI signals
+- **Automated tuple canary in CI** -- unit tuple-contract gates plus compose-backed smoke checks validate default 2-tuple and categorize-labels 3-tuple behavior on every PR
 
 ## Operational Pack
 

--- a/README.md
+++ b/README.md
@@ -23,24 +23,15 @@ This project is intentionally a **read/query proxy**. Ingestion stays on Victori
 
 ```mermaid
 flowchart LR
-    A["Client Experience Layer<br/>Grafana Explore, Dashboards, Logs Drilldown app, Loki API tooling, LLM/MCP/API consumers"]
-    B["Compatibility Edge<br/>Loki read API contract, tenant guardrails, strict tuple compliance"]
-    C["Translation + Execution Core<br/>LogQL translation, compatibility processing, response shaping"]
-    D["Performance Fabric<br/>Tier0 edge cache, L1 memory, optional L2 disk, optional L3 peer cache"]
-    E["Observability + Operations<br/>Metrics, alerts, runbooks, and operational visibility"]
-    F["Source Systems<br/>VictoriaLogs (log data) + vmalert (rules/alerts state)"]
+    A["Clients<br/>Grafana Explore, Dashboards, Logs Drilldown, Loki API tools, LLM/MCP/API consumers"]
+    B["Loki-VL-proxy (Read Compatibility Layer)<br/>Loki API contract + tenant guardrails + LogQL translation + response shaping + tiered cache"]
+    C["Data + Rules Upstream<br/>VictoriaLogs (log data) + vmalert (rules/alerts state)"]
 
-    A --> B --> C --> D --> B
-    C --> F
-    F --> C
-    B --> E
+    A --> B --> C
 
     style A fill:#fef3c7,stroke:#b45309,color:#111827,stroke-width:2px
     style B fill:#dbeafe,stroke:#1d4ed8,color:#111827,stroke-width:2px
-    style C fill:#dcfce7,stroke:#15803d,color:#111827,stroke-width:2px
-    style D fill:#ede9fe,stroke:#6d28d9,color:#111827,stroke-width:2px
-    style E fill:#fee2e2,stroke:#b91c1c,color:#111827,stroke-width:2px
-    style F fill:#e0f2fe,stroke:#0369a1,color:#111827,stroke-width:2px
+    style C fill:#e0f2fe,stroke:#0369a1,color:#111827,stroke-width:2px
 ```
 
 ## Architecture (Detailed)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,9 +25,8 @@
 For Grafana Logs Drilldown and Explore compatibility:
 
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default.
-- With `-emit-structured-metadata=true`, non-Grafana callers receive Loki 3-tuples `[timestamp, line, metadata]` by default.
-- Grafana Explore/Drilldown callers stay on canonical 2-tuples unless they explicitly opt in with `structured_metadata=true` or `X-Loki-Response-Encoding-Flags: structured-metadata`.
-- When emitted, tuple metadata is always a flat key/value object for broad client/parser compatibility, including requests that carry `X-Loki-Response-Encoding-Flags: categorize-labels`.
+- When `X-Loki-Response-Encoding-Flags: categorize-labels` is present and `-emit-structured-metadata=true`, query results emit Loki 3-tuples `[timestamp, line, metadata]`.
+- The 3rd tuple object follows Loki keys only: `structuredMetadata` and/or `parsed` (no snake_case alias keys).
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ All flags follow VictoriaMetrics naming conventions (`-flagName=value`).
 |---|---|---|---|
 | `-label-style` | `LABEL_STYLE` | `passthrough` | `passthrough` or `underscores` |
 | `-metadata-field-mode` | `METADATA_FIELD_MODE` | `hybrid` | `native`, `translated`, or `hybrid` for `detected_fields` and structured metadata exposure |
-| `-emit-structured-metadata` | — | `false` | Enable 3-tuple support. Non-Grafana callers get `[timestamp, line, metadata]` by default; Grafana callers stay on `[timestamp, line]` unless they explicitly opt in (`structured_metadata=true` or `X-Loki-Response-Encoding-Flags: structured-metadata`) |
+| `-emit-structured-metadata` | — | `false` | Enable Loki `categorize-labels` response encoding: requests with `X-Loki-Response-Encoding-Flags: categorize-labels` emit 3-tuples `[timestamp, line, metadata]`, while default/no-flag requests stay canonical 2-tuples |
 | `-field-mapping` | `FIELD_MAPPING` | — | JSON custom field mappings |
 
 ### Label Style Modes

--- a/internal/proxy/multitenant_merge_test.go
+++ b/internal/proxy/multitenant_merge_test.go
@@ -414,8 +414,8 @@ func TestMergeMultiTenantResponsesQueryInjectsTenantLabel(t *testing.T) {
 
 func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 	body, _, err := mergeMultiTenantResponses("query", []string{"tenant-a", "tenant-b"}, []*httptest.ResponseRecorder{
-		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["2","line-a",{"service.name":"orders"}]]}]}}`),
-		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"http.status_code":"200"}]]}]}}`),
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["2","line-a",{"structuredMetadata":{"service.name":"orders"}}]]}]}}`),
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"parsed":{"status":"200"}}]]}]}}`),
 	})
 	if err != nil {
 		t.Fatalf("mergeMultiTenantResponses failed: %v", err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3424,7 +3424,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 	// Chunked streaming: flush partial results as they arrive from VL
 	categorizedLabels := requestWantsCategorizedLabels(r)
 	emitStructuredMetadata := p.shouldEmitStructuredMetadata(r)
-	p.metrics.RecordTupleMode(tupleModeForRequest(r, emitStructuredMetadata))
+	p.metrics.RecordTupleMode(tupleModeForRequest(categorizedLabels, emitStructuredMetadata))
 	if p.streamResponse {
 		p.streamLogQuery(w, resp, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
 		return
@@ -3816,23 +3816,21 @@ func buildStreamValues(ts, msg string, structuredMetadata map[string]string, par
 }
 
 func buildStreamValue(ts, msg string, structuredMetadata map[string]string, parsedFields map[string]string, emitStructuredMetadata bool, categorizedLabels bool) interface{} {
-	if !emitStructuredMetadata {
+	if !emitStructuredMetadata || !categorizedLabels {
 		return []interface{}{ts, msg}
 	}
-	_ = categorizedLabels
 
-	// Legacy-safe fallback: flatten metadata into a simple map[string]string.
-	flat := make(map[string]string, len(structuredMetadata)+len(parsedFields))
-	for key, value := range structuredMetadata {
-		flat[key] = value
+	metadata := map[string]interface{}{}
+	if len(structuredMetadata) > 0 {
+		metadata["structuredMetadata"] = structuredMetadata
 	}
-	for key, value := range parsedFields {
-		flat[key] = value
+	if len(parsedFields) > 0 {
+		metadata["parsed"] = parsedFields
 	}
-	if len(flat) > 0 {
-		return []interface{}{ts, msg, flat}
+	if len(metadata) == 0 {
+		return []interface{}{ts, msg, map[string]interface{}{}}
 	}
-	return []interface{}{ts, msg}
+	return []interface{}{ts, msg, metadata}
 }
 
 func (p *Proxy) classifyEntryFields(entry map[string]interface{}, originalQuery string) (map[string]string, map[string]string, map[string]string) {
@@ -4156,88 +4154,25 @@ func requestWantsCategorizedLabels(r *http.Request) bool {
 	if r == nil {
 		return false
 	}
-	raw := strings.TrimSpace(r.Header.Get("X-Loki-Response-Encoding-Flags"))
-	if raw == "" {
-		return false
-	}
-	for _, part := range strings.Split(raw, ",") {
-		if strings.EqualFold(strings.TrimSpace(part), "categorize-labels") {
-			return true
+	for _, raw := range r.Header.Values("X-Loki-Response-Encoding-Flags") {
+		for _, part := range strings.Split(raw, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), "categorize-labels") {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func requestStructuredMetadataOverride(r *http.Request) (bool, bool) {
-	if r == nil {
-		return false, false
+func tupleModeForRequest(categorizedLabels bool, emitStructuredMetadata bool) string {
+	if emitStructuredMetadata && categorizedLabels {
+		return "categorize_labels_3tuple"
 	}
-	if raw := strings.TrimSpace(r.FormValue("structured_metadata")); raw != "" {
-		if enabled, err := strconv.ParseBool(raw); err == nil {
-			return enabled, true
-		}
-	}
-	if raw := strings.TrimSpace(r.Header.Get("X-Loki-Response-Encoding-Flags")); raw != "" {
-		for _, part := range strings.Split(raw, ",") {
-			if strings.EqualFold(strings.TrimSpace(part), "structured-metadata") {
-				return true, true
-			}
-		}
-	}
-	return false, false
-}
-
-func requestLooksLikeGrafana(r *http.Request) bool {
-	if r == nil {
-		return false
-	}
-	if strings.TrimSpace(r.Header.Get("X-Grafana-User")) != "" {
-		return true
-	}
-	if strings.TrimSpace(r.Header.Get("X-Grafana-Org-Id")) != "" {
-		return true
-	}
-	if strings.TrimSpace(r.Header.Get("X-Dashboard-Uid")) != "" {
-		return true
-	}
-	ua := strings.ToLower(strings.TrimSpace(r.Header.Get("User-Agent")))
-	return strings.Contains(ua, "grafana")
-}
-
-func tupleModeForRequest(r *http.Request, emitStructuredMetadata bool) string {
-	isGrafana := requestLooksLikeGrafana(r)
-	overrideEnabled, overrideSet := requestStructuredMetadataOverride(r)
-
-	if isGrafana {
-		if !emitStructuredMetadata {
-			return "grafana_default_2tuple"
-		}
-		if overrideSet && overrideEnabled {
-			return "grafana_optin_3tuple"
-		}
-		return "grafana_default_3tuple"
-	}
-	if emitStructuredMetadata {
-		return "nongrafana_3tuple"
-	}
-	return "nongrafana_2tuple"
+	return "default_2tuple"
 }
 
 func (p *Proxy) shouldEmitStructuredMetadata(r *http.Request) bool {
-	if !p.emitStructuredMetadata {
-		return false
-	}
-	// Allow explicit per-request override via query/header flags.
-	// - structured_metadata=true|false
-	// - X-Loki-Response-Encoding-Flags: structured-metadata
-	if enabled, ok := requestStructuredMetadataOverride(r); ok {
-		return enabled
-	}
-	// Keep Grafana default on canonical 2-tuples unless explicit opt-in is sent.
-	if requestLooksLikeGrafana(r) {
-		return false
-	}
-	return true
+	return p.emitStructuredMetadata && requestWantsCategorizedLabels(r)
 }
 
 func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, endpoint string, single func(http.ResponseWriter, *http.Request)) bool {

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -2,9 +2,9 @@ package proxy
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -12,13 +12,14 @@ import (
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
 )
 
-func newStreamMetadataTestProxy(t *testing.T, emitStructuredMetadata bool) *Proxy {
+func newStreamMetadataProxy(t *testing.T, backendURL string, emitStructuredMetadata, streamResponse bool) *Proxy {
 	t.Helper()
 	p, err := New(Config{
-		BackendURL:             "http://unused",
+		BackendURL:             backendURL,
 		Cache:                  cache.New(30*time.Second, 100),
 		LogLevel:               "error",
 		EmitStructuredMetadata: emitStructuredMetadata,
+		StreamResponse:         streamResponse,
 		MetadataFieldMode:      MetadataFieldModeHybrid,
 		LabelStyle:             LabelStylePassthrough,
 	})
@@ -28,310 +29,241 @@ func newStreamMetadataTestProxy(t *testing.T, emitStructuredMetadata bool) *Prox
 	return p
 }
 
-func TestVLLogsToLokiStreams_DefaultValuesStayTwoTuple(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, false)
-	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"ok","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","deployment.environment.name":"dev","level":"info"}` + "\n")
+func backendWithSingleNDJSONLine(t *testing.T, line string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(line + "\n"))
+	}))
+}
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false, p.emitStructuredMetadata)
-	if len(streams) != 1 {
-		t.Fatalf("expected 1 stream, got %d", len(streams))
+func decodeFirstTuple(t *testing.T, body []byte) []interface{} {
+	t.Helper()
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
 	}
-	values, ok := streams[0]["values"].([]interface{})
-	if !ok || len(values) != 1 {
-		t.Fatalf("expected one stream value, got %#v", streams[0]["values"])
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
 	}
-	pair, ok := values[0].([]interface{})
-	if !ok {
-		t.Fatalf("expected stream value to be tuple, got %T", values[0])
+	if len(resp.Data.Result) != 1 {
+		t.Fatalf("expected one stream result, got %#v", resp.Data.Result)
 	}
-	if len(pair) != 2 {
-		t.Fatalf("expected canonical [ts, line] tuple, got %v", pair)
+	if len(resp.Data.Result[0].Values) != 1 {
+		t.Fatalf("expected one tuple value, got %#v", resp.Data.Result[0].Values)
+	}
+	return resp.Data.Result[0].Values[0]
+}
+
+func TestRequestWantsCategorizedLabels(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	if requestWantsCategorizedLabels(req) {
+		t.Fatal("unexpected categorize-labels for empty header")
+	}
+
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "foo, categorize-labels,bar")
+	if !requestWantsCategorizedLabels(req) {
+		t.Fatal("expected categorize-labels to be detected from flag list")
+	}
+
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "foo,bar")
+	if requestWantsCategorizedLabels(req) {
+		t.Fatal("did not expect categorize-labels for unrelated flags")
 	}
 }
 
-func TestVLLogsToLokiStreams_EmitStructuredMetadataAddsFlatThirdTupleValueByDefault(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"ok","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","deployment.environment.name":"dev","level":"info"}` + "\n")
+func TestShouldEmitStructuredMetadata(t *testing.T) {
+	pDisabled := newStreamMetadataProxy(t, "http://unused", false, false)
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+	if pDisabled.shouldEmitStructuredMetadata(req) {
+		t.Fatal("must not emit metadata when feature flag is disabled")
+	}
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"}`, false, p.emitStructuredMetadata)
-	if len(streams) != 1 {
-		t.Fatalf("expected 1 stream, got %d", len(streams))
+	pEnabled := newStreamMetadataProxy(t, "http://unused", true, false)
+	noFlags := httptest.NewRequest("GET", "/", nil)
+	if pEnabled.shouldEmitStructuredMetadata(noFlags) {
+		t.Fatal("must not emit metadata for default requests without flags")
 	}
-	values, ok := streams[0]["values"].([]interface{})
-	if !ok || len(values) != 1 {
-		t.Fatalf("expected one stream value, got %#v", streams[0]["values"])
-	}
-	pair, ok := values[0].([]interface{})
-	if !ok {
-		t.Fatalf("expected stream value to be tuple, got %T", values[0])
-	}
-	if len(pair) != 3 {
-		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
-	}
-	meta, ok := pair[2].(map[string]string)
-	if !ok {
-		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
-	}
-	if _, ok := meta["structuredMetadata"]; ok {
-		t.Fatalf("default tuple metadata must be flat for broad parser compatibility, got %v", meta)
-	}
-	if got := meta["service.name"]; got != "otel-app" {
-		t.Fatalf("expected flat structured metadata field service.name=otel-app, got %v", meta)
-	}
-	if got := meta["deployment.environment.name"]; got != "dev" {
-		t.Fatalf("expected flat structured metadata field deployment.environment.name=dev, got %v", meta)
+	if !pEnabled.shouldEmitStructuredMetadata(req) {
+		t.Fatal("expected metadata emission when categorize-labels flag is present")
 	}
 }
 
-func TestVLLogsToLokiStreams_EmitStructuredMetadataWithParserFlattensFieldsByDefault(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","http.status_code":"200","level":"info"}` + "\n")
+func TestQueryRange_DefaultRequestStaysTwoTupleForStrictDecoders(t *testing.T) {
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"line","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","level":"info"}`)
+	defer vlBackend.Close()
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, false, p.emitStructuredMetadata)
-	if len(streams) != 1 {
-		t.Fatalf("expected 1 stream, got %d", len(streams))
-	}
-	values, ok := streams[0]["values"].([]interface{})
-	if !ok || len(values) != 1 {
-		t.Fatalf("expected one stream value, got %#v", streams[0]["values"])
-	}
-	pair, ok := values[0].([]interface{})
-	if !ok {
-		t.Fatalf("expected stream value to be tuple, got %T", values[0])
-	}
-	if len(pair) != 3 {
-		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
-	}
-	meta, ok := pair[2].(map[string]string)
-	if !ok {
-		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
-	}
-	if _, ok := meta["parsed"]; ok {
-		t.Fatalf("default tuple metadata must avoid nested parsed payload for broad parser compatibility, got %v", meta)
-	}
-	if got := meta["http.status_code"]; got != "200" {
-		t.Fatalf("expected parser-derived field in flattened metadata, got %v", meta)
+	p := newStreamMetadataProxy(t, vlBackend.URL, true, false)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"}`)
+	q.Set("start", "1")
+	q.Set("end", "2")
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
+	rec := httptest.NewRecorder()
+
+	p.handleQueryRange(rec, req)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 2 {
+		t.Fatalf("expected strict 2-tuple default query_range response, got %#v", tuple)
 	}
 }
 
-func TestVLLogsToLokiStreams_CategorizedLabelsStillEmitsFlatMetadataForParserSafety(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	body := []byte(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"message\":\"ok\",\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","trace_id":"abc123","http.status_code":"200","level":"info"}` + "\n")
+func TestQueryRange_CategorizeLabelsReturnsLokiThreeTuple(t *testing.T) {
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"line","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","level":"info"}`)
+	defer vlBackend.Close()
 
-	streams := p.vlLogsToLokiStreams(body, `{job="otel-proxy"} | json`, true, p.emitStructuredMetadata)
-	if len(streams) != 1 {
-		t.Fatalf("expected 1 stream, got %d", len(streams))
+	p := newStreamMetadataProxy(t, vlBackend.URL, true, false)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"}`)
+	q.Set("start", "1")
+	q.Set("end", "2")
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+	rec := httptest.NewRecorder()
+
+	p.handleQueryRange(rec, req)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 3 {
+		t.Fatalf("expected 3-tuple categorize-labels response, got %#v", tuple)
 	}
-	values, ok := streams[0]["values"].([]interface{})
-	if !ok || len(values) != 1 {
-		t.Fatalf("expected one stream value, got %#v", streams[0]["values"])
-	}
-	pair, ok := values[0].([]interface{})
-	if !ok || len(pair) != 3 {
-		t.Fatalf("expected [ts, line, metadata] tuple, got %v", pair)
-	}
-	meta, ok := pair[2].(map[string]string)
+	meta, ok := tuple[2].(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected metadata object in tuple[2], got %T", pair[2])
+		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
 	}
-	if _, ok := meta["parsed"]; ok {
-		t.Fatalf("metadata should remain flat map for parser safety, got %v", meta)
+	if _, ok := meta["structuredMetadata"]; !ok {
+		t.Fatalf("expected Loki structuredMetadata payload, got %#v", meta)
 	}
-	if _, ok := meta["structuredMetadata"]; ok {
-		t.Fatalf("metadata should remain flat map for parser safety, got %v", meta)
+	if _, ok := meta["structured_metadata"]; ok {
+		t.Fatalf("non-Loki structured_metadata alias must not be emitted, got %#v", meta)
 	}
-	if got := meta["http.status_code"]; got != "200" {
-		t.Fatalf("expected flattened parser field, got %v", meta)
+}
+
+func TestQuery_DefaultRequestStaysTwoTupleForStrictDecoders(t *testing.T) {
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"line","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","level":"info"}`)
+	defer vlBackend.Close()
+
+	p := newStreamMetadataProxy(t, vlBackend.URL, true, false)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"}`)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query?"+q.Encode(), nil)
+	rec := httptest.NewRecorder()
+
+	p.handleQuery(rec, req)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 2 {
+		t.Fatalf("expected strict 2-tuple default query response, got %#v", tuple)
+	}
+}
+
+func TestQuery_CategorizeLabelsReturnsThreeTuple(t *testing.T) {
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"line","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","level":"info"}`)
+	defer vlBackend.Close()
+
+	p := newStreamMetadataProxy(t, vlBackend.URL, true, false)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"}`)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query?"+q.Encode(), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+	rec := httptest.NewRecorder()
+
+	p.handleQuery(rec, req)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 3 {
+		t.Fatalf("expected 3-tuple categorize-labels query response, got %#v", tuple)
 	}
 }
 
 func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
+	// Brace-heavy line + parser chain protects the regression that previously broke Drilldown/Explore.
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"time=\"2026-01-01T00:00:00Z\" level=error msg=\"Failed to call api\" details=\"{\\\"code\\\":500,\\\"path\\\":\\\"/api/v1/orders\\\"}\"","_stream":"{job=\"otel-proxy\",level=\"error\"}","http.status_code":"500","level":"error"}`)
+	defer vlBackend.Close()
+
+	p := newStreamMetadataProxy(t, vlBackend.URL, true, true)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"} | json | logfmt | drop __error__, __error_details__`)
+	q.Set("start", "1")
+	q.Set("end", "2")
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
 	rec := httptest.NewRecorder()
-	resp := &http.Response{
-		Body: io.NopCloser(strings.NewReader(`{"_time":"2026-01-01T00:00:00Z","_msg":"{\"status\":200}","_stream":"{job=\"otel-proxy\",level=\"info\"}","http.status_code":"200","level":"info"}` + "\n")),
-	}
 
-	p.streamLogQuery(rec, resp, `{job="otel-proxy"} | json`, false, p.emitStructuredMetadata)
-
-	var payload map[string]interface{}
-	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
-		t.Fatalf("decode streamLogQuery response: %v", err)
-	}
-	data, ok := payload["data"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected data object, got %T", payload["data"])
-	}
-	results, ok := data["result"].([]interface{})
-	if !ok || len(results) != 1 {
-		t.Fatalf("expected one stream result, got %v", data["result"])
-	}
-	stream0, ok := results[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected stream object, got %T", results[0])
-	}
-	values, ok := stream0["values"].([]interface{})
-	if !ok || len(values) != 1 {
-		t.Fatalf("expected one stream value, got %v", stream0["values"])
-	}
-	tuple, ok := values[0].([]interface{})
-	if !ok || len(tuple) != 3 {
-		t.Fatalf("expected 3-tuple stream value, got %v", values[0])
+	p.handleQueryRange(rec, req)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 3 {
+		t.Fatalf("expected stream-mode 3-tuple value, got %#v", tuple)
 	}
 	meta, ok := tuple[2].(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected metadata object in tuple[2], got %T", tuple[2])
+		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
 	}
-	if got, ok := meta["http.status_code"]; !ok || got != "200" {
-		t.Fatalf("expected parser metadata in tuple[2], got %v", meta)
-	}
-}
-
-func TestRequestWantsCategorizedLabels(t *testing.T) {
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	if requestWantsCategorizedLabels(req) {
-		t.Fatal("expected false when encoding flag header is absent")
-	}
-
-	req.Header.Set("X-Loki-Response-Encoding-Flags", "foo,categorize-labels,bar")
-	if !requestWantsCategorizedLabels(req) {
-		t.Fatal("expected true when categorize-labels flag is present")
+	if _, ok := meta["parsed"]; !ok {
+		t.Fatalf("expected parsed payload for parser-chain query, got %#v", meta)
 	}
 }
 
-func TestShouldEmitStructuredMetadata_DisablesForGrafanaByDefault(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	req.Header.Set("X-Grafana-User", "admin")
-
-	if p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata disabled for Grafana callers by default")
+func TestBuildStreamValue_CategorizeLabelsEmitsEmptyObjectWhenNoMetadata(t *testing.T) {
+	tuple, ok := buildStreamValue("1", "line", nil, nil, true, true).([]interface{})
+	if !ok {
+		t.Fatalf("expected tuple slice, got %T", tuple)
+	}
+	if len(tuple) != 3 {
+		t.Fatalf("expected 3-tuple for categorize-labels path, got %#v", tuple)
+	}
+	if _, ok := tuple[2].(map[string]interface{}); !ok {
+		t.Fatalf("expected empty metadata object in tuple[2], got %#v", tuple[2])
 	}
 }
 
-func TestShouldEmitStructuredMetadata_AllowsGrafanaOptInViaEncodingFlag(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	req.Header.Set("X-Grafana-User", "admin")
-	req.Header.Set("X-Loki-Response-Encoding-Flags", "structured-metadata")
+func TestClassifyEntryFields_UsesLokiCanonicalMetadataKeysOnly(t *testing.T) {
+	p := newStreamMetadataProxy(t, "http://unused", true, false)
+	_, structuredMetadata, parsed := p.classifyEntryFields(map[string]interface{}{
+		"_time":        "2026-01-01T00:00:00Z",
+		"_msg":         "line",
+		"_stream":      `{job="otel-proxy",level="info"}`,
+		"service.name": "otel-app",
+	}, `{job="otel-proxy"}`)
 
-	if !p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata when Grafana explicitly opts in via encoding flag")
+	tuple, ok := buildStreamValue("1", "line", structuredMetadata, parsed, true, true).([]interface{})
+	if !ok || len(tuple) != 3 {
+		t.Fatalf("expected metadata tuple from classified fields, got %#v", tuple)
+	}
+	meta, ok := tuple[2].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadata object in tuple[2], got %#v", tuple[2])
+	}
+	if _, ok := meta["structuredMetadata"]; !ok {
+		t.Fatalf("expected structuredMetadata key, got %#v", meta)
+	}
+	if _, ok := meta["structured_metadata"]; ok {
+		t.Fatalf("did not expect structured_metadata alias, got %#v", meta)
 	}
 }
 
-func TestShouldEmitStructuredMetadata_AllowsQueryParamOptIn(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?structured_metadata=true", nil)
-	req.Header.Set("X-Grafana-User", "admin")
-
-	if !p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata when structured_metadata=true query param is set")
-	}
-}
-
-func TestShouldEmitStructuredMetadata_AllowsQueryParamOptOut(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?structured_metadata=false", nil)
-	req.Header.Set("X-Grafana-User", "admin")
-
-	if p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata disabled when structured_metadata=false query param is set")
-	}
-}
-
-func TestShouldEmitStructuredMetadata_EnablesForNonGrafanaByDefault(t *testing.T) {
-	p := newStreamMetadataTestProxy(t, true)
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-
-	if !p.shouldEmitStructuredMetadata(req) {
-		t.Fatal("expected structured metadata enabled for non-Grafana callers by default")
-	}
-}
-
-func TestQueryRange_GrafanaDefaultStaysTwoTupleForStrictDecoders(t *testing.T) {
-	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/select/logsql/query" {
-			t.Fatalf("unexpected backend path: %s", r.URL.Path)
-		}
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		_, _ = w.Write([]byte(`{"_time":"2026-04-10T12:00:00Z","_msg":"iptables policy update: \"Drop if no profiles matched\" -j DROP","_stream":"{deployment_environment=\"dev\"}","chain.link.env":"dev","deployment_environment":"dev","service.name":"calico","level":"error"}` + "\n"))
-	}))
+func TestQueryRange_DefaultParserChainStillStaysTwoTuple(t *testing.T) {
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"time=\"2026-01-01T00:00:00Z\" level=error msg=\"api call failed\"","_stream":"{job=\"otel-proxy\",level=\"error\"}","http.status_code":"500","level":"error"}`)
 	defer vlBackend.Close()
 
-	p, err := New(Config{
-		BackendURL:             vlBackend.URL,
-		Cache:                  cache.New(30*time.Second, 100),
-		LogLevel:               "error",
-		EmitStructuredMetadata: true,
-		MetadataFieldMode:      MetadataFieldModeHybrid,
-		LabelStyle:             LabelStylePassthrough,
-	})
-	if err != nil {
-		t.Fatalf("failed to create proxy: %v", err)
-	}
-
+	p := newStreamMetadataProxy(t, vlBackend.URL, true, false)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"} |= "api" | json | logfmt | drop __error__, __error_details__`)
+	q.Set("start", "1")
+	q.Set("end", "2")
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", `/loki/api/v1/query_range?query={deployment_environment="dev"}&start=1&end=2&limit=10`, nil)
-	req.Header.Set("X-Grafana-User", "admin")
+
 	p.handleQueryRange(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	if strings.Contains(rec.Body.String(), `"structuredMetadata"`) {
+		t.Fatalf("default parser-chain response must remain 2-tuple, got body=%s", rec.Body.String())
 	}
-
-	// Strict decoder: Grafana compatibility path expects [ts, line] tuples.
-	var strict struct {
-		Data struct {
-			Result []struct {
-				Values [][2]string `json:"values"`
-			} `json:"result"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &strict); err != nil {
-		t.Fatalf("strict tuple decode failed (possible ReadArray regression): %v\nbody=%s", err, rec.Body.String())
-	}
-	if len(strict.Data.Result) != 1 || len(strict.Data.Result[0].Values) != 1 {
-		t.Fatalf("unexpected strict decode shape: %+v", strict.Data.Result)
-	}
-	if strict.Data.Result[0].Values[0][1] == "" {
-		t.Fatalf("expected non-empty log line in strict decode tuple, got %+v", strict.Data.Result[0].Values[0])
-	}
-}
-
-func TestRequestLooksLikeGrafana(t *testing.T) {
-	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	if requestLooksLikeGrafana(req) {
-		t.Fatal("expected non-Grafana request by default")
-	}
-
-	req.Header.Set("X-Grafana-User", "admin")
-	if !requestLooksLikeGrafana(req) {
-		t.Fatal("expected Grafana detection from X-Grafana-User")
-	}
-
-	req = httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	req.Header.Set("User-Agent", "Grafana/12.4.2")
-	if !requestLooksLikeGrafana(req) {
-		t.Fatal("expected Grafana detection from User-Agent")
-	}
-}
-
-func TestTupleModeForRequest(t *testing.T) {
-	grafanaReq := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	grafanaReq.Header.Set("X-Grafana-User", "admin")
-	if got := tupleModeForRequest(grafanaReq, false); got != "grafana_default_2tuple" {
-		t.Fatalf("unexpected mode for Grafana default 2-tuple: %q", got)
-	}
-
-	grafanaOptInReq := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	grafanaOptInReq.Header.Set("X-Grafana-User", "admin")
-	grafanaOptInReq.Header.Set("X-Loki-Response-Encoding-Flags", "structured-metadata")
-	if got := tupleModeForRequest(grafanaOptInReq, true); got != "grafana_optin_3tuple" {
-		t.Fatalf("unexpected mode for Grafana opt-in 3-tuple: %q", got)
-	}
-
-	nonGrafanaReq := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
-	if got := tupleModeForRequest(nonGrafanaReq, true); got != "nongrafana_3tuple" {
-		t.Fatalf("unexpected mode for non-Grafana 3-tuple: %q", got)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 2 {
+		t.Fatalf("expected 2-tuple default parser-chain response, got %#v", tuple)
 	}
 }


### PR DESCRIPTION
Summary:
- Make tuple shape header-driven with strict Loki behavior.
- Default requests now always return 2-tuples.
- Requests with X-Loki-Response-Encoding-Flags: categorize-labels return 3-tuples with canonical Loki metadata object keys structuredMetadata and parsed.
- Remove Grafana caller sniffing and structured_metadata override parameters from tuple-shape selection.
- Preserve 3-tuple values in multi-tenant merge paths.

Tests:
- Add explicit query_range and query tests for both 2-tuple default and categorize-labels 3-tuple paths.
- Add stream-response parser-chain regression test using brace-heavy log lines.
- Full suite passes with go test ./...

Docs and changelog:
- Update API/config docs to match strict categorize-labels behavior.
- Add Unreleased changelog entries for the compatibility hardening.