### PR TITLE
Stop duplicating OTel resource attributes in log payload

### DIFF
--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -135,9 +135,14 @@ func TestBuildLogger(t *testing.T) {
 	}
 	logger.Info("hello")
 	logs := buf.String()
-	for _, want := range []string{"\"service.name\":\"proxy\"", "\"service.version\":\"v1.2.3\"", "\"deployment.environment.name\":\"prod\"", "\"body\":\"hello\""} {
+	for _, want := range []string{"\"body\":\"hello\"", "\"severity\":{\"text\":\"INFO\",\"number\":9}"} {
 		if !strings.Contains(logs, want) {
 			t.Fatalf("expected %q in %s", want, logs)
+		}
+	}
+	for _, blocked := range []string{"\"service.name\":", "\"service.version\":", "\"service.instance.id\":", "\"deployment.environment.name\":", "\"telemetry.sdk.name\":", "\"telemetry.sdk.language\":", "\"telemetry.sdk.version\":"} {
+		if strings.Contains(logs, blocked) {
+			t.Fatalf("did not expect %q in %s", blocked, logs)
 		}
 	}
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -47,10 +47,6 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
     "number": 9
   },
   "body": "request",
-  "service.name": "loki-vl-proxy",
-  "service.version": "0.27.42",
-  "service.instance.id": "proxy-1",
-  "deployment.environment.name": "prod",
   "component": "proxy",
   "http.route": "query_range",
   "http.request.method": "GET",
@@ -92,8 +88,6 @@ The proxy writes structured logs for:
 | `timestamp` | event time |
 | `severity.text` / `severity.number` | log severity |
 | `body` | message body |
-| `service.*` | stable service identity |
-| `deployment.environment.name` | environment name |
 | `component` | internal subsystem (`proxy`, `disk_cache`, `cache_warmer`, `otlp_metrics`) |
 | `http.*` | request semantics |
 | `client.address` | remote address |
@@ -133,7 +127,9 @@ If the OTLP endpoint is passed as a collector base URL like `http://collector:43
 
 ### OpenTelemetry Resource Attributes for Metrics and Logs
 
-These flags shape both OTLP metric exports and structured logs:
+These flags shape OTLP metric resource attributes. Structured logs intentionally do
+not duplicate resource attributes per line; keep service identity in collector/OTLP
+resource metadata to avoid `message.service.*` duplication in storage.
 
 | Flag | Meaning |
 |---|---|

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -1,11 +1,9 @@
 package observability
 
 import (
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -22,25 +20,21 @@ type LoggerConfig struct {
 
 // NewLogger returns a JSON logger shaped so common log agents can map it to the
 // OpenTelemetry log data model with minimal transformation.
+//
+// Resource attributes (service.*, deployment.environment.name, telemetry.sdk.*)
+// are intentionally not embedded in each log line payload. In OTLP pipelines,
+// those should come from resource metadata once, not duplicated in message.*
+// fields after log ingestion.
 func NewLogger(w io.Writer, cfg LoggerConfig) *slog.Logger {
 	if w == nil {
 		w = os.Stdout
 	}
 	level := parseLevel(cfg.Level)
-	attrs := []any{
-		"service.name", valueOrDefault(cfg.ServiceName, "loki-vl-proxy"),
-		"service.version", valueOrDefault(cfg.ServiceVersion, "dev"),
-		"service.instance.id", valueOrDefault(cfg.ServiceInstanceID, defaultInstanceID()),
-		"telemetry.sdk.name", "loki-vl-proxy",
-		"telemetry.sdk.language", "go",
-		"telemetry.sdk.version", runtime.Version(),
-	}
-	if strings.TrimSpace(cfg.ServiceNamespace) != "" {
-		attrs = append(attrs, "service.namespace", strings.TrimSpace(cfg.ServiceNamespace))
-	}
-	if strings.TrimSpace(cfg.DeploymentEnvironment) != "" {
-		attrs = append(attrs, "deployment.environment.name", strings.TrimSpace(cfg.DeploymentEnvironment))
-	}
+	_ = cfg.ServiceName
+	_ = cfg.ServiceNamespace
+	_ = cfg.ServiceVersion
+	_ = cfg.ServiceInstanceID
+	_ = cfg.DeploymentEnvironment
 
 	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{
 		Level: level,
@@ -61,7 +55,7 @@ func NewLogger(w io.Writer, cfg LoggerConfig) *slog.Logger {
 			}
 		},
 	})
-	return slog.New(handler).With(attrs...)
+	return slog.New(handler)
 }
 
 func parseLevel(level string) slog.Level {
@@ -88,14 +82,6 @@ func severityNumber(level slog.Level) int {
 	default:
 		return 17
 	}
-}
-
-func defaultInstanceID() string {
-	host, err := os.Hostname()
-	if err != nil || strings.TrimSpace(host) == "" {
-		host = "unknown"
-	}
-	return fmt.Sprintf("%s-%d", host, os.Getpid())
 }
 
 func valueOrDefault(v, fallback string) string {

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -29,20 +29,23 @@ func TestNewLogger_EmitsOTelFriendlyJSON(t *testing.T) {
 	if payload["body"] != "request finished" {
 		t.Fatalf("expected body field, got %#v", payload["body"])
 	}
-	if payload["service.name"] != "test-proxy" {
-		t.Fatalf("expected service.name, got %#v", payload["service.name"])
+	if payload["service.name"] != nil {
+		t.Fatalf("did not expect service.name in log payload, got %#v", payload["service.name"])
 	}
-	if payload["service.namespace"] != "edge" {
-		t.Fatalf("expected service.namespace, got %#v", payload["service.namespace"])
+	if payload["service.namespace"] != nil {
+		t.Fatalf("did not expect service.namespace in log payload, got %#v", payload["service.namespace"])
 	}
-	if payload["service.version"] != "1.2.3" {
-		t.Fatalf("expected service.version, got %#v", payload["service.version"])
+	if payload["service.version"] != nil {
+		t.Fatalf("did not expect service.version in log payload, got %#v", payload["service.version"])
 	}
-	if payload["service.instance.id"] != "proxy-1" {
-		t.Fatalf("expected service.instance.id, got %#v", payload["service.instance.id"])
+	if payload["service.instance.id"] != nil {
+		t.Fatalf("did not expect service.instance.id in log payload, got %#v", payload["service.instance.id"])
 	}
-	if payload["deployment.environment.name"] != "prod" {
-		t.Fatalf("expected deployment.environment.name, got %#v", payload["deployment.environment.name"])
+	if payload["deployment.environment.name"] != nil {
+		t.Fatalf("did not expect deployment.environment.name in log payload, got %#v", payload["deployment.environment.name"])
+	}
+	if payload["telemetry.sdk.name"] != nil || payload["telemetry.sdk.language"] != nil || payload["telemetry.sdk.version"] != nil {
+		t.Fatalf("did not expect telemetry.sdk.* in log payload: %#v %#v %#v", payload["telemetry.sdk.name"], payload["telemetry.sdk.language"], payload["telemetry.sdk.version"])
 	}
 	severity, ok := payload["severity"].(map[string]any)
 	if !ok {
@@ -99,12 +102,11 @@ func TestValueOrDefault(t *testing.T) {
 	}
 }
 
-func TestDefaultInstanceID(t *testing.T) {
-	got := defaultInstanceID()
-	if strings.TrimSpace(got) == "" {
-		t.Fatal("expected non-empty instance id")
-	}
-	if !strings.Contains(got, "-") {
-		t.Fatalf("expected host-pid shaped instance id, got %q", got)
+func TestLoggerConfigAllowsEmptyResourceFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LoggerConfig{})
+	logger.Info("ok")
+	if strings.TrimSpace(buf.String()) == "" {
+		t.Fatal("expected log output")
 	}
 }


### PR DESCRIPTION
## Summary
- remove per-event service and telemetry resource attributes from JSON log payload
- keep OTel log body, severity, and timestamp fields unchanged
- document that service identity belongs in OTel resource metadata to avoid message-field duplication in storage
- update logger tests and main logger expectations accordingly

## Why
- prevents duplicated fields such as message.service.* and message.telemetry.sdk.* in VictoriaLogs pipelines
- reduces field-cardinality noise and keeps logs semantically cleaner

## Validation
- go test ./internal/observability ./cmd/proxy ./internal/cache