### PR TITLE
Learn custom dot/underscore aliases and document Grafana builder caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-<!-- Intentionally empty after v0.27.31 release metadata sync -->
+
+### Bug Fixes
+
+- add runtime learning for unique custom underscore-to-dotted field aliases from backend field inventory, with ambiguity safeguards and precedence for explicit mappings and known OTel aliases
+
+### Documentation
+
+- document Grafana Loki datasource builder caveats for dotted field keys and recommend underscore UI mode for stable click-to-filter workflows
 
 ## [0.27.31] - 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Related docs: [Getting Started](docs/getting-started.md), [Configuration](docs/c
 
 Operational note:
 - Grafana datasource queries can use dotted field filters (for example `k8s.cluster.name = \`my-cluster\``) while stream labels remain Loki-compatible underscores.
+- Grafana Loki query builder UI may tokenize dotted keys as `label=host`, `operator=.`, `value=id` for `host.id`. Query execution still works in code mode, but builder editing is safest with underscore aliases (`label-style=underscores`, `metadata-field-mode=translated`).
 
 Related docs: [Compatibility Matrix](docs/compatibility-matrix.md), [Loki Compatibility](docs/compatibility-loki.md), [Logs Drilldown Compatibility](docs/compatibility-drilldown.md), [VictoriaLogs Compatibility](docs/compatibility-victorialogs.md)
 

--- a/docs/translation-modes.md
+++ b/docs/translation-modes.md
@@ -58,6 +58,11 @@ Compatibility behavior:
 - Stream label outputs remain Loki-safe (underscore keys) when `-label-style=underscores`.
 - Field-oriented and metadata surfaces follow `-metadata-field-mode` (`native`, `translated`, `hybrid`).
 
+Caveat for Grafana Loki datasource builder:
+- The builder UI can tokenize dotted keys (for example `host.id`) into `host` `.` `id` controls even when the generated LogQL query executes correctly.
+- For stable click-to-filter workflows from Event Details, prefer underscore aliases in the UI (`-label-style=underscores`, `-metadata-field-mode=translated`) while VL remains dotted internally.
+- Code mode remains valid for dotted expressions when your workflow requires native dotted fields.
+
 ## Mode Profiles
 
 ### Loki-First Profile

--- a/internal/proxy/labels.go
+++ b/internal/proxy/labels.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // LabelStyle controls how VL field names are translated to Loki label names in responses,
@@ -59,15 +60,23 @@ type LabelTranslator struct {
 	style    LabelStyle
 	vlToLoki map[string]string // VL field name → Loki label name
 	lokiToVL map[string]string // Loki label name → VL field name
+
+	// learnedLokiToVL keeps runtime-learned underscore -> dotted mappings for
+	// custom attributes discovered from backend field inventory.
+	learnedMu        sync.RWMutex
+	learnedLokiToVL  map[string]string
+	learnedAmbiguous map[string]struct{}
 }
 
 // NewLabelTranslator creates a label translator with the given style and custom mappings.
 // Custom mappings take precedence over automatic translation.
 func NewLabelTranslator(style LabelStyle, mappings []FieldMapping) *LabelTranslator {
 	lt := &LabelTranslator{
-		style:    style,
-		vlToLoki: make(map[string]string),
-		lokiToVL: make(map[string]string),
+		style:            style,
+		vlToLoki:         make(map[string]string),
+		lokiToVL:         make(map[string]string),
+		learnedLokiToVL:  make(map[string]string),
+		learnedAmbiguous: make(map[string]struct{}),
 	}
 
 	// Register custom mappings (bidirectional)
@@ -113,10 +122,89 @@ func (lt *LabelTranslator) ToVL(lokiLabel string) string {
 		if dotted, ok := knownUnderscoreToDot[lokiLabel]; ok {
 			return dotted
 		}
+		// For custom attributes, use learned aliases only when they were resolved
+		// uniquely from backend field inventory.
+		if learned, ok := lt.resolveLearnedAlias(lokiLabel); ok {
+			return learned
+		}
 		// For unknown labels, pass through as-is — the VL field might already be underscore-based.
 		return lokiLabel
 	default:
 		return lokiLabel
+	}
+}
+
+func (lt *LabelTranslator) resolveLearnedAlias(lokiLabel string) (string, bool) {
+	if lt == nil || lt.style != LabelStyleUnderscores {
+		return "", false
+	}
+	lt.learnedMu.RLock()
+	defer lt.learnedMu.RUnlock()
+	if _, ambiguous := lt.learnedAmbiguous[lokiLabel]; ambiguous {
+		return "", false
+	}
+	mapped, ok := lt.learnedLokiToVL[lokiLabel]
+	return mapped, ok
+}
+
+// LearnFieldAliases captures runtime underscore -> dotted mappings for custom
+// fields based on backend field inventory. Mappings are installed only when an
+// alias resolves to exactly one VL field; collisions are marked ambiguous.
+func (lt *LabelTranslator) LearnFieldAliases(fields []string) {
+	if lt == nil || lt.style != LabelStyleUnderscores || len(fields) == 0 {
+		return
+	}
+
+	buckets := make(map[string]map[string]struct{}, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		alias := strings.TrimSpace(lt.ToLoki(field))
+		if alias == "" || alias == field {
+			continue
+		}
+		bucket := buckets[alias]
+		if bucket == nil {
+			bucket = make(map[string]struct{}, 1)
+			buckets[alias] = bucket
+		}
+		bucket[field] = struct{}{}
+	}
+	if len(buckets) == 0 {
+		return
+	}
+
+	lt.learnedMu.Lock()
+	defer lt.learnedMu.Unlock()
+
+	for alias, bucket := range buckets {
+		// Explicit and known mappings always win.
+		if _, ok := lt.lokiToVL[alias]; ok {
+			continue
+		}
+		if _, ok := knownUnderscoreToDot[alias]; ok {
+			continue
+		}
+		if len(bucket) != 1 {
+			lt.learnedAmbiguous[alias] = struct{}{}
+			delete(lt.learnedLokiToVL, alias)
+			continue
+		}
+		if _, ambiguous := lt.learnedAmbiguous[alias]; ambiguous {
+			continue
+		}
+		var candidate string
+		for field := range bucket {
+			candidate = field
+		}
+		if existing, ok := lt.learnedLokiToVL[alias]; ok && existing != candidate {
+			lt.learnedAmbiguous[alias] = struct{}{}
+			delete(lt.learnedLokiToVL, alias)
+			continue
+		}
+		lt.learnedLokiToVL[alias] = candidate
 	}
 }
 
@@ -238,6 +326,7 @@ func (lt *LabelTranslator) ResolveMetadataCandidates(fieldName string, available
 
 // TranslateLabelsMap translates all keys in a labels map (response direction).
 func (lt *LabelTranslator) TranslateLabelsMap(labels map[string]string) map[string]string {
+	lt.learnFieldAliasesFromMap(labels)
 	if lt.style == LabelStylePassthrough && len(lt.vlToLoki) == 0 {
 		return labels
 	}
@@ -250,6 +339,7 @@ func (lt *LabelTranslator) TranslateLabelsMap(labels map[string]string) map[stri
 
 // TranslateLabelsList translates a list of label names (response direction).
 func (lt *LabelTranslator) TranslateLabelsList(labels []string) []string {
+	lt.LearnFieldAliases(labels)
 	if lt.style == LabelStylePassthrough && len(lt.vlToLoki) == 0 {
 		return labels
 	}
@@ -263,6 +353,17 @@ func (lt *LabelTranslator) TranslateLabelsList(labels []string) []string {
 		}
 	}
 	return result
+}
+
+func (lt *LabelTranslator) learnFieldAliasesFromMap(labels map[string]string) {
+	if lt == nil || lt.style != LabelStyleUnderscores || len(labels) == 0 {
+		return
+	}
+	fields := make([]string, 0, len(labels))
+	for field := range labels {
+		fields = append(fields, field)
+	}
+	lt.LearnFieldAliases(fields)
 }
 
 // IsPassthrough returns true if no translation is needed.

--- a/internal/proxy/labels_test.go
+++ b/internal/proxy/labels_test.go
@@ -107,6 +107,44 @@ func TestLabelTranslator_ToVL_DetectedLevelAliasInPassthrough(t *testing.T) {
 	}
 }
 
+func TestLabelTranslator_ToVL_LearnedCustomAliases(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+
+	if got := lt.ToVL("cll_pipeline_processing"); got != "cll_pipeline_processing" {
+		t.Fatalf("unexpected pre-learn mapping, got %q", got)
+	}
+
+	lt.LearnFieldAliases([]string{"cll.pipeline.processing"})
+	if got := lt.ToVL("cll_pipeline_processing"); got != "cll.pipeline.processing" {
+		t.Fatalf("learned alias mapping failed, got %q", got)
+	}
+}
+
+func TestLabelTranslator_ToVL_LearnedAliasesAmbiguous(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.LearnFieldAliases([]string{"foo.bar", "foo-bar"})
+
+	if got := lt.ToVL("foo_bar"); got != "foo_bar" {
+		t.Fatalf("ambiguous alias should fall back to passthrough, got %q", got)
+	}
+}
+
+func TestLabelTranslator_ToVL_LearnedAliasesDoNotOverrideKnownOrCustom(t *testing.T) {
+	ltKnown := NewLabelTranslator(LabelStyleUnderscores, nil)
+	ltKnown.LearnFieldAliases([]string{"service-name"})
+	if got := ltKnown.ToVL("service_name"); got != "service.name" {
+		t.Fatalf("known semconv alias must win, got %q", got)
+	}
+
+	ltCustom := NewLabelTranslator(LabelStyleUnderscores, []FieldMapping{
+		{VLField: "my.custom.field", LokiLabel: "my_custom_field"},
+	})
+	ltCustom.LearnFieldAliases([]string{"other.custom.field"})
+	if got := ltCustom.ToVL("my_custom_field"); got != "my.custom.field" {
+		t.Fatalf("explicit custom mapping must win, got %q", got)
+	}
+}
+
 func TestLabelTranslator_CustomMappings(t *testing.T) {
 	mappings := []FieldMapping{
 		{VLField: "my_custom_field", LokiLabel: "custom"},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1421,7 +1421,12 @@ func (p *Proxy) fetchVLFieldNames(ctx context.Context, path string, params url.V
 	if resp.StatusCode >= 400 {
 		return nil, &vlAPIError{status: resp.StatusCode, body: string(body)}
 	}
-	return decodeVLFieldHits(body)
+	fields, err := decodeVLFieldHits(body)
+	if err != nil {
+		return nil, err
+	}
+	p.labelTranslator.LearnFieldAliases(fields)
+	return fields, nil
 }
 
 func (p *Proxy) fetchVLFieldValues(ctx context.Context, path string, params url.Values) ([]string, error) {


### PR DESCRIPTION
## Summary
- add runtime learning for underscore->dot custom field aliases from backend field inventory
- only apply learned aliases when mapping is unique; keep ambiguous aliases unresolved
- preserve precedence of explicit field mappings and known OTel aliases
- document Grafana Loki datasource builder caveat for dotted keys and recommend underscore UI mode

## Validation
- go test ./internal/proxy
