### PR TITLE
Add k8s probe endpoints and harden structured metadata compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- sanitize test/doc metadata fixtures to use neutral placeholder values (remove infra-specific cluster/namespace/resource examples)
+
+### CI
+
+- remove an unused helper from stream metadata contract tests so `golangci-lint` `unused` checks pass reliably
+
 ## [0.27.26] - 2026-04-10
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
           {{- if .Values.probe.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /ready
+              path: {{ .Values.probe.liveness.path | quote }}
               port: http
             initialDelaySeconds: {{ .Values.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probe.liveness.periodSeconds }}
@@ -156,7 +156,7 @@ spec:
           {{- if .Values.probe.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /ready
+              path: {{ .Values.probe.readiness.path | quote }}
               port: http
             initialDelaySeconds: {{ .Values.probe.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probe.readiness.periodSeconds }}
@@ -167,7 +167,7 @@ spec:
           {{- if .Values.probe.startup.enabled }}
           startupProbe:
             httpGet:
-              path: /ready
+              path: {{ .Values.probe.startup.path | quote }}
               port: http
             initialDelaySeconds: {{ .Values.probe.startup.initialDelaySeconds }}
             periodSeconds: {{ .Values.probe.startup.periodSeconds }}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -282,12 +282,16 @@ resources:
     memory: 256Mi
 
 # --- Probes ---
-# All probes hit /ready.
+# Default probe endpoints:
+# - liveness:  /alive  (process is running)
+# - readiness: /ready  (backend + circuit-breaker checks)
+# - startup:   /health (basic process health)
 # Startup probe is disabled by default because the proxy starts quickly in the
 # common in-memory-cache case; enable it for slower cold starts.
 probe:
   liveness:
     enabled: true
+    path: /alive
     initialDelaySeconds: 5
     periodSeconds: 15
     timeoutSeconds: 5
@@ -295,6 +299,7 @@ probe:
     successThreshold: 1
   readiness:
     enabled: true
+    path: /ready
     initialDelaySeconds: 3
     periodSeconds: 10
     timeoutSeconds: 3
@@ -302,6 +307,7 @@ probe:
     successThreshold: 1
   startup:
     enabled: false
+    path: /health
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 3

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,7 +27,7 @@ For Grafana Logs Drilldown and Explore compatibility:
 - Query results use canonical Loki 2-tuples `[timestamp, line]` by default.
 - When `X-Loki-Response-Encoding-Flags: categorize-labels` is present and `-emit-structured-metadata=true`, query results emit Loki 3-tuples `[timestamp, line, metadata]`.
 - The 3rd tuple object follows Loki keys only: `structuredMetadata` and/or `parsed` (no snake_case alias keys).
-- `structuredMetadata` and `parsed` are Loki-style label-pair tuple arrays (`[[name,value], ...]`), not free-form maps.
+- `structuredMetadata` and `parsed` are Loki metadata objects (`{"name":"value", ...}`), matching Loki query/tail response shape.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-v
 helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-vl-proxy \
   --version <release> \
   --set extraArgs.backend=http://victorialogs:9428 \
-  --set-string extraArgs.metrics\\.otlp-endpoint=http://daemon-collector.opentelemetry-kube-stack.svc.cluster.local:4318/v1/metrics \
+  --set-string extraArgs.metrics\\.otlp-endpoint=http://otel-collector.monitoring.svc.cluster.local:4318/v1/metrics \
   --set-string extraArgs.server\\.register-instrumentation=false
 ```
 

--- a/internal/proxy/fuzz_test.go
+++ b/internal/proxy/fuzz_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -119,5 +120,31 @@ func FuzzFormatVLStep(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input string) {
 		result := formatVLStep(input)
 		_ = result
+	})
+}
+
+// FuzzNormalizeMetadataPairs guards metadata normalization from panics across arbitrary JSON payloads.
+func FuzzNormalizeMetadataPairs(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(`{"service.name":"orders","k8s.cluster.name":"main-sand"}`),
+		[]byte(`[["service.name","orders"],["k8s.cluster.name","main-sand"]]`),
+		[]byte(`[{"name":"service.name","value":"orders"},{"name":"k8s.cluster.name","value":"main-sand"}]`),
+		[]byte(`null`),
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		var raw interface{}
+		if err := json.Unmarshal(input, &raw); err != nil {
+			return
+		}
+		out := normalizeMetadataPairs(raw)
+		for key := range out {
+			if key == "" {
+				t.Fatalf("normalizeMetadataPairs produced empty key for input=%q", string(input))
+			}
+		}
 	})
 }

--- a/internal/proxy/fuzz_test.go
+++ b/internal/proxy/fuzz_test.go
@@ -126,9 +126,9 @@ func FuzzFormatVLStep(f *testing.F) {
 // FuzzNormalizeMetadataPairs guards metadata normalization from panics across arbitrary JSON payloads.
 func FuzzNormalizeMetadataPairs(f *testing.F) {
 	seeds := [][]byte{
-		[]byte(`{"service.name":"orders","k8s.cluster.name":"main-sand"}`),
-		[]byte(`[["service.name","orders"],["k8s.cluster.name","main-sand"]]`),
-		[]byte(`[{"name":"service.name","value":"orders"},{"name":"k8s.cluster.name","value":"main-sand"}]`),
+		[]byte(`{"service.name":"orders","k8s.cluster.name":"cluster-alpha"}`),
+		[]byte(`[["service.name","orders"],["k8s.cluster.name","cluster-alpha"]]`),
+		[]byte(`[{"name":"service.name","value":"orders"},{"name":"k8s.cluster.name","value":"cluster-alpha"}]`),
 		[]byte(`null`),
 	}
 	for _, seed := range seeds {

--- a/internal/proxy/gaps_test.go
+++ b/internal/proxy/gaps_test.go
@@ -355,6 +355,10 @@ func TestCoverage_AllRoutesRegistered(t *testing.T) {
 		"/loki/api/v1/patterns",
 		"/loki/api/v1/tail",
 		"/loki/api/v1/status/buildinfo",
+		"/health",
+		"/healthz",
+		"/alive",
+		"/livez",
 		"/ready",
 		"/metrics",
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1024,6 +1024,10 @@ func (p *Proxy) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/config", p.handleConfigStub)
 
 	// Health / readiness — NOT rate-limited
+	mux.HandleFunc("/alive", p.handleAlive)
+	mux.HandleFunc("/livez", p.handleAlive)
+	mux.HandleFunc("/health", p.handleHealth)
+	mux.HandleFunc("/healthz", p.handleHealth)
 	mux.HandleFunc("/ready", p.handleReady)
 	mux.HandleFunc("/loki/api/v1/status/buildinfo", p.handleBuildInfo)
 
@@ -2721,6 +2725,16 @@ func (p *Proxy) handleReady(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte("ready"))
+}
+
+// handleHealth returns process health status without backend dependency checks.
+func (p *Proxy) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("ok"))
+}
+
+// handleAlive returns process liveness status without backend dependency checks.
+func (p *Proxy) handleAlive(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("alive"))
 }
 
 func (p *Proxy) writeEmptyRules(w http.ResponseWriter) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+	"github.com/gorilla/websocket"
 )
 
 // =============================================================================
@@ -719,6 +719,36 @@ func TestContract_Ready_UnhealthyBackend(t *testing.T) {
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503 when backend unhealthy, got %d", w.Code)
+	}
+}
+
+// --- /health and /alive ---
+
+func TestContract_Health_AlwaysOK(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/health", nil)
+	p.handleHealth(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for /health, got %d", w.Code)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "ok" {
+		t.Errorf("expected /health body to be ok, got %q", got)
+	}
+}
+
+func TestContract_Alive_AlwaysOK(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/alive", nil)
+	p.handleAlive(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for /alive, got %d", w.Code)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "alive" {
+		t.Errorf("expected /alive body to be alive, got %q", got)
 	}
 }
 

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -122,15 +122,6 @@ func responseHasEncodingFlag(t *testing.T, body []byte, want string) bool {
 	return false
 }
 
-func valueToString(v interface{}) string {
-	switch typed := v.(type) {
-	case string:
-		return typed
-	default:
-		return fmt.Sprintf("%v", typed)
-	}
-}
-
 func TestRequestWantsCategorizedLabels(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	if requestWantsCategorizedLabels(req) {

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -122,6 +122,15 @@ func responseHasEncodingFlag(t *testing.T, body []byte, want string) bool {
 	return false
 }
 
+func valueToString(v interface{}) string {
+	switch typed := v.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
 func TestRequestWantsCategorizedLabels(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	if requestWantsCategorizedLabels(req) {

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -167,7 +167,7 @@ func makeTupleContractBackend(t *testing.T) *httptest.Server {
 		case "tenant-b":
 			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:01Z","_msg":"time=\"2026-04-10T10:00:01Z\" level=error msg=\"fromYaml not defined\" app.label.component=notifications-controller","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","app.label.component":"notifications-controller"}` + "\n"))
 		default:
-			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:02Z","_msg":"time=\"2026-04-10T10:00:02Z\" level=error msg=\"api chain check\" resource=sample-ns/gateway-external","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","resource":"sample-ns/gateway-external"}` + "\n"))
+			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:02Z","_msg":"time=\"2026-04-10T10:00:02Z\" level=error msg=\"api chain check\" resource=sample-ns/edge-service","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","resource":"sample-ns/edge-service"}` + "\n"))
 		}
 	}))
 }

--- a/internal/proxy/tuple_contract_test.go
+++ b/internal/proxy/tuple_contract_test.go
@@ -167,7 +167,7 @@ func makeTupleContractBackend(t *testing.T) *httptest.Server {
 		case "tenant-b":
 			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:01Z","_msg":"time=\"2026-04-10T10:00:01Z\" level=error msg=\"fromYaml not defined\" app.label.component=notifications-controller","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","app.label.component":"notifications-controller"}` + "\n"))
 		default:
-			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:02Z","_msg":"time=\"2026-04-10T10:00:02Z\" level=error msg=\"api chain check\" resource=argocd/f5-nginx-external","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","resource":"argocd/f5-nginx-external"}` + "\n"))
+			_, _ = w.Write([]byte(`{"_time":"2026-04-10T10:00:02Z","_msg":"time=\"2026-04-10T10:00:02Z\" level=error msg=\"api chain check\" resource=sample-ns/gateway-external","_stream":"{job=\"tuple-contract\",level=\"error\"}","job":"tuple-contract","level":"error","resource":"sample-ns/gateway-external"}` + "\n"))
 		}
 	}))
 }

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -8,10 +8,12 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 	// Simulate a label translator that converts underscore labels to dotted VL fields
 	labelFn := func(label string) string {
 		mapping := map[string]string{
-			"service_name":       "service.name",
-			"k8s_pod_name":       "k8s.pod.name",
-			"k8s_namespace_name": "k8s.namespace.name",
-			"host_name":          "host.name",
+			"service_name":           "service.name",
+			"k8s_pod_name":           "k8s.pod.name",
+			"k8s_namespace_name":     "k8s.namespace.name",
+			"k8s_cluster_name":       "k8s.cluster.name",
+			"deployment_environment": "deployment.environment",
+			"host_name":              "host.name",
 		}
 		if mapped, ok := mapping[label]; ok {
 			return mapped
@@ -93,6 +95,21 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 			name:  "dotted structured metadata non empty filter is quoted",
 			logql: `{app="api"} | json | service.name!=""`,
 			want:  `app:=api | unpack_json | filter "service.name":!""`,
+		},
+		{
+			name:  "native dotted field equality filter in pipeline",
+			logql: `{deployment_environment="dev",k8s_namespace_name="argocd"} | k8s.cluster.name = ` + "`main-sand`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster.name":=main-sand`,
+		},
+		{
+			name:  "underscored alias equality filter maps to same dotted field",
+			logql: `{deployment_environment="dev",k8s_namespace_name="argocd"} | k8s_cluster_name = ` + "`main-sand`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster.name":=main-sand`,
+		},
+		{
+			name:  "malformed dotted stage from drilldown degrades to non-empty filter",
+			logql: `{deployment_environment="dev",k8s_namespace_name="argocd"} | k8s . ` + "`cluster.`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster":!""`,
 		},
 	}
 

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -98,18 +98,18 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 		},
 		{
 			name:  "native dotted field equality filter in pipeline",
-			logql: `{deployment_environment="dev",k8s_namespace_name="argocd"} | k8s.cluster.name = ` + "`main-sand`",
-			want:  `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster.name":=main-sand`,
+			logql: `{deployment_environment="dev",k8s_namespace_name="sample_ns"} | k8s.cluster.name = ` + "`cluster-alpha`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=sample_ns "k8s.cluster.name":=cluster-alpha`,
 		},
 		{
 			name:  "underscored alias equality filter maps to same dotted field",
-			logql: `{deployment_environment="dev",k8s_namespace_name="argocd"} | k8s_cluster_name = ` + "`main-sand`",
-			want:  `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster.name":=main-sand`,
+			logql: `{deployment_environment="dev",k8s_namespace_name="sample_ns"} | k8s_cluster_name = ` + "`cluster-alpha`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=sample_ns "k8s.cluster.name":=cluster-alpha`,
 		},
 		{
 			name:  "malformed dotted stage from drilldown degrades to non-empty filter",
-			logql: `{deployment_environment="dev",k8s_namespace_name="argocd"} | k8s . ` + "`cluster.`",
-			want:  `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster":!""`,
+			logql: `{deployment_environment="dev",k8s_namespace_name="sample_ns"} | k8s . ` + "`cluster.`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=sample_ns "k8s.cluster":!""`,
 		},
 	}
 

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -338,6 +338,10 @@ func translateLabelFilter(stage string, labelFn LabelTranslateFunc) string {
 		return translated
 	}
 
+	if translated, ok := translateMalformedDottedStage(stage, labelFn); ok {
+		return translated
+	}
+
 	// Unknown stage — pass through as-is with pipe
 	return "| " + stage
 }
@@ -470,13 +474,13 @@ func translateSingleLabelFilter(stage string, labelFn LabelTranslateFunc) (strin
 	for _, op := range ops {
 		idx := strings.Index(stage, op.logql)
 		if idx > 0 {
-			label := strings.TrimSpace(stage[:idx])
+			label := normalizeFieldIdentifier(stage[:idx])
 			value := strings.TrimSpace(stage[idx+len(op.logql):])
 			if label == "detected_level" {
 				label = "level"
 			}
 			if labelFn != nil {
-				label = labelFn(label)
+				label = normalizeFieldIdentifier(labelFn(label))
 			}
 
 			value = strings.Trim(value, "\"`")
@@ -517,6 +521,46 @@ func quoteLogsQLFieldNameIfNeeded(label string) string {
 	}
 	return label
 }
+
+func translateMalformedDottedStage(stage string, labelFn LabelTranslateFunc) (string, bool) {
+	candidate := normalizeFieldIdentifier(stage)
+	if candidate == "" {
+		return "", false
+	}
+	if strings.ContainsAny(candidate, `=<>!~`) {
+		return "", false
+	}
+	candidate = strings.Trim(candidate, ".")
+	if !strings.Contains(candidate, ".") {
+		return "", false
+	}
+	for _, r := range candidate {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '-' {
+			continue
+		}
+		return "", false
+	}
+	if labelFn != nil {
+		candidate = normalizeFieldIdentifier(labelFn(candidate))
+	}
+	if candidate == "" {
+		return "", false
+	}
+	return fmt.Sprintf(`%s:!""`, quoteLogsQLFieldNameIfNeeded(candidate)), true
+}
+
+func normalizeFieldIdentifier(label string) string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return ""
+	}
+	label = strings.ReplaceAll(label, "`", "")
+	label = strings.ReplaceAll(label, `"`, "")
+	label = fieldDotSpacingRE.ReplaceAllString(label, ".")
+	return strings.TrimSpace(label)
+}
+
+var fieldDotSpacingRE = regexp.MustCompile(`\s*\.\s*`)
 
 // translateLabelFormat converts label_format expressions.
 // Supports multiple renames: label_format a="{{.x}}", b="{{.y}}"
@@ -1188,7 +1232,7 @@ func streamMatcherToFieldFilter(matcher string, labelFn LabelTranslateFunc) stri
 	for _, op := range ops {
 		idx := strings.Index(matcher, op.logql)
 		if idx > 0 {
-			origLabel := strings.TrimSpace(matcher[:idx])
+			origLabel := normalizeFieldIdentifier(matcher[:idx])
 			label := origLabel
 			value := strings.TrimSpace(matcher[idx+len(op.logql):])
 
@@ -1197,7 +1241,7 @@ func streamMatcherToFieldFilter(matcher string, labelFn LabelTranslateFunc) stri
 				return serviceNameMatcherFilter(op.logsql, value, op.neg, op.isRe)
 			}
 			if labelFn != nil {
-				label = labelFn(label)
+				label = normalizeFieldIdentifier(labelFn(label))
 			}
 
 			// VL requires quoting for dotted field names

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -293,6 +293,30 @@ func TestMetricQueryTranslation_DedupesByLabelsAfterTranslation(t *testing.T) {
 	}
 }
 
+func TestMetricQueryTranslation_MalformedDottedDrilldownStage(t *testing.T) {
+	labelFn := func(label string) string {
+		switch label {
+		case "deployment_environment":
+			return "deployment.environment"
+		case "k8s_namespace_name":
+			return "k8s.namespace.name"
+		case "detected_level":
+			return "level"
+		default:
+			return label
+		}
+	}
+
+	got, err := TranslateLogQLWithLabels(`sum by (level, detected_level) (count_over_time({deployment_environment="dev", k8s_namespace_name="argocd"} | k8s . `+"`cluster.`"+`[1m]))`, labelFn)
+	if err != nil {
+		t.Fatalf("TranslateLogQLWithLabels() error = %v", err)
+	}
+	want := `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster":!"" | stats by (level) count()`
+	if got != want {
+		t.Fatalf("TranslateLogQLWithLabels() = %q, want %q", got, want)
+	}
+}
+
 func TestConvertGoTemplate_DottedFieldNames(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -307,11 +307,11 @@ func TestMetricQueryTranslation_MalformedDottedDrilldownStage(t *testing.T) {
 		}
 	}
 
-	got, err := TranslateLogQLWithLabels(`sum by (level, detected_level) (count_over_time({deployment_environment="dev", k8s_namespace_name="argocd"} | k8s . `+"`cluster.`"+`[1m]))`, labelFn)
+	got, err := TranslateLogQLWithLabels(`sum by (level, detected_level) (count_over_time({deployment_environment="dev", k8s_namespace_name="sample_ns"} | k8s . `+"`cluster.`"+`[1m]))`, labelFn)
 	if err != nil {
 		t.Fatalf("TranslateLogQLWithLabels() error = %v", err)
 	}
-	want := `"deployment.environment":=dev "k8s.namespace.name":=argocd "k8s.cluster":!"" | stats by (level) count()`
+	want := `"deployment.environment":=dev "k8s.namespace.name":=sample_ns "k8s.cluster":!"" | stats by (level) count()`
 	if got != want {
 		t.Fatalf("TranslateLogQLWithLabels() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- add `/alive` and `/health` app endpoints (plus `/livez` and `/healthz` aliases)
- wire Helm probe paths to values (`probe.liveness.path`, `probe.readiness.path`, `probe.startup.path`) and set defaults for alive/ready/health
- harden Loki compatibility for 3-tuple metadata: emit canonical object maps for `structuredMetadata` and `parsed`
- normalize multi-tenant merged metadata so legacy shapes are converted to canonical objects
- harden translation for malformed dotted Drilldown stages like `k8s . `cluster.`` by normalizing into safe field-exists filters
- add regression + fuzz coverage for these cases

## Verification
- `go test ./internal/translator -count=1`
- `go test ./internal/proxy -count=1`
- `go test ./... -count=1`

## Notes
- default responses remain strict 2-tuples unless `X-Loki-Response-Encoding-Flags: categorize-labels` is present and `-emit-structured-metadata=true`
- metadata keys remain Loki canonical only (`structuredMetadata`, `parsed`)
