### PR TITLE
Docs/chart: add compatibility profile examples and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- add explicit compatibility profile guidance for chart operators, including recommended combinations of `label-style`, `metadata-field-mode`, and `emit-structured-metadata`
+- link chart values comments directly to compatibility/configuration docs for faster profile selection during deployments
+
 ## [0.27.22] - 2026-04-10
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -97,6 +97,23 @@ extraArgs:
   # forward-headers: "Authorization"
   # forward-authorization: "true" # convenience flag; appends Authorization to forwarded header allowlist
   # forward-cookies: "vmui_session"
+  # Compatibility profile knobs:
+  # - label-style: passthrough | underscores
+  # - metadata-field-mode: native | translated | hybrid
+  # - emit-structured-metadata: true | false
+  #
+  # Common profile examples:
+  # 1) Loki/Grafana conservative:
+  #    label-style=underscores, metadata-field-mode=translated, emit-structured-metadata=false
+  # 2) Drilldown/OTel mixed mode:
+  #    label-style=underscores, metadata-field-mode=hybrid, emit-structured-metadata=true
+  # 3) Native VL field surface:
+  #    label-style=passthrough, metadata-field-mode=native, emit-structured-metadata=true
+  #
+  # Docs:
+  # - https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/configuration.md#compatibility-profiles
+  # - https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/api-reference.md
+  # - https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/compatibility-matrix.md
   # Label translation (OTel compatibility)
   # label-style: "underscores"  # convert VL dotted fields (service.name) to Loki underscores (service_name)
   # field-mapping: '[{"vl_field":"custom.field","loki_label":"custom_label"}]'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,23 @@ See [Translation Modes Guide](translation-modes.md) for mode-selection profiles 
 
 `-metadata-field-mode=hybrid` keeps the label surface Loki-compatible while making field-oriented APIs like `detected_fields` and `detected_field/{name}/values` expose both `service.name` and `service_name` when they differ.
 
+### Compatibility Profiles
+
+The three flags below define the compatibility profile:
+
+- `-label-style`
+- `-metadata-field-mode`
+- `-emit-structured-metadata`
+
+| Profile | Settings | Best For |
+|---|---|---|
+| Loki/Grafana conservative | `label-style=underscores`, `metadata-field-mode=translated`, `emit-structured-metadata=false` | Strict Loki-style field naming with 2-tuple defaults |
+| Drilldown/OTel mixed mode | `label-style=underscores`, `metadata-field-mode=hybrid`, `emit-structured-metadata=true` | Grafana + OTel correlation where both dotted and translated field names are useful |
+| Native VL field surface | `label-style=passthrough`, `metadata-field-mode=native`, `emit-structured-metadata=true` | Consumers that prefer raw VictoriaLogs field names and structured metadata |
+
+For tuple behavior and endpoint-level details, see [API Reference](api-reference.md).
+For support scope by product/version track, see [Compatibility Matrix](compatibility-matrix.md).
+
 ## Cache (L1 In-Memory)
 
 | Flag | Env | Default | Description |


### PR DESCRIPTION
## Summary
- add a compatibility-profile section in chart `values.yaml` comments
- include three concrete profile examples:
  - Loki/Grafana conservative
  - Drilldown/OTel mixed mode
  - Native VL field surface
- add direct docs links from chart comments to configuration, API reference, and compatibility matrix
- add matching `Compatibility Profiles` section to docs configuration guide

## Why
Operators needed clear, copy-paste-able profile guidance directly in chart values and docs when tuning:
- `label-style`
- `metadata-field-mode`
- `emit-structured-metadata`

## Validation
- docs/chart-only change (no runtime code path changes)
