### PR TITLE
Harden categorized stream contract and structured metadata compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,23 @@ jobs:
       - name: Tuple contract gate (default 2-tuple + categorize-labels 3-tuple)
         run: go test ./internal/proxy -run '^TestTupleContract_' -count=1
 
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+          cache: true
+
+      - name: Fuzz smoke (structured metadata normalization)
+        run: go test ./internal/proxy -run '^$' -fuzz=FuzzNormalizeMetadataPairsFromJSON -fuzztime=5s
+
+      - name: Fuzz smoke (merged categorized stream contract)
+        run: go test ./internal/proxy -run '^$' -fuzz=FuzzMergeLokiQueryResponsesStructuredMetadataContract -fuzztime=5s
+
   tuple-smoke:
     runs-on: ubuntu-latest
     needs: [test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Bug Fixes
+
+- align categorized stream responses with upstream Loki/Grafana contract by emitting `data.encodingFlags=["categorize-labels"]` alongside 3-tuples and object-map metadata (`structuredMetadata`/`parsed`)
+- harden query-range windowed and multi-tenant merge stream responses so categorized tuple payloads remain parser-safe and normalized across legacy metadata shapes
+
+### Tests
+
+- add categorized-stream contract coverage for metadata-disabled mode to enforce parser-safe 3-tuple output with empty metadata object
+- add fuzz targets for metadata normalization and merged categorized-stream contract invariants
+
+### CI
+
+- add `fuzz-smoke` PR workflow steps to exercise structured-metadata normalization and merged categorized-stream contract fuzz targets
 ## [0.27.25] - 2026-04-10
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ## [0.27.25] - 2026-04-10
-
 ### Bug Fixes
 
 - normalize merged query stream metadata to Loki pair-tuples (`[[name,value], ...]`) so legacy/object-shaped metadata cannot trigger strict decoder `ReadArray` failures

--- a/internal/proxy/multitenant_merge_test.go
+++ b/internal/proxy/multitenant_merge_test.go
@@ -422,7 +422,8 @@ func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 	}
 	var resp struct {
 		Data struct {
-			Result []struct {
+			EncodingFlags []string `json:"encodingFlags"`
+			Result        []struct {
 				Values [][]interface{} `json:"values"`
 			} `json:"result"`
 		} `json:"data"`
@@ -433,6 +434,16 @@ func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 	if len(resp.Data.Result) != 2 {
 		t.Fatalf("expected 2 merged streams, got %#v", resp.Data.Result)
 	}
+	hasCategorizedFlag := false
+	for _, flag := range resp.Data.EncodingFlags {
+		if flag == "categorize-labels" {
+			hasCategorizedFlag = true
+			break
+		}
+	}
+	if !hasCategorizedFlag {
+		t.Fatalf("expected encodingFlags to include categorize-labels, got %#v", resp.Data.EncodingFlags)
+	}
 	for _, item := range resp.Data.Result {
 		if len(item.Values) == 0 || len(item.Values[0]) != 3 {
 			t.Fatalf("expected merged stream values to preserve 3-tuple shape, got %#v", item.Values)
@@ -442,26 +453,24 @@ func TestMergeMultiTenantResponsesQueryPreservesThreeTupleValues(t *testing.T) {
 			t.Fatalf("expected metadata object in tuple[2], got %#v", item.Values[0][2])
 		}
 		if structured, ok := meta["structuredMetadata"]; ok {
-			pairs, ok := structured.([]interface{})
+			fields, ok := structured.(map[string]interface{})
 			if !ok {
-				t.Fatalf("expected structuredMetadata label-pair array, got %#v", structured)
+				t.Fatalf("expected structuredMetadata metadata object map, got %#v", structured)
 			}
-			for _, rawPair := range pairs {
-				pair, ok := rawPair.([]interface{})
-				if !ok || len(pair) < 2 {
-					t.Fatalf("expected structuredMetadata pair tuple, got %#v", rawPair)
+			for field := range fields {
+				if field == "" {
+					t.Fatalf("expected structuredMetadata to contain non-empty keys, got %#v", structured)
 				}
 			}
 		}
 		if parsed, ok := meta["parsed"]; ok {
-			pairs, ok := parsed.([]interface{})
+			fields, ok := parsed.(map[string]interface{})
 			if !ok {
-				t.Fatalf("expected parsed label-pair array, got %#v", parsed)
+				t.Fatalf("expected parsed metadata object map, got %#v", parsed)
 			}
-			for _, rawPair := range pairs {
-				pair, ok := rawPair.([]interface{})
-				if !ok || len(pair) < 2 {
-					t.Fatalf("expected parsed pair tuple, got %#v", rawPair)
+			for field := range fields {
+				if field == "" {
+					t.Fatalf("expected parsed to contain non-empty keys, got %#v", parsed)
 				}
 			}
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3574,11 +3574,17 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 
 	result, _ := json.Marshal(map[string]interface{}{
 		"status": "success",
-		"data": map[string]interface{}{
-			"resultType": "streams",
-			"result":     streams,
-			"stats":      map[string]interface{}{},
-		},
+		"data": func() map[string]interface{} {
+			data := map[string]interface{}{
+				"resultType": "streams",
+				"result":     streams,
+				"stats":      map[string]interface{}{},
+			}
+			if categorizedLabels {
+				data["encodingFlags"] = []string{"categorize-labels"}
+			}
+			return data
+		}(),
 	})
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(result)
@@ -3592,7 +3598,12 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, origi
 	w.Header().Set("Transfer-Encoding", "chunked")
 
 	// Write opening envelope
-	w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[`))
+	openEnvelope := `{"status":"success","data":{"resultType":"streams"`
+	if categorizedLabels {
+		openEnvelope += `,"encodingFlags":["categorize-labels"]`
+	}
+	openEnvelope += `,"result":[`
+	w.Write([]byte(openEnvelope))
 	if canFlush {
 		flusher.Flush()
 	}
@@ -3933,24 +3944,23 @@ func buildStreamValues(ts, msg string, structuredMetadata map[string]string, par
 }
 
 func buildStreamValue(ts, msg string, structuredMetadata map[string]string, parsedFields map[string]string, emitStructuredMetadata bool, categorizedLabels bool) interface{} {
-	if !emitStructuredMetadata || !categorizedLabels {
+	if !categorizedLabels {
 		return []interface{}{ts, msg}
 	}
 
 	metadata := map[string]interface{}{}
-	if len(structuredMetadata) > 0 {
-		metadata["structuredMetadata"] = metadataFieldPairs(structuredMetadata)
-	}
-	if len(parsedFields) > 0 {
-		metadata["parsed"] = metadataFieldPairs(parsedFields)
-	}
-	if len(metadata) == 0 {
-		return []interface{}{ts, msg, map[string]interface{}{}}
+	if emitStructuredMetadata {
+		if len(structuredMetadata) > 0 {
+			metadata["structuredMetadata"] = metadataFieldMap(structuredMetadata)
+		}
+		if len(parsedFields) > 0 {
+			metadata["parsed"] = metadataFieldMap(parsedFields)
+		}
 	}
 	return []interface{}{ts, msg, metadata}
 }
 
-func metadataFieldPairs(fields map[string]string) [][]string {
+func metadataFieldMap(fields map[string]string) map[string]string {
 	if len(fields) == 0 {
 		return nil
 	}
@@ -3960,9 +3970,9 @@ func metadataFieldPairs(fields map[string]string) [][]string {
 	}
 	sort.Strings(keys)
 
-	pairs := make([][]string, 0, len(keys))
+	pairs := make(map[string]string, len(keys))
 	for _, key := range keys {
-		pairs = append(pairs, []string{key, fields[key]})
+		pairs[key] = fields[key]
 	}
 	return pairs
 }
@@ -4420,9 +4430,10 @@ type lokiSeriesResponse struct {
 type lokiQueryResponse struct {
 	Status string `json:"status"`
 	Data   struct {
-		ResultType string          `json:"resultType"`
-		Result     json.RawMessage `json:"result"`
-		Stats      json.RawMessage `json:"stats,omitempty"`
+		ResultType    string          `json:"resultType"`
+		Result        json.RawMessage `json:"result"`
+		Stats         json.RawMessage `json:"stats,omitempty"`
+		EncodingFlags []string        `json:"encodingFlags,omitempty"`
 	} `json:"data"`
 }
 
@@ -4873,10 +4884,18 @@ func mergeLokiQueryResponses(tenantIDs []string, recorders []*httptest.ResponseR
 		vectors    []lokiVectorResult
 		matrixes   []lokiMatrixResult
 	)
+	encodingFlagsSet := make(map[string]struct{})
 	for i, rec := range recorders {
 		var resp lokiQueryResponse
 		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 			return nil, "", err
+		}
+		for _, flag := range resp.Data.EncodingFlags {
+			flag = strings.TrimSpace(flag)
+			if flag == "" {
+				continue
+			}
+			encodingFlagsSet[flag] = struct{}{}
 		}
 		if resp.Data.ResultType != "" && resultType == "" {
 			resultType = resp.Data.ResultType
@@ -4893,6 +4912,9 @@ func mergeLokiQueryResponses(tenantIDs []string, recorders []*httptest.ResponseR
 			for _, item := range items {
 				item.Stream = injectTenantLabel(item.Stream, tenantIDs[i])
 				normalizeMetadataPairTuples(item.Values)
+				if streamValuesHaveCategorizedMetadata(item.Values) {
+					encodingFlagsSet["categorize-labels"] = struct{}{}
+				}
 				streams = append(streams, item)
 			}
 		case "vector":
@@ -4936,6 +4958,14 @@ func mergeLokiQueryResponses(tenantIDs []string, recorders []*httptest.ResponseR
 	} else {
 		data["stats"] = map[string]interface{}{}
 	}
+	if len(encodingFlagsSet) > 0 {
+		encodingFlags := make([]string, 0, len(encodingFlagsSet))
+		for flag := range encodingFlagsSet {
+			encodingFlags = append(encodingFlags, flag)
+		}
+		sort.Strings(encodingFlags)
+		data["encodingFlags"] = encodingFlags
+	}
 	body, err := json.Marshal(map[string]interface{}{"status": "success", "data": data})
 	return body, "application/json", err
 }
@@ -4950,8 +4980,8 @@ func latestStreamTimestampStrings(values [][]interface{}) string {
 	return fmt.Sprintf("%v", values[0][0])
 }
 
-// normalizeMetadataPairTuples rewrites tuple metadata to Loki-compatible pair tuples.
-// It normalizes legacy pair-object arrays ({name,value}) and flat maps ({k:v}) into [[name,value], ...].
+// normalizeMetadataPairTuples rewrites tuple metadata to Loki categorized-label object maps.
+// It normalizes legacy pair-object arrays ({name,value}) and pair tuples ([[k,v], ...]) into {"k":"v", ...}.
 func normalizeMetadataPairTuples(values [][]interface{}) {
 	for i := range values {
 		if len(values[i]) < 3 {
@@ -4962,34 +4992,65 @@ func normalizeMetadataPairTuples(values [][]interface{}) {
 			continue
 		}
 		if raw, ok := meta["structuredMetadata"]; ok {
-			meta["structuredMetadata"] = normalizeMetadataPairs(raw)
+			if normalized := normalizeMetadataPairs(raw); len(normalized) > 0 {
+				meta["structuredMetadata"] = normalized
+			} else {
+				delete(meta, "structuredMetadata")
+			}
 		}
 		if raw, ok := meta["parsed"]; ok {
-			meta["parsed"] = normalizeMetadataPairs(raw)
+			if normalized := normalizeMetadataPairs(raw); len(normalized) > 0 {
+				meta["parsed"] = normalized
+			} else {
+				delete(meta, "parsed")
+			}
 		}
 		values[i][2] = meta
 	}
 }
 
-func normalizeMetadataPairs(raw interface{}) []interface{} {
+func normalizeMetadataPairs(raw interface{}) map[string]string {
 	switch typed := raw.(type) {
 	case nil:
 		return nil
+	case map[string]string:
+		out := make(map[string]string, len(typed))
+		for key, value := range typed {
+			trimmed := strings.TrimSpace(key)
+			if trimmed == "" {
+				continue
+			}
+			out[trimmed] = value
+		}
+		return out
 	case []interface{}:
-		out := make([]interface{}, 0, len(typed))
+		out := make(map[string]string, len(typed))
 		for _, item := range typed {
 			switch pair := item.(type) {
 			case []interface{}:
 				if len(pair) < 2 {
 					continue
 				}
-				out = append(out, []interface{}{fmt.Sprintf("%v", pair[0]), fmt.Sprintf("%v", pair[1])})
+				key := fmt.Sprintf("%v", pair[0])
+				if strings.TrimSpace(key) == "" {
+					continue
+				}
+				out[key] = fmt.Sprintf("%v", pair[1])
+			case []string:
+				if len(pair) < 2 {
+					continue
+				}
+				key := strings.TrimSpace(pair[0])
+				if key == "" {
+					continue
+				}
+				out[key] = pair[1]
 			case map[string]interface{}:
-				name, _ := pair["name"].(string)
+				name := strings.TrimSpace(fmt.Sprintf("%v", pair["name"]))
 				if name == "" {
 					continue
 				}
-				out = append(out, []interface{}{name, fmt.Sprintf("%v", pair["value"])})
+				out[name] = normalizeMetadataStringValue(pair["value"])
 			}
 		}
 		return out
@@ -4999,14 +5060,37 @@ func normalizeMetadataPairs(raw interface{}) []interface{} {
 			keys = append(keys, key)
 		}
 		sort.Strings(keys)
-		out := make([]interface{}, 0, len(keys))
+		out := make(map[string]string, len(keys))
 		for _, key := range keys {
-			out = append(out, []interface{}{key, fmt.Sprintf("%v", typed[key])})
+			trimmed := strings.TrimSpace(key)
+			if trimmed == "" {
+				continue
+			}
+			out[trimmed] = normalizeMetadataStringValue(typed[key])
 		}
 		return out
 	default:
 		return nil
 	}
+}
+
+func normalizeMetadataStringValue(raw interface{}) string {
+	if raw == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", raw)
+}
+
+func streamValuesHaveCategorizedMetadata(values [][]interface{}) bool {
+	for _, tuple := range values {
+		if len(tuple) < 3 {
+			continue
+		}
+		if _, ok := tuple[2].(map[string]interface{}); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeIndexStatsResponses(recorders []*httptest.ResponseRecorder) ([]byte, string, error) {

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -116,11 +116,17 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 
 	result, _ := json.Marshal(map[string]interface{}{
 		"status": "success",
-		"data": map[string]interface{}{
-			"resultType": "streams",
-			"result":     streams,
-			"stats":      map[string]interface{}{},
-		},
+		"data": func() map[string]interface{} {
+			data := map[string]interface{}{
+				"resultType": "streams",
+				"result":     streams,
+				"stats":      map[string]interface{}{},
+			}
+			if categorizedLabels {
+				data["encodingFlags"] = []string{"categorize-labels"}
+			}
+			return data
+		}(),
 	})
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(result)

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -153,7 +153,7 @@ func TestQueryRangeWindow_ParserChainBraceHeavyLine(t *testing.T) {
 	}
 }
 
-func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
+func TestQueryRangeWindow_CategorizeLabelsUsesMetadataObjectMaps(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		startNs, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
@@ -178,7 +178,8 @@ func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
 
 	var payload struct {
 		Data struct {
-			Result []struct {
+			EncodingFlags []string `json:"encodingFlags"`
+			Result        []struct {
 				Values []json.RawMessage `json:"values"`
 			} `json:"result"`
 		} `json:"data"`
@@ -188,6 +189,16 @@ func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
 	}
 	if len(payload.Data.Result) == 0 || len(payload.Data.Result[0].Values) == 0 {
 		t.Fatalf("expected non-empty stream values: %#v", payload.Data.Result)
+	}
+	hasCategorizedFlag := false
+	for _, flag := range payload.Data.EncodingFlags {
+		if flag == "categorize-labels" {
+			hasCategorizedFlag = true
+			break
+		}
+	}
+	if !hasCategorizedFlag {
+		t.Fatalf("expected encodingFlags to include categorize-labels, body=%s", resp.Body.String())
 	}
 
 	var tuple []json.RawMessage
@@ -199,18 +210,23 @@ func TestQueryRangeWindow_CategorizeLabelsUsesLokiPairArrays(t *testing.T) {
 	}
 
 	var metadata struct {
-		StructuredMetadata [][]string `json:"structuredMetadata"`
-		Parsed             [][]string `json:"parsed"`
+		StructuredMetadata map[string]string `json:"structuredMetadata"`
+		Parsed             map[string]string `json:"parsed"`
 	}
 	if err := json.Unmarshal(tuple[2], &metadata); err != nil {
-		t.Fatalf("expected tuple[2] metadata object with Loki pair arrays, got %s: %v", string(tuple[2]), err)
+		t.Fatalf("expected tuple[2] metadata object with Loki maps, got %s: %v", string(tuple[2]), err)
 	}
 	if len(metadata.Parsed) == 0 && len(metadata.StructuredMetadata) == 0 {
-		t.Fatalf("expected parsed and/or structuredMetadata pairs, got %s", string(tuple[2]))
+		t.Fatalf("expected parsed and/or structuredMetadata maps, got %s", string(tuple[2]))
 	}
-	for _, pair := range append(metadata.StructuredMetadata, metadata.Parsed...) {
-		if len(pair) < 2 || pair[0] == "" {
-			t.Fatalf("expected non-empty metadata pair name, got %s", string(tuple[2]))
+	for field := range metadata.StructuredMetadata {
+		if field == "" {
+			t.Fatalf("expected non-empty structuredMetadata key, got %s", string(tuple[2]))
+		}
+	}
+	for field := range metadata.Parsed {
+		if field == "" {
+			t.Fatalf("expected non-empty parsed key, got %s", string(tuple[2]))
 		}
 	}
 }

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -61,44 +62,64 @@ func decodeFirstTuple(t *testing.T, body []byte) []interface{} {
 	return resp.Data.Result[0].Values[0]
 }
 
-// labelPairsToMap decodes Loki metadata pair-tuples: [[name,value], ...].
-func labelPairsToMap(t *testing.T, raw interface{}) map[string]string {
+// metadataObjectToMap decodes Loki categorized metadata object maps: {"name":"value", ...}.
+func metadataObjectToMap(t *testing.T, raw interface{}) map[string]string {
 	t.Helper()
-	var out map[string]string
-	switch items := raw.(type) {
-	case []interface{}:
-		out = make(map[string]string, len(items))
-		for _, item := range items {
-			pair, ok := item.([]interface{})
-			if !ok {
-				t.Fatalf("expected label pair tuple, got %T", item)
-			}
-			if len(pair) < 2 {
-				t.Fatalf("expected [name,value] pair, got %v", pair)
-			}
-			name, _ := pair[0].(string)
-			value, _ := pair[1].(string)
+	switch typed := raw.(type) {
+	case map[string]string:
+		out := make(map[string]string, len(typed))
+		for name, value := range typed {
 			if name == "" {
-				t.Fatalf("expected non-empty pair name in %v", pair)
+				t.Fatalf("expected non-empty metadata key in %#v", typed)
 			}
 			out[name] = value
 		}
-	case [][]string:
-		out = make(map[string]string, len(items))
-		for _, pair := range items {
-			if len(pair) < 2 {
-				t.Fatalf("expected [name,value] pair, got %v", pair)
-			}
-			name := pair[0]
+		return out
+	case map[string]interface{}:
+		items := typed
+		out := make(map[string]string, len(items))
+		for name, value := range items {
 			if name == "" {
-				t.Fatalf("expected non-empty pair name in %v", pair)
+				t.Fatalf("expected non-empty metadata key in %#v", items)
 			}
-			out[name] = pair[1]
+			switch typedValue := value.(type) {
+			case string:
+				out[name] = typedValue
+			case bool:
+				if typedValue {
+					out[name] = "true"
+				} else {
+					out[name] = "false"
+				}
+			case float64:
+				out[name] = strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typedValue), "0"), ".")
+			default:
+				out[name] = fmt.Sprintf("%v", typedValue)
+			}
 		}
+		return out
 	default:
-		t.Fatalf("expected metadata label pairs array, got %T", raw)
+		t.Fatalf("expected metadata object map, got %T", raw)
 	}
-	return out
+	return map[string]string{}
+}
+
+func responseHasEncodingFlag(t *testing.T, body []byte, want string) bool {
+	t.Helper()
+	var payload struct {
+		Data struct {
+			EncodingFlags []string `json:"encodingFlags"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode response for encodingFlags: %v", err)
+	}
+	for _, flag := range payload.Data.EncodingFlags {
+		if flag == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRequestWantsCategorizedLabels(t *testing.T) {
@@ -173,6 +194,9 @@ func TestQueryRange_CategorizeLabelsReturnsLokiThreeTuple(t *testing.T) {
 	if len(tuple) != 3 {
 		t.Fatalf("expected 3-tuple categorize-labels response, got %#v", tuple)
 	}
+	if !responseHasEncodingFlag(t, rec.Body.Bytes(), "categorize-labels") {
+		t.Fatalf("expected encodingFlags to include categorize-labels, body=%s", rec.Body.String())
+	}
 	meta, ok := tuple[2].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
@@ -181,12 +205,42 @@ func TestQueryRange_CategorizeLabelsReturnsLokiThreeTuple(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected Loki structuredMetadata payload, got %#v", meta)
 	}
-	structured := labelPairsToMap(t, structuredRaw)
+	structured := metadataObjectToMap(t, structuredRaw)
 	if got := structured["service.name"]; got != "otel-app" {
 		t.Fatalf("expected service.name pair in structured metadata, got %#v", structured)
 	}
 	if _, ok := meta["structured_metadata"]; ok {
 		t.Fatalf("non-Loki structured_metadata alias must not be emitted, got %#v", meta)
+	}
+}
+
+func TestQueryRange_CategorizeLabelsFeatureDisabledStillReturnsParserSafeTuple(t *testing.T) {
+	vlBackend := backendWithSingleNDJSONLine(t, `{"_time":"2026-01-01T00:00:00Z","_msg":"line","_stream":"{job=\"otel-proxy\",level=\"info\"}","service.name":"otel-app","level":"info"}`)
+	defer vlBackend.Close()
+
+	p := newStreamMetadataProxy(t, vlBackend.URL, false, false)
+	q := url.Values{}
+	q.Set("query", `{job="otel-proxy"}`)
+	q.Set("start", "1")
+	q.Set("end", "2")
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+	rec := httptest.NewRecorder()
+
+	p.handleQueryRange(rec, req)
+	tuple := decodeFirstTuple(t, rec.Body.Bytes())
+	if len(tuple) != 3 {
+		t.Fatalf("expected 3-tuple categorize-labels response even when metadata feature is disabled, got %#v", tuple)
+	}
+	if !responseHasEncodingFlag(t, rec.Body.Bytes(), "categorize-labels") {
+		t.Fatalf("expected encodingFlags to include categorize-labels, body=%s", rec.Body.String())
+	}
+	meta, ok := tuple[2].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
+	}
+	if len(meta) != 0 {
+		t.Fatalf("expected empty metadata object with feature disabled, got %#v", meta)
 	}
 }
 
@@ -223,6 +277,9 @@ func TestQuery_CategorizeLabelsReturnsThreeTuple(t *testing.T) {
 	if len(tuple) != 3 {
 		t.Fatalf("expected 3-tuple categorize-labels query response, got %#v", tuple)
 	}
+	if !responseHasEncodingFlag(t, rec.Body.Bytes(), "categorize-labels") {
+		t.Fatalf("expected encodingFlags to include categorize-labels, body=%s", rec.Body.String())
+	}
 }
 
 func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
@@ -244,6 +301,9 @@ func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
 	if len(tuple) != 3 {
 		t.Fatalf("expected stream-mode 3-tuple value, got %#v", tuple)
 	}
+	if !responseHasEncodingFlag(t, rec.Body.Bytes(), "categorize-labels") {
+		t.Fatalf("expected encodingFlags to include categorize-labels, body=%s", rec.Body.String())
+	}
 	meta, ok := tuple[2].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected metadata object at tuple[2], got %T", tuple[2])
@@ -252,7 +312,7 @@ func TestStreamLogQuery_StreamingModePreservesThreeTupleMetadata(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected parsed payload for parser-chain query, got %#v", meta)
 	}
-	parsed := labelPairsToMap(t, parsedRaw)
+	parsed := metadataObjectToMap(t, parsedRaw)
 	if got := parsed["http.status_code"]; got != "500" {
 		t.Fatalf("expected http.status_code in parsed payload, got %#v", parsed)
 	}
@@ -292,7 +352,7 @@ func TestClassifyEntryFields_UsesLokiCanonicalMetadataKeysOnly(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected structuredMetadata key, got %#v", meta)
 	}
-	structured := labelPairsToMap(t, structuredRaw)
+	structured := metadataObjectToMap(t, structuredRaw)
 	if got := structured["service.name"]; got != "otel-app" {
 		t.Fatalf("expected service.name in structuredMetadata payload, got %#v", structured)
 	}

--- a/internal/proxy/structured_metadata_fuzz_test.go
+++ b/internal/proxy/structured_metadata_fuzz_test.go
@@ -1,0 +1,143 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func FuzzNormalizeMetadataPairsFromJSON(f *testing.F) {
+	seeds := []string{
+		`{"service.name":"orders","env":"prod"}`,
+		`[["service.name","orders"],["env","prod"]]`,
+		`[{"name":"service.name","value":"orders"},{"name":"env","value":"prod"}]`,
+		`{"":"skip-empty","ok":"v"}`,
+		`null`,
+		`[]`,
+		`{}`,
+		`[1,true,{"name":"k","value":"v"}]`,
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, rawJSON string) {
+		var raw interface{}
+		if err := json.Unmarshal([]byte(rawJSON), &raw); err != nil {
+			return
+		}
+		normalized := normalizeMetadataPairs(raw)
+		for key := range normalized {
+			if key == "" {
+				t.Fatalf("normalizeMetadataPairs must not emit empty keys; input=%s output=%#v", rawJSON, normalized)
+			}
+		}
+	})
+}
+
+func FuzzMergeLokiQueryResponsesStructuredMetadataContract(f *testing.F) {
+	seeds := []struct {
+		structured string
+		parsed     string
+	}{
+		{`{"service.name":"orders"}`, `{"status":"200"}`},
+		{`[["service.name","orders"]]`, `[["status","200"]]`},
+		{`[{"name":"service.name","value":"orders"}]`, `null`},
+		{`null`, `{"status":"500"}`},
+		{`{"":"drop-empty","ok":"v"}`, `[]`},
+	}
+	for _, seed := range seeds {
+		f.Add(seed.structured, seed.parsed)
+	}
+
+	f.Fuzz(func(t *testing.T, structuredJSON string, parsedJSON string) {
+		var structured interface{}
+		if err := json.Unmarshal([]byte(structuredJSON), &structured); err != nil {
+			return
+		}
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(parsedJSON), &parsed); err != nil {
+			return
+		}
+
+		stream := map[string]interface{}{
+			"stream": map[string]string{"app": "api"},
+			"values": []interface{}{
+				[]interface{}{
+					"1775848431328318291",
+					"log line",
+					map[string]interface{}{
+						"structuredMetadata": structured,
+						"parsed":             parsed,
+					},
+				},
+			},
+		}
+		body, err := json.Marshal(map[string]interface{}{
+			"status": "success",
+			"data": map[string]interface{}{
+				"resultType": "streams",
+				"result":     []interface{}{stream},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal seed response: %v", err)
+		}
+
+		rec := httptest.NewRecorder()
+		rec.Header().Set("Content-Type", "application/json")
+		rec.Write(body)
+
+		mergedBody, _, err := mergeLokiQueryResponses([]string{"tenant-a"}, []*httptest.ResponseRecorder{rec})
+		if err != nil {
+			t.Fatalf("mergeLokiQueryResponses failed for structured=%s parsed=%s: %v", structuredJSON, parsedJSON, err)
+		}
+
+		var payload struct {
+			Status string `json:"status"`
+			Data   struct {
+				EncodingFlags []string `json:"encodingFlags"`
+				Result        []struct {
+					Values [][]interface{} `json:"values"`
+				} `json:"result"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(mergedBody, &payload); err != nil {
+			t.Fatalf("merged response must be valid json: %v body=%s", err, string(mergedBody))
+		}
+		if payload.Status != "success" {
+			t.Fatalf("expected success status, got %q body=%s", payload.Status, string(mergedBody))
+		}
+		hasCategorized := false
+		for _, flag := range payload.Data.EncodingFlags {
+			if flag == "categorize-labels" {
+				hasCategorized = true
+				break
+			}
+		}
+		if !hasCategorized {
+			t.Fatalf("expected categorize-labels encoding flag, got %#v body=%s", payload.Data.EncodingFlags, string(mergedBody))
+		}
+		if len(payload.Data.Result) == 0 || len(payload.Data.Result[0].Values) == 0 {
+			t.Fatalf("expected merged stream values, body=%s", string(mergedBody))
+		}
+		tuple := payload.Data.Result[0].Values[0]
+		if len(tuple) != 3 {
+			t.Fatalf("expected 3-tuple, got %#v body=%s", tuple, string(mergedBody))
+		}
+		meta, ok := tuple[2].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected metadata object at tuple[2], got %T body=%s", tuple[2], string(mergedBody))
+		}
+		if raw, ok := meta["structuredMetadata"]; ok {
+			if _, ok := raw.(map[string]interface{}); !ok {
+				t.Fatalf("expected structuredMetadata object map after normalization, got %T (%#v)", raw, raw)
+			}
+		}
+		if raw, ok := meta["parsed"]; ok {
+			if _, ok := raw.(map[string]interface{}); !ok {
+				t.Fatalf("expected parsed object map after normalization, got %T (%#v)", raw, raw)
+			}
+		}
+	})
+}

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -77,7 +77,8 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 	var payload struct {
 		Status string `json:"status"`
 		Data   struct {
-			Result []struct {
+			EncodingFlags []string `json:"encodingFlags"`
+			Result        []struct {
 				Values []json.RawMessage `json:"values"`
 			} `json:"result"`
 		} `json:"data"`
@@ -87,6 +88,16 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 	}
 	if payload.Status != "success" {
 		t.Fatalf("expected success status, got %q body=%s", payload.Status, string(body))
+	}
+	hasCategorizedFlag := false
+	for _, flag := range payload.Data.EncodingFlags {
+		if flag == "categorize-labels" {
+			hasCategorizedFlag = true
+			break
+		}
+	}
+	if !hasCategorizedFlag {
+		t.Fatalf("expected encodingFlags to include categorize-labels, body=%s", string(body))
 	}
 
 	tupleCount := 0
@@ -112,10 +123,10 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 				t.Fatalf("non-Loki structured_metadata alias must not be emitted: %s", string(tuple[2]))
 			}
 			if raw, ok := metadata["structuredMetadata"]; ok {
-				assertMetadataPairArray(t, raw, "structuredMetadata")
+				assertMetadataObjectMap(t, raw, "structuredMetadata")
 			}
 			if raw, ok := metadata["parsed"]; ok {
-				assertMetadataPairArray(t, raw, "parsed")
+				assertMetadataObjectMap(t, raw, "parsed")
 			}
 			if _, ok := metadata["structuredMetadata"]; !ok {
 				if _, ok := metadata["parsed"]; !ok {
@@ -129,15 +140,15 @@ func assertCategorizeLabelsThreeTupleContract(t *testing.T, body []byte) {
 	}
 }
 
-func assertMetadataPairArray(t *testing.T, raw json.RawMessage, key string) {
+func assertMetadataObjectMap(t *testing.T, raw json.RawMessage, key string) {
 	t.Helper()
-	var pairs [][]string
-	if err := json.Unmarshal(raw, &pairs); err != nil {
-		t.Fatalf("expected %s to be Loki label-pair array, got %s: %v", key, string(raw), err)
+	var fields map[string]interface{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("expected %s to be Loki metadata object map, got %s: %v", key, string(raw), err)
 	}
-	for _, pair := range pairs {
-		if len(pair) < 2 || pair[0] == "" {
-			t.Fatalf("expected non-empty %s pair name in %s", key, string(raw))
+	for field := range fields {
+		if field == "" {
+			t.Fatalf("expected non-empty %s key in %s", key, string(raw))
 		}
 	}
 }

--- a/test/e2e-compat/structured_metadata_compat_test.go
+++ b/test/e2e-compat/structured_metadata_compat_test.go
@@ -218,25 +218,16 @@ func firstStreamStructuredMetadata(t *testing.T, response map[string]interface{}
 	if _, ok := meta["structured_metadata"]; ok {
 		t.Fatalf("non-Loki structured_metadata alias must not be emitted: %#v", meta)
 	}
-	structuredRaw, ok := meta["structuredMetadata"].([]interface{})
+	structuredRaw, ok := meta["structuredMetadata"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected structuredMetadata key in metadata object, got %#v", meta)
 	}
 
 	structured := make(map[string]string, len(structuredRaw))
-	for _, item := range structuredRaw {
-		pair, ok := item.([]interface{})
-		if !ok {
-			t.Fatalf("expected structured metadata pair tuple, got %#v", item)
-		}
-		if len(pair) < 2 {
-			t.Fatalf("expected [name,value] structured metadata pair, got %#v", pair)
-		}
-		name, _ := pair[0].(string)
+	for name, v := range structuredRaw {
 		if name == "" {
-			t.Fatalf("expected non-empty structured metadata name in %#v", pair)
+			t.Fatalf("expected non-empty structured metadata name in %#v", structuredRaw)
 		}
-		v := pair[1]
 		switch typed := v.(type) {
 		case string:
 			structured[name] = typed


### PR DESCRIPTION
## Summary
- align categorized stream tuple contract with upstream Loki/Grafana expectations to prevent `ReadArray ... found {` parser failures
- emit `data.encodingFlags=["categorize-labels"]` whenever categorized tuple payloads are returned
- emit `structuredMetadata` and `parsed` as JSON object maps (`{"k":"v"}`), not pair arrays
- harden merge/windowed paths and metadata normalization so legacy/irregular metadata shapes are normalized safely

## What changed
- proxy response contract updates for query/query_range/streaming paths
- query-range windowing response now propagates `encodingFlags` in categorized mode
- multi-tenant merge now preserves/derives `encodingFlags` for categorized stream responses
- normalization now converts accepted legacy forms (`[[k,v]]`, `[{name,value}]`, maps) into object maps and drops empty keys
- new contract test for categorized mode when structured-metadata feature is disabled (still parser-safe 3-tuple with empty metadata object)
- new fuzz tests for normalization and merged categorized stream contract
- CI `fuzz-smoke` job added for these new fuzz targets

## Verification
- `go test ./internal/proxy -count=1`
- `go test ./... -count=1`
- `go test ./internal/proxy -run=^$ -fuzz=FuzzNormalizeMetadataPairsFromJSON -fuzztime=5s`
- `go test ./internal/proxy -run=^$ -fuzz=FuzzMergeLokiQueryResponsesStructuredMetadataContract -fuzztime=5s`

## Upstream contract references checked
- Loki encoder: `pkg/util/marshal/query.go` (`encodeStream` categorized fields)
- Grafana parser: `pkg/tsdb/cloud-monitoring/converter/converter.go` (`encodingFlags`, `readCategorizedStream`)
