### PR TITLE
Harden tuple/rules compatibility and metadata-mode coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
     env:
       PROXY_IMAGE: loki-vl-proxy:tuple-smoke
       PROXY_URL: http://127.0.0.1:3100
+      PROXY_URL_CATEGORIZED: http://127.0.0.1:3102
       SMOKE_QUERY: '{app="e2e-test"}'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,51 @@ jobs:
           go-version: "1.26.1"
           cache: true
 
-      - name: Tuple contract gate (Grafana default must remain strict 2-tuple)
+      - name: Tuple contract gate (default 2-tuple + categorize-labels 3-tuple)
         run: go test ./internal/proxy -run '^TestTupleContract_' -count=1
+
+  tuple-smoke:
+    runs-on: ubuntu-latest
+    needs: [test]
+    env:
+      PROXY_IMAGE: loki-vl-proxy:tuple-smoke
+      PROXY_URL: http://127.0.0.1:3100
+      SMOKE_QUERY: '{app="e2e-test"}'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+          cache: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ env.PROXY_IMAGE }}
+          load: true
+          cache-from: type=gha,scope=e2e-proxy
+          cache-to: type=gha,mode=max,scope=e2e-proxy
+
+      - name: Start e2e stack
+        working-directory: test/e2e-compat
+        run: |
+          docker compose up -d --no-build
+          ../../scripts/ci/wait_e2e_stack.sh 180
+
+      - name: Seed smoke data
+        run: go test -v -tags=e2e -run '^TestSetup_IngestLogs$' ./test/e2e-compat/
+
+      - name: Run tuple smoke script
+        run: ./scripts/smoke-test.sh
+
+      - name: Tear down e2e stack
+        if: always()
+        working-directory: test/e2e-compat
+        run: docker compose down -v
 
   bench:
     runs-on: ubuntu-latest
@@ -145,7 +188,7 @@ jobs:
           - name: drilldown
             pattern: '^(TestSetup_IngestLogs|TestDrilldown_.*|TestFeature_(IndexStats|IndexVolume|IndexVolumeRange|DrilldownClusterLevelOrFilters|MultitenantDrilldownClusterLevelOrFilters)|TestDrilldownTrackScore|TestLokiTrackScore|TestVLTrackScore)$'
           - name: otel-edge
-            pattern: '^(TestSetup_IngestEdgeCaseData|TestSetup_IngestRichData|TestOTel.*|TestQueryDirection_UnderscoreProxy|TestDetectedFields_UnderscoreProxy|TestSeries_UnderscoreProxy|TestMixedLabels_UnderscoreProxy|TestLokiVsProxy_LabelParity|TestGrafanaDrilldown_UnderscoreProxy|TestLabelDeduplication|TestLabelTranslation_EdgeCases|TestOTelCompatibilityScore|TestEdge_.*|TestComplex_.*)$'
+            pattern: '^(TestSetup_IngestEdgeCaseData|TestSetup_IngestRichData|TestOTel.*|TestStructuredMetadata_.*|TestQueryDirection_UnderscoreProxy|TestDetectedFields_UnderscoreProxy|TestSeries_UnderscoreProxy|TestMixedLabels_UnderscoreProxy|TestLokiVsProxy_LabelParity|TestGrafanaDrilldown_UnderscoreProxy|TestLabelDeduplication|TestLabelTranslation_EdgeCases|TestOTelCompatibilityScore|TestEdge_.*|TestComplex_.*)$'
           - name: tail-multitenancy
             pattern: '^(TestSetup_IngestLogs|TestFeature_Multitenancy_.*|TestFeature_AdminDebugEndpoints_DefaultClosed|TestFeature_Tail_.*|TestFeature_QueryAnalytics_Endpoint|TestFeature_SecurityHeaders|TestFeature_MetricsEndpoint|TestFeature_GzipCompression|TestFeature_NoGzipWithoutAccept|TestFeature_DerivedFields_TraceIDInJSON|TestFeature_ResponseStructureConsistency|TestFeature_QueryRange_vs_Query_Consistency|TestFeature_InstantVectorExpression_Compatibility|TestEdge_ConcurrentIdenticalQueries|TestEdge_LongQueryString|TestEdge_CombinedFilterTypes|TestEdge_EmptyResults|TestEdge_RapidSequentialQueries|TestEdge_InstantQuery)$'
     name: e2e-compat (${{ matrix.group.name }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- expand tuple-contract coverage and smoke validation paths to keep strict default 2-tuple and categorize-labels 3-tuple behavior regression-safe
+- add e2e compatibility checks for vlogs alerting plus recording-rule visibility across direct `vmalert`, proxy Prometheus endpoints, legacy Loki YAML, and Grafana datasource-proxy paths
+- add dedicated e2e structured-metadata compatibility coverage for `-metadata-field-mode=hybrid` and `-metadata-field-mode=native`
+
+### CI
+
+- extend CI shard coverage to include structured-metadata compatibility tests so metadata mode regressions fail on pull requests
+
+### Documentation
+
+- update architecture/readme diagrams and migration/testing docs to describe recording-rule remote-write expectations and Grafana datasource-proxy `datasource_type=vlogs` validation flow
+
 ## [0.27.19] - 2026-04-10
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add strict `/query_range` and `/query` contract tests covering both default 2-tuple and `categorize-labels` 3-tuple paths
 - add parser-chain/brace-heavy stream-response regression coverage to prevent `ReadArray` tuple-shape regressions in Grafana Explore/Drilldown
+- extend `TestTupleContract_*` gate coverage to enforce both strict default 2-tuple and `categorize-labels` 3-tuple compliance paths
+- add e2e parity checks for vlogs recording rules and alerts across direct `vmalert`, proxy Prometheus endpoints, legacy Loki YAML rules, and Grafana datasource proxy endpoints
+- add e2e structured-metadata mode checks for `-metadata-field-mode=hybrid` vs `-metadata-field-mode=native` with OTel dotted fields and Loki-compatible underscore labels
 
 ### Documentation
 
 - update API/config docs to describe strict `categorize-labels`-driven 3-tuple behavior and canonical Loki metadata keys
+- update tuple-contract runbook guidance to the strict mode set (`default_2tuple`, `categorize_labels_3tuple`)
+- document pinned e2e stack alerting/runtime updates, including recording-rule coverage and native-metadata profile checks
+- refresh architecture and migration docs/mermaid flows to include optional recording-rule remote-write sinks and Grafana datasource-proxy `datasource_type=vlogs` validation paths
+
+### CI
+
+- add automated `tuple-smoke` workflow job that boots the compat stack, seeds logs, and runs `scripts/smoke-test.sh` (default + categorize-labels checks)
+- add `TestStructuredMetadata_*` coverage to the `e2e-compat (otel-edge)` PR shard so hybrid/native metadata regressions fail on pull requests
+
+### Observability
+
+- align tuple-contract Prometheus alerts with strict mode labels (`default_2tuple`, `categorize_labels_3tuple`) and retire stale `grafana_*` mode assumptions
 
 ## [0.27.18] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI
 
 - extend CI shard coverage to include structured-metadata compatibility tests so metadata mode regressions fail on pull requests
+- harden tuple-smoke wiring to validate strict 2-tuples on the default proxy endpoint and `categorize-labels` 3-tuples on the metadata-enabled endpoint with explicit failure diagnostics
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project is intentionally a **read/query proxy**. Ingestion stays on Victori
 flowchart LR
     A["Clients<br/>Grafana Explore, Dashboards, Logs Drilldown, Loki API tools, LLM/MCP/API consumers"]
     B["Loki-VL-proxy (Read Compatibility Layer)<br/>Loki API contract + tenant guardrails + LogQL translation + response shaping + tiered cache"]
-    C["Data + Rules Upstream<br/>VictoriaLogs (log data) + vmalert (rules/alerts state)"]
+    C["Data + Rules Upstream<br/>VictoriaLogs (log data) + vmalert (rules/alerts state)<br/>+ optional VictoriaMetrics (recording-rule outputs)"]
 
     A --> B --> C
 
@@ -66,6 +66,7 @@ flowchart TD
     subgraph L5["Backends + Outputs"]
         VL["VictoriaLogs"]
         RULES["vmalert / ruler reads"]
+        VMTS["optional VictoriaMetrics<br/>recording-rule outputs"]
         OBS["Prometheus metrics<br/>OTLP export<br/>JSON logs"]
     end
 
@@ -86,6 +87,7 @@ flowchart TD
     Q --> RESP
     T --> VL
     R --> RULES
+    RULES -. recording writes .-> VMTS
     GUARD --> OBS
     Q --> OBS
     T --> OBS

--- a/alerting/loki-vl-proxy-prometheusrule.yaml
+++ b/alerting/loki-vl-proxy-prometheusrule.yaml
@@ -184,45 +184,45 @@ rules:
       action: "Identify top offending clients and inspect rejected query patterns."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-client-bad-request-burst.md'
 
-  - alert: LokiVLProxyGrafanaDefault3TupleUnexpected
-    expr: sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_3tuple"}[10m])) > 0
+  - alert: LokiVLProxyUnexpectedTupleMode
+    expr: sum(rate(loki_vl_proxy_response_tuple_mode_total{mode!~"default_2tuple|categorize_labels_3tuple"}[10m])) > 0
     for: 5m
     labels:
       severity: critical
       service: loki-vl-proxy
-      component: grafana-contract
+      component: tuple-contract
       category: compatibility
       team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
       owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
       source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
       managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
     annotations:
-      summary: "Grafana default request emitted 3-tuple response"
-      description: "Proxy observed grafana_default_3tuple emissions for 5 minutes."
-      impact: "Explore/Drilldown requests can fail with ReadArray tuple-shape decode errors."
-      action: "Validate tuple contract smoke script and inspect recent query path changes."
+      summary: "Unexpected tuple mode emitted"
+      description: "Proxy emitted tuple modes outside the strict contract set: default_2tuple and categorize_labels_3tuple."
+      impact: "Client tuple-shape compatibility may regress and decode failures can follow."
+      action: "Validate tuple contract smoke script and inspect recent query/merge/stream code changes."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
 
-  - alert: LokiVLProxyGrafanaDefault2TupleMissing
+  - alert: LokiVLProxyDefault2TupleMissing
     expr: |
-      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode=~"grafana_default_2tuple|grafana_optin_3tuple|grafana_default_3tuple"}[10m])) > 0
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode=~"default_2tuple|categorize_labels_3tuple"}[10m])) > 0
       and
-      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_2tuple"}[10m])) == 0
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="default_2tuple"}[10m])) == 0
     for: 10m
     labels:
       severity: warning
       service: loki-vl-proxy
-      component: grafana-contract
+      component: tuple-contract
       category: compatibility
       team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
       owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
       source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
       managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
     annotations:
-      summary: "Grafana default 2-tuple emissions missing"
-      description: "Grafana tuple-mode traffic exists but grafana_default_2tuple stayed at zero for 10 minutes."
-      impact: "Tuple-shape drift is likely; Grafana decode failures may follow."
-      action: "Run tuple smoke canary and verify `structured_metadata` overrides are not being forced globally."
+      summary: "Default 2-tuple emissions missing"
+      description: "Tuple-mode traffic exists but mode=default_2tuple stayed at zero for 10 minutes."
+      impact: "All traffic may be forcing categorize-labels, reducing strict 2-tuple compatibility coverage."
+      action: "Run tuple smoke canary and verify callers only send categorize-labels where 3-tuples are expected."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
 
   - alert: LokiVLProxySystemMetricsMissing

--- a/charts/loki-vl-proxy/alerting/loki-vl-proxy-prometheusrule.yaml
+++ b/charts/loki-vl-proxy/alerting/loki-vl-proxy-prometheusrule.yaml
@@ -184,45 +184,45 @@ rules:
       action: "Identify top offending clients and inspect rejected query patterns."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-client-bad-request-burst.md'
 
-  - alert: LokiVLProxyGrafanaDefault3TupleUnexpected
-    expr: sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_3tuple"}[10m])) > 0
+  - alert: LokiVLProxyUnexpectedTupleMode
+    expr: sum(rate(loki_vl_proxy_response_tuple_mode_total{mode!~"default_2tuple|categorize_labels_3tuple"}[10m])) > 0
     for: 5m
     labels:
       severity: critical
       service: loki-vl-proxy
-      component: grafana-contract
+      component: tuple-contract
       category: compatibility
       team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
       owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
       source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
       managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
     annotations:
-      summary: "Grafana default request emitted 3-tuple response"
-      description: "Proxy observed grafana_default_3tuple emissions for 5 minutes."
-      impact: "Explore/Drilldown requests can fail with ReadArray tuple-shape decode errors."
-      action: "Validate tuple contract smoke script and inspect recent query path changes."
+      summary: "Unexpected tuple mode emitted"
+      description: "Proxy emitted tuple modes outside the strict contract set: default_2tuple and categorize_labels_3tuple."
+      impact: "Client tuple-shape compatibility may regress and decode failures can follow."
+      action: "Validate tuple contract smoke script and inspect recent query/merge/stream code changes."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
 
-  - alert: LokiVLProxyGrafanaDefault2TupleMissing
+  - alert: LokiVLProxyDefault2TupleMissing
     expr: |
-      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode=~"grafana_default_2tuple|grafana_optin_3tuple|grafana_default_3tuple"}[10m])) > 0
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode=~"default_2tuple|categorize_labels_3tuple"}[10m])) > 0
       and
-      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="grafana_default_2tuple"}[10m])) == 0
+      sum(rate(loki_vl_proxy_response_tuple_mode_total{mode="default_2tuple"}[10m])) == 0
     for: 10m
     labels:
       severity: warning
       service: loki-vl-proxy
-      component: grafana-contract
+      component: tuple-contract
       category: compatibility
       team: '{{ .Values.prometheusRule.standardLabels.team | default "sre" }}'
       owner: '{{ .Values.prometheusRule.standardLabels.owner | default "reliablyobserve" }}'
       source: '{{ .Values.prometheusRule.standardLabels.source | default "vmalert" }}'
       managed_by: '{{ .Values.prometheusRule.standardLabels.managedBy | default "helm" }}'
     annotations:
-      summary: "Grafana default 2-tuple emissions missing"
-      description: "Grafana tuple-mode traffic exists but grafana_default_2tuple stayed at zero for 10 minutes."
-      impact: "Tuple-shape drift is likely; Grafana decode failures may follow."
-      action: "Run tuple smoke canary and verify `structured_metadata` overrides are not being forced globally."
+      summary: "Default 2-tuple emissions missing"
+      description: "Tuple-mode traffic exists but mode=default_2tuple stayed at zero for 10 minutes."
+      impact: "All traffic may be forcing categorize-labels, reducing strict 2-tuple compatibility coverage."
+      action: "Run tuple smoke canary and verify callers only send categorize-labels where 3-tuples are expected."
       runbook_url: '{{ .Values.prometheusRule.runbookBaseUrl | default "https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/runbooks" }}/loki-vl-proxy-grafana-tuple-contract.md'
 
   - alert: LokiVLProxySystemMetricsMissing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ flowchart TD
     subgraph Backends["Backends + Outputs"]
         VL["VictoriaLogs"]
         VMR["vmalert / ruler read backend"]
+        VMTS["optional VictoriaMetrics<br/>recording-rule outputs"]
         OBS["Prometheus metrics + OTLP + JSON logs"]
     end
 
@@ -59,6 +60,7 @@ flowchart TD
     MODE --> NATIVE --> VL
     MODE --> SYN --> VL
     ROUTE --> ALERT --> VMR
+    VMR -. recording writes .-> VMTS
     GUARD --> OBS
     SHAPE --> OBS
 
@@ -160,6 +162,7 @@ flowchart LR
     BACKEND -->|yes| PROXY["Forward read request with mapped tenant headers"]
     PROXY --> VMR["vmalert / ruler-compatible backend"]
     VMR --> SHAPE["Return legacy Loki YAML or Prometheus JSON view"]
+    VMR -. optional recording-rule writes .-> VMTS["VictoriaMetrics (or compatible remote write sink)"]
 ```
 
 ## Data Model Mapping
@@ -201,6 +204,7 @@ flowchart LR
         LOKI["Loki :3101<br/>(ground truth)"]
         VLP["Loki-VL-proxy<br/>:3100"]
         VL["VictoriaLogs<br/>:9428"]
+        VM["VictoriaMetrics<br/>:8428 (recording-rule sink)"]
         GF["Grafana :3000<br/>Loki / Drilldown / tail datasources"]
     end
 
@@ -209,7 +213,8 @@ flowchart LR
     COMPARE -->|GET /loki/api/v1/*| LOKI
     COMPARE -->|GET /loki/api/v1/*| VLP
     VLP --> VL
-    VLP -. rules / alerts .-> VM["vmalert"]
+    VLP -. rules / alerts .-> VMA["vmalert"]
+    VMA -. optional recording writes .-> VM
     COMPARE --> SCORE
     GF -.->|manual compare| LOKI
     GF -.->|manual compare| VLP

--- a/docs/rules-alerts-migration.md
+++ b/docs/rules-alerts-migration.md
@@ -89,7 +89,7 @@ Minimal example:
 ```yaml
 services:
   vmalert:
-    image: victoriametrics/vmalert:v1.139.0
+    image: victoriametrics/vmalert:v1.138.0
     command:
       - -datasource.url=http://victorialogs:9428
       - -rule=/rules/vmalert-rules.yaml
@@ -102,11 +102,25 @@ For local validation without a real Alertmanager:
 ```yaml
 services:
   vmalert:
-    image: victoriametrics/vmalert:v1.139.0
+    image: victoriametrics/vmalert:v1.138.0
     command:
       - -datasource.url=http://victorialogs:9428
       - -rule=/rules/vmalert-rules.yaml
       - -rule.defaultRuleType=vlogs
+      - -notifier.blackhole
+```
+
+If your file contains recording rules (`record:`), add a remote-write target so `vmalert` can persist those series:
+
+```yaml
+services:
+  vmalert:
+    image: victoriametrics/vmalert:v1.138.0
+    command:
+      - -datasource.url=http://victorialogs:9428
+      - -rule=/rules/vmalert-rules.yaml
+      - -rule.defaultRuleType=vlogs
+      - -remoteWrite.url=http://victoriametrics:8428/api/v1/write
       - -notifier.blackhole
 ```
 
@@ -127,6 +141,9 @@ After `vmalert` is configured and the proxy points at it:
 - `/api/prom/rules` returns the same classic YAML alias
 - `/prometheus/api/v1/rules` returns Prometheus-style JSON
 - `/loki/api/v1/alerts`, `/api/prom/alerts`, and `/prometheus/api/v1/alerts` return JSON alert state
+- Grafana datasource proxy reads stay consistent with direct paths when `datasource_type=vlogs` is set:
+  - `/api/datasources/proxy/uid/<uid>/prometheus/api/v1/rules?datasource_type=vlogs`
+  - `/api/datasources/proxy/uid/<uid>/prometheus/api/v1/alerts?datasource_type=vlogs`
 
 So Grafana can keep reading alert/rule state from the Loki-facing datasource path.
 
@@ -199,6 +216,8 @@ Recommended migration flow:
    - `GET /prometheus/api/v1/rules`
    - `GET /prometheus/api/v1/alerts`
    - `GET /loki/api/v1/rules`
+   - `GET /api/datasources/proxy/uid/<uid>/prometheus/api/v1/rules?datasource_type=vlogs` (from Grafana)
+   - `GET /api/datasources/proxy/uid/<uid>/prometheus/api/v1/alerts?datasource_type=vlogs` (from Grafana)
 6. Confirm Grafana sees the rules/alerts through the Loki datasource path.
 
 ## Real-Life Test Coverage

--- a/docs/runbooks/loki-vl-proxy-grafana-tuple-contract.md
+++ b/docs/runbooks/loki-vl-proxy-grafana-tuple-contract.md
@@ -1,41 +1,42 @@
-# LokiVLProxy Grafana Tuple Contract
+# LokiVLProxy Tuple Contract
 
 ## Alerts Covered
 
-- `LokiVLProxyGrafanaDefault3TupleUnexpected`
-- `LokiVLProxyGrafanaDefault2TupleMissing`
+- `LokiVLProxyUnexpectedTupleMode`
+- `LokiVLProxyDefault2TupleMissing`
 
 ## Symptoms
 
 - Grafana Explore or Logs Drilldown shows tuple decode errors (for example `ReadArray`).
-- `loki_vl_proxy_response_tuple_mode_total` shows `grafana_default_3tuple` increments.
-- `grafana_default_2tuple` drops to zero while Grafana traffic still exists.
+- `loki_vl_proxy_response_tuple_mode_total` contains unexpected mode labels (anything except `default_2tuple` and `categorize_labels_3tuple`).
+- `default_2tuple` drops to zero while tuple traffic still exists.
 
 ## Immediate Checks
 
 1. Confirm proxy health:
    - `curl -fsS http://<proxy>:3100/ready`
-2. Run tuple smoke canary with Grafana-style headers:
+2. Run tuple smoke canary (validates both default 2-tuple and categorize-labels 3-tuple paths):
    - `PROXY_URL=http://<proxy>:3100 ./scripts/smoke-test.sh`
 3. Check tuple mode counters:
    - `curl -fsS http://<proxy>:3100/metrics | rg "loki_vl_proxy_response_tuple_mode_total"`
 
 ## Typical Root Causes
 
-1. Response tuple shape regressed to 3-tuple for default Grafana callers.
-2. A global config or proxy path unintentionally forces structured metadata emission.
-3. Recent query-path changes bypassed strict tuple-shape handling in merge/stream code.
+1. Response tuple shape handling regressed in query/stream/merge paths.
+2. Callers are forcing `categorize-labels` on all traffic, leaving no default 2-tuple compatibility coverage.
+3. Proxy emitted non-contract mode labels after code changes.
 
 ## Mitigation
 
-1. Temporarily force canonical shape for Grafana callers:
-   - keep `-emit-structured-metadata=true` if needed for non-Grafana clients
-   - do not force `structured_metadata=true` globally for Grafana traffic
+1. Keep strict contract behavior:
+   - no flag => `[ts, line]`
+   - `X-Loki-Response-Encoding-Flags: categorize-labels` => `[ts, line, metadata]`
+2. Do not inject `categorize-labels` globally unless all clients support 3-tuples.
 2. Roll back to the previous known-good proxy version if smoke checks fail.
 3. Validate multi-tenant and stream-response paths with the tuple contract tests.
 
 ## Recovery Criteria
 
 - `./scripts/smoke-test.sh` passes for both `/query_range` and `/query`.
-- `grafana_default_3tuple` rate returns to `0`.
-- `grafana_default_2tuple` resumes for active Grafana requests.
+- `loki_vl_proxy_response_tuple_mode_total` only shows `default_2tuple` and `categorize_labels_3tuple`.
+- `default_2tuple` is present for no-flag traffic.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,7 +47,7 @@ docker run --rm \
 # Build binary
 go build -o loki-vl-proxy ./cmd/proxy
 
-# Post-deploy Grafana tuple contract canary (expects recent log data)
+# Post-deploy tuple contract canary (validates default 2-tuple + categorize-labels 3-tuple; expects recent log data)
 PROXY_URL=http://127.0.0.1:3100 ./scripts/smoke-test.sh
 ```
 
@@ -134,6 +134,7 @@ Stack startup now uses [`wait_e2e_stack.sh`](../scripts/ci/wait_e2e_stack.sh) in
 The GitHub-hosted Docker jobs now also prebuild the proxy image once per job through BuildKit cache and start compose stacks with `--no-build`. That keeps the grouped compat shards and UI shards parallel without paying the full Docker rebuild cost every time a stack starts inside the same job.
 
 Compose-backed fleet cache smoke now runs on pull requests and post-merge `main` in CI (`e2e-fleet`), using the dedicated `TestFleetSmoke_*` suite.
+Tuple smoke contract canary also runs automatically in CI (`tuple-smoke`) by seeding e2e data then executing `scripts/smoke-test.sh`.
 
 ### `datasource` shard
 
@@ -202,6 +203,7 @@ The default local stack is pinned to:
 
 - Loki `3.7.1`
 - VictoriaLogs `v1.49.0`
+- vmalert `v1.138.0` (with local VictoriaMetrics remote-write target for recording-rule evaluation)
 - Grafana `12.4.2`
 - Logs Drilldown contract `2.0.1` from `grafana/logs-drilldown` commit `4463f56047de75da95251086d1906fb902ad53a7`
 
@@ -210,6 +212,13 @@ Field-surface defaults in the pinned stack:
 - Labels remain Loki-compatible when `-label-style=underscores` is used
 - `-metadata-field-mode=hybrid` is the default, so field APIs expose both native dotted names and translated aliases
 - If you need a stricter Loki-only field surface for a focused test, run the proxy with `-metadata-field-mode=translated`
+- The compose matrix includes a dedicated native-metadata proxy profile (`-metadata-field-mode=native`) so CI verifies both hybrid and native structured-metadata exposure
+
+Alerting and recording-rule parity coverage:
+
+- `TestAlertingCompat_PrometheusRulesAndAlerts` validates alerting + recording rules from `vmalert` are visible through proxy Prometheus paths
+- `TestAlertingCompat_GrafanaDatasourceRulesAndAlertsParity` validates the same rule/alert payload through Grafana datasource proxy endpoints
+- `TestAlertingCompat_LegacyLokiRulesYAML` validates Loki legacy YAML formatting includes both `alert` and `record` entries
 
 Support window policy:
 

--- a/internal/proxy/ruler_proxy_test.go
+++ b/internal/proxy/ruler_proxy_test.go
@@ -61,6 +61,11 @@ func TestRulerProxy_LegacyRulesYAML(t *testing.T) {
 								"health": "ok",
 								"type":   "alerting",
 							},
+							{
+								"name":  "api_requests_total:rate5m",
+								"query": `sum(rate({app="api"}[5m]))`,
+								"type":  "recording",
+							},
 						},
 					},
 				},
@@ -102,8 +107,14 @@ func TestRulerProxy_LegacyRulesYAML(t *testing.T) {
 	if groups[0].Name != "api" {
 		t.Fatalf("expected group name api, got %q", groups[0].Name)
 	}
-	if len(groups[0].Rules) != 1 || groups[0].Rules[0].Alert != "HighErrorRate" {
-		t.Fatalf("expected alert rule conversion, got %+v", groups[0].Rules)
+	if len(groups[0].Rules) != 2 {
+		t.Fatalf("expected 2 YAML rules, got %+v", groups[0].Rules)
+	}
+	if groups[0].Rules[0].Alert != "HighErrorRate" {
+		t.Fatalf("expected alert rule conversion, got %+v", groups[0].Rules[0])
+	}
+	if groups[0].Rules[1].Record != "api_requests_total:rate5m" {
+		t.Fatalf("expected recording rule conversion, got %+v", groups[0].Rules[1])
 	}
 }
 

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -72,6 +72,57 @@ func assertStrictTwoTupleContract(t *testing.T, body []byte) {
 	}
 }
 
+func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
+	t.Helper()
+	var payload struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []struct {
+				Values []json.RawMessage `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to decode response payload: %v\nbody=%s", err, string(body))
+	}
+	if payload.Status != "success" {
+		t.Fatalf("expected success status, got %q body=%s", payload.Status, string(body))
+	}
+
+	tupleCount := 0
+	for _, stream := range payload.Data.Result {
+		for _, rawTuple := range stream.Values {
+			tupleCount++
+			var tuple []json.RawMessage
+			if err := json.Unmarshal(rawTuple, &tuple); err != nil {
+				t.Fatalf("failed to decode tuple: %v\nraw=%s", err, string(rawTuple))
+			}
+			if len(tuple) != 3 {
+				t.Fatalf("expected 3-tuple [ts,line,metadata], got len=%d tuple=%s", len(tuple), string(rawTuple))
+			}
+
+			var metadata map[string]json.RawMessage
+			if err := json.Unmarshal(tuple[2], &metadata); err != nil {
+				t.Fatalf("expected tuple[2] metadata object, got %s: %v", string(tuple[2]), err)
+			}
+			if len(metadata) == 0 {
+				continue
+			}
+			if _, ok := metadata["structured_metadata"]; ok {
+				t.Fatalf("non-Loki structured_metadata alias must not be emitted: %s", string(tuple[2]))
+			}
+			if _, ok := metadata["structuredMetadata"]; !ok {
+				if _, ok := metadata["parsed"]; !ok {
+					t.Fatalf("expected structuredMetadata and/or parsed metadata keys, got %s", string(tuple[2]))
+				}
+			}
+		}
+	}
+	if tupleCount == 0 {
+		t.Fatalf("expected at least one tuple in response body=%s", string(body))
+	}
+}
+
 func makeTupleContractBackend(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -91,7 +142,7 @@ func makeTupleContractBackend(t *testing.T) *httptest.Server {
 	}))
 }
 
-func TestTupleContract_GrafanaDefaultQueryRangeStrictTwoTuple(t *testing.T) {
+func TestTupleContract_DefaultQueryRangeStrictTwoTuple(t *testing.T) {
 	backend := makeTupleContractBackend(t)
 	defer backend.Close()
 
@@ -102,7 +153,6 @@ func TestTupleContract_GrafanaDefaultQueryRangeStrictTwoTuple(t *testing.T) {
 	params.Set("end", "2")
 	params.Set("limit", "50")
 	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
-	req.Header.Set("X-Grafana-User", "admin")
 
 	rec := httptest.NewRecorder()
 	p.handleQueryRange(rec, req)
@@ -112,7 +162,7 @@ func TestTupleContract_GrafanaDefaultQueryRangeStrictTwoTuple(t *testing.T) {
 	assertStrictTwoTupleContract(t, rec.Body.Bytes())
 }
 
-func TestTupleContract_GrafanaDefaultQueryStrictTwoTuple(t *testing.T) {
+func TestTupleContract_DefaultQueryStrictTwoTuple(t *testing.T) {
 	backend := makeTupleContractBackend(t)
 	defer backend.Close()
 
@@ -121,7 +171,6 @@ func TestTupleContract_GrafanaDefaultQueryStrictTwoTuple(t *testing.T) {
 	params.Set("query", `{job="tuple-contract"} |= "api" | json | logfmt | drop __error__, __error_details__`)
 	params.Set("time", "2")
 	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query?"+params.Encode(), nil)
-	req.Header.Set("X-Grafana-User", "admin")
 
 	rec := httptest.NewRecorder()
 	p.handleQuery(rec, req)
@@ -142,7 +191,6 @@ func TestTupleContract_StreamResponseModeStrictTwoTuple(t *testing.T) {
 	params.Set("end", "2")
 	params.Set("limit", "20")
 	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
-	req.Header.Set("X-Grafana-User", "admin")
 
 	rec := httptest.NewRecorder()
 	p.handleQueryRange(rec, req)
@@ -163,7 +211,6 @@ func TestTupleContract_MultiTenantMergeStrictTwoTuple(t *testing.T) {
 	params.Set("end", "2")
 	params.Set("limit", "50")
 	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
-	req.Header.Set("X-Grafana-User", "admin")
 	req.Header.Set("X-Scope-OrgID", "tenant-a|tenant-b")
 
 	rec := httptest.NewRecorder()
@@ -172,4 +219,44 @@ func TestTupleContract_MultiTenantMergeStrictTwoTuple(t *testing.T) {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
 	assertStrictTwoTupleContract(t, rec.Body.Bytes())
+}
+
+func TestTupleContract_CategorizeLabelsQueryRangeThreeTuple(t *testing.T) {
+	backend := makeTupleContractBackend(t)
+	defer backend.Close()
+
+	p := newTupleContractProxy(t, backend.URL, false)
+	params := url.Values{}
+	params.Set("query", `{job="tuple-contract"} |= "DROP" | json | logfmt | drop __error__, __error_details__`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+	params.Set("limit", "50")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertCategorizeLabelsThreeTupleContract(t, rec.Body.Bytes())
+}
+
+func TestTupleContract_CategorizeLabelsQueryThreeTuple(t *testing.T) {
+	backend := makeTupleContractBackend(t)
+	defer backend.Close()
+
+	p := newTupleContractProxy(t, backend.URL, false)
+	params := url.Values{}
+	params.Set("query", `{job="tuple-contract"} |= "api" | json | logfmt | drop __error__, __error_details__`)
+	params.Set("time", "2")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query?"+params.Encode(), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+
+	rec := httptest.NewRecorder()
+	p.handleQuery(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertCategorizeLabelsThreeTupleContract(t, rec.Body.Bytes())
 }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -33,6 +33,40 @@ check_strict_two_tuple() {
   ' >/dev/null
 }
 
+check_categorize_three_tuple() {
+  local payload="$1"
+  local endpoint="$2"
+
+  echo "$payload" | jq -e '.status == "success"' >/dev/null
+
+  local tuple_count
+  tuple_count="$(echo "$payload" | jq '[.data.result[]?.values[]?] | length')"
+  if [[ "$tuple_count" -eq 0 ]]; then
+    echo "no log tuples returned for ${endpoint} categorize-labels check; cannot validate tuple contract" >&2
+    return 1
+  fi
+
+  echo "$payload" | jq -e '
+    [
+      .data.result[]?.values[]?
+      | (
+          type == "array"
+          and length == 3
+          and (.[0] | type == "string")
+          and (.[1] | type == "string")
+          and (.[2] | type == "object")
+          and ((.[2] | has("structured_metadata")) | not)
+          and (
+            (.[2] | length == 0)
+            or (.[2] | has("structuredMetadata"))
+            or (.[2] | has("parsed"))
+          )
+        )
+    ]
+    | all
+  ' >/dev/null
+}
+
 fetch_query_range() {
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
@@ -54,10 +88,37 @@ fetch_query() {
     "${PROXY_URL}/loki/api/v1/query"
 }
 
+fetch_query_range_categorized() {
+  curl -sS --get \
+    -H 'X-Grafana-User: smoke-canary' \
+    -H 'X-Grafana-Org-Id: 1' \
+    -H 'X-Loki-Response-Encoding-Flags: categorize-labels' \
+    --data-urlencode "query=${QUERY}" \
+    --data-urlencode "start=${start_ns}" \
+    --data-urlencode "end=${now_ns}" \
+    --data-urlencode "limit=${LIMIT}" \
+    "${PROXY_URL}/loki/api/v1/query_range"
+}
+
+fetch_query_categorized() {
+  curl -sS --get \
+    -H 'X-Grafana-User: smoke-canary' \
+    -H 'X-Grafana-Org-Id: 1' \
+    -H 'X-Loki-Response-Encoding-Flags: categorize-labels' \
+    --data-urlencode "query=${QUERY}" \
+    --data-urlencode "time=${now_ns}" \
+    --data-urlencode "limit=${LIMIT}" \
+    "${PROXY_URL}/loki/api/v1/query"
+}
+
 range_payload="$(fetch_query_range)"
 query_payload="$(fetch_query)"
+range_categorized_payload="$(fetch_query_range_categorized)"
+query_categorized_payload="$(fetch_query_categorized)"
 
 check_strict_two_tuple "$range_payload" "/query_range"
 check_strict_two_tuple "$query_payload" "/query"
+check_categorize_three_tuple "$range_categorized_payload" "/query_range"
+check_categorize_three_tuple "$query_categorized_payload" "/query"
 
-echo "tuple contract smoke check passed for /query_range and /query"
+echo "tuple contract smoke check passed for /query_range and /query (default 2-tuple + categorize-labels 3-tuple)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROXY_URL="${PROXY_URL:-http://127.0.0.1:3100}"
+DEFAULT_PROXY_URL="${PROXY_URL_DEFAULT:-${PROXY_URL:-http://127.0.0.1:3100}}"
+CATEGORIZED_PROXY_URL="${PROXY_URL_CATEGORIZED:-${DEFAULT_PROXY_URL}}"
 QUERY="${SMOKE_QUERY:-{job=~\".+\"}}"
 LIMIT="${SMOKE_LIMIT:-20}"
 LOOKBACK_SECONDS="${SMOKE_LOOKBACK_SECONDS:-900}"
@@ -36,10 +37,15 @@ check_strict_two_tuple() {
     return 1
   fi
 
-  echo "$payload" | jq -e '
+  if ! echo "$payload" | jq -e '
     [.data.result[]?.values[]? | (type == "array" and length == 2 and (.[0] | type == "string") and (.[1] | type == "string"))]
     | all
-  ' >/dev/null
+  ' >/dev/null; then
+    local sample
+    sample="$(echo "$payload" | jq -c '.data.result[0].values[0] // empty')"
+    echo "strict 2-tuple contract failed for ${endpoint}; sample tuple=${sample:-<none>}" >&2
+    return 1
+  fi
 }
 
 check_categorize_three_tuple() {
@@ -55,7 +61,7 @@ check_categorize_three_tuple() {
     return 1
   fi
 
-  echo "$payload" | jq -e '
+  if ! echo "$payload" | jq -e '
     [
       .data.result[]?.values[]?
       | (
@@ -73,10 +79,16 @@ check_categorize_three_tuple() {
         )
     ]
     | all
-  ' >/dev/null
+  ' >/dev/null; then
+    local sample
+    sample="$(echo "$payload" | jq -c '.data.result[0].values[0] // empty')"
+    echo "categorize-labels 3-tuple contract failed for ${endpoint}; sample tuple=${sample:-<none>}" >&2
+    return 1
+  fi
 }
 
 fetch_query_range() {
+  local base_url="$1"
   compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
@@ -85,10 +97,11 @@ fetch_query_range() {
     --data-urlencode "start=${start_ns}" \
     --data-urlencode "end=${now_ns}" \
     --data-urlencode "limit=${LIMIT}" \
-    "${PROXY_URL}/loki/api/v1/query_range"
+    "${base_url}/loki/api/v1/query_range"
 }
 
 fetch_query() {
+  local base_url="$1"
   compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
@@ -96,10 +109,11 @@ fetch_query() {
     --data-urlencode "query=${QUERY}" \
     --data-urlencode "time=${now_ns}" \
     --data-urlencode "limit=${LIMIT}" \
-    "${PROXY_URL}/loki/api/v1/query"
+    "${base_url}/loki/api/v1/query"
 }
 
 fetch_query_range_categorized() {
+  local base_url="$1"
   compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
@@ -109,10 +123,11 @@ fetch_query_range_categorized() {
     --data-urlencode "start=${start_ns}" \
     --data-urlencode "end=${now_ns}" \
     --data-urlencode "limit=${LIMIT}" \
-    "${PROXY_URL}/loki/api/v1/query_range"
+    "${base_url}/loki/api/v1/query_range"
 }
 
 fetch_query_categorized() {
+  local base_url="$1"
   compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
@@ -121,18 +136,19 @@ fetch_query_categorized() {
     --data-urlencode "query=${QUERY}" \
     --data-urlencode "time=${now_ns}" \
     --data-urlencode "limit=${LIMIT}" \
-    "${PROXY_URL}/loki/api/v1/query"
+    "${base_url}/loki/api/v1/query"
 }
 
 fetch_with_retry() {
   local fetcher="$1"
   local endpoint="$2"
+  local base_url="$3"
   local payload=""
   local count=0
   local attempt=1
 
   while [[ "$attempt" -le "$RETRIES" ]]; do
-    payload="$($fetcher)"
+    payload="$($fetcher "$base_url")"
     count="$(tuple_count "$payload")"
     if [[ "$count" -gt 0 ]]; then
       echo "$payload"
@@ -148,14 +164,14 @@ fetch_with_retry() {
   return 1
 }
 
-range_payload="$(fetch_with_retry fetch_query_range "/query_range")"
-query_payload="$(fetch_with_retry fetch_query "/query")"
-range_categorized_payload="$(fetch_with_retry fetch_query_range_categorized "/query_range categorize-labels")"
-query_categorized_payload="$(fetch_with_retry fetch_query_categorized "/query categorize-labels")"
+range_payload="$(fetch_with_retry fetch_query_range "/query_range" "$DEFAULT_PROXY_URL")"
+query_payload="$(fetch_with_retry fetch_query "/query" "$DEFAULT_PROXY_URL")"
+range_categorized_payload="$(fetch_with_retry fetch_query_range_categorized "/query_range categorize-labels" "$CATEGORIZED_PROXY_URL")"
+query_categorized_payload="$(fetch_with_retry fetch_query_categorized "/query categorize-labels" "$CATEGORIZED_PROXY_URL")"
 
 check_strict_two_tuple "$range_payload" "/query_range"
 check_strict_two_tuple "$query_payload" "/query"
 check_categorize_three_tuple "$range_categorized_payload" "/query_range"
 check_categorize_three_tuple "$query_categorized_payload" "/query"
 
-echo "tuple contract smoke check passed for /query_range and /query (default 2-tuple + categorize-labels 3-tuple)"
+echo "tuple contract smoke check passed (default=${DEFAULT_PROXY_URL} strict 2-tuple; categorized=${CATEGORIZED_PROXY_URL} 3-tuple)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5,14 +5,23 @@ PROXY_URL="${PROXY_URL:-http://127.0.0.1:3100}"
 QUERY="${SMOKE_QUERY:-{job=~\".+\"}}"
 LIMIT="${SMOKE_LIMIT:-20}"
 LOOKBACK_SECONDS="${SMOKE_LOOKBACK_SECONDS:-900}"
+RETRIES="${SMOKE_RETRIES:-15}"
+RETRY_SLEEP_SECONDS="${SMOKE_RETRY_SLEEP_SECONDS:-2}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required" >&2
   exit 1
 fi
 
-now_ns="$(($(date +%s) * 1000000000))"
-start_ns="$((now_ns - LOOKBACK_SECONDS * 1000000000))"
+compute_window() {
+  now_ns="$(($(date +%s) * 1000000000))"
+  start_ns="$((now_ns - LOOKBACK_SECONDS * 1000000000))"
+}
+
+tuple_count() {
+  local payload="$1"
+  echo "$payload" | jq '[.data.result[]?.values[]?] | length'
+}
 
 check_strict_two_tuple() {
   local payload="$1"
@@ -68,6 +77,7 @@ check_categorize_three_tuple() {
 }
 
 fetch_query_range() {
+  compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
     -H 'X-Grafana-Org-Id: 1' \
@@ -79,6 +89,7 @@ fetch_query_range() {
 }
 
 fetch_query() {
+  compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
     -H 'X-Grafana-Org-Id: 1' \
@@ -89,6 +100,7 @@ fetch_query() {
 }
 
 fetch_query_range_categorized() {
+  compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
     -H 'X-Grafana-Org-Id: 1' \
@@ -101,6 +113,7 @@ fetch_query_range_categorized() {
 }
 
 fetch_query_categorized() {
+  compute_window
   curl -sS --get \
     -H 'X-Grafana-User: smoke-canary' \
     -H 'X-Grafana-Org-Id: 1' \
@@ -111,10 +124,34 @@ fetch_query_categorized() {
     "${PROXY_URL}/loki/api/v1/query"
 }
 
-range_payload="$(fetch_query_range)"
-query_payload="$(fetch_query)"
-range_categorized_payload="$(fetch_query_range_categorized)"
-query_categorized_payload="$(fetch_query_categorized)"
+fetch_with_retry() {
+  local fetcher="$1"
+  local endpoint="$2"
+  local payload=""
+  local count=0
+  local attempt=1
+
+  while [[ "$attempt" -le "$RETRIES" ]]; do
+    payload="$($fetcher)"
+    count="$(tuple_count "$payload")"
+    if [[ "$count" -gt 0 ]]; then
+      echo "$payload"
+      return 0
+    fi
+    if [[ "$attempt" -lt "$RETRIES" ]]; then
+      sleep "$RETRY_SLEEP_SECONDS"
+    fi
+    attempt="$((attempt + 1))"
+  done
+
+  echo "no log tuples returned for ${endpoint} after ${RETRIES} attempts; cannot validate tuple contract" >&2
+  return 1
+}
+
+range_payload="$(fetch_with_retry fetch_query_range "/query_range")"
+query_payload="$(fetch_with_retry fetch_query "/query")"
+range_categorized_payload="$(fetch_with_retry fetch_query_range_categorized "/query_range categorize-labels")"
+query_categorized_payload="$(fetch_with_retry fetch_query_categorized "/query categorize-labels")"
 
 check_strict_two_tuple "$range_payload" "/query_range"
 check_strict_two_tuple "$query_payload" "/query"

--- a/test/e2e-compat/alerting_compat_test.go
+++ b/test/e2e-compat/alerting_compat_test.go
@@ -27,8 +27,10 @@ func TestAlertingCompat_PrometheusRulesAndAlerts(t *testing.T) {
 		t.Fatalf("expected exactly one alerting group via direct=%d proxy=%d", len(directGroups), len(proxyGroups))
 	}
 	assertGroupPresent(t, proxyGroups, "loki-vl-e2e-alerts")
+	assertRulePresent(t, proxyGroups, "ApiGatewayErrorLogLines", "recording", "vlogs")
 	assertRulePresent(t, proxyGroups, "ApiGatewayErrorsPresent", "alerting", "vlogs")
 	assertRulePresent(t, proxyGroups, "PaymentServiceErrorsPresent", "alerting", "vlogs")
+	assertRuleQueryParity(t, directGroups, proxyGroups, "ApiGatewayErrorLogLines")
 	assertRuleStateParity(t, directGroups, proxyGroups, "ApiGatewayErrorsPresent")
 	assertRuleStateParity(t, directGroups, proxyGroups, "PaymentServiceErrorsPresent")
 
@@ -66,6 +68,7 @@ func TestAlertingCompat_LegacyLokiRulesYAML(t *testing.T) {
 	text := string(body)
 	for _, want := range []string{
 		"name: loki-vl-e2e-alerts",
+		"record: ApiGatewayErrorLogLines",
 		"alert: ApiGatewayErrorsPresent",
 		"alert: PaymentServiceErrorsPresent",
 		"severity: page",
@@ -73,6 +76,37 @@ func TestAlertingCompat_LegacyLokiRulesYAML(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected YAML response to contain %q, got %s", want, text)
 		}
+	}
+}
+
+func TestAlertingCompat_GrafanaDatasourceRulesAndAlertsParity(t *testing.T) {
+	ensureDataIngested(t)
+	waitForReady(t, vmalertURL+"/api/v1/rules?datasource_type=vlogs", 30*time.Second)
+	waitForAlertingData(t)
+
+	dsUID := grafanaDatasourceUID(t, "Loki (via VL proxy)")
+	rulesPath := grafanaURL + "/api/datasources/proxy/uid/" + url.PathEscape(dsUID) + "/prometheus/api/v1/rules?datasource_type=vlogs"
+	alertsPath := grafanaURL + "/api/datasources/proxy/uid/" + url.PathEscape(dsUID) + "/prometheus/api/v1/alerts?datasource_type=vlogs"
+
+	rulesViaGrafana := getJSON(t, rulesPath)
+	rulesViaProxy := getJSON(t, proxyURL+"/prometheus/api/v1/rules?datasource_type=vlogs")
+	grafanaGroups := extractArray(extractMap(rulesViaGrafana, "data"), "groups")
+	proxyGroups := extractArray(extractMap(rulesViaProxy, "data"), "groups")
+
+	if len(grafanaGroups) != len(proxyGroups) {
+		t.Fatalf("expected grafana datasource rules parity via proxy=%d grafana=%d", len(proxyGroups), len(grafanaGroups))
+	}
+	assertGroupPresent(t, grafanaGroups, "loki-vl-e2e-alerts")
+	assertRulePresent(t, grafanaGroups, "ApiGatewayErrorLogLines", "recording", "vlogs")
+	assertRulePresent(t, grafanaGroups, "ApiGatewayErrorsPresent", "alerting", "vlogs")
+	assertRulePresent(t, grafanaGroups, "PaymentServiceErrorsPresent", "alerting", "vlogs")
+
+	alertsViaGrafana := getJSON(t, alertsPath)
+	alertsViaProxy := getJSON(t, proxyURL+"/prometheus/api/v1/alerts?datasource_type=vlogs")
+	grafanaAlerts := extractArray(extractMap(alertsViaGrafana, "data"), "alerts")
+	proxyAlerts := extractArray(extractMap(alertsViaProxy, "data"), "alerts")
+	if len(grafanaAlerts) != len(proxyAlerts) {
+		t.Fatalf("expected grafana datasource alerts parity via proxy=%d grafana=%d", len(proxyAlerts), len(grafanaAlerts))
 	}
 }
 
@@ -138,6 +172,38 @@ func assertRuleStateParity(t *testing.T, directGroups, proxyGroups []interface{}
 	if directState != proxyState {
 		t.Fatalf("expected rule %q state parity direct=%q proxy=%q", ruleName, directState, proxyState)
 	}
+}
+
+func assertRuleQueryParity(t *testing.T, directGroups, proxyGroups []interface{}, ruleName string) {
+	t.Helper()
+
+	directRule, ok := findRule(directGroups, ruleName)
+	if !ok {
+		t.Fatalf("expected direct rule %q in %+v", ruleName, directGroups)
+	}
+	proxyRule, ok := findRule(proxyGroups, ruleName)
+	if !ok {
+		t.Fatalf("expected proxy rule %q in %+v", ruleName, proxyGroups)
+	}
+	directQuery, _ := directRule["query"].(string)
+	proxyQuery, _ := proxyRule["query"].(string)
+	if directQuery != proxyQuery {
+		t.Fatalf("expected rule %q query parity direct=%q proxy=%q", ruleName, directQuery, proxyQuery)
+	}
+}
+
+func findRule(groups []interface{}, ruleName string) (map[string]interface{}, bool) {
+	for _, g := range groups {
+		group, _ := g.(map[string]interface{})
+		rules, _ := group["rules"].([]interface{})
+		for _, r := range rules {
+			rule, _ := r.(map[string]interface{})
+			if rule["name"] == ruleName {
+				return rule, true
+			}
+		}
+	}
+	return nil, false
 }
 
 func findRuleState(groups []interface{}, ruleName string) (string, bool) {

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -44,9 +44,25 @@ services:
       retries: 10
       start_period: 5s
 
+  # VictoriaMetrics TSDB for vmalert recording-rule remote write
+  victoriametrics:
+    image: ${VICTORIAMETRICS_IMAGE:-victoriametrics/victoria-metrics:v1.119.0}
+    container_name: e2e-victoriametrics
+    command:
+      - "-storageDataPath=/vm-data"
+      - "-httpListenAddr=:8428"
+    volumes:
+      - vm-data:/vm-data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:8428/health"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   # vmalert alert/rule backend against VictoriaLogs
   vmalert:
-    image: ${VMALERT_IMAGE:-victoriametrics/vmalert:v1.139.0}
+    image: ${VMALERT_IMAGE:-victoriametrics/vmalert:v1.138.0}
     container_name: e2e-vmalert
     working_dir: /rules
     ports:
@@ -54,6 +70,7 @@ services:
     command:
       - "-httpListenAddr=:8880"
       - "-datasource.url=http://victorialogs:9428"
+      - "-remoteWrite.url=http://victoriametrics:8428/api/v1/write"
       - "-notifier.blackhole"
       - "-rule=compat.rules"
       - "-configCheckInterval=5s"
@@ -61,6 +78,8 @@ services:
       - ./vmalert-rules.yml:/rules/compat.rules:ro
     depends_on:
       victorialogs:
+        condition: service_healthy
+      victoriametrics:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:8880/api/v1/rules?datasource_type=vlogs"]
@@ -114,6 +133,38 @@ services:
       - "-log-level=info"
       - "-cache-ttl=5s"
       - "-label-style=underscores"
+      - "-emit-structured-metadata=true"
+    depends_on:
+      victorialogs:
+        condition: service_healthy
+      vmalert:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:3100/ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
+  # Loki-VL-proxy with underscore labels but native metadata field mode
+  loki-vl-proxy-native-metadata:
+    image: ${PROXY_IMAGE:-loki-vl-proxy:e2e-local}
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: e2e-proxy-native-metadata
+    ports:
+      - "3106:3100"
+    command:
+      - "-listen=:3100"
+      - "-backend=http://victorialogs:9428"
+      - "-ruler-backend=http://vmalert:8880"
+      - "-alerts-backend=http://vmalert:8880"
+      - "-log-level=info"
+      - "-cache-ttl=5s"
+      - "-label-style=underscores"
+      - "-metadata-field-mode=native"
+      - "-emit-structured-metadata=true"
     depends_on:
       victorialogs:
         condition: service_healthy
@@ -221,9 +272,11 @@ services:
       - loki
       - loki-vl-proxy
       - loki-vl-proxy-underscore
+      - loki-vl-proxy-native-metadata
       - loki-vl-proxy-tail
       - loki-vl-proxy-tail-native
       - tail-ingress
 
 volumes:
   vl-data:
+  vm-data:

--- a/test/e2e-compat/grafana-datasources.yaml
+++ b/test/e2e-compat/grafana-datasources.yaml
@@ -35,6 +35,17 @@ datasources:
     secureJsonData:
       httpHeaderValue1: "0|fake"
 
+  - name: Loki (via VL proxy native metadata)
+    type: loki
+    access: proxy
+    url: http://loki-vl-proxy-native-metadata:3100
+    isDefault: false
+    jsonData:
+      httpHeaderName1: X-Scope-OrgID
+      maxLines: 1000
+    secureJsonData:
+      httpHeaderValue1: "0"
+
   - name: Loki (via VL proxy live tail)
     type: loki
     access: proxy

--- a/test/e2e-compat/grafana_surface_test.go
+++ b/test/e2e-compat/grafana_surface_test.go
@@ -22,6 +22,7 @@ func TestGrafanaDatasourceCatalogAndHealth(t *testing.T) {
 		{name: "Loki (direct)", kind: "loki"},
 		{name: "Loki (via VL proxy)", kind: "loki"},
 		{name: "Loki (via VL proxy multi-tenant)", kind: "loki"},
+		{name: "Loki (via VL proxy native metadata)", kind: "loki"},
 		{name: "Loki (via VL proxy live tail)", kind: "loki"},
 		{name: "Loki (via ingress tail)", kind: "loki"},
 		{name: "Loki (via VL proxy live tail native)", kind: "loki"},

--- a/test/e2e-compat/structured_metadata_compat_test.go
+++ b/test/e2e-compat/structured_metadata_compat_test.go
@@ -1,0 +1,240 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	proxyNativeMetadataURL = envOrOtel("PROXY_NATIVE_METADATA_URL", "http://localhost:3106")
+	structuredMetadataOnce sync.Once
+)
+
+func TestStructuredMetadata_HybridModeExposesNativeAndTranslatedAliases(t *testing.T) {
+	ensureStructuredMetadataData(t)
+
+	resp := queryRangeCategorized(t, proxyUnderscoreURL, `{service_name="structured-metadata-e2e",level="info"}`)
+	labels := firstStreamLabels(t, resp)
+	metadata := firstStreamStructuredMetadata(t, resp)
+
+	for _, want := range []string{"service_name", "k8s_pod_name"} {
+		if _, ok := labels[want]; !ok {
+			t.Fatalf("hybrid/underscore labels missing %q: %+v", want, labels)
+		}
+	}
+	for _, forbidden := range []string{"service.name", "k8s.pod.name"} {
+		if _, ok := labels[forbidden]; ok {
+			t.Fatalf("hybrid/underscore labels unexpectedly exposed dotted key %q: %+v", forbidden, labels)
+		}
+	}
+
+	for _, want := range []string{
+		"http.target", "http_target",
+		"cloud.region", "cloud_region",
+	} {
+		if _, ok := metadata[want]; !ok {
+			t.Fatalf("hybrid structuredMetadata missing %q: %+v", want, metadata)
+		}
+	}
+}
+
+func TestStructuredMetadata_NativeModeKeepsDottedMetadataWithUnderscoreLabels(t *testing.T) {
+	ensureStructuredMetadataData(t)
+
+	resp := queryRangeCategorized(t, proxyNativeMetadataURL, `{service_name="structured-metadata-e2e",level="info"}`)
+	labels := firstStreamLabels(t, resp)
+	metadata := firstStreamStructuredMetadata(t, resp)
+
+	for _, want := range []string{"service_name", "k8s_pod_name"} {
+		if _, ok := labels[want]; !ok {
+			t.Fatalf("native metadata mode labels missing %q: %+v", want, labels)
+		}
+	}
+	for _, forbidden := range []string{"service.name", "k8s.pod.name"} {
+		if _, ok := labels[forbidden]; ok {
+			t.Fatalf("native metadata mode labels unexpectedly exposed dotted key %q: %+v", forbidden, labels)
+		}
+	}
+
+	for _, want := range []string{"http.target", "cloud.region"} {
+		if _, ok := metadata[want]; !ok {
+			t.Fatalf("native structuredMetadata missing dotted key %q: %+v", want, metadata)
+		}
+	}
+	for _, forbidden := range []string{"http_target", "cloud_region"} {
+		if _, ok := metadata[forbidden]; ok {
+			t.Fatalf("native structuredMetadata unexpectedly exposed translated key %q: %+v", forbidden, metadata)
+		}
+	}
+}
+
+func TestStructuredMetadata_LabelShapeMatchesLokiExpectations(t *testing.T) {
+	ensureStructuredMetadataData(t)
+
+	for name, baseURL := range map[string]string{
+		"loki_direct":             lokiURL,
+		"proxy_hybrid_underscore": proxyUnderscoreURL,
+		"proxy_native_metadata":   proxyNativeMetadataURL,
+	} {
+		resp := queryRangeCategorized(t, baseURL, `{service_name="structured-metadata-e2e",level="info"}`)
+		labels := firstStreamLabels(t, resp)
+
+		if _, ok := labels["service_name"]; !ok {
+			t.Fatalf("%s missing Loki-compatible service_name label: %+v", name, labels)
+		}
+		for key := range labels {
+			if strings.Contains(key, ".") {
+				t.Fatalf("%s returned dotted stream label %q (expected Loki-compatible label keys): %+v", name, key, labels)
+			}
+		}
+	}
+}
+
+func ensureStructuredMetadataData(t *testing.T) {
+	t.Helper()
+	structuredMetadataOnce.Do(func() {
+		now := time.Now().UTC()
+		tsNanos := fmt.Sprintf("%d", now.UnixNano())
+		tsRFC3339 := now.Format(time.RFC3339Nano)
+
+		// Loki-compatible reference stream for label-shape parity checks.
+		lokiPayload := map[string]interface{}{
+			"streams": []map[string]interface{}{
+				{
+					"stream": map[string]string{
+						"service_name": "structured-metadata-e2e",
+						"k8s_pod_name": "structured-metadata-e2e-pod",
+						"level":        "info",
+					},
+					"values": [][]string{{tsNanos, `{"msg":"structured metadata compatibility event"}`}},
+				},
+			},
+		}
+		body, _ := json.Marshal(lokiPayload)
+		resp, err := http.Post(lokiURL+"/loki/api/v1/push", "application/json", strings.NewReader(string(body)))
+		if err != nil {
+			t.Fatalf("push structured metadata stream to Loki: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			t.Fatalf("push structured metadata stream to Loki failed with status %d", resp.StatusCode)
+		}
+
+		// VictoriaLogs stream with extra dotted fields that should surface in structuredMetadata.
+		vlLine := fmt.Sprintf(
+			`{"_time":"%s","_msg":"structured metadata compatibility event","service.name":"structured-metadata-e2e","k8s.pod.name":"structured-metadata-e2e-pod","level":"info","http.target":"/api/login","cloud.region":"eu-west-1"}`,
+			tsRFC3339,
+		)
+		vlURLWithFields := vlURL + "/insert/jsonline?_stream_fields=service.name,k8s.pod.name,level"
+		resp, err = http.Post(vlURLWithFields, "application/stream+json", strings.NewReader(vlLine))
+		if err != nil {
+			t.Fatalf("push structured metadata stream to VictoriaLogs: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			t.Fatalf("push structured metadata stream to VictoriaLogs failed with status %d", resp.StatusCode)
+		}
+
+		time.Sleep(3 * time.Second)
+	})
+}
+
+func queryRangeCategorized(t *testing.T, baseURL, query string) map[string]interface{} {
+	t.Helper()
+	now := time.Now()
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-20*time.Minute).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("limit", "100")
+
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/loki/api/v1/query_range?"+params.Encode(), nil)
+	if err != nil {
+		t.Fatalf("create query_range request: %v", err)
+	}
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("execute query_range request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected query_range 200 from %s, got %d", baseURL, resp.StatusCode)
+	}
+
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode query_range response: %v", err)
+	}
+	return out
+}
+
+func firstStreamLabels(t *testing.T, response map[string]interface{}) map[string]interface{} {
+	t.Helper()
+
+	data := extractMap(response, "data")
+	result := extractArray(data, "result")
+	if len(result) == 0 {
+		t.Fatalf("expected at least one stream result, got %v", response)
+	}
+	stream, _ := result[0].(map[string]interface{})
+	labels, _ := stream["stream"].(map[string]interface{})
+	if len(labels) == 0 {
+		t.Fatalf("expected stream labels, got %v", stream)
+	}
+	return labels
+}
+
+func firstStreamStructuredMetadata(t *testing.T, response map[string]interface{}) map[string]string {
+	t.Helper()
+
+	data := extractMap(response, "data")
+	result := extractArray(data, "result")
+	if len(result) == 0 {
+		t.Fatalf("expected at least one stream result, got %v", response)
+	}
+	stream, _ := result[0].(map[string]interface{})
+	values, _ := stream["values"].([]interface{})
+	if len(values) == 0 {
+		t.Fatalf("expected tuple values, got %v", stream)
+	}
+	firstTuple, _ := values[0].([]interface{})
+	if len(firstTuple) < 3 {
+		t.Fatalf("expected 3-tuple with metadata, got %#v", firstTuple)
+	}
+	meta, _ := firstTuple[2].(map[string]interface{})
+	if meta == nil {
+		t.Fatalf("expected metadata object in tuple[2], got %#v", firstTuple[2])
+	}
+	if _, ok := meta["structured_metadata"]; ok {
+		t.Fatalf("non-Loki structured_metadata alias must not be emitted: %#v", meta)
+	}
+	structuredRaw, ok := meta["structuredMetadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structuredMetadata key in metadata object, got %#v", meta)
+	}
+
+	structured := make(map[string]string, len(structuredRaw))
+	for k, v := range structuredRaw {
+		switch typed := v.(type) {
+		case string:
+			structured[k] = typed
+		case float64:
+			structured[k] = fmt.Sprintf("%g", typed)
+		case bool:
+			structured[k] = fmt.Sprintf("%t", typed)
+		default:
+			structured[k] = fmt.Sprintf("%v", typed)
+		}
+	}
+	return structured
+}

--- a/test/e2e-compat/vmalert-rules.yml
+++ b/test/e2e-compat/vmalert-rules.yml
@@ -3,6 +3,10 @@ groups:
     type: vlogs
     interval: 5s
     rules:
+      - record: ApiGatewayErrorLogLines
+        expr: 'app: "api-gateway" AND level: "error" | stats by (app, cluster) count(*) as error_logs'
+        labels:
+          team: platform
       - alert: ApiGatewayErrorsPresent
         expr: 'app: "api-gateway" AND level: "error" | stats by (app, cluster) count(*) as error_logs | filter error_logs:>0'
         for: 0s


### PR DESCRIPTION
## Summary
- add strict tuple contract hardening for query_range and query, plus smoke script and CI gate updates
- extend alerting and rules compatibility coverage to include recording rules and Grafana datasource-proxy parity paths
- add structured metadata mode e2e coverage for hybrid and native field modes
- update docs, runbooks, changelog, and architecture mermaids for compatibility and recording-rule flow

## Validation
- go test ./internal/proxy -run TestTupleContract_|TestRulerProxy_ -count=1
- targeted e2e compatibility suite covered by new test/e2e-compat additions in this branch

## Notes
- branch rebased on latest main
- commit is SSH-signed