### PR TITLE
Release 0.27.34: wire indexed cache runtime flags + disk/peer warm persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- cap preallocated slice capacities on label-values browse paths to satisfy CodeQL excessive allocation guards for request-driven limits
+
 ## [0.27.34] - 2026-04-11
 
 ### Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.34] - 2026-04-11
+
+### Configuration
+
+- wire runtime support for indexed label-values cache flags end-to-end (`label-values-indexed-cache`, `label-values-hot-limit`, `label-values-index-max-entries`) to remove chart/runtime drift
+- add persistent indexed label-values snapshot controls (`label-values-index-persist-path`, `label-values-index-persist-interval`, `label-values-index-startup-stale-threshold`, `label-values-index-startup-peer-warm-timeout`)
+
+### Reliability
+
+- restore indexed label-values cache state from disk on startup and persist periodic + graceful-shutdown snapshots for rolling updates
+- add startup peer warm fallback when local snapshot is stale/missing so new pods can reuse fresh fleet cache state before serving
+- gate readiness on indexed cache startup warm completion to keep probe behavior consistent during rollouts
+- enable gzip compression for peer cache transport payloads on `_cache/get` to reduce transfer size/latency on large cache objects
+
+### Tests
+
+- add regression coverage for runtime flag wiring, indexed snapshot persistence/restore, stale-disk peer warm fallback, and peer gzip transport behavior
+- pin e2e compose + manifest guards for indexed cache persistence flags so CI fails on drift
+
+### Documentation
+
+- document indexed cache persistence/warm behavior, sizing estimates, and chart/helm examples
+
 ## [0.27.33] - 2026-04-11
 
 ### Configuration

--- a/charts/loki-vl-proxy/Chart.yaml
+++ b/charts/loki-vl-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-vl-proxy
 description: HTTP proxy translating Loki API to VictoriaLogs
 type: application
-version: 0.27.33
-appVersion: "0.27.33"
+version: 0.27.34
+appVersion: "0.27.34"
 home: https://github.com/ReliablyObserve/Loki-VL-proxy
 sources:
   - https://github.com/ReliablyObserve/Loki-VL-proxy

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -130,6 +130,15 @@ extraArgs:
   # stream-response: "true"  # chunked transfer encoding for large results
   # Stream selector optimization — list VL _stream_fields labels for fast index path
   # stream-fields: "app,env,namespace"
+  # Indexed label-values browse cache (high-cardinality UX hardening)
+  # label-values-indexed-cache: "true"
+  # label-values-hot-limit: "200"
+  # label-values-index-max-entries: "200000"
+  # label-values-index-persist-path: "/cache/label-values-index.json"
+  # label-values-index-persist-interval: "30s"
+  # label-values-index-startup-stale-threshold: "60s"
+  # label-values-index-startup-peer-warm-timeout: "5s"
+  # Sizing hint: plan roughly ~96 bytes RAM/value and ~60% of RAM footprint on disk snapshot.
 
 # Go runtime tuning:
 # The chart exports GOMEMLIMIT into the container env.

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -94,6 +94,13 @@ type proxyRuntimeConfig struct {
 	fieldMappingJSON                string
 	streamFieldsCSV                 string
 	extraLabelFieldsCSV             string
+	labelValuesIndexedCache         bool
+	labelValuesHotLimit             int
+	labelValuesIndexMaxEntries      int
+	labelValuesIndexPersistPath     string
+	labelValuesIndexPersistInterval time.Duration
+	labelValuesIndexStartupStale    time.Duration
+	labelValuesIndexPeerWarmTimeout time.Duration
 	peerSelf                        string
 	peerDiscovery                   string
 	peerDNS                         string
@@ -343,6 +350,13 @@ func run(
 	fieldMappingJSON := fs.String("field-mapping", "", `JSON custom field mappings: [{"vl_field":"service.name","loki_label":"service_name"}]`)
 	streamFieldsCSV := fs.String("stream-fields", "", `Comma-separated VL _stream_fields labels for stream selector optimization (e.g., "app,env,namespace")`)
 	extraLabelFieldsCSV := fs.String("extra-label-fields", "", `Comma-separated additional VL field names exposed on /labels and eligible for alias resolution (for example "host.id,custom.pipeline.processing")`)
+	labelValuesIndexedCache := fs.Bool("label-values-indexed-cache", false, "Enable indexed browse cache for /loki/api/v1/label/{name}/values (hot subset first for empty-query requests)")
+	labelValuesHotLimit := fs.Int("label-values-hot-limit", 200, "Default number of label values returned for empty-query browse requests when indexed cache is enabled")
+	labelValuesIndexMaxEntries := fs.Int("label-values-index-max-entries", 200000, "Maximum indexed values retained per tenant+label when indexed label-values cache is enabled")
+	labelValuesIndexPersistPath := fs.String("label-values-index-persist-path", "", "Path to persisted label-values index snapshot JSON file. Empty disables persistence.")
+	labelValuesIndexPersistInterval := fs.Duration("label-values-index-persist-interval", 30*time.Second, "How often to persist the in-memory label-values index snapshot to disk")
+	labelValuesIndexStartupStale := fs.Duration("label-values-index-startup-stale-threshold", 60*time.Second, "Treat on-disk label-values index snapshot older than this as stale and warm from peers before serving")
+	labelValuesIndexPeerWarmTimeout := fs.Duration("label-values-index-startup-peer-warm-timeout", 5*time.Second, "Maximum time to wait for startup label-values index warm from peers when disk snapshot is stale or missing")
 	allowGlobalTenant := fs.Bool("tenant.allow-global", false, `Allow X-Scope-OrgID "*" to bypass AccountID/ProjectID scoping and use the backend default tenant`)
 
 	// Peer cache (fleet distribution)
@@ -450,6 +464,13 @@ func run(
 			fieldMappingJSON:                envCfg.fieldMappingJSON,
 			streamFieldsCSV:                 *streamFieldsCSV,
 			extraLabelFieldsCSV:             envCfg.extraLabelFields,
+			labelValuesIndexedCache:         *labelValuesIndexedCache,
+			labelValuesHotLimit:             *labelValuesHotLimit,
+			labelValuesIndexMaxEntries:      *labelValuesIndexMaxEntries,
+			labelValuesIndexPersistPath:     *labelValuesIndexPersistPath,
+			labelValuesIndexPersistInterval: *labelValuesIndexPersistInterval,
+			labelValuesIndexStartupStale:    *labelValuesIndexStartupStale,
+			labelValuesIndexPeerWarmTimeout: *labelValuesIndexPeerWarmTimeout,
 			peerSelf:                        *peerSelf,
 			peerDiscovery:                   *peerDiscovery,
 			peerDNS:                         *peerDNS,
@@ -495,6 +516,9 @@ func run(
 		tlsKeyFile:  *tlsKeyFile,
 	}, logger, fatal)
 	handleShutdownFn(runtime.shutdownCh, runtime.server, 30*time.Second, logger)
+	if err := runtime.proxy.Shutdown(context.Background()); err != nil {
+		logger.Error("proxy shutdown hook failed", "error", err)
+	}
 	return nil
 }
 
@@ -969,6 +993,13 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		FieldMappings:                   fieldMappings,
 		StreamFields:                    parseCSV(cfg.streamFieldsCSV),
 		ExtraLabelFields:                parseCSV(cfg.extraLabelFieldsCSV),
+		LabelValuesIndexedCache:         cfg.labelValuesIndexedCache,
+		LabelValuesHotLimit:             cfg.labelValuesHotLimit,
+		LabelValuesIndexMaxEntries:      cfg.labelValuesIndexMaxEntries,
+		LabelValuesIndexPersistPath:     cfg.labelValuesIndexPersistPath,
+		LabelValuesIndexPersistInterval: cfg.labelValuesIndexPersistInterval,
+		LabelValuesIndexStartupStale:    cfg.labelValuesIndexStartupStale,
+		LabelValuesIndexPeerWarmTimeout: cfg.labelValuesIndexPeerWarmTimeout,
 		PeerCache:                       peerCache,
 		PeerAuthToken:                   cfg.peerAuthToken,
 	}, nil
@@ -1068,6 +1099,21 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 	}
 	if proxyCfg.LabelStyle == proxy.LabelStyleUnderscores {
 		logger.Info("label translation enabled", "label_style", "underscores", "metadata_field_mode", string(proxyCfg.MetadataFieldMode))
+	}
+	if proxyCfg.LabelValuesIndexedCache {
+		estimatedRAMPerLabelBytes := int64(proxyCfg.LabelValuesIndexMaxEntries) * 96
+		estimatedDiskPerLabelBytes := int64(float64(estimatedRAMPerLabelBytes) * 0.6)
+		logger.Info(
+			"label values indexed cache enabled",
+			"hot_limit", proxyCfg.LabelValuesHotLimit,
+			"max_entries_per_label", proxyCfg.LabelValuesIndexMaxEntries,
+			"persist_path", proxyCfg.LabelValuesIndexPersistPath,
+			"persist_interval", proxyCfg.LabelValuesIndexPersistInterval,
+			"startup_stale_threshold", proxyCfg.LabelValuesIndexStartupStale,
+			"startup_peer_warm_timeout", proxyCfg.LabelValuesIndexPeerWarmTimeout,
+			"estimated_ram_per_label_bytes", estimatedRAMPerLabelBytes,
+			"estimated_disk_per_label_bytes", estimatedDiskPerLabelBytes,
+		)
 	}
 	if proxyCfg.DerivedFields != nil {
 		logger.Info("loaded derived fields", "count", len(proxyCfg.DerivedFields))

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -830,6 +830,13 @@ func TestBuildProxyConfig(t *testing.T) {
 		fieldMappingJSON:                `[{"vl_field":"service.name","loki_label":"service_name"}]`,
 		streamFieldsCSV:                 "app,namespace",
 		extraLabelFieldsCSV:             "host.id,custom.pipeline.processing",
+		labelValuesIndexedCache:         true,
+		labelValuesHotLimit:             250,
+		labelValuesIndexMaxEntries:      12345,
+		labelValuesIndexPersistPath:     "/cache/label-index.json",
+		labelValuesIndexPersistInterval: 45 * time.Second,
+		labelValuesIndexStartupStale:    2 * time.Minute,
+		labelValuesIndexPeerWarmTimeout: 7 * time.Second,
 		peerSelf:                        "10.0.0.1:3100",
 		peerDiscovery:                   "static",
 		peerStatic:                      "10.0.0.2:3100,10.0.0.3:3100",
@@ -900,6 +907,26 @@ func TestBuildProxyConfig(t *testing.T) {
 	}
 	if len(got.ExtraLabelFields) != 2 || got.ExtraLabelFields[0] != "host.id" || got.ExtraLabelFields[1] != "custom.pipeline.processing" {
 		t.Fatalf("unexpected extra label fields: %+v", got.ExtraLabelFields)
+	}
+	if !got.LabelValuesIndexedCache || got.LabelValuesHotLimit != 250 || got.LabelValuesIndexMaxEntries != 12345 {
+		t.Fatalf(
+			"unexpected indexed label-values config: enabled=%v hot_limit=%d max_entries=%d",
+			got.LabelValuesIndexedCache,
+			got.LabelValuesHotLimit,
+			got.LabelValuesIndexMaxEntries,
+		)
+	}
+	if got.LabelValuesIndexPersistPath != "/cache/label-index.json" ||
+		got.LabelValuesIndexPersistInterval != 45*time.Second ||
+		got.LabelValuesIndexStartupStale != 2*time.Minute ||
+		got.LabelValuesIndexPeerWarmTimeout != 7*time.Second {
+		t.Fatalf(
+			"unexpected label-values index persistence config: path=%q interval=%s stale=%s peer_timeout=%s",
+			got.LabelValuesIndexPersistPath,
+			got.LabelValuesIndexPersistInterval,
+			got.LabelValuesIndexStartupStale,
+			got.LabelValuesIndexPeerWarmTimeout,
+		)
 	}
 	if got.TailMode != proxy.TailModeSynthetic {
 		t.Fatalf("unexpected tail mode: %v", got.TailMode)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -30,6 +30,11 @@ For Grafana Logs Drilldown and Explore compatibility:
 - `structuredMetadata` and `parsed` are Loki metadata objects (`{"name":"value", ...}`), matching Loki query/tail response shape.
 - Stream labels stay Loki-compatible on the `stream` object.
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
+- `-extra-label-fields` extends label-facing APIs (`/labels`, `/label/{name}/values`) with explicit VL fields and improves custom dot/underscore alias resolution.
+- Optional indexed browse mode for label values (`-label-values-indexed-cache=true`) supports hotset-first responses and optional `offset`/`search` (`search` or `q`) on `GET /loki/api/v1/label/{name}/values`.
+- Indexed label-values cache snapshots can be persisted to disk (`-label-values-index-persist-path`) and restored at startup.
+- On stale/missing disk snapshot, startup can warm from peer cache before serving (`-label-values-index-startup-stale-threshold`, `-label-values-index-startup-peer-warm-timeout`).
+- Peer cache payload fetches (`/_cache/get`) support gzip response compression for lower network latency/cost on large cache objects.
 - Parsed fields and structured metadata are surfaced through `detected_fields` and `detected_field/{name}/values`.
 - With `-metadata-field-mode=hybrid` (the default), field-oriented APIs expose both native VictoriaLogs dotted names and translated Loki aliases when they differ, for example `service.name` and `service_name`.
 - Synthetic compatibility labels such as `service_name` and `detected_level` stay available on the stream and label APIs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,8 @@ See [Translation Modes Guide](translation-modes.md) for mode-selection profiles 
 | `-metadata-field-mode` | `METADATA_FIELD_MODE` | `hybrid` | `native`, `translated`, or `hybrid` for `detected_fields` and structured metadata exposure |
 | `-emit-structured-metadata` | — | `true` | Enable Loki `categorize-labels` response encoding: requests with `X-Loki-Response-Encoding-Flags: categorize-labels` emit 3-tuples `[timestamp, line, metadata]`, while default/no-flag requests stay canonical 2-tuples |
 | `-field-mapping` | `FIELD_MAPPING` | — | JSON custom field mappings |
-| `-extra-label-fields` | `EXTRA_LABEL_FIELDS` | — | Comma-separated additional VL fields exposed on `/labels` and used for underscore↔dot alias resolution (for example `host.id,k8s.cluster.name`) |
+| `-stream-fields` | — | — | Comma-separated `_stream_fields` labels used for stream selector optimization and label-surface hints |
+| `-extra-label-fields` | `EXTRA_LABEL_FIELDS` | — | Comma-separated additional VL fields to expose on label-facing APIs and alias resolution paths (for example `host.id,k8s.cluster.name`) |
 
 ### Label Style Modes
 
@@ -41,6 +42,95 @@ See [Translation Modes Guide](translation-modes.md) for mode-selection profiles 
 ```bash
 ./loki-vl-proxy -label-style=underscores \
   -field-mapping='[{"vl_field":"my_trace_id","loki_label":"traceID"}]'
+```
+
+### Extra Label Fields (`-extra-label-fields`)
+
+Use this when you need explicit label exposure and alias resolution for fields that are not always discoverable from `stream_field_names`.
+
+What it affects:
+
+- `GET /loki/api/v1/labels`: appends configured fields to the label set.
+- `GET /loki/api/v1/label/{name}/values`: resolves underscore↔dot aliases for custom fields.
+- `GET /loki/api/v1/index/volume` and `GET /loki/api/v1/index/volume_range`: resolves `targetLabels` aliases (for example `host_id` -> `host.id`) before backend grouping.
+
+How values are handled:
+
+- Accepts a comma-separated list.
+- Entries are normalized to canonical VL field names by translator rules.
+- Duplicates are removed.
+- It extends exposure and aliasing only; it does not create or index fields in VictoriaLogs.
+
+Caching and limits:
+
+- It reuses existing label-path caches (`/labels` and `/label/{name}/values`), so repeated lookups do not repeatedly rescan backend metadata.
+- There is no dedicated hard cap on how many entries you can set in `-extra-label-fields`; behavior is intentionally open to match VictoriaLogs field discovery.
+- Existing proxy safeguards still apply (endpoint TTLs, backend timeouts, and standard response-size protections).
+- Practical guidance: keep this list focused on fields you want Loki users to filter on frequently; very large lists can add UI noise in Grafana.
+
+Examples:
+
+```bash
+# Conservative Loki-facing UX + explicit custom fields
+./loki-vl-proxy \
+  -label-style=underscores \
+  -metadata-field-mode=translated \
+  -emit-structured-metadata=true \
+  -extra-label-fields='host.id,k8s.cluster.name,custom.pipeline.processing'
+```
+
+```bash
+# Equivalent via env
+export EXTRA_LABEL_FIELDS='host.id,k8s.cluster.name,custom.pipeline.processing'
+./loki-vl-proxy -label-style=underscores -metadata-field-mode=translated
+```
+
+When to also use `-field-mapping`:
+
+- Use `-extra-label-fields` to extend discovery and alias resolution.
+- Use `-field-mapping` when you need a non-default alias name (for example `custom.pipeline.processing` <-> `pipeline_proc`).
+
+### Indexed Label Values Browse Cache (Optional)
+
+This mode is designed for very high-cardinality labels (for example `k8s_pod_name`) where returning every value on first browse is expensive.
+
+| Flag | Env | Default | Description |
+|---|---|---|---|
+| `-label-values-indexed-cache` | — | `false` | Enable indexed hotset browsing for `GET /loki/api/v1/label/{name}/values` |
+| `-label-values-hot-limit` | — | `200` | Default values returned for empty-query browse when `limit` is not specified |
+| `-label-values-index-max-entries` | — | `200000` | Maximum indexed values retained per tenant+label in memory |
+| `-label-values-index-persist-path` | — | — | Disk path for persisted label-values index snapshot (JSON) |
+| `-label-values-index-persist-interval` | — | `30s` | Periodic snapshot flush interval |
+| `-label-values-index-startup-stale-threshold` | — | `60s` | Disk snapshot freshness threshold before peer warm fallback |
+| `-label-values-index-startup-peer-warm-timeout` | — | `5s` | Startup timeout for peer warm fallback |
+
+Behavior when enabled:
+
+- Empty-query browse (`query` omitted or `query=*`) serves a hot subset first.
+- Supports optional pagination-style parameters on the same endpoint: `limit` and `offset`.
+- Supports optional in-proxy value filtering with `search` (alias `q`), without forcing a full backend refetch when index is warm.
+- Query-scoped requests (`query={...}`) keep standard behavior and still update index state.
+- Startup warm order: restore disk snapshot first, then warm from peer cache when disk snapshot is stale/missing.
+- Rolling update safety: graceful shutdown writes a final snapshot before exit.
+- Readiness behavior: `/ready` stays `503` until label-values startup warm is finished.
+
+Example:
+
+```bash
+./loki-vl-proxy \
+  -label-values-indexed-cache=true \
+  -label-values-hot-limit=200 \
+  -label-values-index-max-entries=200000 \
+  -label-values-index-persist-path=/cache/label-values-index.json \
+  -label-values-index-persist-interval=30s \
+  -label-values-index-startup-stale-threshold=60s \
+  -label-values-index-startup-peer-warm-timeout=5s
+
+Sizing guidance:
+
+- RAM estimate per label key: `label-values-index-max-entries * ~96 bytes`.
+- Disk snapshot estimate per label key: roughly `~60%` of RAM estimate.
+- Total footprint scales with `(tenant_count * indexed_label_count)`.
 ```
 
 ### Metadata Field Modes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,7 +81,11 @@ helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-v
   --set extraArgs.backend=http://victorialogs:9428 \
   --set extraArgs.label-values-indexed-cache=true \
   --set extraArgs.label-values-hot-limit=200 \
-  --set extraArgs.label-values-index-max-entries=200000
+  --set extraArgs.label-values-index-max-entries=200000 \
+  --set extraArgs.label-values-index-persist-path=/cache/label-values-index.json \
+  --set extraArgs.label-values-index-persist-interval=30s \
+  --set extraArgs.label-values-index-startup-stale-threshold=60s \
+  --set extraArgs.label-values-index-startup-peer-warm-timeout=5s
 ```
 
 ### Image Selection

--- a/docs/translation-modes.md
+++ b/docs/translation-modes.md
@@ -10,6 +10,7 @@ This guide explains how field and label translation behaves across proxy surface
 | `-metadata-field-mode` | Controls field exposure for field-oriented APIs and structured metadata payloads | `native`, `translated`, `hybrid` |
 | `-emit-structured-metadata` | Enables 3-tuple metadata responses for explicit `categorize-labels` requests (default: `true`) | `false`, `true` |
 | `-field-mapping` | Custom mapping between VL field name and Loki label name | JSON mappings |
+| `-extra-label-fields` | Explicitly extends label-facing APIs and dot/underscore alias resolution for custom fields | comma-separated VL field names |
 
 ## Surfaces Affected
 
@@ -57,6 +58,7 @@ Compatibility behavior:
 - Underscore aliases for known OTel fields are also accepted (`k8s_cluster_name = ...`) and resolve to the same dotted VL field.
 - Stream label outputs remain Loki-safe (underscore keys) when `-label-style=underscores`.
 - Field-oriented and metadata surfaces follow `-metadata-field-mode` (`native`, `translated`, `hybrid`).
+- `-extra-label-fields` can be used to make custom dotted VL fields reliably visible/resolvable through `/labels`, `/label/<name>/values`, and `targetLabels` in volume APIs.
 
 Caveat for Grafana Loki datasource builder:
 - The builder UI can tokenize dotted keys (for example `host.id`) into `host` `.` `id` controls even when the generated LogQL query executes correctly.
@@ -142,6 +144,7 @@ Use mapping when your VL schema does not follow common OTel naming or you need s
    - `native` for OTel-native field UX
 3. Enable `-emit-structured-metadata=true` when clients need metadata in 3-tuple responses via `categorize-labels`.
 4. Add `-field-mapping` only for non-standard schema cases.
+5. Add `-extra-label-fields` for custom fields you want consistently visible on label-facing APIs and Grafana builder workflows.
 
 ## Related
 

--- a/internal/cache/peer.go
+++ b/internal/cache/peer.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -279,6 +280,21 @@ func (pc *PeerCache) ServeHTTP(w http.ResponseWriter, r *http.Request, localCach
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("X-Cache-TTL-Ms", fmt.Sprintf("%d", remaining.Milliseconds()))
+	if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") && len(value) >= 256 {
+		w.Header().Set("Content-Encoding", "gzip")
+		zw, err := gzip.NewWriterLevel(w, gzip.BestSpeed)
+		if err != nil {
+			http.Error(w, "compression init error", http.StatusInternalServerError)
+			return
+		}
+		if _, err := zw.Write(value); err != nil {
+			_ = zw.Close()
+			http.Error(w, "compression write error", http.StatusInternalServerError)
+			return
+		}
+		_ = zw.Close()
+		return
+	}
 	w.Write(value)
 }
 

--- a/internal/cache/peer_test.go
+++ b/internal/cache/peer_test.go
@@ -1,8 +1,10 @@
 package cache
 
 import (
+	"compress/gzip"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -122,6 +124,40 @@ func TestPeerCache_ServeHTTP_Hit(t *testing.T) {
 	pc.ServeHTTP(w, r, localCache)
 	if w.Code != 200 || w.Body.String() != "hello" {
 		t.Errorf("expected 200/hello, got %d/%q", w.Code, w.Body.String())
+	}
+}
+
+func TestPeerCache_ServeHTTP_HitCompressed(t *testing.T) {
+	localCache := New(60*time.Second, 1000)
+	defer localCache.Close()
+	payload := []byte(strings.Repeat("x", 1024))
+	localCache.Set("test-key", payload)
+
+	pc := NewPeerCache(PeerConfig{SelfAddr: "localhost"})
+	defer pc.Close()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/_cache/get?key=test-key", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	pc.ServeHTTP(w, r, localCache)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("expected gzip content encoding, got %q", w.Header().Get("Content-Encoding"))
+	}
+	zr, err := gzip.NewReader(strings.NewReader(w.Body.String()))
+	if err != nil {
+		t.Fatalf("create gzip reader: %v", err)
+	}
+	defer zr.Close()
+	decoded, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("read gzip payload: %v", err)
+	}
+	if string(decoded) != string(payload) {
+		t.Fatalf("unexpected gzip payload, want len=%d got len=%d", len(payload), len(decoded))
 	}
 }
 

--- a/internal/proxy/label_surface_test.go
+++ b/internal/proxy/label_surface_test.go
@@ -829,6 +829,112 @@ func TestLabelSurface_LabelValuesIndexPersistenceLoop_StartStopAndPersist(t *tes
 	}
 }
 
+func TestLabelSurface_StopLabelValuesIndexPersistenceLoop_TimeoutBranch(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+
+	// Not-started guard branch.
+	p.stopLabelValuesIndexPersistenceLoop(context.Background())
+
+	// Force timeout branch by keeping done channel open until context expires.
+	p.labelValuesIndexPersistStarted.Store(true)
+	p.labelValuesIndexPersistStop = make(chan struct{})
+	p.labelValuesIndexPersistDone = make(chan struct{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	p.stopLabelValuesIndexPersistenceLoop(ctx)
+
+	// Cover already-closed stop-channel branch and immediate done return.
+	close(p.labelValuesIndexPersistDone)
+	p.stopLabelValuesIndexPersistenceLoop(context.Background())
+}
+
+func TestLabelSurface_IndexAndCacheHelpersCoverBranches(t *testing.T) {
+	if !labelValueIndexLess(
+		"a", labelValueIndexEntry{SeenCount: 2, LastSeen: 10},
+		"b", labelValueIndexEntry{SeenCount: 1, LastSeen: 100},
+	) {
+		t.Fatalf("expected higher SeenCount to sort first")
+	}
+	if !labelValueIndexLess(
+		"a", labelValueIndexEntry{SeenCount: 2, LastSeen: 20},
+		"b", labelValueIndexEntry{SeenCount: 2, LastSeen: 10},
+	) {
+		t.Fatalf("expected newer LastSeen to sort first when SeenCount matches")
+	}
+	if !labelValueIndexLess(
+		"a", labelValueIndexEntry{SeenCount: 2, LastSeen: 20},
+		"b", labelValueIndexEntry{SeenCount: 2, LastSeen: 20},
+	) {
+		t.Fatalf("expected lexical tie-breaker to apply when SeenCount and LastSeen match")
+	}
+
+	p := &Proxy{
+		labelValuesIndexedCache:    true,
+		labelValuesHotLimit:        1,
+		labelValuesIndexMaxEntries: 2,
+		labelValuesIndex:           make(map[string]*labelValuesIndexState),
+		cache:                      cache.New(60*time.Second, 1000),
+	}
+	p.updateLabelValuesIndex("tenant-a", "app", []string{"gamma", "alpha", "beta"})
+
+	got, ok := p.selectLabelValuesFromIndex("tenant-a", "app", "", -1, 0)
+	if !ok {
+		t.Fatalf("expected indexed values to be available")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected default hot-limit fallback to return one value, got %v", got)
+	}
+
+	full, ok := p.selectLabelValuesFromIndex("tenant-a", "app", "a", 0, maxLimitValue+500)
+	if !ok || len(full) == 0 {
+		t.Fatalf("expected filtered indexed values with clamped limit, got %v (ok=%v)", full, ok)
+	}
+
+	disabled := &Proxy{labelValuesIndexedCache: false}
+	if values, ok := disabled.selectLabelValuesFromIndex("tenant-a", "app", "", 0, 10); ok || values != nil {
+		t.Fatalf("expected indexed cache disabled path to miss")
+	}
+
+	(*Proxy)(nil).setJSONCacheWithTTL("k:nil", time.Second, map[string]string{"ok": "1"})
+	(&Proxy{}).setJSONCacheWithTTL("k:nocache", time.Second, map[string]string{"ok": "1"})
+	p.setJSONCacheWithTTL("k:marshal-error", time.Second, map[string]interface{}{"bad": make(chan int)})
+	if _, ok := p.cache.Get("k:marshal-error"); ok {
+		t.Fatalf("expected marshal-error payload to not be cached")
+	}
+	p.setJSONCacheWithTTL("k:good", time.Second, map[string]string{"ok": "1"})
+	if _, ok := p.cache.Get("k:good"); !ok {
+		t.Fatalf("expected successful JSON payload to be cached")
+	}
+
+	if parsePositiveInt("0", 7) != 7 || parsePositiveInt("-1", 7) != 7 || parsePositiveInt("9", 7) != 9 {
+		t.Fatalf("unexpected parsePositiveInt behavior")
+	}
+	if parseNonNegativeInt("-1", 7) != 7 || parseNonNegativeInt("0", 7) != 0 || parseNonNegativeInt("9", 7) != 9 {
+		t.Fatalf("unexpected parseNonNegativeInt behavior")
+	}
+
+	if (&Proxy{}).shouldRefreshLabelsInBackground(-1, time.Second) {
+		t.Fatalf("expected refresh=false for non-positive remaining TTL")
+	}
+	if (&Proxy{}).shouldRefreshLabelsInBackground(time.Second, 0) {
+		t.Fatalf("expected refresh=false for non-positive cache TTL")
+	}
+	if !(&Proxy{}).shouldRefreshLabelsInBackground(time.Second, 5*time.Second) {
+		t.Fatalf("expected refresh=true when cache entry is near expiry")
+	}
+
+	if got := (&Proxy{}).labelBackgroundTimeout(); got != 10*time.Second {
+		t.Fatalf("expected default background timeout, got %s", got)
+	}
+	if got := (&Proxy{client: &http.Client{Timeout: 3 * time.Second}}).labelBackgroundTimeout(); got != 3*time.Second {
+		t.Fatalf("expected client timeout override, got %s", got)
+	}
+	if got := (&Proxy{client: &http.Client{Timeout: 30 * time.Second}}).labelBackgroundTimeout(); got != 10*time.Second {
+		t.Fatalf("expected cap to default timeout, got %s", got)
+	}
+}
+
 func waitForCachedKey(t *testing.T, c *cache.Cache, key string) []byte {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/internal/proxy/label_surface_test.go
+++ b/internal/proxy/label_surface_test.go
@@ -1,10 +1,14 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -98,6 +102,120 @@ func TestLabelSurface_LabelValuesResolveCustomAliasFromConfiguredExtras(t *testi
 	}
 	if len(resp.Data) != 1 || resp.Data[0] != "i-host-1" {
 		t.Fatalf("expected host_id value from resolved host.id field, got %v", resp.Data)
+	}
+}
+
+func TestLabelSurface_LabelValuesIndexedBrowseUsesHotsetAndOffsetWithoutBackendRefetch(t *testing.T) {
+	fieldValuesCalls := 0
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.Error(w, "unsupported", http.StatusNotFound)
+		case "/select/logsql/field_values":
+			fieldValuesCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"delta","hits":1},{"value":"alpha","hits":1},{"value":"gamma","hits":1},{"value":"beta","hits":1}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 vlBackend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		LogLevel:                   "error",
+		LabelStyle:                 LabelStyleUnderscores,
+		MetadataFieldMode:          MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:    true,
+		LabelValuesHotLimit:        2,
+		LabelValuesIndexMaxEntries: 1000,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/loki/api/v1/label/app/values", nil)
+	p.handleLabelValues(w1, r1)
+
+	var resp1 struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w1.Body.Bytes(), &resp1); err != nil {
+		t.Fatalf("decode first label values response: %v", err)
+	}
+	if len(resp1.Data) != 2 || resp1.Data[0] != "alpha" || resp1.Data[1] != "beta" {
+		t.Fatalf("expected hotset-first values [alpha beta], got %v", resp1.Data)
+	}
+
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/loki/api/v1/label/app/values?offset=2&limit=2", nil)
+	p.handleLabelValues(w2, r2)
+
+	var resp2 struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("decode second label values response: %v", err)
+	}
+	if len(resp2.Data) != 2 || resp2.Data[0] != "delta" || resp2.Data[1] != "gamma" {
+		t.Fatalf("expected offset window [delta gamma], got %v", resp2.Data)
+	}
+	if fieldValuesCalls != 1 {
+		t.Fatalf("expected single backend field_values call with indexed browse cache, got %d", fieldValuesCalls)
+	}
+}
+
+func TestLabelSurface_LabelValuesIndexedBrowseSearchUsesIndex(t *testing.T) {
+	fieldValuesCalls := 0
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.Error(w, "unsupported", http.StatusNotFound)
+		case "/select/logsql/field_values":
+			fieldValuesCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"alpha","hits":1},{"value":"beta","hits":1},{"value":"delta","hits":1},{"value":"gamma","hits":1}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 vlBackend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		LogLevel:                   "error",
+		LabelStyle:                 LabelStyleUnderscores,
+		MetadataFieldMode:          MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:    true,
+		LabelValuesHotLimit:        2,
+		LabelValuesIndexMaxEntries: 1000,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	seedW := httptest.NewRecorder()
+	seedReq := httptest.NewRequest(http.MethodGet, "/loki/api/v1/label/app/values", nil)
+	p.handleLabelValues(seedW, seedReq)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/loki/api/v1/label/app/values?search=ta&limit=10", nil)
+	p.handleLabelValues(w, r)
+
+	var resp struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode search label values response: %v", err)
+	}
+	if len(resp.Data) != 2 || resp.Data[0] != "beta" || resp.Data[1] != "delta" {
+		t.Fatalf("expected search-filtered indexed values [beta delta], got %v", resp.Data)
+	}
+	if fieldValuesCalls != 1 {
+		t.Fatalf("expected search browse to use index without extra backend calls, got %d", fieldValuesCalls)
 	}
 }
 
@@ -200,5 +318,201 @@ func TestLabelSurface_VolumeRangeTargetLabelsResolveCustomAlias(t *testing.T) {
 
 	if requestedField != "host.id" {
 		t.Fatalf("expected volume_range targetLabels alias host_id to resolve to host.id, got %q", requestedField)
+	}
+}
+
+func TestLabelSurface_TargetLabelInventoryLookupUsesCache(t *testing.T) {
+	streamFieldCalls := 0
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			streamFieldCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"custom.pipeline.processing","hits":3}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL:        vlBackend.URL,
+		Cache:             cache.New(60*time.Second, 1000),
+		LogLevel:          "error",
+		LabelStyle:        LabelStyleUnderscores,
+		MetadataFieldMode: MetadataFieldModeTranslated,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("query", `{service_name="api"}`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+
+	ctx := context.WithValue(context.Background(), orgIDKey, "team-a")
+
+	got1 := p.resolveTargetLabelFields(ctx, "custom_pipeline_processing", params)
+	got2 := p.resolveTargetLabelFields(ctx, "custom_pipeline_processing", params)
+	if len(got1) != 1 || got1[0] != "custom.pipeline.processing" {
+		t.Fatalf("expected first lookup to resolve custom.pipeline.processing, got %v", got1)
+	}
+	if len(got2) != 1 || got2[0] != "custom.pipeline.processing" {
+		t.Fatalf("expected second lookup to resolve custom.pipeline.processing, got %v", got2)
+	}
+	if streamFieldCalls != 1 {
+		t.Fatalf("expected one stream_field_names call due cache reuse, got %d", streamFieldCalls)
+	}
+}
+
+func TestLabelSurface_LabelValuesIndexPersistsOnShutdownAndRestoresOnStartup(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unused in test", http.StatusNotFound)
+	}))
+	defer vlBackend.Close()
+
+	snapshotPath := filepath.Join(t.TempDir(), "label-values-index.json")
+
+	p1, err := New(Config{
+		BackendURL:                      vlBackend.URL,
+		Cache:                           cache.New(60*time.Second, 1000),
+		LogLevel:                        "error",
+		LabelStyle:                      LabelStyleUnderscores,
+		MetadataFieldMode:               MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:         true,
+		LabelValuesHotLimit:             100,
+		LabelValuesIndexMaxEntries:      1000,
+		LabelValuesIndexPersistPath:     snapshotPath,
+		LabelValuesIndexPersistInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("create proxy #1: %v", err)
+	}
+	p1.Init()
+
+	p1.updateLabelValuesIndex("team-a", "host_id", []string{"zeta", "alpha", "beta"})
+	if err := p1.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown proxy #1: %v", err)
+	}
+
+	p2, err := New(Config{
+		BackendURL:                      vlBackend.URL,
+		Cache:                           cache.New(60*time.Second, 1000),
+		LogLevel:                        "error",
+		LabelStyle:                      LabelStyleUnderscores,
+		MetadataFieldMode:               MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:         true,
+		LabelValuesHotLimit:             100,
+		LabelValuesIndexMaxEntries:      1000,
+		LabelValuesIndexPersistPath:     snapshotPath,
+		LabelValuesIndexPersistInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("create proxy #2: %v", err)
+	}
+	p2.Init()
+	defer func() { _ = p2.Shutdown(context.Background()) }()
+
+	got, ok := p2.selectLabelValuesFromIndex("team-a", "host_id", "", 0, 10)
+	if !ok {
+		t.Fatalf("expected restored label-values index to be available")
+	}
+	want := []string{"alpha", "beta", "zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected restored values: want=%v got=%v", want, got)
+	}
+}
+
+func TestLabelSurface_LabelValuesIndexStartupWarmsFromPeersWhenDiskStale(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unused in test", http.StatusNotFound)
+	}))
+	defer vlBackend.Close()
+
+	now := time.Now().UTC()
+	peerSnapshot := labelValuesIndexSnapshot{
+		Version:         1,
+		SavedAtUnixNano: now.UnixNano(),
+		StatesByKey: map[string]map[string]labelValueIndexEntry{
+			labelValuesIndexKey("team-a", "host_id"): {
+				"from-peer": {SeenCount: 9, LastSeen: now.UnixNano()},
+			},
+		},
+	}
+	peerPayload, err := json.Marshal(peerSnapshot)
+	if err != nil {
+		t.Fatalf("marshal peer snapshot: %v", err)
+	}
+	ownerCache := cache.New(5*time.Minute, 1000)
+	ownerCache.SetWithTTL(labelValuesIndexSnapshotCacheKey, peerPayload, 5*time.Minute)
+
+	ownerPeer := cache.NewPeerCache(cache.PeerConfig{SelfAddr: "owner:3100"})
+	peerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_cache/get" {
+			http.NotFound(w, r)
+			return
+		}
+		ownerPeer.ServeHTTP(w, r, ownerCache)
+	}))
+	defer peerSrv.Close()
+
+	peerAddr := strings.TrimPrefix(peerSrv.URL, "http://")
+	localPeer := cache.NewPeerCache(cache.PeerConfig{
+		SelfAddr:      "self:3100",
+		DiscoveryType: "static",
+		StaticPeers:   peerAddr,
+		Timeout:       800 * time.Millisecond,
+	})
+
+	localCache := cache.New(5*time.Minute, 1000)
+	localCache.SetL3(localPeer)
+
+	stalePath := filepath.Join(t.TempDir(), "label-values-index.json")
+	staleSnapshot := labelValuesIndexSnapshot{
+		Version:         1,
+		SavedAtUnixNano: now.Add(-10 * time.Minute).UnixNano(),
+		StatesByKey: map[string]map[string]labelValueIndexEntry{
+			labelValuesIndexKey("team-a", "host_id"): {
+				"from-disk": {SeenCount: 1, LastSeen: now.Add(-10 * time.Minute).UnixNano()},
+			},
+		},
+	}
+	stalePayload, err := json.Marshal(staleSnapshot)
+	if err != nil {
+		t.Fatalf("marshal stale snapshot: %v", err)
+	}
+	if err := os.WriteFile(stalePath, stalePayload, 0o644); err != nil {
+		t.Fatalf("write stale snapshot: %v", err)
+	}
+
+	p, err := New(Config{
+		BackendURL:                      vlBackend.URL,
+		Cache:                           localCache,
+		PeerCache:                       localPeer,
+		LogLevel:                        "error",
+		LabelStyle:                      LabelStyleUnderscores,
+		MetadataFieldMode:               MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:         true,
+		LabelValuesHotLimit:             100,
+		LabelValuesIndexMaxEntries:      1000,
+		LabelValuesIndexPersistPath:     stalePath,
+		LabelValuesIndexPersistInterval: time.Hour,
+		LabelValuesIndexStartupStale:    30 * time.Second,
+		LabelValuesIndexPeerWarmTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+	p.Init()
+	defer func() { _ = p.Shutdown(context.Background()) }()
+
+	got, ok := p.selectLabelValuesFromIndex("team-a", "host_id", "", 0, 10)
+	if !ok {
+		t.Fatalf("expected peer-warmed label-values index to be available")
+	}
+	want := []string{"from-peer"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected peer-warmed values: want=%v got=%v", want, got)
 	}
 }

--- a/internal/proxy/label_surface_test.go
+++ b/internal/proxy/label_surface_test.go
@@ -810,7 +810,7 @@ func TestLabelSurface_LabelValuesIndexPersistenceLoop_StartStopAndPersist(t *tes
 	p.startLabelValuesIndexPersistenceLoop()
 
 	time.Sleep(70 * time.Millisecond)
-	p.stopLabelValuesIndexPersistenceLoop(nil)
+	p.stopLabelValuesIndexPersistenceLoop(context.Background())
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/internal/proxy/label_surface_test.go
+++ b/internal/proxy/label_surface_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -515,4 +516,328 @@ func TestLabelSurface_LabelValuesIndexStartupWarmsFromPeersWhenDiskStale(t *test
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected peer-warmed values: want=%v got=%v", want, got)
 	}
+}
+
+func TestLabelSurface_AsyncRefreshPathsPopulateCache(t *testing.T) {
+	var fieldValuesCalls atomic.Int32
+	var streamsCalls atomic.Int32
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			w.Write([]byte(`{"values":[{"value":"app","hits":3},{"value":"service.name","hits":2},{"value":"service_name","hits":2}]}`))
+		case "/select/logsql/stream_field_values":
+			fieldValuesCalls.Add(1)
+			switch r.URL.Query().Get("field") {
+			case "app":
+				w.Write([]byte(`{"values":[{"value":"alpha","hits":3},{"value":"beta","hits":2}]}`))
+			case "service.name", "service_name":
+				w.Write([]byte(`{"values":[{"value":"svc-a","hits":2}]}`))
+			default:
+				w.Write([]byte(`{"values":[]}`))
+			}
+		case "/select/logsql/field_values":
+			fieldValuesCalls.Add(1)
+			switch r.URL.Query().Get("field") {
+			case "service.name", "service_name", "app":
+				w.Write([]byte(`{"values":[{"value":"svc-a","hits":2}]}`))
+			default:
+				w.Write([]byte(`{"values":[]}`))
+			}
+		case "/select/logsql/field_names":
+			w.Write([]byte(`{"values":[{"value":"service.name","hits":2}]}`))
+		case "/select/logsql/query":
+			w.Write([]byte(`{"_time":"2026-04-04T17:18:49Z","_msg":"level=error msg=ok","_stream":"{service.name=\"svc-a\",service_name=\"svc-a\"}","service.name":"svc-a","service_name":"svc-a"}` + "\n"))
+		case "/select/logsql/streams":
+			streamsCalls.Add(1)
+			w.Write([]byte(`{"values":[{"value":"{service.name=\"svc-a\",service_name=\"svc-a\",detected_level=\"error\"}","hits":4}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:                 vlBackend.URL,
+		Cache:                      c,
+		LogLevel:                   "error",
+		LabelStyle:                 LabelStyleUnderscores,
+		MetadataFieldMode:          MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:    true,
+		LabelValuesHotLimit:        10,
+		LabelValuesIndexMaxEntries: 100,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	p.refreshLabelValuesCacheAsync("", "label_values:async", "app", "", "", "", "")
+	waitForCachedKey(t, c, "label_values:async")
+
+	p.refreshDetectedFieldsCacheAsync("", "detected_fields:async", `{service_name="svc-a"}`, "", "", 100)
+	waitForCachedKey(t, c, "detected_fields:async")
+
+	p.refreshDetectedLabelsCacheAsync("", "detected_labels:async", `{service_name="svc-a"}`, "", "", 100)
+	waitForCachedKey(t, c, "detected_labels:async")
+
+	p.refreshDetectedFieldValuesCacheAsync("", "detected_field_values:async:service_name", "service_name", `{service_name="svc-a"}`, "", "", 100)
+	waitForCachedKey(t, c, "detected_field_values:async:service_name")
+
+	p.refreshDetectedFieldValuesCacheAsync("", "detected_field_values:async:level", "level", `{service_name="svc-a"}`, "", "", 100)
+	waitForCachedKey(t, c, "detected_field_values:async:level")
+
+	if fieldValuesCalls.Load() == 0 {
+		t.Fatalf("expected field_values or stream_field_values calls from async refresh paths")
+	}
+	if streamsCalls.Load() == 0 {
+		t.Fatalf("expected streams call from async detected_labels refresh")
+	}
+}
+
+func TestLabelSurface_LabelValueWindowHelpersCoverLimitBranches(t *testing.T) {
+	p := &Proxy{labelValuesHotLimit: 5}
+	if got := p.defaultLabelValuesLimit(""); got != 5 {
+		t.Fatalf("expected default hot limit, got %d", got)
+	}
+	if got := p.defaultLabelValuesLimit("0"); got != 5 {
+		t.Fatalf("expected invalid explicit limit to fallback to hot limit, got %d", got)
+	}
+	if got := p.defaultLabelValuesLimit("999999"); got != maxLimitValue {
+		t.Fatalf("expected explicit limit to clamp to maxLimitValue, got %d", got)
+	}
+	if got := p.defaultLabelValuesLimit("12"); got != 12 {
+		t.Fatalf("expected explicit positive limit to pass through, got %d", got)
+	}
+
+	window := selectLabelValuesWindow([]string{"alpha", "beta", "delta", "gamma"}, "ta", 0, 10000)
+	if len(window) != 2 || window[0] != "beta" || window[1] != "delta" {
+		t.Fatalf("unexpected search window result: %v", window)
+	}
+	window = selectLabelValuesWindow([]string{"alpha", "beta", "delta", "gamma"}, "", -1, 0)
+	if len(window) != 4 {
+		t.Fatalf("expected full window with normalized offset/limit, got %v", window)
+	}
+}
+
+func TestLabelSurface_RefreshLabelsCacheAsyncPopulatesCache(t *testing.T) {
+	var streamFieldNamesCalls atomic.Int32
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			streamFieldNamesCalls.Add(1)
+			w.Write([]byte(`{"values":[{"value":"service.name","hits":2},{"value":"app","hits":2},{"value":"_msg","hits":2}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:        vlBackend.URL,
+		Cache:             c,
+		LogLevel:          "error",
+		LabelStyle:        LabelStyleUnderscores,
+		MetadataFieldMode: MetadataFieldModeTranslated,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	cacheKey := "labels:async"
+	p.refreshLabelsCacheAsync("", cacheKey, `{service_name="svc-a"}`, "", "")
+	raw := waitForCachedKey(t, c, cacheKey)
+
+	if streamFieldNamesCalls.Load() == 0 {
+		t.Fatalf("expected stream_field_names backend call")
+	}
+
+	var resp struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode labels response: %v", err)
+	}
+	if !contains(resp.Data, "service_name") {
+		t.Fatalf("expected translated and synthetic labels, got %v", resp.Data)
+	}
+	if contains(resp.Data, "_msg") {
+		t.Fatalf("expected internal labels to be filtered, got %v", resp.Data)
+	}
+}
+
+func TestLabelSurface_FetchPreferredLabelNamesCached_UsesCacheAndRecoversFromInvalidPayload(t *testing.T) {
+	var streamFieldNamesCalls atomic.Int32
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			streamFieldNamesCalls.Add(1)
+			w.Write([]byte(`{"values":[{"value":"app","hits":1}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:        vlBackend.URL,
+		Cache:             c,
+		LogLevel:          "error",
+		LabelStyle:        LabelStyleUnderscores,
+		MetadataFieldMode: MetadataFieldModeTranslated,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("query", "*")
+
+	labels, err := p.fetchPreferredLabelNamesCached(context.Background(), params)
+	if err != nil {
+		t.Fatalf("first cached label fetch failed: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "app" {
+		t.Fatalf("unexpected labels: %v", labels)
+	}
+	if streamFieldNamesCalls.Load() != 1 {
+		t.Fatalf("expected one backend call after first fetch, got %d", streamFieldNamesCalls.Load())
+	}
+
+	labels, err = p.fetchPreferredLabelNamesCached(context.Background(), params)
+	if err != nil {
+		t.Fatalf("second cached label fetch failed: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "app" {
+		t.Fatalf("unexpected cached labels: %v", labels)
+	}
+	if streamFieldNamesCalls.Load() != 1 {
+		t.Fatalf("expected cache hit on second fetch, backend calls=%d", streamFieldNamesCalls.Load())
+	}
+
+	cacheKey := "label_inventory::" + params.Encode()
+	c.Set(cacheKey, []byte("{invalid-json"))
+	labels, err = p.fetchPreferredLabelNamesCached(context.Background(), params)
+	if err != nil {
+		t.Fatalf("fetch after invalid cache payload failed: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "app" {
+		t.Fatalf("unexpected labels after cache recovery: %v", labels)
+	}
+	if streamFieldNamesCalls.Load() != 2 {
+		t.Fatalf("expected backend refetch after invalid cache payload, backend calls=%d", streamFieldNamesCalls.Load())
+	}
+}
+
+func TestLabelSurface_DetectedLabelsCacheRoundTripAndInvalidPayload(t *testing.T) {
+	p, err := New(Config{
+		BackendURL:        "http://unused",
+		Cache:             cache.New(60*time.Second, 1000),
+		LogLevel:          "error",
+		LabelStyle:        LabelStyleUnderscores,
+		MetadataFieldMode: MetadataFieldModeTranslated,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), orgIDKey, "tenant-a")
+	labels := []map[string]interface{}{
+		{"label": "service_name", "cardinality": 2},
+	}
+	summaries := map[string]*detectedLabelSummary{
+		"service_name": {
+			label:  "service_name",
+			values: map[string]struct{}{"svc-a": {}, "svc-b": {}},
+		},
+	}
+
+	p.setCachedDetectedLabels(ctx, `{service_name="svc-a"}`, "1", "2", 100, labels, summaries)
+	gotLabels, gotSummaries, ok := p.getCachedDetectedLabels(ctx, `{service_name="svc-a"}`, "1", "2", 100)
+	if !ok {
+		t.Fatalf("expected detected labels cache hit")
+	}
+	if len(gotLabels) != 1 || gotLabels[0]["label"] != "service_name" {
+		t.Fatalf("unexpected cached labels: %#v", gotLabels)
+	}
+	if gotSummaries["service_name"] == nil || len(gotSummaries["service_name"].values) != 2 {
+		t.Fatalf("unexpected cached summaries: %#v", gotSummaries)
+	}
+
+	cacheKey := p.detectedLabelsCacheKey(ctx, `{service_name="svc-a"}`, "1", "2", 100)
+	p.cache.Set(cacheKey, []byte("{invalid-json"))
+	gotLabels, gotSummaries, ok = p.getCachedDetectedLabels(ctx, `{service_name="svc-a"}`, "1", "2", 100)
+	if ok || gotLabels != nil || gotSummaries != nil {
+		t.Fatalf("expected invalid cached labels payload to miss cache, got labels=%#v summaries=%#v ok=%v", gotLabels, gotSummaries, ok)
+	}
+
+	withoutCache := &Proxy{}
+	gotLabels, gotSummaries, ok = withoutCache.getCachedDetectedLabels(context.Background(), "*", "1", "2", 10)
+	if ok || gotLabels != nil || gotSummaries != nil {
+		t.Fatalf("expected cache miss when cache is not configured")
+	}
+	withoutCache.setCachedDetectedLabels(context.Background(), "*", "1", "2", 10, nil, nil)
+}
+
+func TestLabelSurface_LabelValuesIndexPersistenceLoop_StartStopAndPersist(t *testing.T) {
+	persistPath := filepath.Join(t.TempDir(), "label-values-index.json")
+
+	p, err := New(Config{
+		BackendURL:                      "http://unused",
+		Cache:                           cache.New(60*time.Second, 1000),
+		LogLevel:                        "error",
+		LabelStyle:                      LabelStyleUnderscores,
+		MetadataFieldMode:               MetadataFieldModeTranslated,
+		LabelValuesIndexedCache:         true,
+		LabelValuesIndexPersistPath:     persistPath,
+		LabelValuesIndexMaxEntries:      1000,
+		LabelValuesHotLimit:             100,
+		LabelValuesIndexPersistInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	p.updateLabelValuesIndex("", "app", []string{"alpha", "beta"})
+	p.startLabelValuesIndexPersistenceLoop()
+	p.startLabelValuesIndexPersistenceLoop()
+
+	time.Sleep(70 * time.Millisecond)
+	p.stopLabelValuesIndexPersistenceLoop(nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	p.stopLabelValuesIndexPersistenceLoop(ctx)
+
+	raw, err := os.ReadFile(persistPath)
+	if err != nil {
+		t.Fatalf("expected persisted index snapshot file, read error: %v", err)
+	}
+	var snapshot labelValuesIndexSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		t.Fatalf("decode persisted snapshot: %v", err)
+	}
+	if len(snapshot.StatesByKey) == 0 {
+		t.Fatalf("expected persisted snapshot to contain label index state")
+	}
+}
+
+func waitForCachedKey(t *testing.T, c *cache.Cache, key string) []byte {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if raw, ok := c.Get(key); ok {
+			return raw
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for cache key %q", key)
+	return nil
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2299,11 +2299,8 @@ func (p *Proxy) selectLabelValuesFromIndex(orgID, labelName, search string, offs
 		return nil, false
 	}
 
-	valuesCap := limit
-	if valuesCap > maxUserDrivenSlicePrealloc {
-		valuesCap = maxUserDrivenSlicePrealloc
-	}
-	values := make([]string, 0, valuesCap)
+	// Keep preallocation fixed-size so allocation cannot scale with request input.
+	values := make([]string, 0, maxUserDrivenSlicePrealloc)
 	seen := 0
 	for _, candidate := range index.ordered {
 		if search != "" && !strings.Contains(strings.ToLower(candidate), search) {
@@ -2333,11 +2330,8 @@ func selectLabelValuesWindow(values []string, search string, offset, limit int) 
 	}
 
 	search = normalizeLabelValueSearch(search)
-	outCap := min(limit, len(values))
-	if outCap > maxUserDrivenSlicePrealloc {
-		outCap = maxUserDrivenSlicePrealloc
-	}
-	out := make([]string, 0, outCap)
+	// Keep preallocation fixed-size so allocation cannot scale with request input.
+	out := make([]string, 0, maxUserDrivenSlicePrealloc)
 	seen := 0
 	for _, value := range values {
 		if search != "" && !strings.Contains(strings.ToLower(value), search) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -284,6 +284,7 @@ const (
 	maxQueryLength = 65536 // 64KB
 	// maxLimitValue caps the number of results per query.
 	maxLimitValue                     = 10000
+	maxUserDrivenSlicePrealloc        = 512
 	tailWriteTimeout                  = 2 * time.Second
 	maxMultiTenantFanout              = 64
 	maxMultiTenantMergedResponseBytes = 32 << 20
@@ -2298,7 +2299,11 @@ func (p *Proxy) selectLabelValuesFromIndex(orgID, labelName, search string, offs
 		return nil, false
 	}
 
-	values := make([]string, 0, limit)
+	valuesCap := limit
+	if valuesCap > maxUserDrivenSlicePrealloc {
+		valuesCap = maxUserDrivenSlicePrealloc
+	}
+	values := make([]string, 0, valuesCap)
 	seen := 0
 	for _, candidate := range index.ordered {
 		if search != "" && !strings.Contains(strings.ToLower(candidate), search) {
@@ -2328,7 +2333,11 @@ func selectLabelValuesWindow(values []string, search string, offset, limit int) 
 	}
 
 	search = normalizeLabelValueSearch(search)
-	out := make([]string, 0, min(limit, len(values)))
+	outCap := min(limit, len(values))
+	if outCap > maxUserDrivenSlicePrealloc {
+		outCap = maxUserDrivenSlicePrealloc
+	}
+	out := make([]string, 0, outCap)
 	seen := 0
 	for _, value := range values {
 		if search != "" && !strings.Contains(strings.ToLower(value), search) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
@@ -31,6 +32,7 @@ import (
 	mw "github.com/ReliablyObserve/Loki-VL-proxy/internal/middleware"
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/translator"
 	"github.com/gorilla/websocket"
+	"golang.org/x/sync/singleflight"
 	"gopkg.in/yaml.v3"
 )
 
@@ -228,6 +230,24 @@ type Config struct {
 	// ExtraLabelFields extends the auto-discovered label surface with explicit VL field names.
 	// Values may be dotted or underscore aliases; they are normalized to VL-native names.
 	ExtraLabelFields []string
+	// LabelValuesIndexedCache enables indexed browsing for /label/{name}/values.
+	// When enabled, empty-query browsing can return a hot subset first, with optional offset/limit/search.
+	LabelValuesIndexedCache bool
+	// LabelValuesHotLimit is the default number of values returned for empty-query browsing
+	// when LabelValuesIndexedCache is enabled and request limit is not provided.
+	LabelValuesHotLimit int
+	// LabelValuesIndexMaxEntries caps in-memory indexed values per tenant+label.
+	LabelValuesIndexMaxEntries int
+	// LabelValuesIndexPersistPath enables periodic/final persistence of label-values index snapshots.
+	// Empty disables disk persistence.
+	LabelValuesIndexPersistPath string
+	// LabelValuesIndexPersistInterval controls periodic snapshot persistence interval.
+	LabelValuesIndexPersistInterval time.Duration
+	// LabelValuesIndexStartupStale marks on-disk snapshots older than this threshold as stale.
+	// Stale snapshots trigger peer warm fallback before serving.
+	LabelValuesIndexStartupStale time.Duration
+	// LabelValuesIndexPeerWarmTimeout bounds startup peer warm attempts when disk is stale/missing.
+	LabelValuesIndexPeerWarmTimeout time.Duration
 
 	// Peer cache (fleet distribution)
 	PeerCache     *cache.PeerCache // optional peer cache for distributed fleet
@@ -269,6 +289,7 @@ const (
 	maxMultiTenantMergedResponseBytes = 32 << 20
 	maxDetectedScanLines              = 2000
 	maxSyntheticTailSeenEntries       = 4096
+	labelValuesIndexSnapshotCacheKey  = "__label_values_index_snapshot:v1"
 )
 
 // CacheTTLs defines per-endpoint cache TTLs.
@@ -344,6 +365,37 @@ type Proxy struct {
 	queryRangeFreshness             time.Duration
 	queryRangeRecentCacheTTL        time.Duration
 	queryRangeHistoryCacheTTL       time.Duration
+	labelRefreshGroup               singleflight.Group
+	labelValuesIndexedCache         bool
+	labelValuesHotLimit             int
+	labelValuesIndexMaxEntries      int
+	labelValuesIndexPersistPath     string
+	labelValuesIndexPersistInterval time.Duration
+	labelValuesIndexStartupStale    time.Duration
+	labelValuesIndexPeerWarmTimeout time.Duration
+	labelValuesIndexWarmReady       atomic.Bool
+	labelValuesIndexPersistStarted  atomic.Bool
+	labelValuesIndexPersistStop     chan struct{}
+	labelValuesIndexPersistDone     chan struct{}
+	labelValuesIndexMu              sync.RWMutex
+	labelValuesIndex                map[string]*labelValuesIndexState
+}
+
+type labelValueIndexEntry struct {
+	SeenCount uint32 `json:"seen_count"`
+	LastSeen  int64  `json:"last_seen_unix_nano"`
+}
+
+type labelValuesIndexState struct {
+	entries map[string]labelValueIndexEntry
+	dirty   bool
+	ordered []string
+}
+
+type labelValuesIndexSnapshot struct {
+	Version         int                                        `json:"version"`
+	SavedAtUnixNano int64                                      `json:"saved_at_unix_nano"`
+	StatesByKey     map[string]map[string]labelValueIndexEntry `json:"states_by_key"`
 }
 
 type tailConn interface {
@@ -529,6 +581,29 @@ func New(cfg Config) (*Proxy, error) {
 	default:
 		return nil, fmt.Errorf("invalid tail mode %q", tailMode)
 	}
+	labelValuesHotLimit := cfg.LabelValuesHotLimit
+	if labelValuesHotLimit <= 0 {
+		labelValuesHotLimit = 200
+	}
+	labelValuesIndexMaxEntries := cfg.LabelValuesIndexMaxEntries
+	if labelValuesIndexMaxEntries <= 0 {
+		labelValuesIndexMaxEntries = 200000
+	}
+	if labelValuesIndexMaxEntries < labelValuesHotLimit {
+		labelValuesIndexMaxEntries = labelValuesHotLimit
+	}
+	labelValuesIndexPersistInterval := cfg.LabelValuesIndexPersistInterval
+	if labelValuesIndexPersistInterval <= 0 {
+		labelValuesIndexPersistInterval = 30 * time.Second
+	}
+	labelValuesIndexStartupStale := cfg.LabelValuesIndexStartupStale
+	if labelValuesIndexStartupStale <= 0 {
+		labelValuesIndexStartupStale = 60 * time.Second
+	}
+	labelValuesIndexPeerWarmTimeout := cfg.LabelValuesIndexPeerWarmTimeout
+	if labelValuesIndexPeerWarmTimeout <= 0 {
+		labelValuesIndexPeerWarmTimeout = 5 * time.Second
+	}
 
 	labelTranslator := NewLabelTranslator(cfg.LabelStyle, cfg.FieldMappings)
 	declaredLabelFields := buildDeclaredLabelFields(cfg.StreamFields, cfg.ExtraLabelFields, labelTranslator)
@@ -590,6 +665,16 @@ func New(cfg Config) (*Proxy, error) {
 		queryRangeFreshness:             queryRangeFreshness,
 		queryRangeRecentCacheTTL:        queryRangeRecentCacheTTL,
 		queryRangeHistoryCacheTTL:       queryRangeHistoryCacheTTL,
+		labelValuesIndexedCache:         cfg.LabelValuesIndexedCache,
+		labelValuesHotLimit:             labelValuesHotLimit,
+		labelValuesIndexMaxEntries:      labelValuesIndexMaxEntries,
+		labelValuesIndexPersistPath:     strings.TrimSpace(cfg.LabelValuesIndexPersistPath),
+		labelValuesIndexPersistInterval: labelValuesIndexPersistInterval,
+		labelValuesIndexStartupStale:    labelValuesIndexStartupStale,
+		labelValuesIndexPeerWarmTimeout: labelValuesIndexPeerWarmTimeout,
+		labelValuesIndexPersistStop:     make(chan struct{}),
+		labelValuesIndexPersistDone:     make(chan struct{}),
+		labelValuesIndex:                make(map[string]*labelValuesIndexState),
 	}, nil
 }
 
@@ -650,6 +735,17 @@ func buildDeclaredLabelFields(streamFields, extraLabelFields []string, lt *Label
 // Init wires cross-component dependencies after construction.
 func (p *Proxy) Init() {
 	p.metrics.SetCircuitBreakerFunc(p.breaker.State)
+	p.labelValuesIndexWarmReady.Store(true)
+	if p.labelValuesIndexedCache {
+		p.warmLabelValuesIndexOnStartup()
+		p.startLabelValuesIndexPersistenceLoop()
+	}
+}
+
+// Shutdown flushes in-memory caches that should survive rolling restarts.
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	p.stopLabelValuesIndexPersistenceLoop(ctx)
+	return p.persistLabelValuesIndexNow("shutdown")
 }
 
 // ReloadTenantMap hot-reloads tenant mappings (called on SIGHUP).
@@ -660,6 +756,9 @@ func (p *Proxy) ReloadTenantMap(m map[string]TenantMapping) {
 		p.compatCache.InvalidatePrefix("")
 	}
 	p.configMu.Unlock()
+	p.labelValuesIndexMu.Lock()
+	p.labelValuesIndex = make(map[string]*labelValuesIndexState)
+	p.labelValuesIndexMu.Unlock()
 }
 
 // ReloadFieldMappings hot-reloads field mappings and rebuilds the label translator.
@@ -673,6 +772,9 @@ func (p *Proxy) ReloadFieldMappings(mappings []FieldMapping) {
 		p.compatCache.InvalidatePrefix("")
 	}
 	p.configMu.Unlock()
+	p.labelValuesIndexMu.Lock()
+	p.labelValuesIndex = make(map[string]*labelValuesIndexState)
+	p.labelValuesIndexMu.Unlock()
 }
 
 // GetMetrics returns the proxy's metrics instance for external telemetry exporters.
@@ -1492,16 +1594,24 @@ func (p *Proxy) snapshotDeclaredLabelFields() []string {
 	return out
 }
 
+func (p *Proxy) vlGetMetadataCoalesced(ctx context.Context, path string, params url.Values) (int, []byte, error) {
+	key := "vlmeta:get:" + getOrgID(ctx) + ":" + path + "?" + params.Encode()
+	status, _, body, err := p.coalescer.Do(key, func() (*http.Response, error) {
+		return p.vlGet(ctx, path, params)
+	})
+	if err != nil {
+		return 0, nil, err
+	}
+	return status, body, nil
+}
+
 func (p *Proxy) fetchVLFieldNames(ctx context.Context, path string, params url.Values) ([]string, error) {
-	resp, err := p.vlGet(ctx, path, params)
+	status, body, err := p.vlGetMetadataCoalesced(ctx, path, params)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return nil, &vlAPIError{status: resp.StatusCode, body: string(body)}
+	if status >= 400 {
+		return nil, &vlAPIError{status: status, body: string(body)}
 	}
 	fields, err := decodeVLFieldHits(body)
 	if err != nil {
@@ -1512,15 +1622,12 @@ func (p *Proxy) fetchVLFieldNames(ctx context.Context, path string, params url.V
 }
 
 func (p *Proxy) fetchVLFieldValues(ctx context.Context, path string, params url.Values) ([]string, error) {
-	resp, err := p.vlGet(ctx, path, params)
+	status, body, err := p.vlGetMetadataCoalesced(ctx, path, params)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return nil, &vlAPIError{status: resp.StatusCode, body: string(body)}
+	if status >= 400 {
+		return nil, &vlAPIError{status: status, body: string(body)}
 	}
 	return decodeVLFieldHits(body)
 }
@@ -1540,6 +1647,29 @@ func (p *Proxy) fetchPreferredLabelNames(ctx context.Context, params url.Values)
 		return fallback, nil
 	}
 	return nil, err
+}
+
+func (p *Proxy) fetchPreferredLabelNamesCached(ctx context.Context, params url.Values) ([]string, error) {
+	if p == nil || p.cache == nil {
+		return p.fetchPreferredLabelNames(ctx, params)
+	}
+
+	cacheKey := "label_inventory:" + getOrgID(ctx) + ":" + params.Encode()
+	if cached, ok := p.cache.Get(cacheKey); ok {
+		var labels []string
+		if err := json.Unmarshal(cached, &labels); err == nil {
+			return labels, nil
+		}
+	}
+
+	labels, err := p.fetchPreferredLabelNames(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if encoded, err := json.Marshal(labels); err == nil {
+		p.cache.SetWithTTL(cacheKey, encoded, CacheTTLs["labels"])
+	}
+	return labels, nil
 }
 
 func (p *Proxy) fetchPreferredLabelValues(ctx context.Context, labelName string, params url.Values) ([]string, error) {
@@ -1600,6 +1730,735 @@ func (p *Proxy) fetchPreferredLabelValues(ctx context.Context, labelName string,
 	return values, nil
 }
 
+func (p *Proxy) shouldRefreshLabelsInBackground(remaining, ttl time.Duration) bool {
+	if remaining <= 0 || ttl <= 0 {
+		return false
+	}
+	threshold := (ttl * 4) / 5
+	if threshold <= 0 {
+		threshold = ttl / 2
+	}
+	return remaining <= threshold
+}
+
+func (p *Proxy) labelBackgroundTimeout() time.Duration {
+	if p.client != nil && p.client.Timeout > 0 && p.client.Timeout < 10*time.Second {
+		return p.client.Timeout
+	}
+	return 10 * time.Second
+}
+
+func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end string) {
+	refreshKey := "refresh:labels:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+
+			params := url.Values{}
+			if strings.TrimSpace(rawQuery) != "" {
+				translated, terr := p.translateQuery(defaultQuery(rawQuery))
+				if terr == nil {
+					params.Set("query", translated)
+				} else {
+					params.Set("query", "*")
+				}
+			} else {
+				params.Set("query", "*")
+			}
+			if strings.TrimSpace(start) != "" {
+				params.Set("start", start)
+			}
+			if strings.TrimSpace(end) != "" {
+				params.Set("end", end)
+			}
+
+			labels, fetchErr := p.fetchPreferredLabelNames(ctx, params)
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+
+			filtered := make([]string, 0, len(labels))
+			for _, v := range labels {
+				if isVLInternalField(v) {
+					continue
+				}
+				filtered = append(filtered, v)
+			}
+			labels = p.labelTranslator.TranslateLabelsList(filtered)
+			labels = appendSyntheticLabels(labels)
+			p.cache.SetWithTTL(cacheKey, lokiLabelsResponse(labels), CacheTTLs["labels"])
+			return nil, nil
+		})
+		if err != nil {
+			p.log.Debug("background labels refresh failed", "cache_key", cacheKey, "error", err)
+		}
+	}()
+}
+
+func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuery, start, end, limit string) {
+	refreshKey := "refresh:label_values:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+
+			var (
+				values   []string
+				fetchErr error
+			)
+
+			if labelName == "service_name" {
+				values, fetchErr = p.serviceNameValues(ctx, rawQuery, start, end)
+			} else {
+				params := url.Values{}
+				if strings.TrimSpace(rawQuery) != "" {
+					translated, terr := p.translateQuery(defaultQuery(rawQuery))
+					if terr == nil {
+						params.Set("query", translated)
+					} else {
+						params.Set("query", "*")
+					}
+				} else {
+					params.Set("query", "*")
+				}
+				if strings.TrimSpace(start) != "" {
+					params.Set("start", start)
+				}
+				if strings.TrimSpace(end) != "" {
+					params.Set("end", end)
+				}
+				if strings.TrimSpace(limit) != "" {
+					params.Set("limit", limit)
+				}
+				values, fetchErr = p.fetchPreferredLabelValues(ctx, labelName, params)
+			}
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+
+			p.updateLabelValuesIndex(orgID, labelName, values)
+			if p.labelValuesBrowseMode(rawQuery) {
+				if indexedValues, ok := p.selectLabelValuesFromIndex(orgID, labelName, "", 0, p.defaultLabelValuesLimit(limit)); ok {
+					values = indexedValues
+				}
+			}
+			p.cache.SetWithTTL(cacheKey, lokiLabelsResponse(values), CacheTTLs["label_values"])
+			return nil, nil
+		})
+		if err != nil {
+			p.log.Debug("background label values refresh failed", "cache_key", cacheKey, "label", labelName, "error", err)
+		}
+	}()
+}
+
+func (p *Proxy) buildLabelValuesIndexSnapshot(now time.Time) labelValuesIndexSnapshot {
+	p.labelValuesIndexMu.RLock()
+	defer p.labelValuesIndexMu.RUnlock()
+
+	states := make(map[string]map[string]labelValueIndexEntry, len(p.labelValuesIndex))
+	for key, state := range p.labelValuesIndex {
+		if state == nil || len(state.entries) == 0 {
+			continue
+		}
+		entries := make(map[string]labelValueIndexEntry, len(state.entries))
+		for value, entry := range state.entries {
+			entries[value] = entry
+		}
+		states[key] = entries
+	}
+
+	return labelValuesIndexSnapshot{
+		Version:         1,
+		SavedAtUnixNano: now.UnixNano(),
+		StatesByKey:     states,
+	}
+}
+
+func (p *Proxy) applyLabelValuesIndexSnapshot(snapshot labelValuesIndexSnapshot) (states int, values int) {
+	restored := make(map[string]*labelValuesIndexState, len(snapshot.StatesByKey))
+	for key, entries := range snapshot.StatesByKey {
+		if len(entries) == 0 {
+			continue
+		}
+		copied := make(map[string]labelValueIndexEntry, len(entries))
+		for value, entry := range entries {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			copied[value] = entry
+			values++
+		}
+		if len(copied) == 0 {
+			continue
+		}
+		restored[key] = &labelValuesIndexState{
+			entries: copied,
+			dirty:   true,
+		}
+		states++
+	}
+
+	p.labelValuesIndexMu.Lock()
+	p.labelValuesIndex = restored
+	p.labelValuesIndexMu.Unlock()
+	return states, values
+}
+
+func (p *Proxy) persistLabelValuesIndexNow(reason string) error {
+	if !p.labelValuesIndexedCache || strings.TrimSpace(p.labelValuesIndexPersistPath) == "" {
+		return nil
+	}
+
+	snapshot := p.buildLabelValuesIndexSnapshot(time.Now().UTC())
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return fmt.Errorf("marshal label index snapshot: %w", err)
+	}
+
+	path := p.labelValuesIndexPersistPath
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create label index snapshot directory: %w", err)
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write label index snapshot temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename label index snapshot temp file: %w", err)
+	}
+
+	if p.cache != nil {
+		ttl := p.labelValuesIndexStartupStale * 3
+		minTTL := p.labelValuesIndexPersistInterval * 2
+		if ttl < minTTL {
+			ttl = minTTL
+		}
+		if ttl <= 0 {
+			ttl = 5 * time.Minute
+		}
+		p.cache.SetWithTTL(labelValuesIndexSnapshotCacheKey, data, ttl)
+	}
+
+	states, values := p.labelValuesIndexCardinality()
+	if reason == "periodic" {
+		p.log.Debug("label values index snapshot persisted", "path", path, "states", states, "values", values, "bytes", len(data))
+	} else {
+		p.log.Info("label values index snapshot persisted", "reason", reason, "path", path, "states", states, "values", values, "bytes", len(data))
+	}
+	return nil
+}
+
+func (p *Proxy) restoreLabelValuesIndexFromDisk() (bool, int64, error) {
+	if !p.labelValuesIndexedCache || strings.TrimSpace(p.labelValuesIndexPersistPath) == "" {
+		return false, 0, nil
+	}
+
+	data, err := os.ReadFile(p.labelValuesIndexPersistPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, 0, nil
+		}
+		return false, 0, fmt.Errorf("read label index snapshot: %w", err)
+	}
+
+	var snapshot labelValuesIndexSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return false, 0, fmt.Errorf("decode label index snapshot: %w", err)
+	}
+	if snapshot.Version != 1 {
+		return false, 0, fmt.Errorf("unsupported label index snapshot version: %d", snapshot.Version)
+	}
+	if snapshot.SavedAtUnixNano <= 0 {
+		return false, 0, fmt.Errorf("invalid label index snapshot timestamp: %d", snapshot.SavedAtUnixNano)
+	}
+
+	states, values := p.applyLabelValuesIndexSnapshot(snapshot)
+	if p.cache != nil {
+		ttl := p.labelValuesIndexStartupStale * 3
+		if ttl <= 0 {
+			ttl = 5 * time.Minute
+		}
+		p.cache.SetWithTTL(labelValuesIndexSnapshotCacheKey, data, ttl)
+	}
+	p.log.Info(
+		"label values index restored from disk",
+		"path", p.labelValuesIndexPersistPath,
+		"saved_at", time.Unix(0, snapshot.SavedAtUnixNano).UTC().Format(time.RFC3339Nano),
+		"states", states,
+		"values", values,
+	)
+	return true, snapshot.SavedAtUnixNano, nil
+}
+
+func (p *Proxy) restoreLabelValuesIndexFromPeers(minSavedAt int64) (bool, int64, error) {
+	if !p.labelValuesIndexedCache || p.cache == nil || p.peerCache == nil {
+		return false, 0, nil
+	}
+	data, ok := p.cache.Get(labelValuesIndexSnapshotCacheKey)
+	if !ok {
+		return false, 0, nil
+	}
+
+	var snapshot labelValuesIndexSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return false, 0, fmt.Errorf("decode peer label index snapshot: %w", err)
+	}
+	if snapshot.Version != 1 || snapshot.SavedAtUnixNano <= 0 {
+		return false, 0, fmt.Errorf("invalid peer label index snapshot metadata")
+	}
+	if snapshot.SavedAtUnixNano <= minSavedAt {
+		return false, snapshot.SavedAtUnixNano, nil
+	}
+
+	states, values := p.applyLabelValuesIndexSnapshot(snapshot)
+	p.log.Info(
+		"label values index warmed from peers",
+		"saved_at", time.Unix(0, snapshot.SavedAtUnixNano).UTC().Format(time.RFC3339Nano),
+		"states", states,
+		"values", values,
+	)
+	return true, snapshot.SavedAtUnixNano, nil
+}
+
+func (p *Proxy) warmLabelValuesIndexOnStartup() {
+	p.labelValuesIndexWarmReady.Store(false)
+	defer p.labelValuesIndexWarmReady.Store(true)
+
+	var diskSavedAt int64
+	loadedFromDisk, savedAt, err := p.restoreLabelValuesIndexFromDisk()
+	if err != nil {
+		p.log.Warn("label values index disk restore failed", "error", err)
+	}
+	if loadedFromDisk {
+		diskSavedAt = savedAt
+	}
+
+	diskFresh := loadedFromDisk && time.Since(time.Unix(0, diskSavedAt)) <= p.labelValuesIndexStartupStale
+	if !diskFresh {
+		if p.cache != nil {
+			p.cache.Invalidate(labelValuesIndexSnapshotCacheKey)
+		}
+		type peerWarmResult struct {
+			ok      bool
+			savedAt int64
+			err     error
+		}
+		timeout := p.labelValuesIndexPeerWarmTimeout
+		if timeout <= 0 {
+			timeout = 5 * time.Second
+		}
+		resCh := make(chan peerWarmResult, 1)
+		go func() {
+			ok, savedAt, peerErr := p.restoreLabelValuesIndexFromPeers(diskSavedAt)
+			resCh <- peerWarmResult{ok: ok, savedAt: savedAt, err: peerErr}
+		}()
+
+		var res peerWarmResult
+		select {
+		case res = <-resCh:
+		case <-time.After(timeout):
+			p.log.Warn("label values index peer warm timed out", "timeout", timeout.String())
+			res = peerWarmResult{ok: false}
+		}
+		if res.err != nil {
+			p.log.Warn("label values index peer warm failed", "error", res.err)
+		} else if res.ok {
+			diskSavedAt = res.savedAt
+			if persistErr := p.persistLabelValuesIndexNow("startup_peer_warm"); persistErr != nil {
+				p.log.Warn("label values index persistence after peer warm failed", "error", persistErr)
+			}
+		}
+	}
+}
+
+func (p *Proxy) startLabelValuesIndexPersistenceLoop() {
+	if !p.labelValuesIndexedCache || strings.TrimSpace(p.labelValuesIndexPersistPath) == "" || p.labelValuesIndexPersistInterval <= 0 {
+		return
+	}
+	if p.labelValuesIndexPersistStarted.Swap(true) {
+		return
+	}
+	go func() {
+		defer close(p.labelValuesIndexPersistDone)
+		ticker := time.NewTicker(p.labelValuesIndexPersistInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if err := p.persistLabelValuesIndexNow("periodic"); err != nil {
+					p.log.Warn("periodic label values index persistence failed", "error", err)
+				}
+			case <-p.labelValuesIndexPersistStop:
+				return
+			}
+		}
+	}()
+}
+
+func (p *Proxy) stopLabelValuesIndexPersistenceLoop(ctx context.Context) {
+	if !p.labelValuesIndexPersistStarted.Load() {
+		return
+	}
+	select {
+	case <-p.labelValuesIndexPersistStop:
+	default:
+		close(p.labelValuesIndexPersistStop)
+	}
+
+	if ctx == nil {
+		<-p.labelValuesIndexPersistDone
+		return
+	}
+	select {
+	case <-p.labelValuesIndexPersistDone:
+	case <-ctx.Done():
+		p.log.Warn("timeout waiting for label values persistence loop stop", "error", ctx.Err())
+	}
+}
+
+func (p *Proxy) labelValuesIndexCardinality() (states int, values int) {
+	p.labelValuesIndexMu.RLock()
+	defer p.labelValuesIndexMu.RUnlock()
+	for _, state := range p.labelValuesIndex {
+		if state == nil || len(state.entries) == 0 {
+			continue
+		}
+		states++
+		values += len(state.entries)
+	}
+	return states, values
+}
+
+func (p *Proxy) labelValuesBrowseMode(rawQuery string) bool {
+	trimmed := strings.TrimSpace(rawQuery)
+	return trimmed == "" || trimmed == "*"
+}
+
+func (p *Proxy) defaultLabelValuesLimit(limitRaw string) int {
+	if strings.TrimSpace(limitRaw) != "" {
+		limit := parsePositiveInt(limitRaw, p.labelValuesHotLimit)
+		if limit > maxLimitValue {
+			limit = maxLimitValue
+		}
+		return limit
+	}
+	limit := p.labelValuesHotLimit
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > maxLimitValue {
+		limit = maxLimitValue
+	}
+	return limit
+}
+
+func parsePositiveInt(raw string, fallback int) int {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
+}
+
+func parseNonNegativeInt(raw string, fallback int) int {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 0 {
+		return fallback
+	}
+	return n
+}
+
+func normalizeLabelValueSearch(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func labelValuesIndexKey(orgID, labelName string) string {
+	return orgID + "|" + strings.ToLower(strings.TrimSpace(labelName))
+}
+
+func labelValueIndexLess(aName string, a labelValueIndexEntry, bName string, b labelValueIndexEntry) bool {
+	if a.SeenCount != b.SeenCount {
+		return a.SeenCount > b.SeenCount
+	}
+	if a.LastSeen != b.LastSeen {
+		return a.LastSeen > b.LastSeen
+	}
+	return aName < bName
+}
+
+func (p *Proxy) labelValueIndexEnsureOrderedLocked(index *labelValuesIndexState) {
+	if index == nil {
+		return
+	}
+	if !index.dirty && len(index.ordered) > 0 {
+		return
+	}
+	ordered := make([]string, 0, len(index.entries))
+	for value := range index.entries {
+		ordered = append(ordered, value)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := index.entries[ordered[i]]
+		right := index.entries[ordered[j]]
+		return labelValueIndexLess(ordered[i], left, ordered[j], right)
+	})
+	index.ordered = ordered
+	index.dirty = false
+}
+
+func (p *Proxy) updateLabelValuesIndex(orgID, labelName string, values []string) {
+	if !p.labelValuesIndexedCache || len(values) == 0 {
+		return
+	}
+	key := labelValuesIndexKey(orgID, labelName)
+	now := time.Now().UnixNano()
+
+	p.labelValuesIndexMu.Lock()
+	defer p.labelValuesIndexMu.Unlock()
+
+	index, ok := p.labelValuesIndex[key]
+	if !ok {
+		index = &labelValuesIndexState{entries: make(map[string]labelValueIndexEntry, len(values))}
+		p.labelValuesIndex[key] = index
+	}
+
+	for _, value := range values {
+		entry := index.entries[value]
+		if entry.SeenCount < ^uint32(0) {
+			entry.SeenCount++
+		}
+		entry.LastSeen = now
+		index.entries[value] = entry
+	}
+	index.dirty = true
+
+	maxEntries := p.labelValuesIndexMaxEntries
+	if maxEntries <= 0 || len(index.entries) <= maxEntries {
+		return
+	}
+	p.labelValueIndexEnsureOrderedLocked(index)
+	if len(index.ordered) <= maxEntries {
+		return
+	}
+	keep := index.ordered[:maxEntries]
+	pruned := make(map[string]labelValueIndexEntry, len(keep))
+	for _, value := range keep {
+		pruned[value] = index.entries[value]
+	}
+	index.entries = pruned
+	index.ordered = append([]string(nil), keep...)
+	index.dirty = false
+}
+
+func (p *Proxy) selectLabelValuesFromIndex(orgID, labelName, search string, offset, limit int) ([]string, bool) {
+	if !p.labelValuesIndexedCache {
+		return nil, false
+	}
+	if limit <= 0 {
+		limit = p.labelValuesHotLimit
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > maxLimitValue {
+		limit = maxLimitValue
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	key := labelValuesIndexKey(orgID, labelName)
+	search = normalizeLabelValueSearch(search)
+
+	p.labelValuesIndexMu.Lock()
+	defer p.labelValuesIndexMu.Unlock()
+
+	index, ok := p.labelValuesIndex[key]
+	if !ok || len(index.entries) == 0 {
+		return nil, false
+	}
+	p.labelValueIndexEnsureOrderedLocked(index)
+	if len(index.ordered) == 0 {
+		return nil, false
+	}
+
+	values := make([]string, 0, limit)
+	seen := 0
+	for _, candidate := range index.ordered {
+		if search != "" && !strings.Contains(strings.ToLower(candidate), search) {
+			continue
+		}
+		if seen < offset {
+			seen++
+			continue
+		}
+		values = append(values, candidate)
+		if len(values) >= limit {
+			break
+		}
+	}
+	return values, true
+}
+
+func selectLabelValuesWindow(values []string, search string, offset, limit int) []string {
+	if limit <= 0 {
+		limit = maxLimitValue
+	}
+	if limit > maxLimitValue {
+		limit = maxLimitValue
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	search = normalizeLabelValueSearch(search)
+	out := make([]string, 0, min(limit, len(values)))
+	seen := 0
+	for _, value := range values {
+		if search != "" && !strings.Contains(strings.ToLower(value), search) {
+			continue
+		}
+		if seen < offset {
+			seen++
+			continue
+		}
+		out = append(out, value)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func (p *Proxy) setJSONCacheWithTTL(cacheKey string, ttl time.Duration, value interface{}) {
+	if p == nil || p.cache == nil {
+		return
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	p.cache.SetWithTTL(cacheKey, encoded, ttl)
+}
+
+func (p *Proxy) refreshDetectedFieldsCacheAsync(orgID, cacheKey, query, start, end string, lineLimit int) {
+	refreshKey := "refresh:detected_fields:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+			fields, _, detectErr := p.detectFields(ctx, query, start, end, lineLimit)
+			if detectErr != nil {
+				return nil, detectErr
+			}
+			payload := map[string]interface{}{
+				"status": "success",
+				"data":   fields,
+				"fields": fields,
+				"limit":  lineLimit,
+			}
+			p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_fields"], payload)
+			return nil, nil
+		})
+		if err != nil {
+			p.log.Debug("background detected_fields refresh failed", "cache_key", cacheKey, "error", err)
+		}
+	}()
+}
+
+func (p *Proxy) refreshDetectedLabelsCacheAsync(orgID, cacheKey, query, start, end string, lineLimit int) {
+	refreshKey := "refresh:detected_labels:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+			labels, _, detectErr := p.detectLabels(ctx, query, start, end, lineLimit)
+			if detectErr != nil {
+				return nil, detectErr
+			}
+			payload := map[string]interface{}{
+				"status":         "success",
+				"data":           labels,
+				"detectedLabels": labels,
+				"limit":          lineLimit,
+			}
+			p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_labels"], payload)
+			return nil, nil
+		})
+		if err != nil {
+			p.log.Debug("background detected_labels refresh failed", "cache_key", cacheKey, "error", err)
+		}
+	}()
+}
+
+func (p *Proxy) refreshDetectedFieldValuesCacheAsync(orgID, cacheKey, fieldName, query, start, end string, lineLimit int) {
+	refreshKey := "refresh:detected_field_values:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+
+			var (
+				values  []string
+				errVals error
+			)
+			if nativeField, ok, resolveErr := p.resolveNativeDetectedField(ctx, query, start, end, fieldName); resolveErr == nil && ok {
+				values, errVals = p.fetchNativeFieldValues(ctx, query, start, end, nativeField, lineLimit)
+			}
+			if values == nil && errVals == nil {
+				_, fieldValues, detectErr := p.detectFields(ctx, query, start, end, lineLimit)
+				if detectErr != nil {
+					return nil, detectErr
+				}
+				values = fieldValues[fieldName]
+				if values == nil && fieldName == "level" {
+					values = fieldValues["detected_level"]
+				}
+			}
+			if errVals != nil {
+				return nil, errVals
+			}
+
+			payload := map[string]interface{}{
+				"status": "success",
+				"data":   values,
+				"values": values,
+				"limit":  lineLimit,
+			}
+			p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
+			return nil, nil
+		})
+		if err != nil {
+			p.log.Debug("background detected_field_values refresh failed", "cache_key", cacheKey, "field", fieldName, "error", err)
+		}
+	}()
+}
+
 // handleLabels returns label names.
 // Loki: GET /loki/api/v1/labels?start=...&end=...
 // VL:   GET /select/logsql/stream_field_names?query=*&start=...&end=...
@@ -1613,11 +2472,14 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	orgID := r.Header.Get("X-Scope-OrgID")
 	cacheKey := "labels:" + orgID + ":" + r.URL.RawQuery
 
-	if cached, ok := p.cache.Get(cacheKey); ok {
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(cached)
 		p.metrics.RecordRequest("labels", http.StatusOK, time.Since(start))
 		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["labels"]) {
+			p.refreshLabelsCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"))
+		}
 		return
 	}
 	p.metrics.RecordCacheMiss()
@@ -1698,6 +2560,50 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")
 	cacheKey := "label_values:" + orgID + ":" + labelName + ":" + r.URL.RawQuery
+	rawQuery := r.FormValue("query")
+	rawLimit := r.FormValue("limit")
+	rawOffset := r.FormValue("offset")
+	search := r.FormValue("search")
+	if strings.TrimSpace(search) == "" {
+		search = r.FormValue("q")
+	}
+	offset := parseNonNegativeInt(rawOffset, 0)
+	limit := p.defaultLabelValuesLimit(rawLimit)
+	if rawLimit == "" && !p.labelValuesBrowseMode(rawQuery) {
+		limit = maxLimitValue
+	}
+
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(cached)
+		p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
+		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["label_values"]) {
+			p.refreshLabelValuesCacheAsync(
+				orgID,
+				cacheKey,
+				labelName,
+				r.FormValue("query"),
+				r.FormValue("start"),
+				r.FormValue("end"),
+				r.FormValue("limit"),
+			)
+		}
+		return
+	}
+	p.metrics.RecordCacheMiss()
+
+	if p.labelValuesBrowseMode(rawQuery) {
+		if indexedValues, ok := p.selectLabelValuesFromIndex(orgID, labelName, search, offset, limit); ok {
+			result := lokiLabelsResponse(indexedValues)
+			p.cache.SetWithTTL(cacheKey, result, CacheTTLs["label_values"])
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(result)
+			p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
+			return
+		}
+	}
+
 	if labelName == "service_name" {
 		values, err := p.serviceNameValues(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"))
 		if err != nil {
@@ -1706,6 +2612,14 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 			p.metrics.RecordRequest("label_values", status, time.Since(start))
 			return
 		}
+		p.updateLabelValuesIndex(orgID, labelName, values)
+		if p.labelValuesBrowseMode(rawQuery) {
+			if indexedValues, ok := p.selectLabelValuesFromIndex(orgID, labelName, search, offset, limit); ok {
+				values = indexedValues
+			} else {
+				values = selectLabelValuesWindow(values, search, offset, limit)
+			}
+		}
 		result := lokiLabelsResponse(values)
 		p.cache.SetWithTTL(cacheKey, result, CacheTTLs["label_values"])
 		w.Header().Set("Content-Type", "application/json")
@@ -1713,15 +2627,6 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
 		return
 	}
-
-	if cached, ok := p.cache.Get(cacheKey); ok {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(cached)
-		p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
-		p.metrics.RecordCacheHit()
-		return
-	}
-	p.metrics.RecordCacheMiss()
 
 	params := url.Values{}
 	if q := r.FormValue("query"); q != "" {
@@ -1750,6 +2655,17 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		p.writeError(w, status, err.Error())
 		p.metrics.RecordRequest("label_values", status, time.Since(start))
 		return
+	}
+
+	p.updateLabelValuesIndex(orgID, labelName, values)
+	if p.labelValuesBrowseMode(rawQuery) {
+		if indexedValues, ok := p.selectLabelValuesFromIndex(orgID, labelName, search, offset, limit); ok {
+			values = indexedValues
+		} else {
+			values = selectLabelValuesWindow(values, search, offset, limit)
+		}
+	} else if search != "" || offset > 0 || rawLimit != "" {
+		values = selectLabelValuesWindow(values, search, offset, limit)
 	}
 
 	result := lokiLabelsResponse(values)
@@ -1917,7 +2833,7 @@ func (p *Proxy) resolveTargetLabelFields(ctx context.Context, targetLabels strin
 				lookup.Set(key, value)
 			}
 		}
-		available, fetchErr = p.fetchPreferredLabelNames(ctx, lookup)
+		available, fetchErr = p.fetchPreferredLabelNamesCached(ctx, lookup)
 		if fetchErr != nil {
 			p.log.Debug("target label inventory lookup failed; falling back to direct mapping", "error", fetchErr)
 		}
@@ -2085,25 +3001,43 @@ func (p *Proxy) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	if p.handleMultiTenantFanout(w, r, "detected_fields", p.handleDetectedFields) {
 		return
 	}
+	orgID := r.Header.Get("X-Scope-OrgID")
+	cacheKey := "detected_fields:" + orgID + ":" + r.URL.RawQuery
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(cached)
+		p.metrics.RecordRequest("detected_fields", http.StatusOK, time.Since(start))
+		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["detected_fields"]) {
+			p.refreshDetectedFieldsCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), parseDetectedLineLimit(r))
+		}
+		return
+	}
+	p.metrics.RecordCacheMiss()
+
 	r = withOrgID(r)
 	lineLimit := parseDetectedLineLimit(r)
 	fields, _, err := p.detectFields(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
 	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
+		payload := map[string]interface{}{
 			"status": "success",
 			"data":   []interface{}{},
 			"fields": []interface{}{},
 			"limit":  lineLimit,
-		})
+		}
+		p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_fields"], payload)
+		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_fields", http.StatusOK, time.Since(start))
 		return
 	}
-	p.writeJSON(w, map[string]interface{}{
+	payload := map[string]interface{}{
 		"status": "success",
 		"data":   fields,
 		"fields": fields,
 		"limit":  lineLimit,
-	})
+	}
+	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_fields"], payload)
+	p.writeJSON(w, payload)
 	p.metrics.RecordRequest("detected_fields", http.StatusOK, time.Since(start))
 }
 
@@ -2115,6 +3049,7 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 	if p.handleMultiTenantFanout(w, r, "detected_field_values", p.handleDetectedFieldValues) {
 		return
 	}
+	orgID := r.Header.Get("X-Scope-OrgID")
 	r = withOrgID(r)
 	// Extract field name from URL: /loki/api/v1/detected_field/{name}/values
 	path := r.URL.Path
@@ -2132,14 +3067,29 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 	}
 
 	lineLimit := parseDetectedLineLimit(r)
+	cacheKey := "detected_field_values:" + orgID + ":" + fieldName + ":" + r.URL.RawQuery
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(cached)
+		p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
+		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["detected_field_values"]) {
+			p.refreshDetectedFieldValuesCacheAsync(orgID, cacheKey, fieldName, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
+		}
+		return
+	}
+	p.metrics.RecordCacheMiss()
+
 	if nativeField, ok, err := p.resolveNativeDetectedField(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), fieldName); err == nil && ok {
 		if values, valuesErr := p.fetchNativeFieldValues(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), nativeField, lineLimit); valuesErr == nil {
-			p.writeJSON(w, map[string]interface{}{
+			payload := map[string]interface{}{
 				"status": "success",
 				"data":   values,
 				"values": values,
 				"limit":  lineLimit,
-			})
+			}
+			p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
+			p.writeJSON(w, payload)
 			p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
 			return
 		}
@@ -2147,12 +3097,14 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 
 	_, fieldValues, err := p.detectFields(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
 	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
+		payload := map[string]interface{}{
 			"status": "success",
 			"data":   []string{},
 			"values": []string{},
 			"limit":  lineLimit,
-		})
+		}
+		p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
+		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
 		return
 	}
@@ -2161,12 +3113,14 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 		values = fieldValues["detected_level"]
 	}
 
-	p.writeJSON(w, map[string]interface{}{
+	payload := map[string]interface{}{
 		"status": "success",
 		"data":   values,
 		"values": values,
 		"limit":  lineLimit,
-	})
+	}
+	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
+	p.writeJSON(w, payload)
 	p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
 }
 
@@ -2311,26 +3265,44 @@ func (p *Proxy) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
 	if p.handleMultiTenantFanout(w, r, "detected_labels", p.handleDetectedLabels) {
 		return
 	}
+	orgID := r.Header.Get("X-Scope-OrgID")
+	cacheKey := "detected_labels:" + orgID + ":" + r.URL.RawQuery
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(cached)
+		p.metrics.RecordRequest("detected_labels", http.StatusOK, time.Since(start))
+		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["detected_labels"]) {
+			p.refreshDetectedLabelsCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), parseDetectedLineLimit(r))
+		}
+		return
+	}
+	p.metrics.RecordCacheMiss()
+
 	r = withOrgID(r)
 	lineLimit := parseDetectedLineLimit(r)
 	detectedLabels, _, err := p.detectLabels(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
 	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
+		payload := map[string]interface{}{
 			"status":         "success",
 			"data":           []interface{}{},
 			"detectedLabels": []interface{}{},
 			"limit":          lineLimit,
-		})
+		}
+		p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_labels"], payload)
+		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_labels", http.StatusOK, time.Since(start))
 		return
 	}
 
-	p.writeJSON(w, map[string]interface{}{
+	payload := map[string]interface{}{
 		"status":         "success",
 		"data":           detectedLabels,
 		"detectedLabels": detectedLabels,
 		"limit":          lineLimit,
-	})
+	}
+	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_labels"], payload)
+	p.writeJSON(w, payload)
 	p.metrics.RecordRequest("detected_labels", http.StatusOK, time.Since(start))
 }
 
@@ -2861,6 +3833,12 @@ func (p *Proxy) vlLineToTailFrame(vlLine map[string]interface{}) map[string]inte
 
 // handleReady returns readiness status.
 func (p *Proxy) handleReady(w http.ResponseWriter, r *http.Request) {
+	if p.labelValuesIndexedCache && !p.labelValuesIndexWarmReady.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("label values index warming"))
+		return
+	}
+
 	// Probe VL backend health
 	readyReq := withOrgID(r)
 	resp, err := p.vlGet(readyReq.Context(), "/health", nil)

--- a/internal/proxy/utility_coverage_test.go
+++ b/internal/proxy/utility_coverage_test.go
@@ -342,3 +342,94 @@ func TestPeerCacheMiddleware(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeMetadataPairs_Variants(t *testing.T) {
+	if got := normalizeMetadataPairs(nil); got != nil {
+		t.Fatalf("expected nil for nil input, got %#v", got)
+	}
+
+	fromStringMap := normalizeMetadataPairs(map[string]string{
+		" service.name ": "api",
+		"":               "drop-me",
+	})
+	if len(fromStringMap) != 1 || fromStringMap["service.name"] != "api" {
+		t.Fatalf("unexpected map[string]string normalization: %#v", fromStringMap)
+	}
+
+	fromInterfaceMap := normalizeMetadataPairs(map[string]interface{}{
+		" host.id ": "i-1",
+		"count":     3,
+		"":          "drop-me",
+	})
+	if len(fromInterfaceMap) != 2 || fromInterfaceMap["host.id"] != "i-1" || fromInterfaceMap["count"] != "3" {
+		t.Fatalf("unexpected map[string]interface{} normalization: %#v", fromInterfaceMap)
+	}
+
+	fromPairs := normalizeMetadataPairs([]interface{}{
+		[]interface{}{"k8s.cluster.name", "prod"},
+		[]interface{}{"", "drop-me"},
+		[]string{"host.id", "i-2"},
+		map[string]interface{}{"name": "service.name", "value": "api"},
+		map[string]interface{}{"name": "", "value": "drop-me"},
+	})
+	if len(fromPairs) != 3 {
+		t.Fatalf("unexpected []interface{} normalization cardinality: %#v", fromPairs)
+	}
+	if fromPairs["k8s.cluster.name"] != "prod" || fromPairs["host.id"] != "i-2" || fromPairs["service.name"] != "api" {
+		t.Fatalf("unexpected []interface{} normalization values: %#v", fromPairs)
+	}
+
+	if got := normalizeMetadataPairs(struct{ Name string }{Name: "x"}); got != nil {
+		t.Fatalf("expected nil for unsupported input, got %#v", got)
+	}
+}
+
+func TestNormalizeMetadataPairTuples_AndCategorizedDetection(t *testing.T) {
+	values := [][]interface{}{
+		{"1700000000000000000", "line-one", map[string]interface{}{
+			"structuredMetadata": []interface{}{
+				[]interface{}{"host.id", "i-1"},
+				map[string]interface{}{"name": "service.name", "value": "api"},
+			},
+			"parsed": []interface{}{
+				[]string{"k8s.cluster.name", "cluster-a"},
+			},
+		}},
+		{"1700000001000000000", "line-two", map[string]interface{}{
+			"structuredMetadata": []interface{}{
+				[]interface{}{"", "drop-me"},
+			},
+			"parsed": []interface{}{
+				map[string]interface{}{"name": "", "value": "drop-me"},
+			},
+		}},
+		{"1700000002000000000", "line-three"},
+	}
+
+	if !streamValuesHaveCategorizedMetadata(values) {
+		t.Fatalf("expected categorized metadata to be detected before normalization")
+	}
+	normalizeMetadataPairTuples(values)
+
+	meta0, _ := values[0][2].(map[string]interface{})
+	structured0, _ := meta0["structuredMetadata"].(map[string]string)
+	parsed0, _ := meta0["parsed"].(map[string]string)
+	if len(structured0) != 2 || structured0["host.id"] != "i-1" || structured0["service.name"] != "api" {
+		t.Fatalf("unexpected normalized structured metadata: %#v", structured0)
+	}
+	if len(parsed0) != 1 || parsed0["k8s.cluster.name"] != "cluster-a" {
+		t.Fatalf("unexpected normalized parsed metadata: %#v", parsed0)
+	}
+
+	meta1, _ := values[1][2].(map[string]interface{})
+	if _, ok := meta1["structuredMetadata"]; ok {
+		t.Fatalf("expected empty structuredMetadata to be removed, got %#v", meta1["structuredMetadata"])
+	}
+	if _, ok := meta1["parsed"]; ok {
+		t.Fatalf("expected empty parsed metadata to be removed, got %#v", meta1["parsed"])
+	}
+
+	if streamValuesHaveCategorizedMetadata([][]interface{}{{"1700000003000000000", "line-four"}}) {
+		t.Fatalf("expected false when tuples do not contain categorized metadata object")
+	}
+}

--- a/internal/proxy/utility_coverage_test.go
+++ b/internal/proxy/utility_coverage_test.go
@@ -1,11 +1,16 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -431,5 +436,277 @@ func TestNormalizeMetadataPairTuples_AndCategorizedDetection(t *testing.T) {
 
 	if streamValuesHaveCategorizedMetadata([][]interface{}{{"1700000003000000000", "line-four"}}) {
 		t.Fatalf("expected false when tuples do not contain categorized metadata object")
+	}
+}
+
+func TestVLErrorHelpers(t *testing.T) {
+	blank := (&vlAPIError{status: http.StatusBadGateway, body: "   "}).Error()
+	if blank != "victorialogs api error: status 502" {
+		t.Fatalf("unexpected blank-body error text: %q", blank)
+	}
+	trimmed := (&vlAPIError{status: http.StatusBadGateway, body: " backend overloaded  "}).Error()
+	if trimmed != "backend overloaded" {
+		t.Fatalf("unexpected trimmed-body error text: %q", trimmed)
+	}
+
+	if !shouldFallbackToGenericMetadata(&vlAPIError{status: http.StatusNotFound}) {
+		t.Fatalf("expected 4xx vl api error to trigger generic metadata fallback")
+	}
+	if shouldFallbackToGenericMetadata(&vlAPIError{status: http.StatusInternalServerError}) {
+		t.Fatalf("expected 5xx vl api error to skip generic metadata fallback")
+	}
+	if shouldFallbackToGenericMetadata(errors.New("plain error")) {
+		t.Fatalf("expected non-vl error to skip generic metadata fallback")
+	}
+}
+
+func TestCompatCacheResponseAllowedAndBreakerFailure(t *testing.T) {
+	if compatCacheResponseAllowed(nil) {
+		t.Fatalf("nil recorder should not be cacheable")
+	}
+	badStatus := httptest.NewRecorder()
+	badStatus.WriteHeader(http.StatusBadGateway)
+	if compatCacheResponseAllowed(badStatus) {
+		t.Fatalf("non-200 response should not be cacheable")
+	}
+	flushed := httptest.NewRecorder()
+	flushed.WriteHeader(http.StatusOK)
+	flushed.Flush()
+	if compatCacheResponseAllowed(flushed) {
+		t.Fatalf("flushed response should not be cacheable")
+	}
+	withCookie := httptest.NewRecorder()
+	http.SetCookie(withCookie, &http.Cookie{Name: "sid", Value: "abc"})
+	withCookie.WriteHeader(http.StatusOK)
+	if compatCacheResponseAllowed(withCookie) {
+		t.Fatalf("response with cookies should not be cacheable")
+	}
+	withText := httptest.NewRecorder()
+	withText.Header().Set("Content-Type", "text/plain")
+	withText.WriteHeader(http.StatusOK)
+	if compatCacheResponseAllowed(withText) {
+		t.Fatalf("non-json content type should not be cacheable")
+	}
+	withJSON := httptest.NewRecorder()
+	withJSON.Header().Set("Content-Type", "application/json; charset=utf-8")
+	withJSON.WriteHeader(http.StatusOK)
+	if !compatCacheResponseAllowed(withJSON) {
+		t.Fatalf("json response should be cacheable")
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context canceled", err: context.Canceled, want: false},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: false},
+		{name: "net timeout", err: &net.DNSError{IsTimeout: true}, want: false},
+		{name: "string timeout", err: errors.New("upstream timeout"), want: false},
+		{name: "non-timeout", err: errors.New("connection reset by peer"), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRecordBreakerFailure(tc.err); got != tc.want {
+				t.Fatalf("shouldRecordBreakerFailure(%v)=%v want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type hijackRecorder struct {
+	http.ResponseWriter
+	hijacked bool
+}
+
+func (h *hijackRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+func TestStatusCaptureHijack(t *testing.T) {
+	scNoHijack := &statusCapture{ResponseWriter: httptest.NewRecorder()}
+	if _, _, err := scNoHijack.Hijack(); err == nil {
+		t.Fatalf("expected hijack to fail when wrapped writer has no hijacker")
+	}
+
+	h := &hijackRecorder{ResponseWriter: httptest.NewRecorder()}
+	scHijack := &statusCapture{ResponseWriter: h}
+	if _, _, err := scHijack.Hijack(); err != nil {
+		t.Fatalf("expected hijack to pass through, got error: %v", err)
+	}
+	if !h.hijacked {
+		t.Fatalf("expected wrapped hijacker to be called")
+	}
+}
+
+func TestHandleReady_WarmingAndOpenBreakerBackendError(t *testing.T) {
+	pWarm := newTestProxy(t, "http://unused")
+	pWarm.labelValuesIndexedCache = true
+	pWarm.labelValuesIndexWarmReady.Store(false)
+	wWarm := httptest.NewRecorder()
+	rWarm := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	pWarm.handleReady(wWarm, rWarm)
+	if wWarm.Code != http.StatusServiceUnavailable || wWarm.Body.String() != "label values index warming" {
+		t.Fatalf("expected warming readiness response, got code=%d body=%q", wWarm.Code, wWarm.Body.String())
+	}
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer vlBackend.Close()
+
+	pOpen := newTestProxy(t, vlBackend.URL)
+	for i := 0; i < 10; i++ {
+		pOpen.breaker.RecordFailure()
+	}
+	wOpen := httptest.NewRecorder()
+	rOpen := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	pOpen.handleReady(wOpen, rOpen)
+	if wOpen.Code != http.StatusServiceUnavailable || wOpen.Body.String() != "backend not ready" {
+		t.Fatalf("expected open-breaker readiness failure to surface as backend not ready, got code=%d body=%q", wOpen.Code, wOpen.Body.String())
+	}
+}
+
+func TestLabelValuesWindowAndDefaultLimit(t *testing.T) {
+	values := []string{"Alpha", "beta", "gamma", "alphabet"}
+	out := selectLabelValuesWindow(values, "  AL  ", -5, 0)
+	if len(out) != 2 || out[0] != "Alpha" || out[1] != "alphabet" {
+		t.Fatalf("unexpected search+offset+limit default window: %#v", out)
+	}
+
+	out = selectLabelValuesWindow(values, "", 1, 2)
+	if len(out) != 2 || out[0] != "beta" || out[1] != "gamma" {
+		t.Fatalf("unexpected paged window: %#v", out)
+	}
+
+	p := &Proxy{labelValuesHotLimit: 50}
+	if got := p.defaultLabelValuesLimit("25"); got != 25 {
+		t.Fatalf("explicit limit should win, got %d", got)
+	}
+	if got := p.defaultLabelValuesLimit("0"); got != 50 {
+		t.Fatalf("invalid explicit limit should fall back to hot limit, got %d", got)
+	}
+	if got := p.defaultLabelValuesLimit("999999"); got != maxLimitValue {
+		t.Fatalf("explicit limit should be clamped to max, got %d", got)
+	}
+
+	p.labelValuesHotLimit = 0
+	if got := p.defaultLabelValuesLimit(""); got != 200 {
+		t.Fatalf("empty limit with unset hot limit should default to 200, got %d", got)
+	}
+	p.labelValuesHotLimit = maxLimitValue + 100
+	if got := p.defaultLabelValuesLimit(""); got != maxLimitValue {
+		t.Fatalf("hot limit should be clamped to max, got %d", got)
+	}
+}
+
+func TestFetchVLFieldValues_ErrorPaths(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"a","hits":1},{"value":"b","hits":2}]}`))
+		case "/bad":
+			http.Error(w, "backend failed", http.StatusBadGateway)
+		case "/invalid":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{not-json`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	ctx := context.Background()
+
+	got, err := p.fetchVLFieldValues(ctx, "/ok", url.Values{})
+	if err != nil || len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("expected decoded values, got values=%#v err=%v", got, err)
+	}
+
+	if _, err := p.fetchVLFieldValues(ctx, "/bad", url.Values{}); err == nil {
+		t.Fatalf("expected API status error from /bad")
+	} else if _, ok := err.(*vlAPIError); !ok {
+		t.Fatalf("expected vlAPIError from /bad, got %T", err)
+	}
+
+	if _, err := p.fetchVLFieldValues(ctx, "/invalid", url.Values{}); err == nil {
+		t.Fatalf("expected decode error from /invalid")
+	}
+
+	for i := 0; i < 10; i++ {
+		p.breaker.RecordFailure()
+	}
+	if _, err := p.fetchVLFieldValues(ctx, "/ok", url.Values{}); err == nil {
+		t.Fatalf("expected breaker-open transport error")
+	}
+}
+
+func TestNormalizeMetadataStringValue(t *testing.T) {
+	if got := normalizeMetadataStringValue(nil); got != "" {
+		t.Fatalf("nil metadata value should normalize to empty string, got %q", got)
+	}
+	if got := normalizeMetadataStringValue(42); got != "42" {
+		t.Fatalf("numeric metadata value should stringify, got %q", got)
+	}
+}
+
+func TestProxyStatsQueryAndRangeBranches(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stats_query":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"resultType":"vector","result":[{"metric":{"service.name":"api"},"value":[1712434882,"5"]}]}}`))
+		case "/select/logsql/stats_query_range":
+			http.Error(w, "backend blew up", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+
+	wQuery := httptest.NewRecorder()
+	rQuery := httptest.NewRequest(http.MethodGet, `/loki/api/v1/query?query=sum(rate({app="api"}[1m]))&time=1712434882`, nil)
+	p.proxyStatsQuery(wQuery, rQuery, `sum(rate({app="api"}[1m]))`)
+	if wQuery.Code != http.StatusOK {
+		t.Fatalf("expected query stats proxy success, got %d body=%s", wQuery.Code, wQuery.Body.String())
+	}
+	if ct := wQuery.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json content type, got %q", ct)
+	}
+	if body := wQuery.Body.String(); !strings.Contains(body, `"resultType":"vector"`) || !strings.Contains(body, `"status":"success"`) {
+		t.Fatalf("expected Loki-wrapped stats query response, got %s", body)
+	}
+
+	wRange := httptest.NewRecorder()
+	rRange := httptest.NewRequest(http.MethodGet, `/loki/api/v1/query_range?query=sum(rate({app="api"}[1m]))&start=1712434800&end=1712438400&step=60`, nil)
+	p.proxyStatsQueryRange(wRange, rRange, `sum(rate({app="api"}[1m]))`)
+	if wRange.Code != http.StatusInternalServerError {
+		t.Fatalf("expected stats query_range backend status passthrough, got %d body=%s", wRange.Code, wRange.Body.String())
+	}
+	if body := wRange.Body.String(); !strings.Contains(body, "backend blew up") {
+		t.Fatalf("expected backend error body in query_range response, got %s", body)
+	}
+
+	for i := 0; i < 10; i++ {
+		p.breaker.RecordFailure()
+	}
+	wQueryErr := httptest.NewRecorder()
+	rQueryErr := httptest.NewRequest(http.MethodGet, `/loki/api/v1/query?query=sum(rate({app="api"}[1m]))`, nil)
+	p.proxyStatsQuery(wQueryErr, rQueryErr, `sum(rate({app="api"}[1m]))`)
+	if wQueryErr.Code != http.StatusBadGateway {
+		t.Fatalf("expected transport error branch to map to 502, got %d body=%s", wQueryErr.Code, wQueryErr.Body.String())
+	}
+	if body := wQueryErr.Body.String(); !strings.Contains(strings.ToLower(body), "circuit breaker open") {
+		t.Fatalf("expected circuit breaker error in query response, got %s", body)
 	}
 }

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -97,6 +97,8 @@ services:
     container_name: e2e-proxy
     ports:
       - "3100:3100"
+    volumes:
+      - proxy-cache:/cache
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -104,6 +106,13 @@ services:
       - "-alerts-backend=http://vmalert:8880"
       - "-log-level=info"
       - "-cache-ttl=5s"
+      - "-label-values-indexed-cache=true"
+      - "-label-values-hot-limit=200"
+      - "-label-values-index-max-entries=50000"
+      - "-label-values-index-persist-path=/cache/label-values-index.json"
+      - "-label-values-index-persist-interval=5s"
+      - "-label-values-index-startup-stale-threshold=30s"
+      - "-label-values-index-startup-peer-warm-timeout=2s"
     depends_on:
       victorialogs:
         condition: service_healthy
@@ -343,3 +352,4 @@ services:
 volumes:
   vl-data:
   vm-data:
+  proxy-cache:

--- a/test/e2e-compat/matrix_manifest_test.go
+++ b/test/e2e-compat/matrix_manifest_test.go
@@ -117,6 +117,12 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 	// - native + underscores + emit=true
 	// - translated + underscores + emit=false
 	profileExpectations := []string{
+		"loki-vl-proxy:",
+		`- "-label-values-indexed-cache=true"`,
+		`- "-label-values-hot-limit=200"`,
+		`- "-label-values-index-max-entries=50000"`,
+		`- "-label-values-index-persist-path=/cache/label-values-index.json"`,
+		`- "-label-values-index-persist-interval=5s"`,
 		"loki-vl-proxy-underscore:",
 		`- "-metadata-field-mode=hybrid"`,
 		`- "-emit-structured-metadata=true"`,


### PR DESCRIPTION
## Summary
- wire runtime support for indexed label-values cache flags end-to-end so chart flags are no longer rejected
- add persistent label-values index snapshots (periodic + graceful-shutdown flush) with startup restore
- add startup peer warm fallback when disk snapshot is stale/missing, before serving traffic
- add readiness guard for startup warm completion and peer payload gzip transport compression
- bump chart/app version to 0.27.34 and document sizing/helm usage updates

## Flags now fully wired
- -label-values-indexed-cache
- -label-values-hot-limit
- -label-values-index-max-entries
- -label-values-index-persist-path
- -label-values-index-persist-interval
- -label-values-index-startup-stale-threshold
- -label-values-index-startup-peer-warm-timeout

## Tests
- go test ./... (1411 passed)
- added regression coverage for:
  - runtime config wiring
  - disk persistence + restore
  - stale-disk startup peer warm
  - peer-cache gzip response path
  - compose manifest guards for indexed-cache persistence flags
