### PR TITLE
Fix GitHub release asset upload failure in publish-release

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -354,7 +354,8 @@ jobs:
           name: ${{ steps.meta.outputs.tag }}
           body_path: ${{ steps.meta.outputs.notes_file }}
           files: |
-            dist/loki-vl-proxy-*
+            dist/loki-vl-proxy-linux-*
+            dist/loki-vl-proxy-darwin-*
             dist/checksums.txt
             dist/loki-vl-proxy-*.tgz
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,8 @@ jobs:
           name: ${{ steps.version.outputs.tag }}
           body_path: ${{ steps.release_notes.outputs.notes_file }}
           files: |
-            dist/loki-vl-proxy-*
+            dist/loki-vl-proxy-linux-*
+            dist/loki-vl-proxy-darwin-*
             dist/checksums.txt
             dist/loki-vl-proxy-*.tgz
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix `TestLoad_HighConcurrency_MemoryStability` memory delta arithmetic to avoid unsigned underflow false-positives after GC, keeping release validation deterministic
 
+### CI
+
+- fix release asset upload globs to avoid duplicate `.tgz` matches in GitHub Release publishing, which could fail with REST asset update `Not Found`
+
 ## [0.27.34] - 2026-04-11
 
 ### Configuration


### PR DESCRIPTION
## Summary
- fix overlapping release asset globs in both release workflows
- avoid matching the Helm chart archive twice during GitHub Release upload
- add an Unreleased changelog note for this CI reliability fix

## Root cause
In `Create GitHub Release`, `files` included both:
- `dist/loki-vl-proxy-*`
- `dist/loki-vl-proxy-*.tgz`

The first pattern already matched the chart archive, so the same `.tgz` was uploaded twice. This triggered release-asset update errors (`Not Found`) in `softprops/action-gh-release`.

## Validation target
- failing job reference: https://github.com/ReliablyObserve/Loki-VL-proxy/actions/runs/24301201773/job/70954870306
