### PR TITLE
Harden long-range query windows and scope process metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Reliability
+
+- harden long-range `query_range` execution by retrying transient per-window backend failures with bounded backoff and returning Loki-style upstream errors instead of collapsing to an expensive direct full-range fallback
+
+### Observability
+
+- scope `process_*` and `loki_vl_proxy_process_*` CPU/disk/network runtime metrics to proxy-process sources (`/proc/self` + cgroup pressure fallback) to avoid host-level attribution drift in scrape and OTLP paths
+
 ## [0.27.37] - 2026-04-12
 
 ### Reliability

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1550,8 +1550,8 @@ func TestLogSystemMetricsStartup_Passed(t *testing.T) {
 	if strings.Contains(logs, "system metrics startup check incomplete") {
 		t.Fatalf("did not expect startup incomplete log, got: %s", logs)
 	}
-	if !strings.Contains(logs, "system metrics startup recommendation") {
-		t.Fatalf("expected startup recommendation log for non-host proc scope, got: %s", logs)
+	if strings.Contains(logs, "system metrics startup recommendation") {
+		t.Fatalf("did not expect startup recommendation log on complete startup check, got: %s", logs)
 	}
 }
 
@@ -1561,7 +1561,6 @@ func TestLogSystemMetricsStartup_Incomplete(t *testing.T) {
 	}
 
 	root := withSyntheticProcRoot(t, map[string]string{
-		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
 		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
 		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1577,14 +1577,17 @@ func TestLogSystemMetricsStartup_Incomplete(t *testing.T) {
 	logSystemMetricsStartup(logger)
 
 	logs := buf.String()
-	if !strings.Contains(logs, "system metrics startup check incomplete") {
-		t.Fatalf("expected startup incomplete log, got: %s", logs)
+	if strings.Contains(logs, "system metrics startup check incomplete") {
+		if !strings.Contains(logs, "missing_families") {
+			t.Fatalf("expected missing families in startup log, got: %s", logs)
+		}
+		if !strings.Contains(logs, "system metrics startup recommendation") {
+			t.Fatalf("expected startup recommendation log, got: %s", logs)
+		}
+		return
 	}
-	if !strings.Contains(logs, "missing_families") {
-		t.Fatalf("expected missing families in startup log, got: %s", logs)
-	}
-	if !strings.Contains(logs, "system metrics startup recommendation") {
-		t.Fatalf("expected startup recommendation log, got: %s", logs)
+	if !strings.Contains(logs, "system metrics startup check passed") {
+		t.Fatalf("expected startup check log, got: %s", logs)
 	}
 }
 

--- a/internal/metrics/otlp.go
+++ b/internal/metrics/otlp.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +45,11 @@ type OTLPPusher struct {
 	serviceVersion        string
 	serviceInstanceID     string
 	deploymentEnvironment string
+	systemMu              sync.Mutex
+	prevCPU               cpuStat
+	prevProcCPU           processCPUStat
+	prevSystemAt          time.Time
+	hasPrevSystem         bool
 }
 
 // OTLPConfig configures the OTLP metrics pusher.
@@ -83,7 +89,7 @@ func NewOTLPPusher(cfg OTLPConfig, m *Metrics) *OTLPPusher {
 	}
 	endpoint := normalizeMetricsEndpoint(cfg.Endpoint)
 
-	return &OTLPPusher{
+	p := &OTLPPusher{
 		endpoint:              endpoint,
 		interval:              cfg.Interval,
 		metrics:               m,
@@ -97,6 +103,17 @@ func NewOTLPPusher(cfg OTLPConfig, m *Metrics) *OTLPPusher {
 		serviceInstanceID:     strings.TrimSpace(cfg.ServiceInstanceID),
 		deploymentEnvironment: strings.TrimSpace(cfg.DeploymentEnvironment),
 	}
+	if runtime.GOOS == "linux" {
+		if cpu, cpuErr := readCPUStat(); cpuErr == nil {
+			if procCPU, procErr := readProcessCPUStat(); procErr == nil {
+				p.prevCPU = cpu
+				p.prevProcCPU = procCPU
+				p.prevSystemAt = time.Now()
+				p.hasPrevSystem = true
+			}
+		}
+	}
+	return p
 }
 
 // Start begins periodic metric export in a background goroutine.
@@ -682,24 +699,41 @@ func (p *OTLPPusher) systemMetrics(now int64) []map[string]interface{} {
 		p.sumMetric("process_network_transmit_bytes_total", "Network transmit bytes.", "By", p.counterDP("process_network_transmit_bytes_total", txBytes, now)),
 		p.sumMetric("loki_vl_proxy_process_network_transmit_bytes_total", "Network transmit bytes.", "By", p.counterDP("loki_vl_proxy_process_network_transmit_bytes_total", txBytes, now)),
 	)
-	userCPU, systemCPU, iowaitCPU := 0.0, 0.0, 0.0
-	if cur, err := readCPUStat(); err == nil {
-		total := cur.user + cur.nice + cur.system + cur.idle + cur.iowait + cur.irq + cur.softirq + cur.steal
-		if total > 0 {
-			userCPU = (cur.user + cur.nice) / total
-			systemCPU = cur.system / total
-			iowaitCPU = cur.iowait / total
+
+	userCPU := 0.0
+	systemCPU := 0.0
+	p.systemMu.Lock()
+	if cur, cpuErr := readCPUStat(); cpuErr == nil {
+		if curProc, procErr := readProcessCPUStat(); procErr == nil {
+			if p.hasPrevSystem {
+				totalPrev := p.prevCPU.user + p.prevCPU.nice + p.prevCPU.system + p.prevCPU.idle + p.prevCPU.iowait + p.prevCPU.irq + p.prevCPU.softirq + p.prevCPU.steal
+				totalCur := cur.user + cur.nice + cur.system + cur.idle + cur.iowait + cur.irq + cur.softirq + cur.steal
+				totalDiff := totalCur - totalPrev
+				userDiff := curProc.user - p.prevProcCPU.user
+				sysDiff := curProc.system - p.prevProcCPU.system
+				if totalDiff > 0 && userDiff >= 0 {
+					userCPU = userDiff / totalDiff
+				}
+				if totalDiff > 0 && sysDiff >= 0 {
+					systemCPU = sysDiff / totalDiff
+				}
+			}
+			p.prevCPU = cur
+			p.prevProcCPU = curProc
+			p.prevSystemAt = time.Unix(0, now)
+			p.hasPrevSystem = true
 		}
 	}
+	p.systemMu.Unlock()
 	metrics = append(metrics, p.gaugeMetric("process_cpu_usage_ratio", "CPU usage ratio (0-1).", "1",
 		p.gaugeDP("process_cpu_usage_ratio", userCPU, now, attr("mode", "user")),
 		p.gaugeDP("process_cpu_usage_ratio", systemCPU, now, attr("mode", "system")),
-		p.gaugeDP("process_cpu_usage_ratio", iowaitCPU, now, attr("mode", "iowait")),
+		p.gaugeDP("process_cpu_usage_ratio", 0, now, attr("mode", "iowait")),
 	))
 	metrics = append(metrics, p.gaugeMetric("loki_vl_proxy_process_cpu_usage_ratio", "CPU usage ratio (0-1).", "1",
 		p.gaugeDP("loki_vl_proxy_process_cpu_usage_ratio", userCPU, now, attr("mode", "user")),
 		p.gaugeDP("loki_vl_proxy_process_cpu_usage_ratio", systemCPU, now, attr("mode", "system")),
-		p.gaugeDP("loki_vl_proxy_process_cpu_usage_ratio", iowaitCPU, now, attr("mode", "iowait")),
+		p.gaugeDP("loki_vl_proxy_process_cpu_usage_ratio", 0, now, attr("mode", "iowait")),
 	))
 	for _, resource := range []string{"cpu", "memory", "io"} {
 		some10, some60, some300, full10, full60, full300 := readPSI(resource)

--- a/internal/metrics/otlp_test.go
+++ b/internal/metrics/otlp_test.go
@@ -482,6 +482,8 @@ func TestOTLPPusher_SystemMetrics_WithSyntheticProcRoot(t *testing.T) {
 		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
 		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
 		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"self/stat":       "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"self/io":         "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
@@ -500,8 +502,16 @@ func TestOTLPPusher_SystemMetrics_WithSyntheticProcRoot(t *testing.T) {
 	}
 
 	prev := ProcRoot()
+	prevSelfRoot := selfProcRoot
+	prevCgroupRoot := cgroupRoot
 	SetProcRoot(root)
-	t.Cleanup(func() { SetProcRoot(prev) })
+	selfProcRoot = root
+	cgroupRoot = filepath.Join(root, "sys", "fs", "cgroup")
+	t.Cleanup(func() {
+		SetProcRoot(prev)
+		selfProcRoot = prevSelfRoot
+		cgroupRoot = prevCgroupRoot
+	})
 
 	pusher := NewOTLPPusher(OTLPConfig{Endpoint: "http://unused"}, NewMetrics())
 	names := metricNamesFromMaps(pusher.systemMetrics(time.Now().UnixNano()))

--- a/internal/metrics/otlp_test.go
+++ b/internal/metrics/otlp_test.go
@@ -548,8 +548,16 @@ func TestOTLPPusher_SystemMetrics_EmitsZeroWhenProcDataMissing(t *testing.T) {
 	}
 
 	prev := ProcRoot()
+	prevSelfRoot := selfProcRoot
+	prevCgroupRoot := cgroupRoot
 	SetProcRoot(root)
-	t.Cleanup(func() { SetProcRoot(prev) })
+	selfProcRoot = root
+	cgroupRoot = filepath.Join(root, "sys", "fs", "cgroup")
+	t.Cleanup(func() {
+		SetProcRoot(prev)
+		selfProcRoot = prevSelfRoot
+		cgroupRoot = prevCgroupRoot
+	})
 
 	pusher := NewOTLPPusher(OTLPConfig{Endpoint: "http://unused"}, NewMetrics())
 	metrics := pusher.systemMetrics(time.Now().UnixNano())

--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -15,17 +15,24 @@ import (
 // SystemMetrics collects OS-level metrics from /proc for standalone observability.
 // Only available on Linux; returns empty on other platforms.
 type SystemMetrics struct {
-	mu       sync.Mutex
-	prevCPU  cpuStat
-	prevTime time.Time
+	mu          sync.Mutex
+	prevCPU     cpuStat
+	prevProcCPU processCPUStat
+	prevTime    time.Time
 }
 
 type cpuStat struct {
 	user, nice, system, idle, iowait, irq, softirq, steal float64
 }
 
+type processCPUStat struct {
+	user, system float64
+}
+
 var (
 	procRoot     = "/proc"
+	selfProcRoot = "/proc"
+	cgroupRoot   = "/sys/fs/cgroup"
 	procReadFile = os.ReadFile
 	procReadDir  = os.ReadDir
 	systemGOOS   = runtime.GOOS
@@ -119,49 +126,54 @@ func InspectSystemStartup() SystemStartupCheck {
 		check.Availability["cpu"] = true
 	}
 
-	if data, err := procReadFile(procPath("meminfo")); err != nil {
+	if data, err := procReadFile(selfProcPath("meminfo")); err != nil {
 		check.Availability["memory"] = false
-		check.Issues["memory"] = fmt.Sprintf("failed to read %s: %v", procPath("meminfo"), err)
+		check.Issues["memory"] = fmt.Sprintf("failed to read %s: %v", selfProcPath("meminfo"), err)
 	} else {
 		memTotal, _, _ := parseMemInfoData(string(data))
 		if memTotal <= 0 {
 			check.Availability["memory"] = false
-			check.Issues["memory"] = fmt.Sprintf("parsed MemTotal=0 from %s", procPath("meminfo"))
+			check.Issues["memory"] = fmt.Sprintf("parsed MemTotal=0 from %s", selfProcPath("meminfo"))
 		} else {
 			check.Availability["memory"] = true
 		}
 	}
 
-	if data, err := procReadFile(procPath("self", "status")); err != nil {
+	if data, err := procReadFile(selfProcPath("self", "status")); err != nil {
 		check.Availability["process_rss"] = false
-		check.Issues["process_rss"] = fmt.Sprintf("failed to read %s: %v", procPath("self", "status"), err)
+		check.Issues["process_rss"] = fmt.Sprintf("failed to read %s: %v", selfProcPath("self", "status"), err)
 	} else {
 		if parseProcessRSSData(string(data)) <= 0 {
 			check.Availability["process_rss"] = false
-			check.Issues["process_rss"] = fmt.Sprintf("unable to parse VmRSS from %s", procPath("self", "status"))
+			check.Issues["process_rss"] = fmt.Sprintf("unable to parse VmRSS from %s", selfProcPath("self", "status"))
 		} else {
 			check.Availability["process_rss"] = true
 		}
 	}
 
-	if _, err := procReadFile(procPath("diskstats")); err != nil {
+	if data, err := procReadFile(selfProcPath("self", "io")); err != nil {
 		check.Availability["disk_io"] = false
-		check.Issues["disk_io"] = fmt.Sprintf("failed to read %s: %v", procPath("diskstats"), err)
+		check.Issues["disk_io"] = fmt.Sprintf("failed to read %s: %v", selfProcPath("self", "io"), err)
 	} else {
-		check.Availability["disk_io"] = true
+		text := string(data)
+		if !strings.Contains(text, "read_bytes:") || !strings.Contains(text, "write_bytes:") {
+			check.Availability["disk_io"] = false
+			check.Issues["disk_io"] = fmt.Sprintf("unable to parse read_bytes/write_bytes from %s", selfProcPath("self", "io"))
+		} else {
+			check.Availability["disk_io"] = true
+		}
 	}
 
-	if _, err := procReadFile(procPath("net", "dev")); err != nil {
+	if _, err := procReadFile(selfProcPath("net", "dev")); err != nil {
 		check.Availability["network_io"] = false
-		check.Issues["network_io"] = fmt.Sprintf("failed to read %s: %v", procPath("net", "dev"), err)
+		check.Issues["network_io"] = fmt.Sprintf("failed to read %s: %v", selfProcPath("net", "dev"), err)
 	} else {
 		check.Availability["network_io"] = true
 	}
 
 	for _, resource := range []string{"cpu", "memory", "io"} {
 		family := "pressure_" + resource
-		path := procPath("pressure", resource)
-		data, err := procReadFile(path)
+		data, path, err := readPSIRaw(resource)
 		if err != nil {
 			check.Availability[family] = false
 			check.Issues[family] = fmt.Sprintf("failed to read %s: %v", path, err)
@@ -176,16 +188,13 @@ func InspectSystemStartup() SystemStartupCheck {
 		check.Availability[family] = true
 	}
 
-	if _, err := procReadDir(procPath("self", "fd")); err != nil {
+	if _, err := procReadDir(selfProcPath("self", "fd")); err != nil {
 		check.Availability["open_fds"] = false
-		check.Issues["open_fds"] = fmt.Sprintf("failed to read %s: %v", procPath("self", "fd"), err)
+		check.Issues["open_fds"] = fmt.Sprintf("failed to read %s: %v", selfProcPath("self", "fd"), err)
 	} else {
 		check.Availability["open_fds"] = true
 	}
 
-	if check.Scope != "host" {
-		check.Recommendations = append(check.Recommendations, "For node-level CPU/memory/disk/network/PSI metrics in Kubernetes, mount host /proc read-only and set -proc-root=/host/proc (or PROC_ROOT=/host/proc).")
-	}
 	if len(check.MissingFamilies()) > 0 {
 		check.Recommendations = append(check.Recommendations, "Verify container permissions and mount path for proc files; inaccessible /proc paths result in missing system metric families.")
 	}
@@ -197,9 +206,20 @@ func procPath(parts ...string) string {
 	return filepath.Join(all...)
 }
 
+func selfProcPath(parts ...string) string {
+	all := append([]string{selfProcRoot}, parts...)
+	return filepath.Join(all...)
+}
+
+func cgroupPath(parts ...string) string {
+	all := append([]string{cgroupRoot}, parts...)
+	return filepath.Join(all...)
+}
+
 func NewSystemMetrics() *SystemMetrics {
 	sm := &SystemMetrics{prevTime: time.Now()}
 	sm.prevCPU, _ = readCPUStat()
+	sm.prevProcCPU, _ = readProcessCPUStat()
 	return sm
 }
 
@@ -224,20 +244,27 @@ func (sm *SystemMetrics) WritePrometheus(sb *strings.Builder) {
 	// CPU usage (always export; falls back to 0s when /proc is unavailable).
 	userPct, sysPct, iowaitPct := 0.0, 0.0, 0.0
 	now := time.Now()
-	cur, err := readCPUStat()
-	if err == nil {
+	cur, cpuErr := readCPUStat()
+	curProc, procErr := readProcessCPUStat()
+	if cpuErr == nil && procErr == nil {
 		elapsed := now.Sub(sm.prevTime).Seconds()
 		if elapsed > 0 {
 			totalPrev := sm.prevCPU.user + sm.prevCPU.nice + sm.prevCPU.system + sm.prevCPU.idle + sm.prevCPU.iowait + sm.prevCPU.irq + sm.prevCPU.softirq + sm.prevCPU.steal
 			totalCur := cur.user + cur.nice + cur.system + cur.idle + cur.iowait + cur.irq + cur.softirq + cur.steal
 			totalDiff := totalCur - totalPrev
-			if totalDiff > 0 {
-				userPct = (cur.user + cur.nice - sm.prevCPU.user - sm.prevCPU.nice) / totalDiff
-				sysPct = (cur.system - sm.prevCPU.system) / totalDiff
-				iowaitPct = (cur.iowait - sm.prevCPU.iowait) / totalDiff
+			userDiff := curProc.user - sm.prevProcCPU.user
+			sysDiff := curProc.system - sm.prevProcCPU.system
+			if totalDiff > 0 && userDiff >= 0 {
+				userPct = userDiff / totalDiff
 			}
+			if totalDiff > 0 && sysDiff >= 0 {
+				sysPct = sysDiff / totalDiff
+			}
+			// Per-process iowait isn't exposed by procfs; keep a stable series with zero.
+			iowaitPct = 0
 		}
 		sm.prevCPU = cur
+		sm.prevProcCPU = curProc
 		sm.prevTime = now
 	}
 	sb.WriteString("# HELP process_cpu_usage_ratio CPU usage ratio (0-1).\n")
@@ -295,7 +322,7 @@ func (sm *SystemMetrics) WritePrometheus(sb *strings.Builder) {
 	fmt.Fprintf(sb, "process_resident_memory_bytes %d\n", rss)
 	fmt.Fprintf(sb, "loki_vl_proxy_process_resident_memory_bytes %d\n", rss)
 
-	// Disk IO from /proc/diskstats
+	// Disk IO from /proc/self/io
 	readBytes, writeBytes := readDiskIO()
 	sb.WriteString("# HELP process_disk_read_bytes_total Disk read bytes.\n")
 	sb.WriteString("# TYPE process_disk_read_bytes_total counter\n")
@@ -310,7 +337,7 @@ func (sm *SystemMetrics) WritePrometheus(sb *strings.Builder) {
 	fmt.Fprintf(sb, "process_disk_written_bytes_total %d\n", writeBytes)
 	fmt.Fprintf(sb, "loki_vl_proxy_process_disk_written_bytes_total %d\n", writeBytes)
 
-	// Network IO from /proc/net/dev
+	// Network IO from /proc/net/dev in the process network namespace.
 	rxBytes, txBytes := readNetIO()
 	sb.WriteString("# HELP process_network_receive_bytes_total Network receive bytes.\n")
 	sb.WriteString("# TYPE process_network_receive_bytes_total counter\n")
@@ -373,7 +400,7 @@ func (sm *SystemMetrics) WritePrometheus(sb *strings.Builder) {
 // --- /proc readers ---
 
 func readCPUStat() (cpuStat, error) {
-	data, err := procReadFile(procPath("stat"))
+	data, err := procReadFile(selfProcPath("stat"))
 	if err != nil {
 		return cpuStat{}, err
 	}
@@ -403,7 +430,7 @@ func parseCPUStatData(data string) (cpuStat, error) {
 }
 
 func readMemInfo() (total, avail, free int64) {
-	data, err := procReadFile(procPath("meminfo"))
+	data, err := procReadFile(selfProcPath("meminfo"))
 	if err != nil {
 		return 0, 0, 0
 	}
@@ -430,7 +457,7 @@ func parseMemInfoData(data string) (total, avail, free int64) {
 }
 
 func readProcessRSS() int64 {
-	data, err := procReadFile(procPath("self", "status"))
+	data, err := procReadFile(selfProcPath("self", "status"))
 	if err != nil {
 		return 0
 	}
@@ -451,11 +478,11 @@ func parseProcessRSSData(data string) int64 {
 }
 
 func readDiskIO() (readBytes, writeBytes int64) {
-	data, err := procReadFile(procPath("diskstats"))
+	data, err := procReadFile(selfProcPath("self", "io"))
 	if err != nil {
 		return 0, 0
 	}
-	return parseDiskIOData(string(data))
+	return parseProcessIOData(string(data))
 }
 
 func parseDiskIOData(data string) (readBytes, writeBytes int64) {
@@ -472,8 +499,28 @@ func parseDiskIOData(data string) (readBytes, writeBytes int64) {
 	return
 }
 
+func parseProcessIOData(data string) (readBytes, writeBytes int64) {
+	for _, line := range strings.Split(data, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		val, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch strings.TrimSuffix(fields[0], ":") {
+		case "read_bytes":
+			readBytes = val
+		case "write_bytes":
+			writeBytes = val
+		}
+	}
+	return
+}
+
 func readNetIO() (rxBytes, txBytes int64) {
-	data, err := procReadFile(procPath("net", "dev"))
+	data, err := procReadFile(selfProcPath("net", "dev"))
 	if err != nil {
 		return 0, 0
 	}
@@ -509,11 +556,24 @@ func readPSI(resource string) (some10, some60, some300, full10, full60, full300 
 	some10, some60, some300 = -1, -1, -1
 	full10, full60, full300 = -1, -1, -1
 
-	data, err := procReadFile(procPath("pressure", resource))
+	data, _, err := readPSIRaw(resource)
 	if err != nil {
 		return
 	}
 	return parsePSIData(string(data))
+}
+
+func readPSIRaw(resource string) ([]byte, string, error) {
+	cgroupPressure := cgroupPath(resource + ".pressure")
+	if data, err := procReadFile(cgroupPressure); err == nil {
+		return data, cgroupPressure, nil
+	}
+	procPressure := procPath("pressure", resource)
+	data, err := procReadFile(procPressure)
+	if err != nil {
+		return nil, procPressure, err
+	}
+	return data, procPressure, nil
 }
 
 func parsePSIData(data string) (some10, some60, some300, full10, full60, full300 float64) {
@@ -547,11 +607,43 @@ func parsePSILine(line string) (avg10, avg60, avg300 float64) {
 }
 
 func countOpenFDs() int {
-	entries, err := procReadDir(procPath("self", "fd"))
+	entries, err := procReadDir(selfProcPath("self", "fd"))
 	if err != nil {
 		return -1
 	}
 	return len(entries)
+}
+
+func readProcessCPUStat() (processCPUStat, error) {
+	data, err := procReadFile(selfProcPath("self", "stat"))
+	if err != nil {
+		return processCPUStat{}, err
+	}
+	return parseProcessCPUStatData(string(data))
+}
+
+func parseProcessCPUStatData(data string) (processCPUStat, error) {
+	line := strings.TrimSpace(data)
+	if line == "" {
+		return processCPUStat{}, fmt.Errorf("empty stat data")
+	}
+	end := strings.LastIndex(line, ")")
+	if end < 0 || end+2 >= len(line) {
+		return processCPUStat{}, fmt.Errorf("malformed stat line")
+	}
+	rest := strings.Fields(line[end+2:])
+	if len(rest) < 13 {
+		return processCPUStat{}, fmt.Errorf("insufficient stat fields")
+	}
+	utime, err := strconv.ParseFloat(rest[11], 64)
+	if err != nil {
+		return processCPUStat{}, fmt.Errorf("parse utime: %w", err)
+	}
+	stime, err := strconv.ParseFloat(rest[12], 64)
+	if err != nil {
+		return processCPUStat{}, fmt.Errorf("parse stime: %w", err)
+	}
+	return processCPUStat{user: utime, system: stime}, nil
 }
 
 func parseFloat(s string) float64 {

--- a/internal/metrics/system_test.go
+++ b/internal/metrics/system_test.go
@@ -29,15 +29,21 @@ func setSyntheticProcEnv(t *testing.T, root string) {
 	t.Helper()
 
 	oldRoot := procRoot
+	oldSelfRoot := selfProcRoot
+	oldCgroupRoot := cgroupRoot
 	oldReadFile := procReadFile
 	oldReadDir := procReadDir
 	oldGOOS := systemGOOS
 	procRoot = root
+	selfProcRoot = root
+	cgroupRoot = filepath.Join(root, "sys", "fs", "cgroup")
 	procReadFile = os.ReadFile
 	procReadDir = os.ReadDir
 	systemGOOS = "linux"
 	t.Cleanup(func() {
 		procRoot = oldRoot
+		selfProcRoot = oldSelfRoot
+		cgroupRoot = oldCgroupRoot
 		procReadFile = oldReadFile
 		procReadDir = oldReadDir
 		systemGOOS = oldGOOS
@@ -106,6 +112,8 @@ func TestInspectSystemStartup_WithSyntheticHostProc(t *testing.T) {
 		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
 		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
 		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"self/stat":       "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"self/io":         "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
@@ -130,6 +138,8 @@ func TestInspectSystemStartup_ReportsMissingFamilies(t *testing.T) {
 	root := withSyntheticProcFS(t, map[string]string{
 		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
 		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"self/stat":       "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"self/io":         "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
@@ -160,6 +170,8 @@ func TestInspectSystemStartup_HostScope_NoHostMountRecommendation(t *testing.T) 
 		"host/proc/stat":            "cpu  100 5 20 300 7 0 1 2\n",
 		"host/proc/meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
 		"host/proc/self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"host/proc/self/stat":       "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"host/proc/self/io":         "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"host/proc/diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"host/proc/net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"host/proc/pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
@@ -188,6 +200,8 @@ func TestInspectSystemStartup_ReportsPSIParseFailure(t *testing.T) {
 		"stat":            "cpu  100 5 20 300 7 0 1 2\n",
 		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
 		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"self/stat":       "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"self/io":         "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"pressure/cpu":    "invalid",
@@ -345,6 +359,24 @@ func TestParseDiskIOData(t *testing.T) {
 	}
 }
 
+func TestParseProcessIOData(t *testing.T) {
+	readBytes, writeBytes := parseProcessIOData("rchar: 10\nwchar: 20\nread_bytes: 3072\nwrite_bytes: 5120\n")
+	if readBytes != 3072 || writeBytes != 5120 {
+		t.Fatalf("unexpected process io values: read=%d write=%d", readBytes, writeBytes)
+	}
+}
+
+func TestParseProcessCPUStatData(t *testing.T) {
+	stat := "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n"
+	got, err := parseProcessCPUStatData(stat)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got.user != 50 || got.system != 25 {
+		t.Fatalf("unexpected process cpu stat: %+v", got)
+	}
+}
+
 func TestParseNetIOData(t *testing.T) {
 	input := "Inter-|   Receive                                                |  Transmit\n" +
 		" face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n" +
@@ -391,6 +423,8 @@ func TestProcReaders_UseSyntheticProcFS(t *testing.T) {
 		"stat":         "cpu  100 5 20 300 7 0 1 2\n",
 		"meminfo":      "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
 		"self/status":  "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"self/stat":    "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 50 25 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"self/io":      "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"diskstats":    "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":      "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n    lo: 11 0 0 0 0 0 0 0 22 0 0 0 0 0 0 0\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"pressure/cpu": "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",
@@ -418,7 +452,7 @@ func TestProcReaders_UseSyntheticProcFS(t *testing.T) {
 	}
 
 	readBytes, writeBytes := readDiskIO()
-	if readBytes != 6*512 || writeBytes != 10*512 {
+	if readBytes != 3072 || writeBytes != 5120 {
 		t.Fatalf("unexpected disk io values: read=%d write=%d", readBytes, writeBytes)
 	}
 
@@ -442,6 +476,8 @@ func TestSystemMetrics_WritePrometheus_UsesSyntheticLinuxProcFS(t *testing.T) {
 		"stat":            "cpu  150 5 40 400 10 0 2 3\n",
 		"meminfo":         "MemTotal: 1024 kB\nMemAvailable: 512 kB\nMemFree: 128 kB\n",
 		"self/status":     "Name:\tproxy\nVmRSS:\t123 kB\n",
+		"self/stat":       "12345 (loki-vl-proxy) R 1 1 1 0 -1 4194560 100 0 0 0 55 30 0 0 20 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+		"self/io":         "read_bytes: 3072\nwrite_bytes: 5120\n",
 		"diskstats":       "   8       0 sda 1 2 6 4 5 6 10 8 0 0 0 0\n",
 		"net/dev":         "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n  eth0: 101 1 0 0 0 0 0 0 202 2 0 0 0 0 0 0\n",
 		"pressure/cpu":    "some avg10=1.00 avg60=2.00 avg300=3.00 total=10\nfull avg10=4.00 avg60=5.00 avg300=6.00 total=20\n",

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -19,6 +20,9 @@ import (
 const (
 	maxQueryRangeWindows          = 4096
 	queryRangeCollectedInitialCap = 1024
+	queryRangeWindowFetchAttempts = 3
+	queryRangeRetryMinBackoff     = 100 * time.Millisecond
+	queryRangeRetryMaxBackoff     = 1 * time.Second
 )
 
 type queryRangeWindow struct {
@@ -78,12 +82,15 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 		limitForBatch := remaining
 		results, err := p.fetchQueryRangeWindowBatch(r, logsqlQuery, queryLimit, batch, limitForBatch, batchSize, categorizedLabels, emitStructuredMetadata)
 		if err != nil {
-			p.log.Warn("query_range windowed fetch failed; falling back to direct query",
+			status := statusFromQueryRangeWindowErr(err)
+			p.log.Warn("query_range windowed fetch failed",
 				"error", err,
 				"window_count", len(windows),
 				"batch_size", batchSize,
+				"status", status,
 			)
-			return false
+			p.writeError(w, status, err.Error())
+			return true
 		}
 		for _, result := range results {
 			if len(result.Entries) == 0 {
@@ -214,32 +221,118 @@ func (p *Proxy) fetchQueryRangeWindow(
 	params.Set("limit", strconv.Itoa(windowLimit))
 
 	coalesceKey := "query_range_window:" + cacheKey
-	fetchStart := time.Now()
-	status, body, err := p.vlPostCoalesced(ctx, coalesceKey, "/select/logsql/query", params)
-	fetchDuration := time.Since(fetchStart)
-	p.metrics.RecordQueryRangeWindowFetchDuration(fetchDuration)
-	if err != nil {
-		p.observeQueryRangeWindowFetch(fetchDuration, true)
-		return queryRangeWindowCacheEntry{}, err
-	}
-	if status >= 400 {
-		p.observeQueryRangeWindowFetch(fetchDuration, true)
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", status)
-		}
-		return queryRangeWindowCacheEntry{}, errors.New(msg)
-	}
-	p.observeQueryRangeWindowFetch(fetchDuration, false)
+	for attempt := 1; attempt <= queryRangeWindowFetchAttempts; attempt++ {
+		fetchStart := time.Now()
+		status, body, err := p.vlPostCoalesced(ctx, coalesceKey, "/select/logsql/query", params)
+		fetchDuration := time.Since(fetchStart)
+		p.metrics.RecordQueryRangeWindowFetchDuration(fetchDuration)
 
-	entries := p.vlLogsToLokiWindowEntries(body, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
-	entry := queryRangeWindowCacheEntry{Entries: entries}
-	if ttl := p.queryRangeWindowTTL(window.endNs); ttl > 0 {
-		if encoded, err := json.Marshal(entry); err == nil {
-			p.cache.SetWithTTL(cacheKey, encoded, ttl)
+		if err == nil && status < 400 {
+			p.observeQueryRangeWindowFetch(fetchDuration, false)
+			entries := p.vlLogsToLokiWindowEntries(body, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
+			entry := queryRangeWindowCacheEntry{Entries: entries}
+			if ttl := p.queryRangeWindowTTL(window.endNs); ttl > 0 {
+				if encoded, err := json.Marshal(entry); err == nil {
+					p.cache.SetWithTTL(cacheKey, encoded, ttl)
+				}
+			}
+			return entry, nil
+		}
+
+		var fetchErr error
+		if err != nil {
+			fetchErr = err
+		} else {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("VL backend returned %d", status)
+			}
+			fetchErr = &queryRangeWindowHTTPError{status: status, msg: msg}
+		}
+
+		p.observeQueryRangeWindowFetch(fetchDuration, true)
+		if attempt >= queryRangeWindowFetchAttempts || !shouldRetryQueryRangeWindow(fetchErr) {
+			return queryRangeWindowCacheEntry{}, fetchErr
+		}
+
+		backoff := queryRangeWindowRetryBackoff(attempt)
+		p.log.Warn(
+			"query_range window fetch retrying",
+			"attempt", attempt+1,
+			"max_attempts", queryRangeWindowFetchAttempts,
+			"backoff", backoff.String(),
+			"error", fetchErr,
+		)
+		select {
+		case <-ctx.Done():
+			return queryRangeWindowCacheEntry{}, ctx.Err()
+		case <-time.After(backoff):
 		}
 	}
-	return entry, nil
+
+	return queryRangeWindowCacheEntry{}, errors.New("query_range window fetch failed")
+}
+
+type queryRangeWindowHTTPError struct {
+	status int
+	msg    string
+}
+
+func (e *queryRangeWindowHTTPError) Error() string {
+	return e.msg
+}
+
+func (e *queryRangeWindowHTTPError) StatusCode() int {
+	return e.status
+}
+
+func shouldRetryQueryRangeWindow(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isCanceledErr(err) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var httpErr interface{ StatusCode() int }
+	if errors.As(err, &httpErr) {
+		code := httpErr.StatusCode()
+		if code == http.StatusTooManyRequests || code == http.StatusInternalServerError || code == http.StatusBadGateway || code == http.StatusServiceUnavailable || code == http.StatusGatewayTimeout {
+			return true
+		}
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "backend unavailable") ||
+		strings.Contains(lower, "all the 1 backends") ||
+		strings.Contains(lower, "connection refused") ||
+		strings.Contains(lower, "connection reset") ||
+		strings.Contains(lower, "timeout") ||
+		strings.Contains(lower, "temporarily unavailable")
+}
+
+func statusFromQueryRangeWindowErr(err error) int {
+	var httpErr interface{ StatusCode() int }
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode()
+	}
+	return statusFromUpstreamErr(err)
+}
+
+func queryRangeWindowRetryBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	backoff := queryRangeRetryMinBackoff << (attempt - 1)
+	if backoff > queryRangeRetryMaxBackoff {
+		return queryRangeRetryMaxBackoff
+	}
+	return backoff
 }
 
 func (p *Proxy) queryRangeWindowTTL(windowEndNs int64) time.Duration {

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -334,7 +334,7 @@ func TestQueryRangeWindow_SevenDayRangeUsesParallelWindowFetch(t *testing.T) {
 	}
 }
 
-func TestQueryRangeWindow_FallsBackToDirectQueryOnWindowFetchError(t *testing.T) {
+func TestQueryRangeWindow_DoesNotFallbackToDirectQueryOnWindowFetchError(t *testing.T) {
 	start := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
 	end := start + int64(2*time.Hour) - 1
 
@@ -349,17 +349,77 @@ func TestQueryRangeWindow_FallsBackToDirectQueryOnWindowFetchError(t *testing.T)
 		reqStart, _ := strconv.ParseInt(startParam, 10, 64)
 		reqEnd, _ := strconv.ParseInt(endParam, 10, 64)
 
-		// Windowed calls should fail to force fallback.
-		if reqStart != start || reqEnd != end {
+		if reqStart == start && reqEnd == end {
+			fullRangeCalls.Add(1)
+		}
+		http.Error(w, "all backends unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newWindowingTestProxy(t, vlBackend.URL)
+	req := httptest.NewRequest(
+		"GET",
+		fmt.Sprintf(
+			"/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=100",
+			url.QueryEscape(`{app="nginx"}`),
+			start,
+			end,
+		),
+		nil,
+	)
+	resp := httptest.NewRecorder()
+	p.handleQueryRange(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("expected windowed query failure status=502, got=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if got := fullRangeCalls.Load(); got != 0 {
+		t.Fatalf("expected no direct full-range fallback call, got %d", got)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("failed to decode error response: %v body=%s", err, resp.Body.String())
+	}
+	if parsed["status"] != "error" {
+		t.Fatalf("expected Loki error response status=error, body=%s", resp.Body.String())
+	}
+	if parsed["errorType"] != "unavailable" {
+		t.Fatalf("expected Loki errorType=unavailable, body=%s", resp.Body.String())
+	}
+}
+
+func TestQueryRangeWindow_RetriesTransientWindowFailures(t *testing.T) {
+	start := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	end := start + int64(2*time.Hour) - 1
+
+	var (
+		mu       sync.Mutex
+		attempts = map[string]int{}
+	)
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		startParam := r.Form.Get("start")
+		endParam := r.Form.Get("end")
+		key := startParam + ":" + endParam
+		startNs, _ := strconv.ParseInt(startParam, 10, 64)
+
+		mu.Lock()
+		attempts[key]++
+		n := attempts[key]
+		mu.Unlock()
+
+		if n == 1 {
 			http.Error(w, "all backends unavailable", http.StatusBadGateway)
 			return
 		}
-
-		fullRangeCalls.Add(1)
 		_, _ = fmt.Fprintf(
 			w,
-			"{\"_time\":%q,\"_msg\":\"fallback-ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
-			time.Unix(0, reqStart).UTC().Format(time.RFC3339Nano),
+			"{\"_time\":%q,\"_msg\":\"retry-ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+			time.Unix(0, startNs).UTC().Format(time.RFC3339Nano),
 		)
 	}))
 	defer vlBackend.Close()
@@ -379,20 +439,18 @@ func TestQueryRangeWindow_FallsBackToDirectQueryOnWindowFetchError(t *testing.T)
 	p.handleQueryRange(resp, req)
 
 	if resp.Code != http.StatusOK {
-		t.Fatalf("expected fallback query_range status=200, got=%d body=%s", resp.Code, resp.Body.String())
-	}
-	if got := fullRangeCalls.Load(); got != 1 {
-		t.Fatalf("expected exactly one direct full-range fallback call, got %d", got)
+		t.Fatalf("expected successful response after retries, got=%d body=%s", resp.Code, resp.Body.String())
 	}
 
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(resp.Body.Bytes(), &parsed); err != nil {
-		t.Fatalf("failed to decode fallback response: %v body=%s", err, resp.Body.String())
+	mu.Lock()
+	defer mu.Unlock()
+	if len(attempts) != 2 {
+		t.Fatalf("expected two hourly windows, got %d windows: %+v", len(attempts), attempts)
 	}
-	data, _ := parsed["data"].(map[string]interface{})
-	result, _ := data["result"].([]interface{})
-	if len(result) == 0 {
-		t.Fatalf("expected non-empty result from direct fallback, body=%s", resp.Body.String())
+	for window, n := range attempts {
+		if n < 2 {
+			t.Fatalf("expected at least one retry for window %s, got %d attempts", window, n)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove expensive direct full-range fallback when query_range window fetch fails and return proper Loki error instead
- add transient per-window retries with bounded exponential backoff for backend unavailability and timeout conditions
- scope proxy process metrics to app process sources (/proc/self and cgroup pressure) instead of host-level disk and CPU attribution
- align OTLP exporter with the same process-scoped metric model

## Tests
- go test ./internal/proxy -run QueryRangeWindow -count=1
- go test ./internal/metrics -count=1

## Notes
- Existing unrelated dirty files were left out of this commit: CHANGELOG.md, internal/proxy/proxy.go, internal/proxy/drilldown_compat_test.go.