### PR TITLE
Fix drilldown include/exclude filter reset on repeated clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Reliability
 
 - add long-range phase-5 adaptive timeout budgeting with partial-response fallback and warm-cache continuation to avoid hard user-facing failures during backend saturation
+- harden drilldown include/exclude query translation by deduplicating repeated field filters and making the latest include/exclude toggle authoritative for the same field/value
 
 ### Observability
 

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -121,6 +121,26 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 			logql: `{app="api"} | custom . ` + "`pipeline.`",
 			want:  `app:=api ~"custom\.pipeline\."`,
 		},
+		{
+			name:  "repeated include filter clicks are deduplicated after parser",
+			logql: `{app="api"} | json | source_message_bytes="89" | source_message_bytes = "89" | source_message_bytes = ` + "`89`",
+			want:  `app:=api | unpack_json | filter source_message_bytes:=89`,
+		},
+		{
+			name:  "repeated exclude filter clicks are deduplicated after parser",
+			logql: `{app="api"} | json | source_message_bytes!="89" | source_message_bytes != "89"`,
+			want:  `app:=api | unpack_json | filter -source_message_bytes:=89`,
+		},
+		{
+			name:  "include then exclude same value keeps latest filter stage",
+			logql: `{app="api"} | json | source_message_bytes="89" | source_message_bytes!="89"`,
+			want:  `app:=api | unpack_json | filter -source_message_bytes:=89`,
+		},
+		{
+			name:  "exclude then include same value keeps latest filter stage",
+			logql: `{app="api"} | json | source_message_bytes!="89" | source_message_bytes="89"`,
+			want:  `app:=api | unpack_json | filter source_message_bytes:=89`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -165,6 +165,9 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 	// Track whether we've seen a parser pipe (json, logfmt, pattern, regexp).
 	// After a parser, label filters must become VL `| filter` pipes.
 	afterParser := false
+	// Track canonical label-filter stages so repeated drilldown include/exclude
+	// clicks don't accumulate duplicate or contradictory filters.
+	labelFilterLatest := make(map[string]int)
 
 	// 2. Process pipeline stages: | operator ...
 	// LogQL line filters: |= "text", != "text", |~ "regexp", !~ "regexp"
@@ -235,7 +238,17 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 			if afterParser && !strings.HasPrefix(translated, "|") && isFieldFilter(translated) {
 				translated = "| filter " + translated
 			}
-			parts = append(parts, translated)
+			if _, baseKey, ok := canonicalLabelFilterStage(stage, labelFn); ok {
+				if idx, exists := labelFilterLatest[baseKey]; exists {
+					// Latest action wins for the same field/value filter identity.
+					parts[idx] = translated
+				} else {
+					labelFilterLatest[baseKey] = len(parts)
+					parts = append(parts, translated)
+				}
+			} else {
+				parts = append(parts, translated)
+			}
 		}
 	}
 
@@ -562,6 +575,16 @@ func translateMalformedDottedStage(stage string, labelFn LabelTranslateFunc) (st
 		return fmt.Sprintf(`~"%s"`, regexp.QuoteMeta(candidate+".")), true
 	}
 	return fmt.Sprintf(`%s:!""`, quoteLogsQLFieldNameIfNeeded(candidate)), true
+}
+
+func canonicalLabelFilterStage(stage string, labelFn LabelTranslateFunc) (canonical string, baseKey string, ok bool) {
+	if translated, ok := translateSingleLabelFilter(stage, labelFn); ok {
+		return translated, strings.TrimPrefix(translated, "-"), true
+	}
+	if translated, ok := translateMalformedDottedStage(stage, labelFn); ok {
+		return translated, translated, true
+	}
+	return "", "", false
 }
 
 func normalizeFieldIdentifier(label string) string {


### PR DESCRIPTION
## Summary
- harden LogQL pipeline filter translation for drilldown include/exclude actions
- deduplicate repeated identical label filters generated by repeated clicks
- for same field/value filter identity, keep latest toggle (include/exclude) instead of accumulating contradictory stages
- add regression tests for repeated include/exclude and toggle sequences after parser stages

## Validation
- go test ./internal/translator -count=1
- go test ./... -count=1