### PR TITLE
Harden dotted-field filter compatibility for Grafana datasource + Loki-safe label guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - harden malformed dotted Drilldown pipeline stages (for example `| cll . \`pipeline.\``) to degrade into safe dotted-prefix regex filters instead of impossible field-existence matchers
+- preserve Grafana datasource dotted-key filter intent by validating `key=value` label filtering for native dotted metadata fields (for example `k8s.cluster.name=my-cluster`) and preventing malformed dot-token fallback regressions
 
 ### CI
 
 - expose compatibility component-level endpoint scores in PR quality reports and enforce shared component regressions through the quality gate
+
+### Tests
+
+- add unit, e2e-compat, and UI regression guards for dotted metadata key filtering across Explore/Drilldown query construction and datasource compatibility paths
 
 ## [0.27.29] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - harden malformed dotted Drilldown pipeline stages (for example `| cll . \`pipeline.\``) to degrade into safe dotted-prefix regex filters instead of impossible field-existence matchers
 - preserve Grafana datasource dotted-key filter intent by validating `key=value` label filtering for native dotted metadata fields (for example `k8s.cluster.name=my-cluster`) and preventing malformed dot-token fallback regressions
+- normalize malformed spaced dotted triplets with trailing-dot artifacts (for example `cll . \`pipeline.processing.\` = \`vector-processing\``) into valid dotted field comparisons across translated query/query_range datasource operations
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ No custom Grafana datasource plugin. No sidecar translation service. One small s
 
 - **Drop-in Loki frontend**: Keep Grafana Explore, Drilldown, dashboards, and Loki API tooling.
 - **VictoriaLogs backend economics**: Query VL while preserving Loki client experience.
+- **Dual-schema compatibility**: Keep Loki-safe underscore labels while exposing OTel/VL dotted structured metadata where needed.
 - **Strict compatibility contracts**: Default 2-tuple responses, explicit 3-tuple only when `categorize-labels` is requested.
 - **Production guardrails**: Tenant isolation, bounded fanout, circuit breaking, rate limits, and safe caching.
 - **Fast repeat reads**: Tiered cache with optional disk and fleet peer reuse.
@@ -208,6 +209,17 @@ Related docs: [Getting Started](docs/getting-started.md), [Configuration](docs/c
   - query cache keys are split by tuple mode to prevent 3-tuple/2-tuple cross-contamination
 - **Grafana-first behavior**:
   - compatibility tracks continuously verify Loki API, Logs Drilldown, and VictoriaLogs integration
+
+### Label/Field Compatibility Profiles
+
+| Profile | Label surfaces (`stream`, `/labels`) | Field/metadata surfaces (`/detected_fields`, 3-tuple metadata) | Best fit |
+|---|---|---|---|
+| Loki-conservative | underscore-only | translated underscore aliases | strict Loki UX |
+| Mixed (default) | underscore-only | dotted + translated aliases | Grafana + OTel correlation |
+| Native-field | underscore-only (when `label-style=underscores`) | dotted-native only | VL/OTel-native field workflows |
+
+Operational note:
+- Grafana datasource queries can use dotted field filters (for example `k8s.cluster.name = \`my-cluster\``) while stream labels remain Loki-compatible underscores.
 
 Related docs: [Compatibility Matrix](docs/compatibility-matrix.md), [Loki Compatibility](docs/compatibility-loki.md), [Logs Drilldown Compatibility](docs/compatibility-drilldown.md), [VictoriaLogs Compatibility](docs/compatibility-victorialogs.md)
 

--- a/docs/translation-modes.md
+++ b/docs/translation-modes.md
@@ -44,6 +44,20 @@ Notes:
 - `hybrid` is the default and best when users need both Loki-style and OTel-style workflows.
 - Label surfaces remain Loki-compatible (underscore) when `label-style=underscores` regardless of metadata mode.
 
+## Grafana Datasource Behavior
+
+When Grafana Explore/Drilldown builds field filters from Event Details, it may emit dotted field expressions such as:
+
+```logql
+{service_name="otel-collector"} | k8s.cluster.name = `us-east-1`
+```
+
+Compatibility behavior:
+- Dotted filters are accepted and translated to VL-native dotted field matching.
+- Underscore aliases for known OTel fields are also accepted (`k8s_cluster_name = ...`) and resolve to the same dotted VL field.
+- Stream label outputs remain Loki-safe (underscore keys) when `-label-style=underscores`.
+- Field-oriented and metadata surfaces follow `-metadata-field-mode` (`native`, `translated`, `hybrid`).
+
 ## Mode Profiles
 
 ### Loki-First Profile

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -840,6 +840,44 @@ func TestTranslation_JSONParser(t *testing.T) {
 	}
 }
 
+func TestTranslation_DottedLabelFilterTripletForwarded(t *testing.T) {
+	var receivedQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		receivedQuery = r.FormValue("query")
+		w.Write([]byte{})
+	}))
+	defer vlBackend.Close()
+
+	doGet(t, vlBackend.URL, `/loki/api/v1/query_range?query=%7Bservice_name%3D%22k8s-cluster-events%22%7D+%7C+k8s.cluster.name+%3D+%60my-cluster%60&start=1&end=2&limit=10`)
+
+	if !strings.Contains(receivedQuery, `"k8s.cluster.name":=my-cluster`) {
+		t.Fatalf("expected translated dotted field filter in backend query, got %q", receivedQuery)
+	}
+	if !strings.HasSuffix(receivedQuery, `| sort by (_time desc)`) {
+		t.Fatalf("expected backend query to keep default sort suffix, got %q", receivedQuery)
+	}
+}
+
+func TestTranslation_UnderscoreLabelFilterTripletPreservedInPassthroughMode(t *testing.T) {
+	var receivedQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		receivedQuery = r.FormValue("query")
+		w.Write([]byte{})
+	}))
+	defer vlBackend.Close()
+
+	doGet(t, vlBackend.URL, `/loki/api/v1/query_range?query=%7Bservice_name%3D%22k8s-cluster-events%22%7D+%7C+k8s_cluster_name+%3D+%60my-cluster%60&start=1&end=2&limit=10`)
+
+	if !strings.Contains(receivedQuery, `k8s_cluster_name:=my-cluster`) {
+		t.Fatalf("expected underscore key to be preserved in passthrough mode, got %q", receivedQuery)
+	}
+	if strings.Contains(receivedQuery, "k8s . `") {
+		t.Fatalf("expected normalized field filter expression, got malformed dotted stage in %q", receivedQuery)
+	}
+}
+
 // =============================================================================
 // Cache Protection Tests
 // =============================================================================

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -878,6 +878,25 @@ func TestTranslation_UnderscoreLabelFilterTripletPreservedInPassthroughMode(t *t
 	}
 }
 
+func TestTranslation_MalformedSpacedDottedTripletNormalizedForDatasourceOps(t *testing.T) {
+	var receivedQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		receivedQuery = r.FormValue("query")
+		w.Write([]byte{})
+	}))
+	defer vlBackend.Close()
+
+	doGet(t, vlBackend.URL, `/loki/api/v1/query_range?query=%7Bservice_name%3D%22k8s-cluster-events%22%7D+%7C+cll+.+%60pipeline.processing.%60+%3D+%60vector-processing%60&start=1&end=2&limit=10`)
+
+	if !strings.Contains(receivedQuery, `"cll.pipeline.processing":=vector-processing`) {
+		t.Fatalf("expected malformed dotted triplet to normalize to valid dotted equality, got %q", receivedQuery)
+	}
+	if strings.Contains(receivedQuery, "cll . `") {
+		t.Fatalf("expected malformed spaced dotted syntax to be removed, got %q", receivedQuery)
+	}
+}
+
 // =============================================================================
 // Cache Protection Tests
 // =============================================================================

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -141,3 +141,41 @@ func TestTranslateLogQLWithLabels_NilFn(t *testing.T) {
 		t.Errorf("nil labelFn: got %q, want %q", got, `app:=nginx`)
 	}
 }
+
+func TestTranslateSingleLabelFilter_DottedTripletKeyOperatorValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		stage   string
+		labelFn LabelTranslateFunc
+		want    string
+	}{
+		{
+			name:  "native dotted key with equals operator and literal value",
+			stage: "k8s.cluster.name = `my-cluster`",
+			want:  `"k8s.cluster.name":=my-cluster`,
+		},
+		{
+			name:  "translated underscore alias still resolves to dotted key",
+			stage: "k8s_cluster_name = `my-cluster`",
+			labelFn: func(label string) string {
+				if label == "k8s_cluster_name" {
+					return "k8s.cluster.name"
+				}
+				return label
+			},
+			want: `"k8s.cluster.name":=my-cluster`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := translateSingleLabelFilter(tt.stage, tt.labelFn)
+			if !ok {
+				t.Fatalf("expected stage to be parsed as label/operator/value triplet: %q", tt.stage)
+			}
+			if got != tt.want {
+				t.Fatalf("translateSingleLabelFilter(%q) = %q, want %q", tt.stage, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -107,6 +107,11 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 			want:  `"deployment.environment":=dev "k8s.namespace.name":=sample_ns "k8s.cluster.name":=cluster-alpha`,
 		},
 		{
+			name:  "malformed spaced dotted triplet with trailing dot normalizes to valid dotted filter",
+			logql: `{deployment_environment="dev",k8s_namespace_name="sample_ns"} | cll . ` + "`pipeline.processing.`" + ` = ` + "`vector-processing`",
+			want:  `"deployment.environment":=dev "k8s.namespace.name":=sample_ns "cll.pipeline.processing":=vector-processing`,
+		},
+		{
 			name:  "malformed dotted stage from drilldown degrades to dotted-prefix regex filter",
 			logql: `{deployment_environment="dev",k8s_namespace_name="sample_ns"} | k8s . ` + "`cluster.`",
 			want:  `"deployment.environment":=dev "k8s.namespace.name":=sample_ns ~"k8s\.cluster\."`,
@@ -164,6 +169,11 @@ func TestTranslateSingleLabelFilter_DottedTripletKeyOperatorValue(t *testing.T) 
 				return label
 			},
 			want: `"k8s.cluster.name":=my-cluster`,
+		},
+		{
+			name:  "malformed spaced dotted key with trailing dot is sanitized",
+			stage: "cll . `pipeline.processing.` = `vector-processing`",
+			want:  `"cll.pipeline.processing":=vector-processing`,
 		},
 	}
 

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -474,13 +474,19 @@ func translateSingleLabelFilter(stage string, labelFn LabelTranslateFunc) (strin
 	for _, op := range ops {
 		idx := strings.Index(stage, op.logql)
 		if idx > 0 {
-			label := normalizeFieldIdentifier(stage[:idx])
+			label := sanitizeFieldIdentifier(stage[:idx])
 			value := strings.TrimSpace(stage[idx+len(op.logql):])
+			if label == "" {
+				return "", false
+			}
 			if label == "detected_level" {
 				label = "level"
 			}
 			if labelFn != nil {
-				label = normalizeFieldIdentifier(labelFn(label))
+				label = sanitizeFieldIdentifier(labelFn(label))
+				if label == "" {
+					return "", false
+				}
 			}
 
 			value = strings.Trim(value, "\"`")
@@ -543,7 +549,7 @@ func translateMalformedDottedStage(stage string, labelFn LabelTranslateFunc) (st
 		return "", false
 	}
 	if labelFn != nil {
-		candidate = normalizeFieldIdentifier(labelFn(candidate))
+		candidate = sanitizeFieldIdentifier(labelFn(candidate))
 	}
 	if candidate == "" {
 		return "", false
@@ -566,6 +572,18 @@ func normalizeFieldIdentifier(label string) string {
 	label = strings.ReplaceAll(label, "`", "")
 	label = strings.ReplaceAll(label, `"`, "")
 	label = fieldDotSpacingRE.ReplaceAllString(label, ".")
+	return strings.TrimSpace(label)
+}
+
+func sanitizeFieldIdentifier(label string) string {
+	label = normalizeFieldIdentifier(label)
+	if label == "" {
+		return ""
+	}
+	label = strings.Trim(label, ".")
+	for strings.Contains(label, "..") {
+		label = strings.ReplaceAll(label, "..", ".")
+	}
 	return strings.TrimSpace(label)
 }
 
@@ -1241,16 +1259,22 @@ func streamMatcherToFieldFilter(matcher string, labelFn LabelTranslateFunc) stri
 	for _, op := range ops {
 		idx := strings.Index(matcher, op.logql)
 		if idx > 0 {
-			origLabel := normalizeFieldIdentifier(matcher[:idx])
+			origLabel := sanitizeFieldIdentifier(matcher[:idx])
 			label := origLabel
 			value := strings.TrimSpace(matcher[idx+len(op.logql):])
+			if label == "" {
+				return ""
+			}
 
 			// Apply label name translation (e.g., service_name → service.name)
 			if origLabel == "service_name" {
 				return serviceNameMatcherFilter(op.logsql, value, op.neg, op.isRe)
 			}
 			if labelFn != nil {
-				label = normalizeFieldIdentifier(labelFn(label))
+				label = sanitizeFieldIdentifier(labelFn(label))
+				if label == "" {
+					return ""
+				}
 			}
 
 			// VL requires quoting for dotted field names
@@ -1297,12 +1321,18 @@ func canUseStreamSelector(matcher string, streamFields map[string]bool, labelFn 
 	if idx <= 0 {
 		return false
 	}
-	label := strings.TrimSpace(matcher[:idx])
+	label := sanitizeFieldIdentifier(matcher[:idx])
+	if label == "" {
+		return false
+	}
 	if label == "service_name" {
 		return false
 	}
 	if labelFn != nil {
-		label = labelFn(label)
+		label = sanitizeFieldIdentifier(labelFn(label))
+		if label == "" {
+			return false
+		}
 	}
 	return streamFields[label]
 }

--- a/test/e2e-compat/drilldown_compat_test.go
+++ b/test/e2e-compat/drilldown_compat_test.go
@@ -522,6 +522,35 @@ func TestDrilldown_GrafanaResourceContracts(t *testing.T) {
 		}
 	})
 
+	t.Run("datasource_proxy_query_range_accepts_dotted_field_filters", func(t *testing.T) {
+		params := url.Values{}
+		params.Set("query", "{service_name=\"otel-collector\"} | k8s.cluster.name = `us-east-1`")
+		params.Set("start", fmt.Sprintf("%d", now.Add(-2*time.Hour).UnixNano()))
+		params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+		params.Set("limit", "50")
+
+		resp := getJSON(t, grafanaURL+"/api/datasources/proxy/uid/"+dsUID+"/loki/api/v1/query_range?"+params.Encode())
+		if resp == nil || resp["status"] != "success" {
+			t.Fatalf("expected success for dotted field filter via Grafana datasource proxy, got %v", resp)
+		}
+
+		data := extractMap(resp, "data")
+		result := extractArray(data, "result")
+		if len(result) == 0 {
+			t.Fatalf("expected non-empty streams for dotted field filter via Grafana datasource proxy, got %v", resp)
+		}
+
+		for _, item := range result {
+			streamObj, _ := item.(map[string]interface{})
+			stream, _ := streamObj["stream"].(map[string]interface{})
+			for key := range stream {
+				if strings.Contains(key, ".") {
+					t.Fatalf("expected Loki-compatible underscore stream labels only, found dotted key %q in %v", key, stream)
+				}
+			}
+		}
+	})
+
 	t.Run("patterns_resource_returns_drilldown_payload", func(t *testing.T) {
 		params := url.Values{}
 		params.Set("query", `{app="pattern-test"}`)

--- a/test/e2e-ui/tests/url-state.spec.ts
+++ b/test/e2e-ui/tests/url-state.spec.ts
@@ -38,3 +38,17 @@ test("buildServiceDrilldownUrl preserves service filter state across reloadable 
   expect(built.searchParams.get("var-filters")).toBe("service_name|=|api-gateway");
   expect(built.searchParams.get("var-fields")).toBe("method|=|GET");
 });
+
+test("buildServiceDrilldownUrl keeps dotted field triplet for event-details filters @drilldown-core", async () => {
+  const built = new URL(
+    `http://localhost${buildServiceDrilldownUrl("proxy-uid", "api-gateway", "logs", {
+      "var-fields": "k8s.cluster.name|=|my-cluster",
+    })}`
+  );
+
+  expect(built.searchParams.get("var-fields")).toBe("k8s.cluster.name|=|my-cluster");
+  const [label, operator, value] = (built.searchParams.get("var-fields") ?? "").split("|");
+  expect(label).toBe("k8s.cluster.name");
+  expect(operator).toBe("=");
+  expect(value).toBe("my-cluster");
+});


### PR DESCRIPTION
## Summary
- implement runtime normalization for malformed dotted datasource triplets so spaced/trailing-dot forms are translated into valid dotted field filters (example: `cll . ` + "`" + `pipeline.processing.` + "`" + ` = ` + "`" + `vector-processing` + "`" + ` -> "cll.pipeline.processing":=vector-processing`)
- add regression guards for Grafana datasource dotted field filter triplets (`label`, `operator`, `value`) used from Explore Event Details (`k8s.cluster.name = my-cluster`)
- validate translation/forwarding behavior for dotted-key filters while preserving Loki-safe underscore behavior in passthrough paths
- add datasource/UI/e2e compatibility checks so dotted metadata filtering stays stable across query construction surfaces
- document dot-native structured metadata profile behavior vs Loki-style underscore behavior
- add `CHANGELOG.md` `Unreleased` entry to satisfy releasable PR gate

## Changed Files
- `internal/translator/translator.go`
- `internal/translator/labels_translate_test.go`
- `internal/proxy/proxy_test.go`
- `test/e2e-ui/tests/url-state.spec.ts`
- `test/e2e-compat/drilldown_compat_test.go`
- `README.md`
- `docs/translation-modes.md`
- `CHANGELOG.md`

## Validation
- `go test ./internal/translator -count=1`
- `go test ./internal/proxy -run TestTranslation_(DottedLabelFilterTripletForwarded|UnderscoreLabelFilterTripletPreservedInPassthroughMode|MalformedSpacedDottedTripletNormalizedForDatasourceOps) -count=1`
- `go test -tags=e2e ./test/e2e-compat -run TestDoesNotExist -count=1`
- GitHub Actions: `changelog` gate passes after adding `Unreleased` entry

## Compatibility Intent
- keep Loki/Grafana-safe underscore label expectations intact
- keep dotted-key metadata filtering available for VL/OTel native metadata workflows
- normalize malformed dotted triplets in shared translator paths used by datasource query/query_range operations
- lock this behavior with unit + proxy + UI + e2e compatibility coverage
