### PR TITLE
Fix auto-release flake in memory stability load test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - cap preallocated slice capacities on label-values browse paths to satisfy CodeQL excessive allocation guards for request-driven limits
 
+### Tests
+
+- fix `TestLoad_HighConcurrency_MemoryStability` memory delta arithmetic to avoid unsigned underflow false-positives after GC, keeping release validation deterministic
+
 ## [0.27.34] - 2026-04-11
 
 ### Configuration

--- a/internal/proxy/perf_test.go
+++ b/internal/proxy/perf_test.go
@@ -678,7 +678,14 @@ func TestLoad_HighConcurrency_MemoryStability(t *testing.T) {
 
 	totalRequests := concurrency * requestsPerGoroutine
 	rps := float64(totalRequests) / elapsed.Seconds()
-	memGrowthMB := float64(memAfter.Alloc-memBefore.Alloc) / 1024 / 1024
+	memDeltaBytes := int64(memAfter.Alloc) - int64(memBefore.Alloc)
+	memGrowthBytes := memDeltaBytes
+	if memGrowthBytes < 0 {
+		// GC may reduce Alloc below baseline; treat that as zero growth.
+		memGrowthBytes = 0
+	}
+	memDeltaMB := float64(memDeltaBytes) / 1024 / 1024
+	memGrowthMB := float64(memGrowthBytes) / 1024 / 1024
 
 	t.Logf("Load test results:")
 	t.Logf("  Total requests: %d", totalRequests)
@@ -687,8 +694,8 @@ func TestLoad_HighConcurrency_MemoryStability(t *testing.T) {
 	t.Logf("  Throughput: %.0f req/s", rps)
 	t.Logf("  Backend calls: %d (cache effectiveness: %.1f%%)",
 		requestCount.Load(), 100*(1-float64(requestCount.Load())/float64(totalRequests)))
-	t.Logf("  Memory growth: %.1f MB (before: %.1f MB, after: %.1f MB)",
-		memGrowthMB, float64(memBefore.Alloc)/1024/1024, float64(memAfter.Alloc)/1024/1024)
+	t.Logf("  Memory growth: %.1f MB (delta: %.1f MB, before: %.1f MB, after: %.1f MB)",
+		memGrowthMB, memDeltaMB, float64(memBefore.Alloc)/1024/1024, float64(memAfter.Alloc)/1024/1024)
 	t.Logf("  GC cycles: %d", memAfter.NumGC-memBefore.NumGC)
 
 	// Assertions


### PR DESCRIPTION
## Summary
- fix unsigned underflow in TestLoad_HighConcurrency_MemoryStability memory delta calculation
- treat negative post-GC delta as zero growth for threshold assertion
- keep full delta in logs for visibility

## Why
Auto Release failed on main in job 70919601210 due to a false-positive huge memory growth value caused by unsigned subtraction when memAfter.Alloc < memBefore.Alloc.

## Validation
- go test ./internal/proxy -run TestLoad_HighConcurrency_MemoryStability -count=30
- go test ./... -count=1

Refs: https://github.com/ReliablyObserve/Loki-VL-proxy/actions/runs/24287644040/job/70919601210
