### PR TITLE
Fix ReadArray tuple decode by emitting Loki label-pair metadata arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- emit `structuredMetadata` and `parsed` tuple metadata in Loki label-pair array shape (`[{name,value}]`) when `X-Loki-Response-Encoding-Flags: categorize-labels` is enabled, preventing strict decoder `ReadArray` failures on object-shaped payloads
+
+### Tests
+
+- harden tuple regression guards across single-tenant, multi-tenant merge, and query-range windowing paths to enforce Loki metadata pair-array shape and fail fast on future tuple payload regressions
+
 ## [0.27.22] - 2026-04-10
 
 ### Bug Fixes

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,6 +27,7 @@ For Grafana Logs Drilldown and Explore compatibility:
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default.
 - When `X-Loki-Response-Encoding-Flags: categorize-labels` is present and `-emit-structured-metadata=true`, query results emit Loki 3-tuples `[timestamp, line, metadata]`.
 - The 3rd tuple object follows Loki keys only: `structuredMetadata` and/or `parsed` (no snake_case alias keys).
+- `structuredMetadata` and `parsed` are Loki-style label-pair arrays (`[{name,value}, ...]`), not free-form maps.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.

--- a/internal/proxy/multitenant_merge_test.go
+++ b/internal/proxy/multitenant_merge_test.go
@@ -414,8 +414,8 @@ func TestMergeMultiTenantResponsesQueryInjectsTenantLabel(t *testing.T) {
 
 func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 	body, _, err := mergeMultiTenantResponses("query", []string{"tenant-a", "tenant-b"}, []*httptest.ResponseRecorder{
-		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["2","line-a",{"structuredMetadata":{"service.name":"orders"}}]]}]}}`),
-		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"parsed":{"status":"200"}}]]}]}}`),
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["2","line-a",{"structuredMetadata":[{"name":"service.name","value":"orders"}]}]]}]}}`),
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"parsed":[{"name":"status","value":"200"}]}]]}]}}`),
 	})
 	if err != nil {
 		t.Fatalf("mergeMultiTenantResponses failed: %v", err)
@@ -436,6 +436,20 @@ func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 	for _, item := range resp.Data.Result {
 		if len(item.Values) == 0 || len(item.Values[0]) != 3 {
 			t.Fatalf("expected merged stream values to preserve 3-tuple shape, got %#v", item.Values)
+		}
+		meta, ok := item.Values[0][2].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected metadata object in tuple[2], got %#v", item.Values[0][2])
+		}
+		if structured, ok := meta["structuredMetadata"]; ok {
+			if _, ok := structured.([]interface{}); !ok {
+				t.Fatalf("expected structuredMetadata label-pair array, got %#v", structured)
+			}
+		}
+		if parsed, ok := meta["parsed"]; ok {
+			if _, ok := parsed.([]interface{}); !ok {
+				t.Fatalf("expected parsed label-pair array, got %#v", parsed)
+			}
 		}
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3939,15 +3939,35 @@ func buildStreamValue(ts, msg string, structuredMetadata map[string]string, pars
 
 	metadata := map[string]interface{}{}
 	if len(structuredMetadata) > 0 {
-		metadata["structuredMetadata"] = structuredMetadata
+		metadata["structuredMetadata"] = metadataFieldPairs(structuredMetadata)
 	}
 	if len(parsedFields) > 0 {
-		metadata["parsed"] = parsedFields
+		metadata["parsed"] = metadataFieldPairs(parsedFields)
 	}
 	if len(metadata) == 0 {
 		return []interface{}{ts, msg, map[string]interface{}{}}
 	}
 	return []interface{}{ts, msg, metadata}
+}
+
+func metadataFieldPairs(fields map[string]string) []map[string]string {
+	if len(fields) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]map[string]string, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, map[string]string{
+			"name":  key,
+			"value": fields[key],
+		})
+	}
+	return pairs
 }
 
 func (p *Proxy) classifyEntryFields(entry map[string]interface{}, originalQuery string) (map[string]string, map[string]string, map[string]string) {

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -153,6 +153,74 @@ func TestQueryRangeWindow_ParserChainBraceHeavyLine(t *testing.T) {
 	}
 }
 
+func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		startNs, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+		msg := `time="2026-01-01T00:00:00Z" level=error status=500 component=ingester`
+		_, _ = fmt.Fprintf(w, "{\"_time\":%q,\"_msg\":%q,\"_stream\":\"{app=\\\"iptables\\\"}\",\"http.status_code\":\"500\"}\n", time.Unix(0, startNs).UTC().Format(time.RFC3339Nano), msg)
+	}))
+	defer vlBackend.Close()
+
+	p := newWindowingTestProxy(t, vlBackend.URL)
+	p.emitStructuredMetadata = true
+
+	start := time.Now().Add(-12 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	end := start + int64(2*time.Hour) - 1
+	q := `{app="iptables"} | json | logfmt | drop __error__, __error_details__`
+	req := httptest.NewRequest("GET", fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=100", url.QueryEscape(q), start, end), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+	resp := httptest.NewRecorder()
+	p.handleQueryRange(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var payload struct {
+		Data struct {
+			Result []struct {
+				Values []json.RawMessage `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v body=%s", err, resp.Body.String())
+	}
+	if len(payload.Data.Result) == 0 || len(payload.Data.Result[0].Values) == 0 {
+		t.Fatalf("expected non-empty stream values: %#v", payload.Data.Result)
+	}
+
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(payload.Data.Result[0].Values[0], &tuple); err != nil {
+		t.Fatalf("expected stream tuple array, got %s: %v", string(payload.Data.Result[0].Values[0]), err)
+	}
+	if len(tuple) != 3 {
+		t.Fatalf("expected categorize-labels 3-tuple, got len=%d tuple=%s", len(tuple), string(payload.Data.Result[0].Values[0]))
+	}
+
+	var metadata struct {
+		StructuredMetadata []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"structuredMetadata"`
+		Parsed []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"parsed"`
+	}
+	if err := json.Unmarshal(tuple[2], &metadata); err != nil {
+		t.Fatalf("expected tuple[2] metadata object with Loki pair arrays, got %s: %v", string(tuple[2]), err)
+	}
+	if len(metadata.Parsed) == 0 && len(metadata.StructuredMetadata) == 0 {
+		t.Fatalf("expected parsed and/or structuredMetadata pairs, got %s", string(tuple[2]))
+	}
+	for _, pair := range append(metadata.StructuredMetadata, metadata.Parsed...) {
+		if pair.Name == "" {
+			t.Fatalf("expected non-empty metadata pair name, got %s", string(tuple[2]))
+		}
+	}
+}
+
 func TestQueryRangeWindow_MultiTenantCompatibility(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -61,6 +61,39 @@ func decodeFirstTuple(t *testing.T, body []byte) []interface{} {
 	return resp.Data.Result[0].Values[0]
 }
 
+func labelPairsToMap(t *testing.T, raw interface{}) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	switch items := raw.(type) {
+	case []interface{}:
+		out = make(map[string]string, len(items))
+		for _, item := range items {
+			pair, ok := item.(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected label pair object, got %T", item)
+			}
+			name, _ := pair["name"].(string)
+			value, _ := pair["value"].(string)
+			if name == "" {
+				t.Fatalf("expected non-empty pair name in %v", pair)
+			}
+			out[name] = value
+		}
+	case []map[string]string:
+		out = make(map[string]string, len(items))
+		for _, pair := range items {
+			name := pair["name"]
+			if name == "" {
+				t.Fatalf("expected non-empty pair name in %v", pair)
+			}
+			out[name] = pair["value"]
+		}
+	default:
+		t.Fatalf("expected metadata label pairs array, got %T", raw)
+	}
+	return out
+}
+
 func TestRequestWantsCategorizedLabels(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	if requestWantsCategorizedLabels(req) {
@@ -137,8 +170,13 @@ func TestQueryRange_CategorizeLabelsReturnsLokiThreeTuple(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
 	}
-	if _, ok := meta["structuredMetadata"]; !ok {
+	structuredRaw, ok := meta["structuredMetadata"]
+	if !ok {
 		t.Fatalf("expected Loki structuredMetadata payload, got %#v", meta)
+	}
+	structured := labelPairsToMap(t, structuredRaw)
+	if got := structured["service.name"]; got != "otel-app" {
+		t.Fatalf("expected service.name pair in structured metadata, got %#v", structured)
 	}
 	if _, ok := meta["structured_metadata"]; ok {
 		t.Fatalf("non-Loki structured_metadata alias must not be emitted, got %#v", meta)
@@ -203,8 +241,13 @@ func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
 	}
-	if _, ok := meta["parsed"]; !ok {
+	parsedRaw, ok := meta["parsed"]
+	if !ok {
 		t.Fatalf("expected parsed payload for parser-chain query, got %#v", meta)
+	}
+	parsed := labelPairsToMap(t, parsedRaw)
+	if got := parsed["http.status_code"]; got != "500" {
+		t.Fatalf("expected http.status_code in parsed payload, got %#v", parsed)
 	}
 }
 
@@ -238,8 +281,13 @@ func TestClassifyEntryFields_UsesLokiCanonicalMetadataKeysOnly(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected metadata object in tuple[2], got %#v", tuple[2])
 	}
-	if _, ok := meta["structuredMetadata"]; !ok {
+	structuredRaw, ok := meta["structuredMetadata"]
+	if !ok {
 		t.Fatalf("expected structuredMetadata key, got %#v", meta)
+	}
+	structured := labelPairsToMap(t, structuredRaw)
+	if got := structured["service.name"]; got != "otel-app" {
+		t.Fatalf("expected service.name in structuredMetadata payload, got %#v", structured)
 	}
 	if _, ok := meta["structured_metadata"]; ok {
 		t.Fatalf("did not expect structured_metadata alias, got %#v", meta)

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -61,6 +61,7 @@ func decodeFirstTuple(t *testing.T, body []byte) []interface{} {
 	return resp.Data.Result[0].Values[0]
 }
 
+// labelPairsToMap accepts decoded JSON as either []interface{} or []map[string]string.
 func labelPairsToMap(t *testing.T, raw interface{}) map[string]string {
 	t.Helper()
 	var out map[string]string

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -63,7 +63,7 @@ func decodeFirstTuple(t *testing.T, body []byte) []interface{} {
 
 func labelPairsToMap(t *testing.T, raw interface{}) map[string]string {
 	t.Helper()
-	out := map[string]string{}
+	var out map[string]string
 	switch items := raw.(type) {
 	case []interface{}:
 		out = make(map[string]string, len(items))

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -111,6 +111,12 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 			if _, ok := metadata["structured_metadata"]; ok {
 				t.Fatalf("non-Loki structured_metadata alias must not be emitted: %s", string(tuple[2]))
 			}
+			if raw, ok := metadata["structuredMetadata"]; ok {
+				assertMetadataPairArray(t, raw, "structuredMetadata")
+			}
+			if raw, ok := metadata["parsed"]; ok {
+				assertMetadataPairArray(t, raw, "parsed")
+			}
 			if _, ok := metadata["structuredMetadata"]; !ok {
 				if _, ok := metadata["parsed"]; !ok {
 					t.Fatalf("expected structuredMetadata and/or parsed metadata keys, got %s", string(tuple[2]))
@@ -120,6 +126,22 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 	}
 	if tupleCount == 0 {
 		t.Fatalf("expected at least one tuple in response body=%s", string(body))
+	}
+}
+
+func assertMetadataPairArray(t *testing.T, raw json.RawMessage, key string) {
+	t.Helper()
+	var pairs []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &pairs); err != nil {
+		t.Fatalf("expected %s to be Loki label-pair array, got %s: %v", key, string(raw), err)
+	}
+	for _, pair := range pairs {
+		if pair.Name == "" {
+			t.Fatalf("expected non-empty %s pair name in %s", key, string(raw))
+		}
 	}
 }
 

--- a/test/e2e-compat/structured_metadata_compat_test.go
+++ b/test/e2e-compat/structured_metadata_compat_test.go
@@ -218,22 +218,31 @@ func firstStreamStructuredMetadata(t *testing.T, response map[string]interface{}
 	if _, ok := meta["structured_metadata"]; ok {
 		t.Fatalf("non-Loki structured_metadata alias must not be emitted: %#v", meta)
 	}
-	structuredRaw, ok := meta["structuredMetadata"].(map[string]interface{})
+	structuredRaw, ok := meta["structuredMetadata"].([]interface{})
 	if !ok {
 		t.Fatalf("expected structuredMetadata key in metadata object, got %#v", meta)
 	}
 
 	structured := make(map[string]string, len(structuredRaw))
-	for k, v := range structuredRaw {
+	for _, item := range structuredRaw {
+		pair, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected structured metadata pair object, got %#v", item)
+		}
+		name, _ := pair["name"].(string)
+		if name == "" {
+			t.Fatalf("expected non-empty structured metadata name in %#v", pair)
+		}
+		v := pair["value"]
 		switch typed := v.(type) {
 		case string:
-			structured[k] = typed
+			structured[name] = typed
 		case float64:
-			structured[k] = fmt.Sprintf("%g", typed)
+			structured[name] = fmt.Sprintf("%g", typed)
 		case bool:
-			structured[k] = fmt.Sprintf("%t", typed)
+			structured[name] = fmt.Sprintf("%t", typed)
 		default:
-			structured[k] = fmt.Sprintf("%v", typed)
+			structured[name] = fmt.Sprintf("%v", typed)
 		}
 	}
 	return structured


### PR DESCRIPTION
## Summary
- fix `query`/`query_range` 3-tuple metadata payload shape for `X-Loki-Response-Encoding-Flags: categorize-labels`
- emit `structuredMetadata` and `parsed` as Loki label-pair arrays (`[{name,value}, ...]`) instead of map objects
- keep default requests on canonical 2-tuples and preserve empty-object fallback for metadata tuples
- update proxy unit tests and structured metadata e2e compat decoding to validate label-pair array shape
- document tuple payload shape in API reference

## Why
A strict tuple decoder path is still failing with:
`ReadArray: expect [ or , or ] or n, but found {` (trace: `a7a334b172a8b555674a618bc2f10a5c`).
This points to object-shaped metadata fields where Loki-compatible array shape is expected.

## Validation
- `go test ./internal/proxy -run 'TestQueryRange_DefaultRequestStaysTwoTupleForStrictDecoders|TestQueryRange_CategorizeLabelsReturnsLokiThreeTuple|TestQuery_DefaultRequestStaysTwoTupleForStrictDecoders|TestQuery_CategorizeLabelsReturnsThreeTuple|TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata|TestBuildStreamValue_CategorizeLabelsEmitsEmptyObjectWhenNoMetadata|TestClassifyEntryFields_UsesLokiCanonicalMetadataKeysOnly|TestShouldEmitStructuredMetadata' -count=1`
