### PR TITLE
Harden long-range query reliability and breaker behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- harden backend circuit-breaker accounting for long-range queries by counting only transport reachability failures as breaker failures, preventing transient upstream HTTP 5xx responses from opening the local breaker
+- keep canceled/timeout upstream transport errors out of breaker failure accounting so client cancellations and timeout paths do not unnecessarily block subsequent traffic
+
+### Tests
+
+- add breaker regression coverage for upstream HTTP 502, transport connection failure, and canceled transport error paths
+- add a 7-day query-range windowing regression test to verify adaptive parallel window fetch behavior under long time-range fanout
+
 ## [0.27.28] - 2026-04-11
 
 ### Bug Fixes

--- a/internal/proxy/circuit_breaker_transport_test.go
+++ b/internal/proxy/circuit_breaker_transport_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newBreakerTestProxy(t *testing.T, backendURL string, failThreshold int) *Proxy {
+	t.Helper()
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:      backendURL,
+		Cache:           c,
+		LogLevel:        "error",
+		CBFailThreshold: failThreshold,
+		CBOpenDuration:  time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	return p
+}
+
+func TestCircuitBreaker_DoesNotTripOnUpstreamHTTP5xx(t *testing.T) {
+	var calls atomic.Int64
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, `{"status":"error","error":"all backends unavailable"}`, http.StatusBadGateway)
+	}))
+	defer backend.Close()
+
+	p := newBreakerTestProxy(t, backend.URL, 1)
+	params := url.Values{"query": []string{"*"}}
+
+	for i := 0; i < 3; i++ {
+		resp, err := p.vlPost(context.Background(), "/select/logsql/query", params)
+		if err != nil {
+			t.Fatalf("vlPost attempt %d returned unexpected error: %v", i+1, err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("vlPost attempt %d status=%d want=%d", i+1, resp.StatusCode, http.StatusBadGateway)
+		}
+		_ = resp.Body.Close()
+	}
+
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("unexpected backend call count: got=%d want=3", got)
+	}
+	if state := p.breaker.State(); state != "closed" {
+		t.Fatalf("breaker should stay closed on upstream HTTP errors, got state=%s", state)
+	}
+	if !p.breaker.Allow() {
+		t.Fatal("breaker should still allow traffic after repeated upstream HTTP 502 responses")
+	}
+}
+
+func TestCircuitBreaker_TripsOnTransportFailure(t *testing.T) {
+	p := newBreakerTestProxy(t, "http://unused", 2)
+	p.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("dial tcp: connect: connection refused")
+		}),
+	}
+
+	params := url.Values{"query": []string{"*"}}
+	for i := 0; i < 2; i++ {
+		if _, err := p.vlGet(context.Background(), "/select/logsql/query", params); err == nil {
+			t.Fatalf("expected transport error on attempt %d", i+1)
+		}
+	}
+
+	if state := p.breaker.State(); state != "open" {
+		t.Fatalf("breaker should open after consecutive transport failures, got state=%s", state)
+	}
+	if p.breaker.Allow() {
+		t.Fatal("breaker unexpectedly allowed request while open")
+	}
+}
+
+func TestCircuitBreaker_IgnoresCanceledTransportError(t *testing.T) {
+	p := newBreakerTestProxy(t, "http://unused", 1)
+	p.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, context.Canceled
+		}),
+	}
+
+	params := url.Values{"query": []string{"*"}}
+	if _, err := p.vlGet(context.Background(), "/select/logsql/query", params); err == nil {
+		t.Fatal("expected context canceled error")
+	}
+
+	if state := p.breaker.State(); state != "closed" {
+		t.Fatalf("breaker should stay closed on canceled request errors, got state=%s", state)
+	}
+	if !p.breaker.Allow() {
+		t.Fatal("breaker should continue allowing traffic after canceled errors")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3038,17 +3038,14 @@ func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*htt
 	duration := time.Since(start)
 	if err != nil {
 		recordUpstreamCall(ctx, 0, duration, true)
-		if !isCanceledErr(err) {
+		if shouldRecordBreakerFailure(err) {
 			p.breaker.RecordFailure()
 		}
 		return nil, err
 	}
 	recordUpstreamCall(ctx, resp.StatusCode, duration, false)
-	if resp.StatusCode >= 500 {
-		p.breaker.RecordFailure()
-	} else {
-		p.breaker.RecordSuccess()
-	}
+	// Any completed HTTP response proves backend reachability; keep breaker for transport failures only.
+	p.breaker.RecordSuccess()
 	return resp, nil
 }
 
@@ -3073,17 +3070,14 @@ func (p *Proxy) vlPost(ctx context.Context, path string, params url.Values) (*ht
 	duration := time.Since(start)
 	if err != nil {
 		recordUpstreamCall(ctx, 0, duration, true)
-		if !isCanceledErr(err) {
+		if shouldRecordBreakerFailure(err) {
 			p.breaker.RecordFailure()
 		}
 		return nil, err
 	}
 	recordUpstreamCall(ctx, resp.StatusCode, duration, false)
-	if resp.StatusCode >= 500 {
-		p.breaker.RecordFailure()
-	} else {
-		p.breaker.RecordSuccess()
-	}
+	// Any completed HTTP response proves backend reachability; keep breaker for transport failures only.
+	p.breaker.RecordSuccess()
 	return resp, nil
 }
 
@@ -5575,6 +5569,26 @@ func isCanceledErr(err error) bool {
 		return true
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "context canceled")
+}
+
+func shouldRecordBreakerFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isCanceledErr(err) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "context canceled") ||
+		strings.Contains(lower, "deadline exceeded") ||
+		strings.Contains(lower, "timeout") {
+		return false
+	}
+	return true
 }
 
 // lokiErrorType returns the Loki/Prometheus-style errorType for an HTTP status code.

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -270,6 +270,70 @@ func TestQueryRangeWindow_MultiTenantCompatibility(t *testing.T) {
 	}
 }
 
+func TestQueryRangeWindow_SevenDayRangeUsesParallelWindowFetch(t *testing.T) {
+	var calls atomic.Int64
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		current := inFlight.Add(1)
+		for {
+			observed := maxInFlight.Load()
+			if current <= observed || maxInFlight.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		defer inFlight.Add(-1)
+
+		_ = r.ParseForm()
+		startNs, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+		time.Sleep(10 * time.Millisecond)
+		_, _ = fmt.Fprintf(w, "{\"_time\":%q,\"_msg\":\"ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n", time.Unix(0, startNs).UTC().Format(time.RFC3339Nano))
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 10000)
+	p, err := New(Config{
+		BackendURL:                      vlBackend.URL,
+		Cache:                           c,
+		LogLevel:                        "error",
+		QueryRangeWindowingEnabled:      true,
+		QueryRangeSplitInterval:         time.Hour,
+		QueryRangeAdaptiveParallel:      true,
+		QueryRangeParallelMin:           2,
+		QueryRangeParallelMax:           8,
+		QueryRangeLatencyTarget:         500 * time.Millisecond,
+		QueryRangeLatencyBackoff:        5 * time.Second,
+		QueryRangeAdaptiveCooldown:      0,
+		QueryRangeErrorBackoffThreshold: 0.5,
+		QueryRangeFreshness:             10 * time.Minute,
+		QueryRangeRecentCacheTTL:        0,
+		QueryRangeHistoryCacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	start := time.Now().Add(-7 * 24 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	end := start + int64(7*24*time.Hour) - 1
+	req := httptest.NewRequest("GET", fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=5000", url.QueryEscape(`{app="nginx"}`), start, end), nil)
+	resp := httptest.NewRecorder()
+	p.handleQueryRange(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	const expectedWindows = int64(7 * 24)
+	if got := calls.Load(); got != expectedWindows {
+		t.Fatalf("expected %d window fetches for 7-day range, got %d", expectedWindows, got)
+	}
+	if got := maxInFlight.Load(); got < 2 {
+		t.Fatalf("expected at least 2 concurrent window fetches for adaptive parallel mode, got %d", got)
+	}
+}
+
 func TestQueryRangeWindow_ParseLokiTimeAndNormalization(t *testing.T) {
 	t.Run("rfc3339", func(t *testing.T) {
 		raw := "2026-04-10T12:00:00Z"


### PR DESCRIPTION
## Problem
Long-range Explore queries (for example 7d) can surface transient upstream 502 unavailable responses. The proxy was treating upstream HTTP 5xx responses as breaker failures, which can open the local circuit breaker and amplify traffic disruption.

## Fix
- keep circuit-breaker failure accounting focused on transport reachability failures only
- do not count canceled/timeout transport errors as breaker failures
- continue returning upstream HTTP errors to callers without tripping the breaker state

## Regression Coverage
- breaker behavior tests for upstream HTTP 502, transport connection failure, and canceled transport errors
- 7-day query_range windowing test proving adaptive parallel fanout is exercised concurrently

## Validation
- go test ./internal/proxy -count=1
- go test ./... -count=1