### PR TITLE
Optimize long-range query stability with phases 2-5, KPIs, and regression coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- add long-range phase-2 stream-aware window batching controls to reduce backend saturation spikes on expensive 2d/7d query mixes
+- add long-range phase-3 fast-path behavior that prioritizes early panel viability and avoids expensive all-window retries when backend pressure is transient
+- add long-range phase-4 overlap-aware window coalescing reuse to reduce repeated upstream calls across Grafana refresh/back-navigation traffic
+
+### Reliability
+
+- add long-range phase-5 adaptive timeout budgeting with partial-response fallback and warm-cache continuation to avoid hard user-facing failures during backend saturation
+
+### Observability
+
+- add phase KPI metrics for long-range resilience and tuning: `loki_vl_proxy_window_retry_total`, `loki_vl_proxy_window_degraded_batch_total`, `loki_vl_proxy_window_partial_response_total`, and `loki_vl_proxy_window_prefilter_hit_ratio`
+- update the packaged proxy metrics dashboard and observability docs for ops.sand no-data hardening and phase KPI visibility
+
+### Tests
+
+- add regression coverage for stream-aware batching, overlap/coalescing behavior, degraded-batch fallback, and partial-response long-range safety paths
+- add benchmark coverage for phase-1/2 controls to track fanout/query-call reductions and backend-pressure tradeoffs
+
 ## [0.27.40] - 2026-04-13
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Observability
 
 - add phase KPI metrics for long-range resilience and tuning: `loki_vl_proxy_window_retry_total`, `loki_vl_proxy_window_degraded_batch_total`, `loki_vl_proxy_window_partial_response_total`, and `loki_vl_proxy_window_prefilter_hit_ratio`
-- update the packaged proxy metrics dashboard and observability docs for ops.sand no-data hardening and phase KPI visibility
+- update the packaged proxy metrics dashboard and observability docs for no-data hardening and phase KPI visibility
 
 ### Tests
 

--- a/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
+++ b/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
@@ -519,7 +519,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 93},
       "targets": [
         {
-          "expr": "max(loki_vl_proxy_window_adaptive_parallel_current{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"})",
+          "expr": "max(loki_vl_proxy_window_adaptive_parallel_current{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
           "legendFormat": "parallel"
         }
       ],
@@ -533,16 +533,76 @@
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 93},
       "targets": [
         {
-          "expr": "max(loki_vl_proxy_window_adaptive_latency_ewma_seconds{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"})",
+          "expr": "max(loki_vl_proxy_window_adaptive_latency_ewma_seconds{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
           "legendFormat": "latency ewma"
         },
         {
-          "expr": "max(loki_vl_proxy_window_adaptive_error_ewma{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"})",
+          "expr": "max(loki_vl_proxy_window_adaptive_error_ewma{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
           "legendFormat": "error ewma"
         }
       ],
       "fieldConfig": {
         "defaults": {"unit": "short", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Long-Range Resilience KPIs",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 101},
+      "collapsed": false
+    },
+    {
+      "title": "Prefilter Keep/Skip Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 102},
+      "targets": [
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_prefilter_kept_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "kept/s"
+        },
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_prefilter_skipped_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "skipped/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Retry/Degraded/Partial Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 102},
+      "targets": [
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_retry_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "retry/s"
+        },
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_degraded_batch_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "degraded/s"
+        },
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_partial_response_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "partial/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Prefilter Hit Ratio",
+      "type": "stat",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 102},
+      "targets": [
+        {
+          "expr": "100 * max(loki_vl_proxy_window_prefilter_hit_ratio{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
+          "legendFormat": "hit ratio %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "percent", "min": 0, "max": 100}
       }
     }
   ],
@@ -555,13 +615,12 @@
         "label": "Datasource",
         "type": "datasource",
         "query": "prometheus",
-        "regex": "/^(Prometheus|Thanos|VictoriaMetrics|Mimir|Cortex|prometheus)$/",
+        "regex": "/.*/",
         "refresh": 1,
         "hide": 0,
         "includeAll": false,
         "multi": false,
-        "options": [],
-        "current": {"text": "VictoriaMetrics", "value": "VictoriaMetrics"}
+        "options": []
       },
       {
         "name": "job",
@@ -642,5 +701,5 @@
   "timezone": "browser",
   "title": "Loki-VL-Proxy Metrics",
   "uid": "loki-vl-proxy-metrics",
-  "version": 5
+  "version": 6
 }

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -153,6 +153,44 @@ extraArgs:
   # Sizing hint: plan roughly ~96 bytes RAM/value and ~60% of RAM footprint on disk snapshot.
   # System metrics scope override (chart auto-injects when systemMetrics.hostProc.enabled=true):
   # proc-root: "/host/proc"
+  #
+  # Full optional flag catalog (commented defaults from runtime):
+  # cache-max-bytes: "268435456"                # 256Mi L1 max bytes
+  # compat-cache-enabled: "true"                # enable Tier0 compatibility-edge cache
+  # compat-cache-max-percent: "10"              # Tier0 share of L1 cache budget (max 50)
+  # backend-timeout: "120s"                     # upstream request timeout
+  # backend-tls-skip-verify: "false"
+  # deployment-environment: ""                  # OTel deployment.environment.name
+  # otel-service-name: "loki-vl-proxy"
+  # otel-service-namespace: ""
+  # otel-service-instance-id: ""
+  # otlp-headers: ""                            # comma-separated key=value pairs
+  # response-gzip: "true"
+  # max-lines: "1000"
+  # auth.enabled: "false"                       # require tenant header
+  # tenant.allow-global: "false"                # allow global tenant map wildcard entry
+  # metrics.max-tenants: "256"
+  # metrics.max-clients: "256"
+  # metrics.trust-proxy-headers: "false"
+  # server.register-instrumentation: "true"     # expose /metrics
+  # server.enable-pprof: "false"
+  # server.enable-query-analytics: "false"
+  # server.admin-auth-token: ""                 # bearer token for admin/debug endpoints
+  # tail.mode: "auto"                           # auto | native | synthetic
+  # tail.allowed-origins: ""                    # comma-separated websocket origin allowlist
+  # ruler-backend: ""                           # optional /rules passthrough backend
+  # alerts-backend: ""                          # optional /alerts passthrough backend
+  # extra-label-fields: "service.name,host.name"
+  # peer-auth-token: ""                         # token required for /_cache/get peer calls
+  # peer-discovery: "dns"                       # chart-managed via peerCache.* values
+  # peer-dns: ""                                # chart-managed when peerCache.enabled=true
+  # peer-self: ""                               # chart-managed when peerCache.enabled=true
+  # peer-static: ""                             # used with peer-discovery=static
+  # disk-cache-min-ttl: "30s"                   # skip L2 writes for very short-lived entries
+  # tls-cert-file: ""                           # enable HTTPS listener when cert+key set
+  # tls-key-file: ""
+  # tls-client-ca-file: ""
+  # tls-require-client-cert: "false"
 
 # Go runtime tuning:
 # The chart exports GOMEMLIMIT into the container env.

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -73,6 +73,17 @@ extraArgs:
   query-range-freshness: "10m"
   query-range-recent-cache-ttl: "0s"
   query-range-history-cache-ttl: "24h"
+  # Long-range phase controls (defaults shown here; uncomment to override quickly):
+  # query-range-prefilter-index-stats: "true"          # preflight /select/logsql/hits to skip empty windows
+  # query-range-prefilter-min-windows: "8"             # prefilter engages only when split windows >= this threshold
+  # query-range-stream-aware-batching: "true"          # reduce concurrency for expensive windows
+  # query-range-expensive-hit-threshold: "2000"        # hits/window threshold considered expensive
+  # query-range-expensive-max-parallel: "1"            # max parallelism for expensive windows
+  # query-range-align-windows: "true"                  # align split boundaries for overlap cache reuse
+  # query-range-window-timeout: "20s"                  # per-window timeout budget (0 disables)
+  # query-range-partial-responses: "false"             # return partial response on retryable backend failures
+  # query-range-background-warm: "true"                # continue warming failed windows in background
+  # query-range-background-warm-max-windows: "24"      # cap background warm fanout
   # Indexed label-values browse cache (high-cardinality label UX).
   # Keep disabled by default; enable when label value lists are large and you
   # want hotset-first responses with optional offset/search.
@@ -98,6 +109,7 @@ extraArgs:
   # otlp-interval: "30s"
   # otlp-compression: "gzip"
   # otlp-timeout: "10s"
+  # otlp-tls-skip-verify: "false"
   # Backend auth to VictoriaLogs
   # backend-basic-auth: "user:password"
   # forward-headers: "Authorization"
@@ -139,6 +151,8 @@ extraArgs:
   # label-values-index-startup-stale-threshold: "60s"
   # label-values-index-startup-peer-warm-timeout: "5s"
   # Sizing hint: plan roughly ~96 bytes RAM/value and ~60% of RAM footprint on disk snapshot.
+  # System metrics scope override (chart auto-injects when systemMetrics.hostProc.enabled=true):
+  # proc-root: "/host/proc"
 
 # Go runtime tuning:
 # The chart exports GOMEMLIMIT into the container env.

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -48,66 +48,74 @@ type envConfig struct {
 }
 
 type proxyRuntimeConfig struct {
-	backendURL                      string
-	rulerBackendURL                 string
-	alertsBackendURL                string
-	cache                           *cache.Cache
-	compatCache                     *cache.Cache
-	logLevel                        string
-	tenantMapJSON                   string
-	maxLines                        int
-	backendTimeout                  time.Duration
-	backendBasicAuth                string
-	backendTLSSkip                  bool
-	forwardHeaders                  string
-	forwardAuthorization            bool
-	forwardCookies                  string
-	derivedFieldsJSON               string
-	streamResponse                  bool
-	emitStructuredMetadata          bool
-	queryRangeWindowing             bool
-	queryRangeSplitInterval         time.Duration
-	queryRangeMaxParallel           int
-	queryRangeAdaptiveParallel      bool
-	queryRangeParallelMin           int
-	queryRangeParallelMax           int
-	queryRangeLatencyTarget         time.Duration
-	queryRangeLatencyBackoff        time.Duration
-	queryRangeAdaptiveCooldown      time.Duration
-	queryRangeErrorBackoffThreshold float64
-	queryRangeFreshness             time.Duration
-	queryRangeRecentCacheTTL        time.Duration
-	queryRangeHistoryTTL            time.Duration
-	queryRangePrefilterIndexStats   bool
-	queryRangePrefilterMinWindows   int
-	authEnabled                     bool
-	allowGlobalTenant               bool
-	registerInstrumentation         *bool
-	enablePprof                     bool
-	enableQueryAnalytics            bool
-	adminAuthToken                  string
-	tailAllowedOrigins              string
-	tailMode                        string
-	metricsMaxTenants               int
-	metricsMaxClients               int
-	metricsTrustProxyHeaders        bool
-	labelStyle                      string
-	metadataFieldMode               string
-	fieldMappingJSON                string
-	streamFieldsCSV                 string
-	extraLabelFieldsCSV             string
-	labelValuesIndexedCache         bool
-	labelValuesHotLimit             int
-	labelValuesIndexMaxEntries      int
-	labelValuesIndexPersistPath     string
-	labelValuesIndexPersistInterval time.Duration
-	labelValuesIndexStartupStale    time.Duration
-	labelValuesIndexPeerWarmTimeout time.Duration
-	peerSelf                        string
-	peerDiscovery                   string
-	peerDNS                         string
-	peerStatic                      string
-	peerAuthToken                   string
+	backendURL                         string
+	rulerBackendURL                    string
+	alertsBackendURL                   string
+	cache                              *cache.Cache
+	compatCache                        *cache.Cache
+	logLevel                           string
+	tenantMapJSON                      string
+	maxLines                           int
+	backendTimeout                     time.Duration
+	backendBasicAuth                   string
+	backendTLSSkip                     bool
+	forwardHeaders                     string
+	forwardAuthorization               bool
+	forwardCookies                     string
+	derivedFieldsJSON                  string
+	streamResponse                     bool
+	emitStructuredMetadata             bool
+	queryRangeWindowing                bool
+	queryRangeSplitInterval            time.Duration
+	queryRangeMaxParallel              int
+	queryRangeAdaptiveParallel         bool
+	queryRangeParallelMin              int
+	queryRangeParallelMax              int
+	queryRangeLatencyTarget            time.Duration
+	queryRangeLatencyBackoff           time.Duration
+	queryRangeAdaptiveCooldown         time.Duration
+	queryRangeErrorBackoffThreshold    float64
+	queryRangeFreshness                time.Duration
+	queryRangeRecentCacheTTL           time.Duration
+	queryRangeHistoryTTL               time.Duration
+	queryRangePrefilterIndexStats      bool
+	queryRangePrefilterMinWindows      int
+	queryRangeStreamAwareBatching      bool
+	queryRangeExpensiveHitThreshold    int64
+	queryRangeExpensiveMaxParallel     int
+	queryRangeAlignWindows             bool
+	queryRangeWindowTimeout            time.Duration
+	queryRangePartialResponses         bool
+	queryRangeBackgroundWarm           bool
+	queryRangeBackgroundWarmMaxWindows int
+	authEnabled                        bool
+	allowGlobalTenant                  bool
+	registerInstrumentation            *bool
+	enablePprof                        bool
+	enableQueryAnalytics               bool
+	adminAuthToken                     string
+	tailAllowedOrigins                 string
+	tailMode                           string
+	metricsMaxTenants                  int
+	metricsMaxClients                  int
+	metricsTrustProxyHeaders           bool
+	labelStyle                         string
+	metadataFieldMode                  string
+	fieldMappingJSON                   string
+	streamFieldsCSV                    string
+	extraLabelFieldsCSV                string
+	labelValuesIndexedCache            bool
+	labelValuesHotLimit                int
+	labelValuesIndexMaxEntries         int
+	labelValuesIndexPersistPath        string
+	labelValuesIndexPersistInterval    time.Duration
+	labelValuesIndexStartupStale       time.Duration
+	labelValuesIndexPeerWarmTimeout    time.Duration
+	peerSelf                           string
+	peerDiscovery                      string
+	peerDNS                            string
+	peerStatic                         string
+	peerAuthToken                      string
 }
 
 type otlpRuntimeConfig struct {
@@ -331,6 +339,14 @@ func run(
 	queryRangeHistoryTTL := fs.Duration("query-range-history-cache-ttl", 24*time.Hour, "Cache TTL for historical query_range windows older than -query-range-freshness")
 	queryRangePrefilterIndexStats := fs.Bool("query-range-prefilter-index-stats", true, "Use /select/logsql/hits preflight to skip empty query_range windows before log fanout")
 	queryRangePrefilterMinWindows := fs.Int("query-range-prefilter-min-windows", 8, "Minimum split windows required before enabling query_range prefilter")
+	queryRangeStreamAwareBatching := fs.Bool("query-range-stream-aware-batching", true, "Reduce query_range batch parallelism for expensive windows estimated from prefilter hits")
+	queryRangeExpensiveHitThreshold := fs.Int64("query-range-expensive-hit-threshold", 2000, "Prefilter hit threshold above which a query_range window is treated as expensive")
+	queryRangeExpensiveMaxParallel := fs.Int("query-range-expensive-max-parallel", 1, "Maximum window parallelism for expensive query_range windows")
+	queryRangeAlignWindows := fs.Bool("query-range-align-windows", true, "Align query_range split windows to fixed interval boundaries for overlap cache reuse")
+	queryRangeWindowTimeout := fs.Duration("query-range-window-timeout", 20*time.Second, "Per-window backend timeout budget for query_range window fetches (0 disables)")
+	queryRangePartialResponses := fs.Bool("query-range-partial-responses", false, "Allow partial query_range responses on retryable backend failures")
+	queryRangeBackgroundWarm := fs.Bool("query-range-background-warm", true, "Warm failed query_range windows in background after partial response")
+	queryRangeBackgroundWarmMaxWindows := fs.Int("query-range-background-warm-max-windows", 24, "Maximum query_range windows warmed in background after partial response")
 
 	// Loki-style auth / instrumentation controls
 	authEnabled := fs.Bool("auth.enabled", false, "Require X-Scope-OrgID on query requests. When false, requests without a tenant header use the backend default tenant.")
@@ -426,64 +442,72 @@ func run(
 			MaxBytes:      *diskCacheMaxBytes,
 		},
 		proxyCfg: proxyRuntimeConfig{
-			backendURL:                      envCfg.backendURL,
-			rulerBackendURL:                 envCfg.rulerBackendURL,
-			alertsBackendURL:                envCfg.alertsBackendURL,
-			logLevel:                        *logLevel,
-			tenantMapJSON:                   envCfg.tenantMapJSON,
-			maxLines:                        *maxLines,
-			backendTimeout:                  *backendTimeout,
-			backendBasicAuth:                *backendBasicAuth,
-			backendTLSSkip:                  *backendTLSSkip,
-			forwardHeaders:                  *forwardHeaders,
-			forwardAuthorization:            *forwardAuthorization,
-			forwardCookies:                  *forwardCookies,
-			derivedFieldsJSON:               *derivedFieldsJSON,
-			streamResponse:                  *streamResponse,
-			emitStructuredMetadata:          *emitStructuredMetadata,
-			queryRangeWindowing:             *queryRangeWindowing,
-			queryRangeSplitInterval:         *queryRangeSplitInterval,
-			queryRangeMaxParallel:           *queryRangeMaxParallel,
-			queryRangeAdaptiveParallel:      *queryRangeAdaptiveParallel,
-			queryRangeParallelMin:           *queryRangeParallelMin,
-			queryRangeParallelMax:           *queryRangeParallelMax,
-			queryRangeLatencyTarget:         *queryRangeLatencyTarget,
-			queryRangeLatencyBackoff:        *queryRangeLatencyBackoff,
-			queryRangeAdaptiveCooldown:      *queryRangeAdaptiveCooldown,
-			queryRangeErrorBackoffThreshold: *queryRangeErrorBackoffThreshold,
-			queryRangeFreshness:             *queryRangeFreshness,
-			queryRangeRecentCacheTTL:        *queryRangeRecentCacheTTL,
-			queryRangeHistoryTTL:            *queryRangeHistoryTTL,
-			queryRangePrefilterIndexStats:   *queryRangePrefilterIndexStats,
-			queryRangePrefilterMinWindows:   *queryRangePrefilterMinWindows,
-			authEnabled:                     *authEnabled,
-			allowGlobalTenant:               *allowGlobalTenant,
-			registerInstrumentation:         registerInstrumentation,
-			enablePprof:                     *enablePprof,
-			enableQueryAnalytics:            *enableQueryAnalytics,
-			adminAuthToken:                  *adminAuthToken,
-			tailAllowedOrigins:              *tailAllowedOrigins,
-			tailMode:                        *tailMode,
-			metricsMaxTenants:               *metricsMaxTenants,
-			metricsMaxClients:               *metricsMaxClients,
-			metricsTrustProxyHeaders:        *metricsTrustProxyHeaders,
-			labelStyle:                      envCfg.labelStyle,
-			metadataFieldMode:               envCfg.metadataFieldMode,
-			fieldMappingJSON:                envCfg.fieldMappingJSON,
-			streamFieldsCSV:                 *streamFieldsCSV,
-			extraLabelFieldsCSV:             envCfg.extraLabelFields,
-			labelValuesIndexedCache:         *labelValuesIndexedCache,
-			labelValuesHotLimit:             *labelValuesHotLimit,
-			labelValuesIndexMaxEntries:      *labelValuesIndexMaxEntries,
-			labelValuesIndexPersistPath:     *labelValuesIndexPersistPath,
-			labelValuesIndexPersistInterval: *labelValuesIndexPersistInterval,
-			labelValuesIndexStartupStale:    *labelValuesIndexStartupStale,
-			labelValuesIndexPeerWarmTimeout: *labelValuesIndexPeerWarmTimeout,
-			peerSelf:                        *peerSelf,
-			peerDiscovery:                   *peerDiscovery,
-			peerDNS:                         *peerDNS,
-			peerStatic:                      *peerStatic,
-			peerAuthToken:                   *peerAuthToken,
+			backendURL:                         envCfg.backendURL,
+			rulerBackendURL:                    envCfg.rulerBackendURL,
+			alertsBackendURL:                   envCfg.alertsBackendURL,
+			logLevel:                           *logLevel,
+			tenantMapJSON:                      envCfg.tenantMapJSON,
+			maxLines:                           *maxLines,
+			backendTimeout:                     *backendTimeout,
+			backendBasicAuth:                   *backendBasicAuth,
+			backendTLSSkip:                     *backendTLSSkip,
+			forwardHeaders:                     *forwardHeaders,
+			forwardAuthorization:               *forwardAuthorization,
+			forwardCookies:                     *forwardCookies,
+			derivedFieldsJSON:                  *derivedFieldsJSON,
+			streamResponse:                     *streamResponse,
+			emitStructuredMetadata:             *emitStructuredMetadata,
+			queryRangeWindowing:                *queryRangeWindowing,
+			queryRangeSplitInterval:            *queryRangeSplitInterval,
+			queryRangeMaxParallel:              *queryRangeMaxParallel,
+			queryRangeAdaptiveParallel:         *queryRangeAdaptiveParallel,
+			queryRangeParallelMin:              *queryRangeParallelMin,
+			queryRangeParallelMax:              *queryRangeParallelMax,
+			queryRangeLatencyTarget:            *queryRangeLatencyTarget,
+			queryRangeLatencyBackoff:           *queryRangeLatencyBackoff,
+			queryRangeAdaptiveCooldown:         *queryRangeAdaptiveCooldown,
+			queryRangeErrorBackoffThreshold:    *queryRangeErrorBackoffThreshold,
+			queryRangeFreshness:                *queryRangeFreshness,
+			queryRangeRecentCacheTTL:           *queryRangeRecentCacheTTL,
+			queryRangeHistoryTTL:               *queryRangeHistoryTTL,
+			queryRangePrefilterIndexStats:      *queryRangePrefilterIndexStats,
+			queryRangePrefilterMinWindows:      *queryRangePrefilterMinWindows,
+			queryRangeStreamAwareBatching:      *queryRangeStreamAwareBatching,
+			queryRangeExpensiveHitThreshold:    *queryRangeExpensiveHitThreshold,
+			queryRangeExpensiveMaxParallel:     *queryRangeExpensiveMaxParallel,
+			queryRangeAlignWindows:             *queryRangeAlignWindows,
+			queryRangeWindowTimeout:            *queryRangeWindowTimeout,
+			queryRangePartialResponses:         *queryRangePartialResponses,
+			queryRangeBackgroundWarm:           *queryRangeBackgroundWarm,
+			queryRangeBackgroundWarmMaxWindows: *queryRangeBackgroundWarmMaxWindows,
+			authEnabled:                        *authEnabled,
+			allowGlobalTenant:                  *allowGlobalTenant,
+			registerInstrumentation:            registerInstrumentation,
+			enablePprof:                        *enablePprof,
+			enableQueryAnalytics:               *enableQueryAnalytics,
+			adminAuthToken:                     *adminAuthToken,
+			tailAllowedOrigins:                 *tailAllowedOrigins,
+			tailMode:                           *tailMode,
+			metricsMaxTenants:                  *metricsMaxTenants,
+			metricsMaxClients:                  *metricsMaxClients,
+			metricsTrustProxyHeaders:           *metricsTrustProxyHeaders,
+			labelStyle:                         envCfg.labelStyle,
+			metadataFieldMode:                  envCfg.metadataFieldMode,
+			fieldMappingJSON:                   envCfg.fieldMappingJSON,
+			streamFieldsCSV:                    *streamFieldsCSV,
+			extraLabelFieldsCSV:                envCfg.extraLabelFields,
+			labelValuesIndexedCache:            *labelValuesIndexedCache,
+			labelValuesHotLimit:                *labelValuesHotLimit,
+			labelValuesIndexMaxEntries:         *labelValuesIndexMaxEntries,
+			labelValuesIndexPersistPath:        *labelValuesIndexPersistPath,
+			labelValuesIndexPersistInterval:    *labelValuesIndexPersistInterval,
+			labelValuesIndexStartupStale:       *labelValuesIndexStartupStale,
+			labelValuesIndexPeerWarmTimeout:    *labelValuesIndexPeerWarmTimeout,
+			peerSelf:                           *peerSelf,
+			peerDiscovery:                      *peerDiscovery,
+			peerDNS:                            *peerDNS,
+			peerStatic:                         *peerStatic,
+			peerAuthToken:                      *peerAuthToken,
 		},
 		otlpCfg: otlpRuntimeConfig{
 			endpoint:              envCfg.otlpEndpoint,
@@ -957,62 +981,70 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 	}
 
 	return proxy.Config{
-		BackendURL:                      cfg.backendURL,
-		RulerBackendURL:                 cfg.rulerBackendURL,
-		AlertsBackendURL:                alertsBackendURL,
-		Cache:                           cfg.cache,
-		CompatCache:                     cfg.compatCache,
-		LogLevel:                        cfg.logLevel,
-		TenantMap:                       tenantMap,
-		MaxLines:                        cfg.maxLines,
-		BackendTimeout:                  cfg.backendTimeout,
-		BackendBasicAuth:                cfg.backendBasicAuth,
-		BackendTLSSkip:                  cfg.backendTLSSkip,
-		ForwardHeaders:                  parseForwardHeaders(cfg.forwardHeaders, cfg.forwardAuthorization),
-		ForwardCookies:                  parseCSV(cfg.forwardCookies),
-		DerivedFields:                   derivedFields,
-		StreamResponse:                  cfg.streamResponse,
-		EmitStructuredMetadata:          cfg.emitStructuredMetadata,
-		QueryRangeWindowingEnabled:      cfg.queryRangeWindowing,
-		QueryRangeSplitInterval:         cfg.queryRangeSplitInterval,
-		QueryRangeMaxParallel:           cfg.queryRangeMaxParallel,
-		QueryRangeAdaptiveParallel:      cfg.queryRangeAdaptiveParallel,
-		QueryRangeParallelMin:           cfg.queryRangeParallelMin,
-		QueryRangeParallelMax:           cfg.queryRangeParallelMax,
-		QueryRangeLatencyTarget:         cfg.queryRangeLatencyTarget,
-		QueryRangeLatencyBackoff:        cfg.queryRangeLatencyBackoff,
-		QueryRangeAdaptiveCooldown:      cfg.queryRangeAdaptiveCooldown,
-		QueryRangeErrorBackoffThreshold: cfg.queryRangeErrorBackoffThreshold,
-		QueryRangeFreshness:             cfg.queryRangeFreshness,
-		QueryRangeRecentCacheTTL:        cfg.queryRangeRecentCacheTTL,
-		QueryRangeHistoryCacheTTL:       cfg.queryRangeHistoryTTL,
-		QueryRangePrefilterIndexStats:   cfg.queryRangePrefilterIndexStats,
-		QueryRangePrefilterMinWindows:   cfg.queryRangePrefilterMinWindows,
-		AuthEnabled:                     cfg.authEnabled,
-		AllowGlobalTenant:               cfg.allowGlobalTenant,
-		RegisterInstrumentation:         cfg.registerInstrumentation,
-		EnablePprof:                     cfg.enablePprof,
-		EnableQueryAnalytics:            cfg.enableQueryAnalytics,
-		AdminAuthToken:                  cfg.adminAuthToken,
-		TailAllowedOrigins:              parseCSV(cfg.tailAllowedOrigins),
-		TailMode:                        tailMode,
-		MetricsMaxTenants:               cfg.metricsMaxTenants,
-		MetricsMaxClients:               cfg.metricsMaxClients,
-		MetricsTrustProxyHeaders:        cfg.metricsTrustProxyHeaders,
-		LabelStyle:                      ls,
-		MetadataFieldMode:               mfm,
-		FieldMappings:                   fieldMappings,
-		StreamFields:                    parseCSV(cfg.streamFieldsCSV),
-		ExtraLabelFields:                parseCSV(cfg.extraLabelFieldsCSV),
-		LabelValuesIndexedCache:         cfg.labelValuesIndexedCache,
-		LabelValuesHotLimit:             cfg.labelValuesHotLimit,
-		LabelValuesIndexMaxEntries:      cfg.labelValuesIndexMaxEntries,
-		LabelValuesIndexPersistPath:     cfg.labelValuesIndexPersistPath,
-		LabelValuesIndexPersistInterval: cfg.labelValuesIndexPersistInterval,
-		LabelValuesIndexStartupStale:    cfg.labelValuesIndexStartupStale,
-		LabelValuesIndexPeerWarmTimeout: cfg.labelValuesIndexPeerWarmTimeout,
-		PeerCache:                       peerCache,
-		PeerAuthToken:                   cfg.peerAuthToken,
+		BackendURL:                         cfg.backendURL,
+		RulerBackendURL:                    cfg.rulerBackendURL,
+		AlertsBackendURL:                   alertsBackendURL,
+		Cache:                              cfg.cache,
+		CompatCache:                        cfg.compatCache,
+		LogLevel:                           cfg.logLevel,
+		TenantMap:                          tenantMap,
+		MaxLines:                           cfg.maxLines,
+		BackendTimeout:                     cfg.backendTimeout,
+		BackendBasicAuth:                   cfg.backendBasicAuth,
+		BackendTLSSkip:                     cfg.backendTLSSkip,
+		ForwardHeaders:                     parseForwardHeaders(cfg.forwardHeaders, cfg.forwardAuthorization),
+		ForwardCookies:                     parseCSV(cfg.forwardCookies),
+		DerivedFields:                      derivedFields,
+		StreamResponse:                     cfg.streamResponse,
+		EmitStructuredMetadata:             cfg.emitStructuredMetadata,
+		QueryRangeWindowingEnabled:         cfg.queryRangeWindowing,
+		QueryRangeSplitInterval:            cfg.queryRangeSplitInterval,
+		QueryRangeMaxParallel:              cfg.queryRangeMaxParallel,
+		QueryRangeAdaptiveParallel:         cfg.queryRangeAdaptiveParallel,
+		QueryRangeParallelMin:              cfg.queryRangeParallelMin,
+		QueryRangeParallelMax:              cfg.queryRangeParallelMax,
+		QueryRangeLatencyTarget:            cfg.queryRangeLatencyTarget,
+		QueryRangeLatencyBackoff:           cfg.queryRangeLatencyBackoff,
+		QueryRangeAdaptiveCooldown:         cfg.queryRangeAdaptiveCooldown,
+		QueryRangeErrorBackoffThreshold:    cfg.queryRangeErrorBackoffThreshold,
+		QueryRangeFreshness:                cfg.queryRangeFreshness,
+		QueryRangeRecentCacheTTL:           cfg.queryRangeRecentCacheTTL,
+		QueryRangeHistoryCacheTTL:          cfg.queryRangeHistoryTTL,
+		QueryRangePrefilterIndexStats:      cfg.queryRangePrefilterIndexStats,
+		QueryRangePrefilterMinWindows:      cfg.queryRangePrefilterMinWindows,
+		QueryRangeStreamAwareBatching:      cfg.queryRangeStreamAwareBatching,
+		QueryRangeExpensiveHitThreshold:    cfg.queryRangeExpensiveHitThreshold,
+		QueryRangeExpensiveMaxParallel:     cfg.queryRangeExpensiveMaxParallel,
+		QueryRangeAlignWindows:             cfg.queryRangeAlignWindows,
+		QueryRangeWindowTimeout:            cfg.queryRangeWindowTimeout,
+		QueryRangePartialResponses:         cfg.queryRangePartialResponses,
+		QueryRangeBackgroundWarm:           cfg.queryRangeBackgroundWarm,
+		QueryRangeBackgroundWarmMaxWindows: cfg.queryRangeBackgroundWarmMaxWindows,
+		AuthEnabled:                        cfg.authEnabled,
+		AllowGlobalTenant:                  cfg.allowGlobalTenant,
+		RegisterInstrumentation:            cfg.registerInstrumentation,
+		EnablePprof:                        cfg.enablePprof,
+		EnableQueryAnalytics:               cfg.enableQueryAnalytics,
+		AdminAuthToken:                     cfg.adminAuthToken,
+		TailAllowedOrigins:                 parseCSV(cfg.tailAllowedOrigins),
+		TailMode:                           tailMode,
+		MetricsMaxTenants:                  cfg.metricsMaxTenants,
+		MetricsMaxClients:                  cfg.metricsMaxClients,
+		MetricsTrustProxyHeaders:           cfg.metricsTrustProxyHeaders,
+		LabelStyle:                         ls,
+		MetadataFieldMode:                  mfm,
+		FieldMappings:                      fieldMappings,
+		StreamFields:                       parseCSV(cfg.streamFieldsCSV),
+		ExtraLabelFields:                   parseCSV(cfg.extraLabelFieldsCSV),
+		LabelValuesIndexedCache:            cfg.labelValuesIndexedCache,
+		LabelValuesHotLimit:                cfg.labelValuesHotLimit,
+		LabelValuesIndexMaxEntries:         cfg.labelValuesIndexMaxEntries,
+		LabelValuesIndexPersistPath:        cfg.labelValuesIndexPersistPath,
+		LabelValuesIndexPersistInterval:    cfg.labelValuesIndexPersistInterval,
+		LabelValuesIndexStartupStale:       cfg.labelValuesIndexStartupStale,
+		LabelValuesIndexPeerWarmTimeout:    cfg.labelValuesIndexPeerWarmTimeout,
+		PeerCache:                          peerCache,
+		PeerAuthToken:                      cfg.peerAuthToken,
 	}, nil
 }
 
@@ -1141,6 +1173,14 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 			"history_cache_ttl", proxyCfg.QueryRangeHistoryCacheTTL,
 			"prefilter_index_stats", proxyCfg.QueryRangePrefilterIndexStats,
 			"prefilter_min_windows", proxyCfg.QueryRangePrefilterMinWindows,
+			"stream_aware_batching", proxyCfg.QueryRangeStreamAwareBatching,
+			"expensive_hit_threshold", proxyCfg.QueryRangeExpensiveHitThreshold,
+			"expensive_max_parallel", proxyCfg.QueryRangeExpensiveMaxParallel,
+			"align_windows", proxyCfg.QueryRangeAlignWindows,
+			"window_timeout", proxyCfg.QueryRangeWindowTimeout,
+			"partial_responses", proxyCfg.QueryRangePartialResponses,
+			"background_warm", proxyCfg.QueryRangeBackgroundWarm,
+			"background_warm_max_windows", proxyCfg.QueryRangeBackgroundWarmMaxWindows,
 		)
 	}
 	if proxyCfg.PeerCache != nil {

--- a/dashboard/loki-vl-proxy.json
+++ b/dashboard/loki-vl-proxy.json
@@ -519,7 +519,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 93},
       "targets": [
         {
-          "expr": "max(loki_vl_proxy_window_adaptive_parallel_current{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"})",
+          "expr": "max(loki_vl_proxy_window_adaptive_parallel_current{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
           "legendFormat": "parallel"
         }
       ],
@@ -533,16 +533,76 @@
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 93},
       "targets": [
         {
-          "expr": "max(loki_vl_proxy_window_adaptive_latency_ewma_seconds{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"})",
+          "expr": "max(loki_vl_proxy_window_adaptive_latency_ewma_seconds{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
           "legendFormat": "latency ewma"
         },
         {
-          "expr": "max(loki_vl_proxy_window_adaptive_error_ewma{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"})",
+          "expr": "max(loki_vl_proxy_window_adaptive_error_ewma{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
           "legendFormat": "error ewma"
         }
       ],
       "fieldConfig": {
         "defaults": {"unit": "short", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Long-Range Resilience KPIs",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 101},
+      "collapsed": false
+    },
+    {
+      "title": "Prefilter Keep/Skip Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 102},
+      "targets": [
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_prefilter_kept_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "kept/s"
+        },
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_prefilter_skipped_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "skipped/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Retry/Degraded/Partial Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 102},
+      "targets": [
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_retry_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "retry/s"
+        },
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_degraded_batch_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "degraded/s"
+        },
+        {
+          "expr": "sum(rate(loki_vl_proxy_window_partial_response_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "partial/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Prefilter Hit Ratio",
+      "type": "stat",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 102},
+      "targets": [
+        {
+          "expr": "100 * max(loki_vl_proxy_window_prefilter_hit_ratio{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}) or vector(0)",
+          "legendFormat": "hit ratio %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "percent", "min": 0, "max": 100}
       }
     }
   ],
@@ -555,13 +615,12 @@
         "label": "Datasource",
         "type": "datasource",
         "query": "prometheus",
-        "regex": "/^(Prometheus|Thanos|VictoriaMetrics|Mimir|Cortex|prometheus)$/",
+        "regex": "/.*/",
         "refresh": 1,
         "hide": 0,
         "includeAll": false,
         "multi": false,
-        "options": [],
-        "current": {"text": "VictoriaMetrics", "value": "VictoriaMetrics"}
+        "options": []
       },
       {
         "name": "job",
@@ -642,5 +701,5 @@
   "timezone": "browser",
   "title": "Loki-VL-Proxy Metrics",
   "uid": "loki-vl-proxy-metrics",
-  "version": 5
+  "version": 6
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -182,6 +182,10 @@ These are the primary signals for long-range query performance and backend prote
 | `loki_vl_proxy_window_prefilter_error_total` | counter | none | prefilter failures (proxy safely falls back to full window fanout) |
 | `loki_vl_proxy_window_prefilter_kept_total` | counter | none | split windows retained for real log fanout |
 | `loki_vl_proxy_window_prefilter_skipped_total` | counter | none | split windows skipped as empty by prefilter |
+| `loki_vl_proxy_window_prefilter_hit_ratio` | gauge | none | current prefilter kept/total ratio (0-1) |
+| `loki_vl_proxy_window_retry_total` | counter | none | per-window retry attempts after retryable backend failures |
+| `loki_vl_proxy_window_degraded_batch_total` | counter | none | batches that were downgraded to lower parallelism |
+| `loki_vl_proxy_window_partial_response_total` | counter | none | partial query-range responses returned when slow windows exceed budget |
 | `loki_vl_proxy_window_prefilter_duration_seconds` | histogram | none | prefilter latency |
 | `loki_vl_proxy_window_adaptive_parallel_current` | gauge | none | current adaptive split-window parallelism |
 | `loki_vl_proxy_window_adaptive_latency_ewma_seconds` | gauge | none | adaptive EWMA latency |
@@ -254,6 +258,17 @@ It also includes a `Query-Range Windowing` section for cache/tuning signals:
 - window merge p50/p95 latency
 - window cache hit ratio
 - adaptive window parallelism + EWMA latency/error
+
+It also includes a `Long-Range Resilience KPIs` section for phase tuning:
+
+- prefilter kept/skipped rate
+- retry/degraded-batch/partial-response rate
+- prefilter hit ratio
+
+Dashboard datasource notes (ops.sand hardening):
+
+- datasource variable regex is intentionally permissive (`/.*/`) so the dashboard works with scrape-backed and OTLP-backed metric datasources without renaming
+- key stat panels use explicit zero fallbacks so dashboards remain readable during cold starts and low-traffic windows
 
 ### Active Backend E2E Healthchecks
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -265,7 +265,7 @@ It also includes a `Long-Range Resilience KPIs` section for phase tuning:
 - retry/degraded-batch/partial-response rate
 - prefilter hit ratio
 
-Dashboard datasource notes (ops.sand hardening):
+Dashboard datasource notes:
 
 - datasource variable regex is intentionally permissive (`/.*/`) so the dashboard works with scrape-backed and OTLP-backed metric datasources without renaming
 - key stat panels use explicit zero fallbacks so dashboards remain readable during cold starts and low-traffic windows

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -99,6 +99,26 @@ Always cap disk cache explicitly with `-disk-cache-max-bytes` for predictable re
 
 Measured on Apple M3 Max (14 cores), Go 1.26.1, `-benchmem`.
 
+### Long-Range Phase Program Benchmarks (1h split windows)
+
+Command:
+
+```bash
+go test ./internal/proxy -run '^$' -bench 'BenchmarkQueryRangeWindowing_(NoPrefilter|WithPrefilter|StreamAwareBatching_Off|StreamAwareBatching_On)$' -benchmem -benchtime=10x
+```
+
+| Benchmark | ns/op | hits_calls/op | query_calls/op | max_inflight | allocs/op | Key result |
+|---|---:|---:|---:|---:|---:|---|
+| `NoPrefilter` | 39,525,225 | 0 | 49 | n/a | 11,582 | baseline full fanout |
+| `WithPrefilter` | 11,672,412 | 48 | 9 | n/a | 10,346 | ~81.6% fewer backend query calls |
+| `StreamAwareBatching_Off` | 17,048,771 | n/a | n/a | 4 | 9,490 | higher concurrency under load |
+| `StreamAwareBatching_On` | 62,808,025 | n/a | n/a | 1 | 9,656 | lower concurrency spikes, more stable backend pressure |
+
+Notes:
+
+- Prefiltering is the largest direct backend-load reduction lever for sparse long ranges.
+- Stream-aware batching intentionally trades raw synthetic throughput for lower backend saturation risk and fewer breaker cascades on real 2d/7d traffic.
+
 ### Per-Request Latency
 
 | Operation | Latency | Allocs | Bytes/op |

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -56,6 +56,10 @@ type Metrics struct {
 	windowPrefilterErrors         atomic.Int64
 	windowPrefilterKept           atomic.Int64
 	windowPrefilterSkipped        atomic.Int64
+	windowPrefilterHitRatioPpm    atomic.Int64
+	windowRetries                 atomic.Int64
+	windowDegradedBatches         atomic.Int64
+	windowPartialResponses        atomic.Int64
 	windowPrefilterDuration       *histogram
 	windowAdaptiveParallelCurrent atomic.Int64
 	windowAdaptiveLatencyEWMAms   atomic.Int64
@@ -690,6 +694,32 @@ func (m *Metrics) RecordQueryRangeWindowPrefilterOutcome(kept, skipped int) {
 	if skipped > 0 {
 		m.windowPrefilterSkipped.Add(int64(skipped))
 	}
+	total := kept + skipped
+	if total > 0 {
+		ratio := float64(kept) / float64(total)
+		if ratio < 0 {
+			ratio = 0
+		}
+		if ratio > 1 {
+			ratio = 1
+		}
+		m.windowPrefilterHitRatioPpm.Store(int64(ratio * 1_000_000))
+	}
+}
+
+// RecordQueryRangeWindowRetry records retry attempts for query_range window fetches.
+func (m *Metrics) RecordQueryRangeWindowRetry() {
+	m.windowRetries.Add(1)
+}
+
+// RecordQueryRangeWindowDegradedBatch records degraded batch execution events.
+func (m *Metrics) RecordQueryRangeWindowDegradedBatch() {
+	m.windowDegradedBatches.Add(1)
+}
+
+// RecordQueryRangeWindowPartialResponse records partial query_range responses.
+func (m *Metrics) RecordQueryRangeWindowPartialResponse() {
+	m.windowPartialResponses.Add(1)
 }
 
 // RecordQueryRangeAdaptiveState records adaptive query_range controller state.
@@ -999,6 +1029,22 @@ func (m *Metrics) Handler(w http.ResponseWriter, r *http.Request) {
 	sb.WriteString("# HELP loki_vl_proxy_window_prefilter_skipped_total Query-range windows skipped after prefilter.\n")
 	sb.WriteString("# TYPE loki_vl_proxy_window_prefilter_skipped_total counter\n")
 	fmt.Fprintf(&sb, "loki_vl_proxy_window_prefilter_skipped_total %d\n", m.windowPrefilterSkipped.Load())
+
+	sb.WriteString("# HELP loki_vl_proxy_window_prefilter_hit_ratio Prefilter hit ratio (kept / total windows).\n")
+	sb.WriteString("# TYPE loki_vl_proxy_window_prefilter_hit_ratio gauge\n")
+	fmt.Fprintf(&sb, "loki_vl_proxy_window_prefilter_hit_ratio %g\n", float64(m.windowPrefilterHitRatioPpm.Load())/1000000.0)
+
+	sb.WriteString("# HELP loki_vl_proxy_window_retry_total Query-range window retry attempts.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_window_retry_total counter\n")
+	fmt.Fprintf(&sb, "loki_vl_proxy_window_retry_total %d\n", m.windowRetries.Load())
+
+	sb.WriteString("# HELP loki_vl_proxy_window_degraded_batch_total Query-range batches degraded to lower parallelism.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_window_degraded_batch_total counter\n")
+	fmt.Fprintf(&sb, "loki_vl_proxy_window_degraded_batch_total %d\n", m.windowDegradedBatches.Load())
+
+	sb.WriteString("# HELP loki_vl_proxy_window_partial_response_total Query-range partial responses due to retryable backend failures.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_window_partial_response_total counter\n")
+	fmt.Fprintf(&sb, "loki_vl_proxy_window_partial_response_total %d\n", m.windowPartialResponses.Load())
 
 	sb.WriteString("# HELP loki_vl_proxy_window_prefilter_duration_seconds Query-range window prefilter duration.\n")
 	sb.WriteString("# TYPE loki_vl_proxy_window_prefilter_duration_seconds histogram\n")

--- a/internal/metrics/metrics_phase_kpi_test.go
+++ b/internal/metrics/metrics_phase_kpi_test.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMetrics_ExportsWindowPhaseKPIs(t *testing.T) {
+	m := NewMetrics()
+	m.RecordQueryRangeWindowPrefilterOutcome(8, 2) // 0.8 hit ratio
+	m.RecordQueryRangeWindowRetry()
+	m.RecordQueryRangeWindowRetry()
+	m.RecordQueryRangeWindowDegradedBatch()
+	m.RecordQueryRangeWindowPartialResponse()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	m.Handler(w, r)
+	body := w.Body.String()
+
+	for _, snippet := range []string{
+		"loki_vl_proxy_window_prefilter_hit_ratio 0.8",
+		"loki_vl_proxy_window_retry_total 2",
+		"loki_vl_proxy_window_degraded_batch_total 1",
+		"loki_vl_proxy_window_partial_response_total 1",
+	} {
+		if !strings.Contains(body, snippet) {
+			t.Fatalf("expected metrics output to contain %q\n%s", snippet, body)
+		}
+	}
+}

--- a/internal/metrics/otlp.go
+++ b/internal/metrics/otlp.go
@@ -539,7 +539,7 @@ func (p *OTLPPusher) backendDurationMetrics(now int64) []map[string]interface{} 
 }
 
 func (p *OTLPPusher) queryRangeWindowMetrics(now int64) []map[string]interface{} {
-	metrics := make([]map[string]interface{}, 0, 11)
+	metrics := make([]map[string]interface{}, 0, 15)
 	if p.metrics.windowFetch != nil {
 		metrics = append(metrics, p.histogramMetric(
 			"loki_vl_proxy_window_fetch_seconds",
@@ -596,6 +596,30 @@ func (p *OTLPPusher) queryRangeWindowMetrics(now int64) []map[string]interface{}
 			"Query-range windows skipped after prefilter.",
 			"{window}",
 			p.counterDP("loki_vl_proxy_window_prefilter_skipped_total", p.metrics.windowPrefilterSkipped.Load(), now),
+		),
+		p.gaugeMetric(
+			"loki_vl_proxy_window_prefilter_hit_ratio",
+			"Prefilter hit ratio (kept / total windows).",
+			"",
+			p.gaugeDP("loki_vl_proxy_window_prefilter_hit_ratio", float64(p.metrics.windowPrefilterHitRatioPpm.Load())/1000000.0, now),
+		),
+		p.sumMetric(
+			"loki_vl_proxy_window_retry_total",
+			"Query-range window retry attempts.",
+			"",
+			p.counterDP("loki_vl_proxy_window_retry_total", p.metrics.windowRetries.Load(), now),
+		),
+		p.sumMetric(
+			"loki_vl_proxy_window_degraded_batch_total",
+			"Query-range batches degraded to lower parallelism.",
+			"",
+			p.counterDP("loki_vl_proxy_window_degraded_batch_total", p.metrics.windowDegradedBatches.Load(), now),
+		),
+		p.sumMetric(
+			"loki_vl_proxy_window_partial_response_total",
+			"Query-range partial responses due to retryable backend failures.",
+			"",
+			p.counterDP("loki_vl_proxy_window_partial_response_total", p.metrics.windowPartialResponses.Load(), now),
 		),
 		p.gaugeMetric(
 			"loki_vl_proxy_window_adaptive_parallel_current",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -206,21 +206,29 @@ type Config struct {
 	// Query range windowing/cache options.
 	// When enabled, eligible log query_range requests are split into time windows,
 	// fetched with bounded parallelism, and merged in Loki-compatible direction order.
-	QueryRangeWindowingEnabled      bool
-	QueryRangeSplitInterval         time.Duration
-	QueryRangeMaxParallel           int
-	QueryRangeAdaptiveParallel      bool
-	QueryRangeParallelMin           int
-	QueryRangeParallelMax           int
-	QueryRangeLatencyTarget         time.Duration
-	QueryRangeLatencyBackoff        time.Duration
-	QueryRangeAdaptiveCooldown      time.Duration
-	QueryRangeErrorBackoffThreshold float64
-	QueryRangeFreshness             time.Duration
-	QueryRangeRecentCacheTTL        time.Duration
-	QueryRangeHistoryCacheTTL       time.Duration
-	QueryRangePrefilterIndexStats   bool
-	QueryRangePrefilterMinWindows   int
+	QueryRangeWindowingEnabled         bool
+	QueryRangeSplitInterval            time.Duration
+	QueryRangeMaxParallel              int
+	QueryRangeAdaptiveParallel         bool
+	QueryRangeParallelMin              int
+	QueryRangeParallelMax              int
+	QueryRangeLatencyTarget            time.Duration
+	QueryRangeLatencyBackoff           time.Duration
+	QueryRangeAdaptiveCooldown         time.Duration
+	QueryRangeErrorBackoffThreshold    float64
+	QueryRangeFreshness                time.Duration
+	QueryRangeRecentCacheTTL           time.Duration
+	QueryRangeHistoryCacheTTL          time.Duration
+	QueryRangePrefilterIndexStats      bool
+	QueryRangePrefilterMinWindows      int
+	QueryRangeStreamAwareBatching      bool
+	QueryRangeExpensiveHitThreshold    int64
+	QueryRangeExpensiveMaxParallel     int
+	QueryRangeAlignWindows             bool
+	QueryRangeWindowTimeout            time.Duration
+	QueryRangePartialResponses         bool
+	QueryRangeBackgroundWarm           bool
+	QueryRangeBackgroundWarmMaxWindows int
 
 	// Label translation
 	LabelStyle        LabelStyle        // how to translate VL field names to Loki labels
@@ -312,79 +320,87 @@ var CacheTTLs = map[string]time.Duration{
 }
 
 type Proxy struct {
-	backend                         *url.URL
-	rulerBackend                    *url.URL
-	alertsBackend                   *url.URL
-	client                          *http.Client
-	tailClient                      *http.Client
-	cache                           *cache.Cache
-	compatCache                     *cache.Cache
-	log                             *slog.Logger
-	metrics                         *metrics.Metrics
-	queryTracker                    *metrics.QueryTracker
-	coalescer                       *mw.Coalescer
-	limiter                         *mw.RateLimiter
-	breaker                         *mw.CircuitBreaker
-	configMu                        sync.RWMutex // protects tenantMap and labelTranslator
-	tenantMap                       map[string]TenantMapping
-	authEnabled                     bool
-	allowGlobalTenant               bool
-	maxLines                        int
-	forwardHeaders                  []string          // headers to copy from client request to VL
-	forwardCookies                  map[string]bool   // cookie names to copy from client request to VL
-	backendHeaders                  map[string]string // static headers on all VL requests
-	derivedFields                   []DerivedField
-	streamResponse                  bool
-	emitStructuredMetadata          bool
-	labelTranslator                 *LabelTranslator
-	metadataFieldMode               MetadataFieldMode
-	streamFieldsMap                 map[string]bool  // known _stream_fields for VL stream selector optimization
-	declaredLabelFields             []string         // configured VL-native label fields (stream_fields + extras)
-	peerCache                       *cache.PeerCache // L3 fleet peer cache
-	peerAuthToken                   string
-	registerInstrumentation         bool
-	enablePprof                     bool
-	enableQueryAnalytics            bool
-	adminAuthToken                  string
-	tailAllowedOrigins              map[string]struct{}
-	tailMode                        TailMode
-	metricsTrustProxyHeaders        bool
-	translationCache                *cache.Cache
-	queryRangeWindowing             bool
-	queryRangeSplitInterval         time.Duration
-	queryRangeMaxParallel           int
-	queryRangeAdaptiveParallel      bool
-	queryRangeParallelMin           int
-	queryRangeParallelMax           int
-	queryRangeLatencyTarget         time.Duration
-	queryRangeLatencyBackoff        time.Duration
-	queryRangeAdaptiveCooldown      time.Duration
-	queryRangeErrorBackoffThreshold float64
-	queryRangeAdaptiveMu            sync.Mutex
-	queryRangeParallelCurrent       int
-	queryRangeLatencyEWMA           time.Duration
-	queryRangeErrorEWMA             float64
-	queryRangeAdaptiveLastAdjust    time.Time
-	queryRangeFreshness             time.Duration
-	queryRangeRecentCacheTTL        time.Duration
-	queryRangeHistoryCacheTTL       time.Duration
-	queryRangePrefilterIndexStats   bool
-	queryRangePrefilterMinWindows   int
-	labelRefreshGroup               singleflight.Group
-	labelValuesIndexedCache         bool
-	labelValuesHotLimit             int
-	labelValuesIndexMaxEntries      int
-	labelValuesIndexPersistPath     string
-	labelValuesIndexPersistInterval time.Duration
-	labelValuesIndexStartupStale    time.Duration
-	labelValuesIndexPeerWarmTimeout time.Duration
-	labelValuesIndexWarmReady       atomic.Bool
-	labelValuesIndexPersistStarted  atomic.Bool
-	labelValuesIndexPersistDirty    atomic.Bool
-	labelValuesIndexPersistStop     chan struct{}
-	labelValuesIndexPersistDone     chan struct{}
-	labelValuesIndexMu              sync.RWMutex
-	labelValuesIndex                map[string]*labelValuesIndexState
+	backend                               *url.URL
+	rulerBackend                          *url.URL
+	alertsBackend                         *url.URL
+	client                                *http.Client
+	tailClient                            *http.Client
+	cache                                 *cache.Cache
+	compatCache                           *cache.Cache
+	log                                   *slog.Logger
+	metrics                               *metrics.Metrics
+	queryTracker                          *metrics.QueryTracker
+	coalescer                             *mw.Coalescer
+	limiter                               *mw.RateLimiter
+	breaker                               *mw.CircuitBreaker
+	configMu                              sync.RWMutex // protects tenantMap and labelTranslator
+	tenantMap                             map[string]TenantMapping
+	authEnabled                           bool
+	allowGlobalTenant                     bool
+	maxLines                              int
+	forwardHeaders                        []string          // headers to copy from client request to VL
+	forwardCookies                        map[string]bool   // cookie names to copy from client request to VL
+	backendHeaders                        map[string]string // static headers on all VL requests
+	derivedFields                         []DerivedField
+	streamResponse                        bool
+	emitStructuredMetadata                bool
+	labelTranslator                       *LabelTranslator
+	metadataFieldMode                     MetadataFieldMode
+	streamFieldsMap                       map[string]bool  // known _stream_fields for VL stream selector optimization
+	declaredLabelFields                   []string         // configured VL-native label fields (stream_fields + extras)
+	peerCache                             *cache.PeerCache // L3 fleet peer cache
+	peerAuthToken                         string
+	registerInstrumentation               bool
+	enablePprof                           bool
+	enableQueryAnalytics                  bool
+	adminAuthToken                        string
+	tailAllowedOrigins                    map[string]struct{}
+	tailMode                              TailMode
+	metricsTrustProxyHeaders              bool
+	translationCache                      *cache.Cache
+	queryRangeWindowing                   bool
+	queryRangeSplitInterval               time.Duration
+	queryRangeMaxParallel                 int
+	queryRangeAdaptiveParallel            bool
+	queryRangeParallelMin                 int
+	queryRangeParallelMax                 int
+	queryRangeLatencyTarget               time.Duration
+	queryRangeLatencyBackoff              time.Duration
+	queryRangeAdaptiveCooldown            time.Duration
+	queryRangeErrorBackoffThreshold       float64
+	queryRangeAdaptiveMu                  sync.Mutex
+	queryRangeParallelCurrent             int
+	queryRangeLatencyEWMA                 time.Duration
+	queryRangeErrorEWMA                   float64
+	queryRangeAdaptiveLastAdjust          time.Time
+	queryRangeFreshness                   time.Duration
+	queryRangeRecentCacheTTL              time.Duration
+	queryRangeHistoryCacheTTL             time.Duration
+	queryRangePrefilterIndexStats         bool
+	queryRangePrefilterMinWindows         int
+	queryRangeStreamAwareBatching         bool
+	queryRangeExpensiveWindowHitThreshold int64
+	queryRangeExpensiveWindowMaxParallel  int
+	queryRangeAlignWindows                bool
+	queryRangeWindowTimeout               time.Duration
+	queryRangePartialResponses            bool
+	queryRangeBackgroundWarm              bool
+	queryRangeBackgroundWarmMaxWindows    int
+	labelRefreshGroup                     singleflight.Group
+	labelValuesIndexedCache               bool
+	labelValuesHotLimit                   int
+	labelValuesIndexMaxEntries            int
+	labelValuesIndexPersistPath           string
+	labelValuesIndexPersistInterval       time.Duration
+	labelValuesIndexStartupStale          time.Duration
+	labelValuesIndexPeerWarmTimeout       time.Duration
+	labelValuesIndexWarmReady             atomic.Bool
+	labelValuesIndexPersistStarted        atomic.Bool
+	labelValuesIndexPersistDirty          atomic.Bool
+	labelValuesIndexPersistStop           chan struct{}
+	labelValuesIndexPersistDone           chan struct{}
+	labelValuesIndexMu                    sync.RWMutex
+	labelValuesIndex                      map[string]*labelValuesIndexState
 }
 
 type labelValueIndexEntry struct {
@@ -582,6 +598,25 @@ func New(cfg Config) (*Proxy, error) {
 	if queryRangePrefilterMinWindows <= 0 {
 		queryRangePrefilterMinWindows = 8
 	}
+	queryRangeExpensiveHitThreshold := cfg.QueryRangeExpensiveHitThreshold
+	if queryRangeExpensiveHitThreshold <= 0 {
+		queryRangeExpensiveHitThreshold = 2000
+	}
+	queryRangeExpensiveMaxParallel := cfg.QueryRangeExpensiveMaxParallel
+	if queryRangeExpensiveMaxParallel <= 0 {
+		queryRangeExpensiveMaxParallel = 1
+	}
+	if queryRangeExpensiveMaxParallel > queryRangeParallelMax {
+		queryRangeExpensiveMaxParallel = queryRangeParallelMax
+	}
+	queryRangeWindowTimeout := cfg.QueryRangeWindowTimeout
+	if queryRangeWindowTimeout < 0 {
+		queryRangeWindowTimeout = 0
+	}
+	queryRangeBackgroundWarmMaxWindows := cfg.QueryRangeBackgroundWarmMaxWindows
+	if queryRangeBackgroundWarmMaxWindows <= 0 {
+		queryRangeBackgroundWarmMaxWindows = 24
+	}
 	tailMode := cfg.TailMode
 	if tailMode == "" {
 		tailMode = TailModeAuto
@@ -629,64 +664,72 @@ func New(cfg Config) (*Proxy, error) {
 		tailClient: &http.Client{
 			Transport: tailTransport,
 		},
-		cache:                           cfg.Cache,
-		compatCache:                     cfg.CompatCache,
-		log:                             logger,
-		metrics:                         metrics.NewMetricsWithLimits(cfg.MetricsMaxTenants, cfg.MetricsMaxClients),
-		queryTracker:                    metrics.NewQueryTracker(10000),
-		coalescer:                       mw.NewCoalescer(),
-		limiter:                         mw.NewRateLimiter(maxConcurrent, ratePerSec, rateBurst),
-		breaker:                         mw.NewCircuitBreaker(cbFail, 3, cbOpen),
-		tenantMap:                       cfg.TenantMap,
-		authEnabled:                     cfg.AuthEnabled,
-		allowGlobalTenant:               cfg.AllowGlobalTenant,
-		maxLines:                        maxLines,
-		forwardHeaders:                  cfg.ForwardHeaders,
-		forwardCookies:                  forwardCookies,
-		backendHeaders:                  backendHeaders,
-		derivedFields:                   cfg.DerivedFields,
-		streamResponse:                  cfg.StreamResponse,
-		emitStructuredMetadata:          cfg.EmitStructuredMetadata,
-		labelTranslator:                 labelTranslator,
-		metadataFieldMode:               metadataFieldMode,
-		streamFieldsMap:                 buildStreamFieldsMap(cfg.StreamFields),
-		declaredLabelFields:             declaredLabelFields,
-		peerCache:                       cfg.PeerCache,
-		peerAuthToken:                   cfg.PeerAuthToken,
-		registerInstrumentation:         registerInstrumentation,
-		enablePprof:                     cfg.EnablePprof,
-		enableQueryAnalytics:            cfg.EnableQueryAnalytics,
-		adminAuthToken:                  cfg.AdminAuthToken,
-		tailAllowedOrigins:              tailAllowedOrigins,
-		tailMode:                        tailMode,
-		metricsTrustProxyHeaders:        cfg.MetricsTrustProxyHeaders,
-		translationCache:                cache.New(5*time.Minute, 5000),
-		queryRangeWindowing:             cfg.QueryRangeWindowingEnabled && cfg.QueryRangeSplitInterval > 0,
-		queryRangeSplitInterval:         cfg.QueryRangeSplitInterval,
-		queryRangeMaxParallel:           queryRangeMaxParallel,
-		queryRangeAdaptiveParallel:      cfg.QueryRangeAdaptiveParallel,
-		queryRangeParallelMin:           queryRangeParallelMin,
-		queryRangeParallelMax:           queryRangeParallelMax,
-		queryRangeLatencyTarget:         queryRangeLatencyTarget,
-		queryRangeLatencyBackoff:        queryRangeLatencyBackoff,
-		queryRangeAdaptiveCooldown:      queryRangeAdaptiveCooldown,
-		queryRangeErrorBackoffThreshold: queryRangeErrorBackoffThreshold,
-		queryRangeParallelCurrent:       queryRangeParallelMin,
-		queryRangeFreshness:             queryRangeFreshness,
-		queryRangeRecentCacheTTL:        queryRangeRecentCacheTTL,
-		queryRangeHistoryCacheTTL:       queryRangeHistoryCacheTTL,
-		queryRangePrefilterIndexStats:   cfg.QueryRangePrefilterIndexStats,
-		queryRangePrefilterMinWindows:   queryRangePrefilterMinWindows,
-		labelValuesIndexedCache:         cfg.LabelValuesIndexedCache,
-		labelValuesHotLimit:             labelValuesHotLimit,
-		labelValuesIndexMaxEntries:      labelValuesIndexMaxEntries,
-		labelValuesIndexPersistPath:     strings.TrimSpace(cfg.LabelValuesIndexPersistPath),
-		labelValuesIndexPersistInterval: labelValuesIndexPersistInterval,
-		labelValuesIndexStartupStale:    labelValuesIndexStartupStale,
-		labelValuesIndexPeerWarmTimeout: labelValuesIndexPeerWarmTimeout,
-		labelValuesIndexPersistStop:     make(chan struct{}),
-		labelValuesIndexPersistDone:     make(chan struct{}),
-		labelValuesIndex:                make(map[string]*labelValuesIndexState),
+		cache:                                 cfg.Cache,
+		compatCache:                           cfg.CompatCache,
+		log:                                   logger,
+		metrics:                               metrics.NewMetricsWithLimits(cfg.MetricsMaxTenants, cfg.MetricsMaxClients),
+		queryTracker:                          metrics.NewQueryTracker(10000),
+		coalescer:                             mw.NewCoalescer(),
+		limiter:                               mw.NewRateLimiter(maxConcurrent, ratePerSec, rateBurst),
+		breaker:                               mw.NewCircuitBreaker(cbFail, 3, cbOpen),
+		tenantMap:                             cfg.TenantMap,
+		authEnabled:                           cfg.AuthEnabled,
+		allowGlobalTenant:                     cfg.AllowGlobalTenant,
+		maxLines:                              maxLines,
+		forwardHeaders:                        cfg.ForwardHeaders,
+		forwardCookies:                        forwardCookies,
+		backendHeaders:                        backendHeaders,
+		derivedFields:                         cfg.DerivedFields,
+		streamResponse:                        cfg.StreamResponse,
+		emitStructuredMetadata:                cfg.EmitStructuredMetadata,
+		labelTranslator:                       labelTranslator,
+		metadataFieldMode:                     metadataFieldMode,
+		streamFieldsMap:                       buildStreamFieldsMap(cfg.StreamFields),
+		declaredLabelFields:                   declaredLabelFields,
+		peerCache:                             cfg.PeerCache,
+		peerAuthToken:                         cfg.PeerAuthToken,
+		registerInstrumentation:               registerInstrumentation,
+		enablePprof:                           cfg.EnablePprof,
+		enableQueryAnalytics:                  cfg.EnableQueryAnalytics,
+		adminAuthToken:                        cfg.AdminAuthToken,
+		tailAllowedOrigins:                    tailAllowedOrigins,
+		tailMode:                              tailMode,
+		metricsTrustProxyHeaders:              cfg.MetricsTrustProxyHeaders,
+		translationCache:                      cache.New(5*time.Minute, 5000),
+		queryRangeWindowing:                   cfg.QueryRangeWindowingEnabled && cfg.QueryRangeSplitInterval > 0,
+		queryRangeSplitInterval:               cfg.QueryRangeSplitInterval,
+		queryRangeMaxParallel:                 queryRangeMaxParallel,
+		queryRangeAdaptiveParallel:            cfg.QueryRangeAdaptiveParallel,
+		queryRangeParallelMin:                 queryRangeParallelMin,
+		queryRangeParallelMax:                 queryRangeParallelMax,
+		queryRangeLatencyTarget:               queryRangeLatencyTarget,
+		queryRangeLatencyBackoff:              queryRangeLatencyBackoff,
+		queryRangeAdaptiveCooldown:            queryRangeAdaptiveCooldown,
+		queryRangeErrorBackoffThreshold:       queryRangeErrorBackoffThreshold,
+		queryRangeParallelCurrent:             queryRangeParallelMin,
+		queryRangeFreshness:                   queryRangeFreshness,
+		queryRangeRecentCacheTTL:              queryRangeRecentCacheTTL,
+		queryRangeHistoryCacheTTL:             queryRangeHistoryCacheTTL,
+		queryRangePrefilterIndexStats:         cfg.QueryRangePrefilterIndexStats,
+		queryRangePrefilterMinWindows:         queryRangePrefilterMinWindows,
+		queryRangeStreamAwareBatching:         cfg.QueryRangeStreamAwareBatching,
+		queryRangeExpensiveWindowHitThreshold: queryRangeExpensiveHitThreshold,
+		queryRangeExpensiveWindowMaxParallel:  queryRangeExpensiveMaxParallel,
+		queryRangeAlignWindows:                cfg.QueryRangeAlignWindows,
+		queryRangeWindowTimeout:               queryRangeWindowTimeout,
+		queryRangePartialResponses:            cfg.QueryRangePartialResponses,
+		queryRangeBackgroundWarm:              cfg.QueryRangeBackgroundWarm,
+		queryRangeBackgroundWarmMaxWindows:    queryRangeBackgroundWarmMaxWindows,
+		labelValuesIndexedCache:               cfg.LabelValuesIndexedCache,
+		labelValuesHotLimit:                   labelValuesHotLimit,
+		labelValuesIndexMaxEntries:            labelValuesIndexMaxEntries,
+		labelValuesIndexPersistPath:           strings.TrimSpace(cfg.LabelValuesIndexPersistPath),
+		labelValuesIndexPersistInterval:       labelValuesIndexPersistInterval,
+		labelValuesIndexStartupStale:          labelValuesIndexStartupStale,
+		labelValuesIndexPeerWarmTimeout:       labelValuesIndexPeerWarmTimeout,
+		labelValuesIndexPersistStop:           make(chan struct{}),
+		labelValuesIndexPersistDone:           make(chan struct{}),
+		labelValuesIndex:                      make(map[string]*labelValuesIndexState),
 	}, nil
 }
 
@@ -2923,30 +2966,53 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	r = withOrgID(r)
-	query := r.FormValue("query")
+	orgID := r.Header.Get("X-Scope-OrgID")
+	cacheKey := "volume:" + orgID + ":" + r.URL.RawQuery
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(cached)
+		p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
+		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume"]) {
+			p.refreshVolumeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("targetLabels"))
+		}
+		return
+	}
+	p.metrics.RecordCacheMiss()
+
+	result, err := p.computeVolumeResult(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("targetLabels"))
+	if err != nil {
+		result = map[string]interface{}{
+			"status": "success",
+			"data":   map[string]interface{}{"resultType": "vector", "result": []interface{}{}},
+		}
+	}
+	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["volume"], result)
+	p.writeJSON(w, result)
+	p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
+}
+
+func (p *Proxy) computeVolumeResult(ctx context.Context, query, start, end, targetLabels string) (map[string]interface{}, error) {
 	if query == "" {
 		query = "*"
 	}
-	targetLabels := r.FormValue("targetLabels")
 	if targetLabels == "" {
 		targetLabels = inferPrimaryTargetLabel(query)
 	}
 	if usesDerivedVolumeLabels(targetLabels) {
-		result, err := p.volumeByDerivedLabels(r.Context(), query, r.FormValue("start"), r.FormValue("end"), targetLabels, "")
+		result, err := p.volumeByDerivedLabels(ctx, query, start, end, targetLabels, "")
 		if err == nil {
-			p.writeJSON(w, result)
-			p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
-			return
+			return result, nil
 		}
 	}
 	logsqlQuery, _ := p.translateQuery(query)
 
 	params := url.Values{}
 	params.Set("query", logsqlQuery+" | sort by (_time desc)")
-	if s := r.FormValue("start"); s != "" {
+	if s := start; s != "" {
 		params.Set("start", formatVLTimestamp(s))
 	}
-	if e := r.FormValue("end"); e != "" {
+	if e := end; e != "" {
 		params.Set("end", formatVLTimestamp(e))
 	}
 	// VL v1.49+ requires step for hits
@@ -2955,27 +3021,41 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	// Request field-level grouping
 	if targetLabels != "" {
-		mappedFields := p.resolveTargetLabelFields(r.Context(), targetLabels, params)
+		mappedFields := p.resolveTargetLabelFields(ctx, targetLabels, params)
 		if len(mappedFields) > 0 {
 			params.Set("field", strings.Join(mappedFields, ","))
 		}
 	}
 
-	resp, err := p.vlGet(r.Context(), "/select/logsql/hits", params)
+	resp, err := p.vlGet(ctx, "/select/logsql/hits", params)
 	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
-			"status": "success",
-			"data":   map[string]interface{}{"resultType": "vector", "result": []interface{}{}},
-		})
-		p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
-		return
+		return nil, err
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 
-	result := p.hitsToVolumeVector(body)
-	p.writeJSON(w, result)
-	p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
+	return p.hitsToVolumeVector(body), nil
+}
+
+func (p *Proxy) refreshVolumeCacheAsync(orgID, cacheKey, rawQuery, start, end, targetLabels string) {
+	refreshKey := "refresh:volume:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+			result, err := p.computeVolumeResult(ctx, rawQuery, start, end, targetLabels)
+			if err == nil {
+				p.setJSONCacheWithTTL(cacheKey, CacheTTLs["volume"], result)
+			}
+			return nil, err
+		})
+		if err != nil {
+			p.log.Debug("background volume refresh failed", "cache_key", cacheKey, "error", err)
+		}
+	}()
 }
 
 // handleVolumeRange returns volume range data via VL /select/logsql/hits with step.
@@ -2987,58 +3067,95 @@ func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	r = withOrgID(r)
-	query := r.FormValue("query")
+	orgID := r.Header.Get("X-Scope-OrgID")
+	cacheKey := "volume_range:" + orgID + ":" + r.URL.RawQuery
+	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(cached)
+		p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
+		p.metrics.RecordCacheHit()
+		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume_range"]) {
+			p.refreshVolumeRangeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"), r.FormValue("targetLabels"))
+		}
+		return
+	}
+	p.metrics.RecordCacheMiss()
+
+	result, err := p.computeVolumeRangeResult(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"), r.FormValue("targetLabels"))
+	if err != nil {
+		result = map[string]interface{}{
+			"status": "success",
+			"data":   map[string]interface{}{"resultType": "matrix", "result": []interface{}{}},
+		}
+	}
+	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["volume_range"], result)
+	p.writeJSON(w, result)
+	p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
+}
+
+func (p *Proxy) computeVolumeRangeResult(ctx context.Context, query, start, end, step, targetLabels string) (map[string]interface{}, error) {
 	if query == "" {
 		query = "*"
 	}
-	targetLabels := r.FormValue("targetLabels")
 	if targetLabels == "" {
 		targetLabels = inferPrimaryTargetLabel(query)
 	}
 	if usesDerivedVolumeLabels(targetLabels) {
-		result, err := p.volumeByDerivedLabels(r.Context(), query, r.FormValue("start"), r.FormValue("end"), targetLabels, r.FormValue("step"))
+		result, err := p.volumeByDerivedLabels(ctx, query, start, end, targetLabels, step)
 		if err == nil {
-			p.writeJSON(w, result)
-			p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
-			return
+			return result, nil
 		}
 	}
 	logsqlQuery, _ := p.translateQuery(query)
 
 	params := url.Values{}
 	params.Set("query", logsqlQuery+" | sort by (_time desc)")
-	if s := r.FormValue("start"); s != "" {
+	if s := start; s != "" {
 		params.Set("start", formatVLTimestamp(s))
 	}
-	if e := r.FormValue("end"); e != "" {
+	if e := end; e != "" {
 		params.Set("end", formatVLTimestamp(e))
 	}
-	if step := r.FormValue("step"); step != "" {
+	if step != "" {
 		params.Set("step", formatVLStep(step))
 	}
 	// Forward targetLabels for field-level grouping (same as /volume)
 	if targetLabels != "" {
-		mappedFields := p.resolveTargetLabelFields(r.Context(), targetLabels, params)
+		mappedFields := p.resolveTargetLabelFields(ctx, targetLabels, params)
 		if len(mappedFields) > 0 {
 			params.Set("field", strings.Join(mappedFields, ","))
 		}
 	}
 
-	resp, err := p.vlGet(r.Context(), "/select/logsql/hits", params)
+	resp, err := p.vlGet(ctx, "/select/logsql/hits", params)
 	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
-			"status": "success",
-			"data":   map[string]interface{}{"resultType": "matrix", "result": []interface{}{}},
-		})
-		p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
-		return
+		return nil, err
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 
-	result := p.hitsToVolumeMatrix(body)
-	p.writeJSON(w, result)
-	p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
+	return p.hitsToVolumeMatrix(body), nil
+}
+
+func (p *Proxy) refreshVolumeRangeCacheAsync(orgID, cacheKey, rawQuery, start, end, step, targetLabels string) {
+	refreshKey := "refresh:volume_range:" + cacheKey
+	go func() {
+		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), p.labelBackgroundTimeout())
+			defer cancel()
+			if orgID != "" {
+				ctx = context.WithValue(ctx, orgIDKey, orgID)
+			}
+			result, err := p.computeVolumeRangeResult(ctx, rawQuery, start, end, step, targetLabels)
+			if err == nil {
+				p.setJSONCacheWithTTL(cacheKey, CacheTTLs["volume_range"], result)
+			}
+			return nil, err
+		})
+		if err != nil {
+			p.log.Debug("background volume_range refresh failed", "cache_key", cacheKey, "error", err)
+		}
+	}()
 }
 
 // handleDetectedFields returns detected field names.

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -51,7 +51,13 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 	if !ok {
 		return false
 	}
-	windows := splitQueryRangeWindows(startNs, endNs, p.queryRangeSplitInterval, r.FormValue("direction"))
+	windows := splitQueryRangeWindowsWithOptions(
+		startNs,
+		endNs,
+		p.queryRangeSplitInterval,
+		r.FormValue("direction"),
+		p.queryRangeAlignWindows,
+	)
 	if len(windows) <= 1 {
 		return false
 	}
@@ -71,7 +77,7 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 	emitStructuredMetadata := p.shouldEmitStructuredMetadata(r)
 	p.metrics.RecordTupleMode(tupleModeForRequest(categorizedLabels, emitStructuredMetadata))
 
-	filteredWindows, prefilterErr := p.prefilterQueryRangeWindowsByHits(r.Context(), r, logsqlQuery, windows)
+	filteredWindows, windowHitEstimate, prefilterErr := p.prefilterQueryRangeWindowsByHits(r.Context(), r, logsqlQuery, windows)
 	if prefilterErr != nil {
 		p.log.Debug(
 			"query_range window prefilter unavailable; using full window set",
@@ -107,7 +113,7 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 	// Keep preallocation constant-sized to avoid any user-influenced allocation growth.
 	collected := make([]queryRangeWindowEntry, 0, queryRangeCollectedInitialCap)
 	for i := 0; i < len(windows) && remaining > 0; {
-		parallel := p.queryRangeWindowParallelLimit()
+		parallel := p.queryRangeWindowBatchParallelLimit(windows[i], windowHitEstimate)
 		batchSize := min(parallel, len(windows)-i)
 		if batchSize <= 0 {
 			batchSize = 1
@@ -126,6 +132,8 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 			retryable := shouldRetryQueryRangeWindow(err)
 			if retryable && batchSize > 1 {
 				nextBatchSize := max(1, batchSize/2)
+				p.metrics.RecordQueryRangeWindowDegradedBatch()
+				p.metrics.RecordQueryRangeWindowRetry()
 				p.log.Warn("query_range windowed batch backoff",
 					"error", err,
 					"window_count", len(windows),
@@ -148,6 +156,7 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 
 			if retryable && batchSize == 1 && retryAttempt < queryRangeBatchRetryAttempts {
 				retryAttempt++
+				p.metrics.RecordQueryRangeWindowRetry()
 				backoff := queryRangeWindowRetryBackoff(retryAttempt)
 				p.log.Warn("query_range single-window retrying after batch failure",
 					"error", err,
@@ -164,6 +173,18 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 				case <-time.After(backoff):
 				}
 				continue
+			}
+			if retryable && p.queryRangePartialResponses {
+				p.metrics.RecordQueryRangeWindowPartialResponse()
+				w.Header().Set("X-Loki-VL-Partial-Response", "true")
+				if p.queryRangeBackgroundWarm {
+					p.warmQueryRangeWindowsAsync(r.Clone(context.Background()), logsqlQuery, queryLimit, windows[i:], categorizedLabels, emitStructuredMetadata)
+				}
+				p.log.Warn("query_range returning partial response after retryable batch failure",
+					"error", err,
+					"remaining_windows", len(windows)-i,
+				)
+				break
 			}
 			status := statusFromQueryRangeWindowErr(err)
 			p.log.Warn("query_range windowed fetch failed",
@@ -228,6 +249,36 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 	return true
 }
 
+func (p *Proxy) warmQueryRangeWindowsAsync(
+	r *http.Request,
+	logsqlQuery string,
+	queryLimit string,
+	windows []queryRangeWindow,
+	categorizedLabels bool,
+	emitStructuredMetadata bool,
+) {
+	if len(windows) == 0 || p == nil {
+		return
+	}
+	maxWarm := p.queryRangeBackgroundWarmMaxWindows
+	if maxWarm <= 0 || maxWarm > len(windows) {
+		maxWarm = len(windows)
+	}
+	toWarm := append([]queryRangeWindow(nil), windows[:maxWarm]...)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		for _, window := range toWarm {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			_, _ = p.fetchQueryRangeWindow(ctx, r, logsqlQuery, queryLimit, 1000, window, categorizedLabels, emitStructuredMetadata)
+		}
+	}()
+}
+
 func (p *Proxy) fetchQueryRangeWindowBatch(
 	r *http.Request,
 	logsqlQuery string,
@@ -287,6 +338,13 @@ func (p *Proxy) fetchQueryRangeWindow(
 	categorizedLabels bool,
 	emitStructuredMetadata bool,
 ) (queryRangeWindowCacheEntry, error) {
+	fetchCtx := ctx
+	cancel := func() {}
+	if p.queryRangeWindowTimeout > 0 {
+		fetchCtx, cancel = context.WithTimeout(ctx, p.queryRangeWindowTimeout)
+	}
+	defer cancel()
+
 	cacheKey := p.queryRangeWindowCacheKey(r, logsqlQuery, queryLimit, window, categorizedLabels, emitStructuredMetadata)
 	if cached, ok := p.cache.Get(cacheKey); ok {
 		var entry queryRangeWindowCacheEntry
@@ -307,7 +365,7 @@ func (p *Proxy) fetchQueryRangeWindow(
 	coalesceKey := "query_range_window:" + cacheKey
 	for attempt := 1; attempt <= queryRangeWindowFetchAttempts; attempt++ {
 		fetchStart := time.Now()
-		status, body, err := p.vlPostCoalesced(ctx, coalesceKey, "/select/logsql/query", params)
+		status, body, err := p.vlPostCoalesced(fetchCtx, coalesceKey, "/select/logsql/query", params)
 		fetchDuration := time.Since(fetchStart)
 		p.metrics.RecordQueryRangeWindowFetchDuration(fetchDuration)
 
@@ -339,6 +397,7 @@ func (p *Proxy) fetchQueryRangeWindow(
 			return queryRangeWindowCacheEntry{}, fetchErr
 		}
 
+		p.metrics.RecordQueryRangeWindowRetry()
 		backoff := queryRangeWindowRetryBackoff(attempt)
 		p.log.Warn(
 			"query_range window fetch retrying",
@@ -348,8 +407,8 @@ func (p *Proxy) fetchQueryRangeWindow(
 			"error", fetchErr,
 		)
 		select {
-		case <-ctx.Done():
-			return queryRangeWindowCacheEntry{}, ctx.Err()
+		case <-fetchCtx.Done():
+			return queryRangeWindowCacheEntry{}, fetchCtx.Err()
 		case <-time.After(backoff):
 		}
 	}
@@ -362,9 +421,9 @@ func (p *Proxy) prefilterQueryRangeWindowsByHits(
 	r *http.Request,
 	logsqlQuery string,
 	windows []queryRangeWindow,
-) ([]queryRangeWindow, error) {
+) ([]queryRangeWindow, map[string]int64, error) {
 	if !p.queryRangePrefilterIndexStats || len(windows) < p.queryRangePrefilterMinWindows {
-		return windows, nil
+		return windows, nil, nil
 	}
 	p.metrics.RecordQueryRangeWindowPrefilterAttempt()
 	start := time.Now()
@@ -378,6 +437,7 @@ func (p *Proxy) prefilterQueryRangeWindowsByHits(
 	}
 
 	keep := make([]bool, len(windows))
+	estimates := make([]int64, len(windows))
 	maxParallel := min(4, max(1, p.queryRangeWindowParallelLimit()))
 	maxParallel = min(maxParallel, len(windows))
 	g, gctx := errgroup.WithContext(ctx)
@@ -386,38 +446,47 @@ func (p *Proxy) prefilterQueryRangeWindowsByHits(
 		i := i
 		window := windows[i]
 		g.Go(func() error {
-			hasHits, err := p.queryRangeWindowHasHits(gctx, r, prefilterQuery, window)
+			hitEstimate, err := p.queryRangeWindowHitEstimate(gctx, r, prefilterQuery, window)
 			if err != nil {
 				return err
 			}
-			keep[i] = hasHits
+			estimates[i] = hitEstimate
+			keep[i] = hitEstimate > 0
 			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
 		p.metrics.RecordQueryRangeWindowPrefilterError()
-		return windows, err
+		return windows, nil, err
 	}
 
 	filtered := make([]queryRangeWindow, 0, len(windows))
+	filteredEstimates := make(map[string]int64, len(windows))
 	for i, hasHits := range keep {
 		if hasHits {
 			filtered = append(filtered, windows[i])
+			filteredEstimates[queryRangeWindowKey(windows[i])] = estimates[i]
 		}
 	}
 	p.metrics.RecordQueryRangeWindowPrefilterOutcome(len(filtered), len(windows)-len(filtered))
-	return filtered, nil
+	return filtered, filteredEstimates, nil
 }
 
-func (p *Proxy) queryRangeWindowHasHits(
+func (p *Proxy) queryRangeWindowHitEstimate(
 	ctx context.Context,
 	r *http.Request,
 	logsqlQuery string,
 	window queryRangeWindow,
-) (bool, error) {
+) (int64, error) {
 	cacheKey := p.queryRangeWindowHasHitsCacheKey(r, logsqlQuery, window)
 	if cached, ok := p.cache.Get(cacheKey); ok && len(cached) > 0 {
-		return cached[0] == '1', nil
+		if est, err := strconv.ParseInt(strings.TrimSpace(string(cached)), 10, 64); err == nil && est >= 0 {
+			return est, nil
+		}
+		if cached[0] == '1' {
+			return 1, nil
+		}
+		return 0, nil
 	}
 
 	params := url.Values{}
@@ -431,15 +500,14 @@ func (p *Proxy) queryRangeWindowHasHits(
 	for attempt := 1; attempt <= queryRangePrefilterAttempts; attempt++ {
 		status, body, err := p.vlGetCoalescedWithStatus(ctx, coalesceKey, "/select/logsql/hits", params)
 		if err == nil && status < http.StatusBadRequest {
-			hasHits := sumHitsValues(body) > 0
-			if ttl := p.queryRangeWindowPrefilterTTL(window.endNs); ttl > 0 {
-				if hasHits {
-					p.cache.SetWithTTL(cacheKey, []byte("1"), ttl)
-				} else {
-					p.cache.SetWithTTL(cacheKey, []byte("0"), ttl)
-				}
+			hitEstimate := int64(sumHitsValues(body))
+			if hitEstimate < 0 {
+				hitEstimate = 0
 			}
-			return hasHits, nil
+			if ttl := p.queryRangeWindowPrefilterTTL(window.endNs); ttl > 0 {
+				p.cache.SetWithTTL(cacheKey, []byte(strconv.FormatInt(hitEstimate, 10)), ttl)
+			}
+			return hitEstimate, nil
 		}
 		if err == nil {
 			msg := strings.TrimSpace(string(body))
@@ -449,15 +517,47 @@ func (p *Proxy) queryRangeWindowHasHits(
 			err = &queryRangeWindowHTTPError{status: status, msg: msg}
 		}
 		if attempt >= queryRangePrefilterAttempts || !shouldRetryQueryRangeWindow(err) {
-			return false, err
+			return 0, err
 		}
+		p.metrics.RecordQueryRangeWindowRetry()
 		select {
 		case <-ctx.Done():
-			return false, ctx.Err()
+			return 0, ctx.Err()
 		case <-time.After(queryRangeWindowRetryBackoff(attempt)):
 		}
 	}
-	return false, errors.New("query_range window prefilter failed")
+	return 0, errors.New("query_range window prefilter failed")
+}
+
+func queryRangeWindowKey(window queryRangeWindow) string {
+	return strconv.FormatInt(window.startNs, 10) + ":" + strconv.FormatInt(window.endNs, 10)
+}
+
+func (p *Proxy) queryRangeWindowBatchParallelLimit(window queryRangeWindow, estimates map[string]int64) int {
+	parallel := p.queryRangeWindowParallelLimit()
+	if !p.queryRangeStreamAwareBatching || parallel <= 1 {
+		return parallel
+	}
+	threshold := p.queryRangeExpensiveWindowHitThreshold
+	if threshold <= 0 {
+		return parallel
+	}
+	if estimates == nil {
+		return parallel
+	}
+	hitEstimate, ok := estimates[queryRangeWindowKey(window)]
+	if !ok || hitEstimate < threshold {
+		return parallel
+	}
+	capParallel := p.queryRangeExpensiveWindowMaxParallel
+	if capParallel <= 0 {
+		capParallel = 1
+	}
+	if capParallel < parallel {
+		p.metrics.RecordQueryRangeWindowDegradedBatch()
+		return capParallel
+	}
+	return parallel
 }
 
 func (p *Proxy) queryRangeWindowHasHitsCacheKey(
@@ -685,6 +785,10 @@ func withQueryDirectionSort(logsqlQuery, direction string) string {
 }
 
 func splitQueryRangeWindows(startNs, endNs int64, interval time.Duration, direction string) []queryRangeWindow {
+	return splitQueryRangeWindowsWithOptions(startNs, endNs, interval, direction, false)
+}
+
+func splitQueryRangeWindowsWithOptions(startNs, endNs int64, interval time.Duration, direction string, align bool) []queryRangeWindow {
 	if interval <= 0 || endNs < startNs {
 		return nil
 	}
@@ -694,6 +798,29 @@ func splitQueryRangeWindows(startNs, endNs int64, interval time.Duration, direct
 	}
 	windows := make([]queryRangeWindow, 0, min(int((endNs-startNs)/step)+1, maxQueryRangeWindows))
 	cursor := startNs
+	if align {
+		if rem := cursor % step; rem != 0 {
+			if rem < 0 {
+				rem += step
+			}
+			firstEnd := cursor + (step - rem) - 1
+			if firstEnd >= cursor {
+				if firstEnd > endNs {
+					firstEnd = endNs
+				}
+				windows = append(windows, queryRangeWindow{startNs: cursor, endNs: firstEnd})
+				if firstEnd == endNs || len(windows) >= maxQueryRangeWindows {
+					if direction != "forward" {
+						for i, j := 0, len(windows)-1; i < j; i, j = i+1, j-1 {
+							windows[i], windows[j] = windows[j], windows[i]
+						}
+					}
+					return windows
+				}
+				cursor = firstEnd + 1
+			}
+		}
+	}
 	for cursor <= endNs && len(windows) < maxQueryRangeWindows {
 		windowEnd := cursor + step - 1
 		if windowEnd < cursor || windowEnd > endNs {

--- a/internal/proxy/query_range_windowing_prefilter_bench_test.go
+++ b/internal/proxy/query_range_windowing_prefilter_bench_test.go
@@ -22,6 +22,14 @@ func BenchmarkQueryRangeWindowing_WithPrefilter(b *testing.B) {
 	benchmarkQueryRangeWindowingPrefilter(b, true)
 }
 
+func BenchmarkQueryRangeWindowing_StreamAwareBatching_Off(b *testing.B) {
+	benchmarkQueryRangeWindowingStreamAware(b, false)
+}
+
+func BenchmarkQueryRangeWindowing_StreamAwareBatching_On(b *testing.B) {
+	benchmarkQueryRangeWindowingStreamAware(b, true)
+}
+
 func benchmarkQueryRangeWindowingPrefilter(b *testing.B, prefilter bool) {
 	baseStart := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
 	baseEnd := baseStart + int64(48*time.Hour) - 1
@@ -105,4 +113,81 @@ func benchmarkQueryRangeWindowingPrefilter(b *testing.B, prefilter bool) {
 
 	b.ReportMetric(float64(queryCalls.Load())/float64(b.N), "query_calls/op")
 	b.ReportMetric(float64(hitsCalls.Load())/float64(b.N), "hits_calls/op")
+}
+
+func benchmarkQueryRangeWindowingStreamAware(b *testing.B, streamAware bool) {
+	baseStart := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	baseEnd := baseStart + int64(24*time.Hour) - 1
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		switch r.URL.Path {
+		case "/select/logsql/hits":
+			_, _ = w.Write([]byte(`{"hits":[{"fields":{"app":"nginx"},"timestamps":["2026-01-01T00:00:00Z"],"values":[50000]}]}`))
+		case "/select/logsql/query":
+			cur := inFlight.Add(1)
+			for {
+				prev := maxInFlight.Load()
+				if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			time.Sleep(2 * time.Millisecond)
+			inFlight.Add(-1)
+			windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+			_, _ = fmt.Fprintf(
+				w,
+				"{\"_time\":%q,\"_msg\":\"ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+				time.Unix(0, windowStart).UTC().Format(time.RFC3339Nano),
+			)
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                      backend.URL,
+		Cache:                           cache.New(60*time.Second, 50000),
+		LogLevel:                        "error",
+		QueryRangeWindowingEnabled:      true,
+		QueryRangeSplitInterval:         time.Hour,
+		QueryRangeMaxParallel:           4,
+		QueryRangeAdaptiveParallel:      false,
+		QueryRangeFreshness:             10 * time.Minute,
+		QueryRangeRecentCacheTTL:        0,
+		QueryRangeHistoryCacheTTL:       24 * time.Hour,
+		QueryRangePrefilterIndexStats:   true,
+		QueryRangePrefilterMinWindows:   1,
+		QueryRangeStreamAwareBatching:   streamAware,
+		QueryRangeExpensiveHitThreshold: 1,
+		QueryRangeExpensiveMaxParallel:  1,
+	})
+	if err != nil {
+		b.Fatalf("failed to create proxy: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(
+			http.MethodGet,
+			fmt.Sprintf(
+				"/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=5000",
+				url.QueryEscape(fmt.Sprintf(`{app="nginx",iter="%d"}`, i)),
+				baseStart,
+				baseEnd,
+			),
+			nil,
+		)
+		w := httptest.NewRecorder()
+		p.handleQueryRange(w, req)
+		if w.Code != http.StatusOK {
+			b.Fatalf("unexpected status: %d body=%s", w.Code, strings.TrimSpace(w.Body.String()))
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(maxInFlight.Load()), "max_inflight")
 }

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -496,6 +496,314 @@ func TestQueryRangeWindow_PrefilterFailureFallsBackToAllWindows(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryRangeWindow_StreamAwareBatchingCapsExpensiveWindows(t *testing.T) {
+	start := time.Now().Add(-6 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	end := start + int64(6*time.Hour) - 1
+
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		switch r.URL.Path {
+		case "/select/logsql/hits":
+			windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+			_, _ = fmt.Fprintf(
+				w,
+				`{"hits":[{"fields":{"app":"nginx"},"timestamps":["%s"],"values":[100000]}]}`,
+				time.Unix(0, windowStart).UTC().Format(time.RFC3339),
+			)
+		case "/select/logsql/query":
+			cur := inFlight.Add(1)
+			for {
+				prev := maxInFlight.Load()
+				if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			inFlight.Add(-1)
+			windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+			_, _ = fmt.Fprintf(
+				w,
+				"{\"_time\":%q,\"_msg\":\"ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+				time.Unix(0, windowStart).UTC().Format(time.RFC3339Nano),
+			)
+		default:
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 10000)
+	p, err := New(Config{
+		BackendURL:                      vlBackend.URL,
+		Cache:                           c,
+		LogLevel:                        "error",
+		QueryRangeWindowingEnabled:      true,
+		QueryRangeSplitInterval:         time.Hour,
+		QueryRangeMaxParallel:           4,
+		QueryRangeAdaptiveParallel:      false,
+		QueryRangeFreshness:             10 * time.Minute,
+		QueryRangeRecentCacheTTL:        0,
+		QueryRangeHistoryCacheTTL:       24 * time.Hour,
+		QueryRangePrefilterIndexStats:   true,
+		QueryRangePrefilterMinWindows:   1,
+		QueryRangeStreamAwareBatching:   true,
+		QueryRangeExpensiveHitThreshold: 1,
+		QueryRangeExpensiveMaxParallel:  1,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=1000", url.QueryEscape(`{app="nginx"}`), start, end),
+		nil,
+	)
+	resp := httptest.NewRecorder()
+	p.handleQueryRange(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", resp.Code, resp.Body.String())
+	}
+	if got := maxInFlight.Load(); got > 1 {
+		t.Fatalf("expected expensive windows to be processed with max parallel 1, got=%d", got)
+	}
+}
+
+func TestQueryRangeWindow_AlignedWindowsImproveOverlapReuse(t *testing.T) {
+	run := func(t *testing.T, aligned bool) int64 {
+		t.Helper()
+		var backendCalls atomic.Int64
+		vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/select/logsql/query" {
+				t.Fatalf("unexpected backend path: %s", r.URL.Path)
+			}
+			backendCalls.Add(1)
+			_ = r.ParseForm()
+			windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+			_, _ = fmt.Fprintf(
+				w,
+				"{\"_time\":%q,\"_msg\":\"ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+				time.Unix(0, windowStart).UTC().Format(time.RFC3339Nano),
+			)
+		}))
+		defer vlBackend.Close()
+
+		p, err := New(Config{
+			BackendURL:                 vlBackend.URL,
+			Cache:                      cache.New(60*time.Second, 20000),
+			LogLevel:                   "error",
+			QueryRangeWindowingEnabled: true,
+			QueryRangeSplitInterval:    time.Hour,
+			QueryRangeMaxParallel:      1,
+			QueryRangeAdaptiveParallel: false,
+			QueryRangeFreshness:        10 * time.Minute,
+			QueryRangeRecentCacheTTL:   0,
+			QueryRangeHistoryCacheTTL:  24 * time.Hour,
+			QueryRangeAlignWindows:     aligned,
+		})
+		if err != nil {
+			t.Fatalf("failed to create proxy: %v", err)
+		}
+
+		base := time.Now().Add(-12 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+		start1 := base + int64(15*time.Minute)
+		end1 := start1 + int64(4*time.Hour) - 1
+		start2 := start1 + int64(10*time.Minute)
+		end2 := end1 + int64(10*time.Minute)
+
+		req1 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=1000", url.QueryEscape(`{app="nginx"}`), start1, end1), nil)
+		w1 := httptest.NewRecorder()
+		p.handleQueryRange(w1, req1)
+		if w1.Code != http.StatusOK {
+			t.Fatalf("unexpected status for request1: %d body=%s", w1.Code, w1.Body.String())
+		}
+		callsAfterFirst := backendCalls.Load()
+
+		req2 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=1000", url.QueryEscape(`{app="nginx"}`), start2, end2), nil)
+		w2 := httptest.NewRecorder()
+		p.handleQueryRange(w2, req2)
+		if w2.Code != http.StatusOK {
+			t.Fatalf("unexpected status for request2: %d body=%s", w2.Code, w2.Body.String())
+		}
+		callsAfterSecond := backendCalls.Load()
+		return callsAfterSecond - callsAfterFirst
+	}
+
+	deltaUnaligned := run(t, false)
+	deltaAligned := run(t, true)
+	if deltaAligned >= deltaUnaligned {
+		t.Fatalf("expected aligned windows to require fewer additional backend calls: aligned=%d unaligned=%d", deltaAligned, deltaUnaligned)
+	}
+}
+
+func TestQueryRangeWindow_PartialResponseOnRetryableFailure(t *testing.T) {
+	start := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	end := start + int64(3*time.Hour) - 1
+	oldestWindowStart := start
+	oldestWindowEnd := start + int64(time.Hour) - 1
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+		windowEnd, _ := strconv.ParseInt(r.Form.Get("end"), 10, 64)
+		if windowStart == oldestWindowStart && windowEnd == oldestWindowEnd {
+			http.Error(w, "all backends unavailable", http.StatusBadGateway)
+			return
+		}
+		_, _ = fmt.Fprintf(
+			w,
+			"{\"_time\":%q,\"_msg\":\"ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+			time.Unix(0, windowStart).UTC().Format(time.RFC3339Nano),
+		)
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 vlBackend.URL,
+		Cache:                      cache.New(60*time.Second, 10000),
+		LogLevel:                   "error",
+		QueryRangeWindowingEnabled: true,
+		QueryRangeSplitInterval:    time.Hour,
+		QueryRangeMaxParallel:      1,
+		QueryRangeAdaptiveParallel: false,
+		QueryRangeFreshness:        10 * time.Minute,
+		QueryRangeRecentCacheTTL:   0,
+		QueryRangeHistoryCacheTTL:  24 * time.Hour,
+		QueryRangePartialResponses: true,
+		QueryRangeBackgroundWarm:   false,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=5000", url.QueryEscape(`{app="nginx"}`), start, end),
+		nil,
+	)
+	resp := httptest.NewRecorder()
+	p.handleQueryRange(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected partial-success status=200, got=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if got := resp.Header().Get("X-Loki-VL-Partial-Response"); got != "true" {
+		t.Fatalf("expected X-Loki-VL-Partial-Response=true, got %q", got)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("failed to decode response: %v body=%s", err, resp.Body.String())
+	}
+	if parsed["status"] != "success" {
+		t.Fatalf("expected success body for partial response, got=%v", parsed["status"])
+	}
+	data, _ := parsed["data"].(map[string]interface{})
+	result, _ := data["result"].([]interface{})
+	if len(result) == 0 {
+		t.Fatalf("expected non-empty partial result set")
+	}
+
+	metricsBody := collectMetricsText(t, p.metrics)
+	for _, snippet := range []string{
+		"loki_vl_proxy_window_partial_response_total 1",
+		"loki_vl_proxy_window_retry_total ",
+	} {
+		if !strings.Contains(metricsBody, snippet) {
+			t.Fatalf("expected metrics to include %q\nmetrics:\n%s", snippet, metricsBody)
+		}
+	}
+}
+
+func TestQueryRangeWindow_SevenDayRegressionSLO(t *testing.T) {
+	start := time.Now().Add(-7 * 24 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
+	end := start + int64(7*24*time.Hour) - 1
+	stepNs := int64(time.Hour)
+
+	var hitsCalls atomic.Int64
+	var queryCalls atomic.Int64
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		switch r.URL.Path {
+		case "/select/logsql/hits":
+			hitsCalls.Add(1)
+			windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+			idx := int((windowStart - start) / stepNs)
+			val := 0
+			// Sparse long-range history: only every 8th window has events.
+			if idx%8 == 0 {
+				val = 1000
+			}
+			_, _ = fmt.Fprintf(
+				w,
+				`{"hits":[{"fields":{"app":"nginx"},"timestamps":["%s"],"values":[%d]}]}`,
+				time.Unix(0, windowStart).UTC().Format(time.RFC3339),
+				val,
+			)
+		case "/select/logsql/query":
+			queryCalls.Add(1)
+			windowStart, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+			time.Sleep(2 * time.Millisecond)
+			_, _ = fmt.Fprintf(
+				w,
+				"{\"_time\":%q,\"_msg\":\"ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+				time.Unix(0, windowStart).UTC().Format(time.RFC3339Nano),
+			)
+		default:
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL:                      vlBackend.URL,
+		Cache:                           cache.New(60*time.Second, 100000),
+		LogLevel:                        "error",
+		QueryRangeWindowingEnabled:      true,
+		QueryRangeSplitInterval:         time.Hour,
+		QueryRangeMaxParallel:           4,
+		QueryRangeAdaptiveParallel:      false,
+		QueryRangeFreshness:             10 * time.Minute,
+		QueryRangeRecentCacheTTL:        0,
+		QueryRangeHistoryCacheTTL:       24 * time.Hour,
+		QueryRangePrefilterIndexStats:   true,
+		QueryRangePrefilterMinWindows:   1,
+		QueryRangeStreamAwareBatching:   true,
+		QueryRangeExpensiveHitThreshold: 500,
+		QueryRangeExpensiveMaxParallel:  1,
+		QueryRangeAlignWindows:          true,
+		QueryRangeWindowTimeout:         10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=5000", url.QueryEscape(`{app="nginx"} | json`), start, end), nil)
+	resp := httptest.NewRecorder()
+
+	begin := time.Now()
+	p.handleQueryRange(resp, req)
+	duration := time.Since(begin)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", resp.Code, resp.Body.String())
+	}
+	if duration > 2*time.Second {
+		t.Fatalf("expected 7d sparse-range regression test under 2s, got %s", duration)
+	}
+	if got := queryCalls.Load(); got > 30 {
+		t.Fatalf("expected <=30 window query fanout calls after prefilter, got %d", got)
+	}
+	if got := hitsCalls.Load(); got < 168 {
+		t.Fatalf("expected prefilter to inspect all 168 windows, got %d", got)
+	}
+}
 func TestQueryRangeWindow_DoesNotFallbackToDirectQueryOnWindowFetchError(t *testing.T) {
 	start := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
 	end := start + int64(2*time.Hour) - 1

--- a/internal/proxy/volume_cache_test.go
+++ b/internal/proxy/volume_cache_test.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+)
+
+func TestVolumeEndpoint_UsesCacheOnRepeatQueries(t *testing.T) {
+	var hitsCalls atomic.Int64
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		hitsCalls.Add(1)
+		_, _ = w.Write([]byte(`{"hits":[{"fields":{"app":"api"},"timestamps":["2026-04-10T00:00:00Z"],"values":[3]}]}`))
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL: vlBackend.URL,
+		Cache:      cache.New(60*time.Second, 1000),
+		LogLevel:   "error",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	q := url.QueryEscape(`{app="api"}`)
+	req1 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/index/volume?query=%s&start=now-1h&end=now&targetLabels=app", q), nil)
+	w1 := httptest.NewRecorder()
+	p.handleVolume(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("unexpected status on first volume call: %d body=%s", w1.Code, w1.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/index/volume?query=%s&start=now-1h&end=now&targetLabels=app", q), nil)
+	w2 := httptest.NewRecorder()
+	p.handleVolume(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("unexpected status on second volume call: %d body=%s", w2.Code, w2.Body.String())
+	}
+
+	if got := hitsCalls.Load(); got != 1 {
+		t.Fatalf("expected backend to be called once for cached repeat volume query, got %d", got)
+	}
+}
+
+func TestVolumeRangeEndpoint_UsesCacheOnRepeatQueries(t *testing.T) {
+	var hitsCalls atomic.Int64
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		hitsCalls.Add(1)
+		_, _ = w.Write([]byte(`{"hits":[{"fields":{"app":"api"},"timestamps":["2026-04-10T00:00:00Z","2026-04-10T00:01:00Z"],"values":[2,1]}]}`))
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL: vlBackend.URL,
+		Cache:      cache.New(60*time.Second, 1000),
+		LogLevel:   "error",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	q := url.QueryEscape(`{app="api"}`)
+	req1 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/index/volume_range?query=%s&start=now-1h&end=now&step=60&targetLabels=app", q), nil)
+	w1 := httptest.NewRecorder()
+	p.handleVolumeRange(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("unexpected status on first volume_range call: %d body=%s", w1.Code, w1.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/loki/api/v1/index/volume_range?query=%s&start=now-1h&end=now&step=60&targetLabels=app", q), nil)
+	w2 := httptest.NewRecorder()
+	p.handleVolumeRange(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("unexpected status on second volume_range call: %d body=%s", w2.Code, w2.Body.String())
+	}
+
+	if got := hitsCalls.Load(); got != 1 {
+		t.Fatalf("expected backend to be called once for cached repeat volume_range query, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

This PR completes long-range optimization phases 2-5 on top of phase-1 prefiltering, adds KPI visibility, and hardens dashboard behavior.

## What changed

- Long-range execution hardening:
  - stream-aware batching for expensive windows
  - overlap/window coalescing reuse to reduce refresh-time refetches
  - adaptive timeout budgeting with partial-response fallback and continued cache warm behavior
- New long-range KPI metrics surfaced:
  - `loki_vl_proxy_window_retry_total`
  - `loki_vl_proxy_window_degraded_batch_total`
  - `loki_vl_proxy_window_partial_response_total`
  - `loki_vl_proxy_window_prefilter_hit_ratio`
- Dashboard updates (`dashboard/loki-vl-proxy.json` + chart copy):
  - datasource selector regex made permissive (`/.*/`) to avoid datasource-name lockout
  - resilience KPI row/panels added
  - additional zero-fallbacks added on adaptive/risk panels
- Docs updated with benchmark tables and dashboard/observability notes:
  - `docs/performance.md`
  - `docs/observability.md`
- Changelog entry added under `Unreleased`.

## Chart quick-toggle coverage

- Added a chart-local quick-toggle catalog under `extraArgs` in `charts/loki-vl-proxy/values.yaml` for phase long-range controls that were previously runtime-only defaults.
- Included commented default values and one-line behavior notes for:
  - `query-range-prefilter-index-stats`, `query-range-prefilter-min-windows`
  - `query-range-stream-aware-batching`, `query-range-expensive-hit-threshold`, `query-range-expensive-max-parallel`
  - `query-range-align-windows`, `query-range-window-timeout`
  - `query-range-partial-responses`, `query-range-background-warm`, `query-range-background-warm-max-windows`
  - `otlp-tls-skip-verify`, `proc-root` hint
- Goal: operators can enable/tune directly from Helm values without opening external docs.

## Phase benchmark tables

Environment: Apple M3 Max, Go 1.26.1

Command:

```bash
go test ./internal/proxy -run '^$' -bench 'BenchmarkQueryRangeWindowing_(NoPrefilter|WithPrefilter|StreamAwareBatching_Off|StreamAwareBatching_On)$' -benchmem -benchtime=10x
```

| Benchmark | ns/op | hits_calls/op | query_calls/op | max_inflight | allocs/op |
|---|---:|---:|---:|---:|---:|
| `NoPrefilter` | 39,525,225 | 0 | 49 | n/a | 11,582 |
| `WithPrefilter` | 11,672,412 | 48 | 9 | n/a | 10,346 |
| `StreamAwareBatching_Off` | 17,048,771 | n/a | n/a | 4 | 9,490 |
| `StreamAwareBatching_On` | 62,808,025 | n/a | n/a | 1 | 9,656 |

Derived impact from measured run:

| Signal | Baseline | Optimized | Delta |
|---|---:|---:|---:|
| Backend query fanout (`query_calls/op`) | 49 | 9 | -81.6% |
| End-to-end synthetic bench latency (`ns/op`) | 39,525,225 | 11,672,412 | -70.5% |
| Expensive-window max in-flight (stream-aware) | 4 | 1 | -75% peak concurrency |

Interpretation:

- Prefiltering is the largest direct backend-load reduction mechanism.
- Stream-aware mode intentionally reduces expensive-window concurrency spikes to stabilize backend pressure; it is a protection-mode tradeoff, not a pure micro-benchmark throughput optimization.

## Validation

- `go test ./...` -> `1459 passed in 9 packages`
- `./scripts/ci/sync_observability_assets.sh --check` -> assets in sync


- Expanded further to include a full commented optional-flag catalog (runtime defaults) for remaining non-default flags such as security, tail, instrumentation, peer, and TLS knobs.

