### PR TITLE
proxy: harden structured_metadata tuple compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- normalize merged query stream metadata to Loki pair-tuples (`[[name,value], ...]`) so legacy/object-shaped metadata cannot trigger strict decoder `ReadArray` failures
+
+### Tests
+
+- extend tuple regression coverage for query-range and multitenant merge paths to lock pair-tuple metadata compatibility
+
 ## [0.27.24] - 2026-04-10
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- emit `structuredMetadata` and `parsed` tuple metadata in Loki label-pair array shape (`[{name,value}]`) when `X-Loki-Response-Encoding-Flags: categorize-labels` is enabled, preventing strict decoder `ReadArray` failures on object-shaped payloads
+- emit `structuredMetadata` and `parsed` tuple metadata as Loki pair-tuples (`[[name,value], ...]`) when `X-Loki-Response-Encoding-Flags: categorize-labels` is enabled, preventing strict decoder `ReadArray` failures on object-shaped or `{name,value}` pair payloads
+- normalize multi-tenant merged stream metadata to pair-tuples (`[[name,value], ...]`) so legacy backend shapes cannot leak incompatible tuple payloads to strict decoders
 
 ### Tests
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,7 +27,7 @@ For Grafana Logs Drilldown and Explore compatibility:
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default.
 - When `X-Loki-Response-Encoding-Flags: categorize-labels` is present and `-emit-structured-metadata=true`, query results emit Loki 3-tuples `[timestamp, line, metadata]`.
 - The 3rd tuple object follows Loki keys only: `structuredMetadata` and/or `parsed` (no snake_case alias keys).
-- `structuredMetadata` and `parsed` are Loki-style label-pair arrays (`[{name,value}, ...]`), not free-form maps.
+- `structuredMetadata` and `parsed` are Loki-style label-pair tuple arrays (`[[name,value], ...]`), not free-form maps.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.

--- a/internal/proxy/multitenant_merge_test.go
+++ b/internal/proxy/multitenant_merge_test.go
@@ -415,7 +415,7 @@ func TestMergeMultiTenantResponsesQueryInjectsTenantLabel(t *testing.T) {
 func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 	body, _, err := mergeMultiTenantResponses("query", []string{"tenant-a", "tenant-b"}, []*httptest.ResponseRecorder{
 		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["2","line-a",{"structuredMetadata":[{"name":"service.name","value":"orders"}]}]]}]}}`),
-		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"parsed":[{"name":"status","value":"200"}]}]]}]}}`),
+		recorderWithJSON(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1","line-b",{"parsed":{"status":"200"}}]]}]}}`),
 	})
 	if err != nil {
 		t.Fatalf("mergeMultiTenantResponses failed: %v", err)
@@ -442,13 +442,27 @@ func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 			t.Fatalf("expected metadata object in tuple[2], got %#v", item.Values[0][2])
 		}
 		if structured, ok := meta["structuredMetadata"]; ok {
-			if _, ok := structured.([]interface{}); !ok {
+			pairs, ok := structured.([]interface{})
+			if !ok {
 				t.Fatalf("expected structuredMetadata label-pair array, got %#v", structured)
+			}
+			for _, rawPair := range pairs {
+				pair, ok := rawPair.([]interface{})
+				if !ok || len(pair) < 2 {
+					t.Fatalf("expected structuredMetadata pair tuple, got %#v", rawPair)
+				}
 			}
 		}
 		if parsed, ok := meta["parsed"]; ok {
-			if _, ok := parsed.([]interface{}); !ok {
+			pairs, ok := parsed.([]interface{})
+			if !ok {
 				t.Fatalf("expected parsed label-pair array, got %#v", parsed)
+			}
+			for _, rawPair := range pairs {
+				pair, ok := rawPair.([]interface{})
+				if !ok || len(pair) < 2 {
+					t.Fatalf("expected parsed pair tuple, got %#v", rawPair)
+				}
 			}
 		}
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3950,7 +3950,7 @@ func buildStreamValue(ts, msg string, structuredMetadata map[string]string, pars
 	return []interface{}{ts, msg, metadata}
 }
 
-func metadataFieldPairs(fields map[string]string) []map[string]string {
+func metadataFieldPairs(fields map[string]string) [][]string {
 	if len(fields) == 0 {
 		return nil
 	}
@@ -3960,12 +3960,9 @@ func metadataFieldPairs(fields map[string]string) []map[string]string {
 	}
 	sort.Strings(keys)
 
-	pairs := make([]map[string]string, 0, len(keys))
+	pairs := make([][]string, 0, len(keys))
 	for _, key := range keys {
-		pairs = append(pairs, map[string]string{
-			"name":  key,
-			"value": fields[key],
-		})
+		pairs = append(pairs, []string{key, fields[key]})
 	}
 	return pairs
 }
@@ -4895,6 +4892,7 @@ func mergeLokiQueryResponses(tenantIDs []string, recorders []*httptest.ResponseR
 			}
 			for _, item := range items {
 				item.Stream = injectTenantLabel(item.Stream, tenantIDs[i])
+				normalizeMetadataPairTuples(item.Values)
 				streams = append(streams, item)
 			}
 		case "vector":
@@ -4950,6 +4948,65 @@ func latestStreamTimestampStrings(values [][]interface{}) string {
 		return ""
 	}
 	return fmt.Sprintf("%v", values[0][0])
+}
+
+// normalizeMetadataPairTuples rewrites tuple metadata to Loki-compatible pair tuples.
+// It normalizes legacy pair-object arrays ({name,value}) and flat maps ({k:v}) into [[name,value], ...].
+func normalizeMetadataPairTuples(values [][]interface{}) {
+	for i := range values {
+		if len(values[i]) < 3 {
+			continue
+		}
+		meta, ok := values[i][2].(map[string]interface{})
+		if !ok || len(meta) == 0 {
+			continue
+		}
+		if raw, ok := meta["structuredMetadata"]; ok {
+			meta["structuredMetadata"] = normalizeMetadataPairs(raw)
+		}
+		if raw, ok := meta["parsed"]; ok {
+			meta["parsed"] = normalizeMetadataPairs(raw)
+		}
+		values[i][2] = meta
+	}
+}
+
+func normalizeMetadataPairs(raw interface{}) []interface{} {
+	switch typed := raw.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		out := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			switch pair := item.(type) {
+			case []interface{}:
+				if len(pair) < 2 {
+					continue
+				}
+				out = append(out, []interface{}{fmt.Sprintf("%v", pair[0]), fmt.Sprintf("%v", pair[1])})
+			case map[string]interface{}:
+				name, _ := pair["name"].(string)
+				if name == "" {
+					continue
+				}
+				out = append(out, []interface{}{name, fmt.Sprintf("%v", pair["value"])})
+			}
+		}
+		return out
+	case map[string]interface{}:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		out := make([]interface{}, 0, len(keys))
+		for _, key := range keys {
+			out = append(out, []interface{}{key, fmt.Sprintf("%v", typed[key])})
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func mergeIndexStatsResponses(recorders []*httptest.ResponseRecorder) ([]byte, string, error) {

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -199,14 +199,8 @@ func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
 	}
 
 	var metadata struct {
-		StructuredMetadata []struct {
-			Name  string `json:"name"`
-			Value string `json:"value"`
-		} `json:"structuredMetadata"`
-		Parsed []struct {
-			Name  string `json:"name"`
-			Value string `json:"value"`
-		} `json:"parsed"`
+		StructuredMetadata [][]string `json:"structuredMetadata"`
+		Parsed             [][]string `json:"parsed"`
 	}
 	if err := json.Unmarshal(tuple[2], &metadata); err != nil {
 		t.Fatalf("expected tuple[2] metadata object with Loki pair arrays, got %s: %v", string(tuple[2]), err)
@@ -215,7 +209,7 @@ func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
 		t.Fatalf("expected parsed and/or structuredMetadata pairs, got %s", string(tuple[2]))
 	}
 	for _, pair := range append(metadata.StructuredMetadata, metadata.Parsed...) {
-		if pair.Name == "" {
+		if len(pair) < 2 || pair[0] == "" {
 			t.Fatalf("expected non-empty metadata pair name, got %s", string(tuple[2]))
 		}
 	}

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -61,7 +61,7 @@ func decodeFirstTuple(t *testing.T, body []byte) []interface{} {
 	return resp.Data.Result[0].Values[0]
 }
 
-// labelPairsToMap accepts decoded JSON as either []interface{} or []map[string]string.
+// labelPairsToMap decodes Loki metadata pair-tuples: [[name,value], ...].
 func labelPairsToMap(t *testing.T, raw interface{}) map[string]string {
 	t.Helper()
 	var out map[string]string
@@ -69,25 +69,31 @@ func labelPairsToMap(t *testing.T, raw interface{}) map[string]string {
 	case []interface{}:
 		out = make(map[string]string, len(items))
 		for _, item := range items {
-			pair, ok := item.(map[string]interface{})
+			pair, ok := item.([]interface{})
 			if !ok {
-				t.Fatalf("expected label pair object, got %T", item)
+				t.Fatalf("expected label pair tuple, got %T", item)
 			}
-			name, _ := pair["name"].(string)
-			value, _ := pair["value"].(string)
+			if len(pair) < 2 {
+				t.Fatalf("expected [name,value] pair, got %v", pair)
+			}
+			name, _ := pair[0].(string)
+			value, _ := pair[1].(string)
 			if name == "" {
 				t.Fatalf("expected non-empty pair name in %v", pair)
 			}
 			out[name] = value
 		}
-	case []map[string]string:
+	case [][]string:
 		out = make(map[string]string, len(items))
 		for _, pair := range items {
-			name := pair["name"]
+			if len(pair) < 2 {
+				t.Fatalf("expected [name,value] pair, got %v", pair)
+			}
+			name := pair[0]
 			if name == "" {
 				t.Fatalf("expected non-empty pair name in %v", pair)
 			}
-			out[name] = pair["value"]
+			out[name] = pair[1]
 		}
 	default:
 		t.Fatalf("expected metadata label pairs array, got %T", raw)

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -131,15 +131,12 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 
 func assertMetadataPairArray(t *testing.T, raw json.RawMessage, key string) {
 	t.Helper()
-	var pairs []struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
-	}
+	var pairs [][]string
 	if err := json.Unmarshal(raw, &pairs); err != nil {
 		t.Fatalf("expected %s to be Loki label-pair array, got %s: %v", key, string(raw), err)
 	}
 	for _, pair := range pairs {
-		if pair.Name == "" {
+		if len(pair) < 2 || pair[0] == "" {
 			t.Fatalf("expected non-empty %s pair name in %s", key, string(raw))
 		}
 	}

--- a/test/e2e-compat/structured_metadata_compat_test.go
+++ b/test/e2e-compat/structured_metadata_compat_test.go
@@ -225,15 +225,18 @@ func firstStreamStructuredMetadata(t *testing.T, response map[string]interface{}
 
 	structured := make(map[string]string, len(structuredRaw))
 	for _, item := range structuredRaw {
-		pair, ok := item.(map[string]interface{})
+		pair, ok := item.([]interface{})
 		if !ok {
-			t.Fatalf("expected structured metadata pair object, got %#v", item)
+			t.Fatalf("expected structured metadata pair tuple, got %#v", item)
 		}
-		name, _ := pair["name"].(string)
+		if len(pair) < 2 {
+			t.Fatalf("expected [name,value] structured metadata pair, got %#v", pair)
+		}
+		name, _ := pair[0].(string)
 		if name == "" {
 			t.Fatalf("expected non-empty structured metadata name in %#v", pair)
 		}
-		v := pair["value"]
+		v := pair[1]
 		switch typed := v.(type) {
 		case string:
 			structured[name] = typed


### PR DESCRIPTION
## Summary
- fix `structuredMetadata` serialization to always use Loki-compatible pair-tuples (`[[name,value], ...]`)
- normalize legacy/object-shaped metadata during multi-tenant/query-range merge to tuple pairs
- add regression tests for stream metadata, tuple contract, query-range windowing, multi-tenant merge, and e2e compatibility
- document tuple shape in API docs and changelog

## Why
Observed runtime decode errors in strict Loki-compatible readers:

```
ReadArray: expect [ or , or ] or n, but found {
```

This happened when metadata appeared as object entries (for example `{\"name\":...,\"value\":...}`) instead of tuple entries.

## Validation
- `go test ./internal/proxy`
