### PR TITLE
release: align 1.0.0 artifacts and auto-release versioning

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -40,6 +40,8 @@ jobs:
         run: |
           set -euo pipefail
           LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | head -1 || echo "v0.0.0")
+          LATEST_VERSION="${LATEST_TAG#v}"
+          CHART_VERSION="$(awk -F: '/^version:/ {v=$2; gsub(/[ "]/, "", v); print v; exit}' charts/loki-vl-proxy/Chart.yaml)"
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           echo "Latest tag: $LATEST_TAG"
 
@@ -65,6 +67,16 @@ jobs:
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Only docs/ci/metadata files changed; skipping release"
             exit 0
+          fi
+
+          if echo "${CHART_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            MAX_VERSION="$(printf '%s\n%s\n' "${LATEST_VERSION}" "${CHART_VERSION}" | sort -V | tail -1)"
+            if [ "${MAX_VERSION}" = "${CHART_VERSION}" ] && [ "${CHART_VERSION}" != "${LATEST_VERSION}" ]; then
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+              echo "next_version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+              echo "Chart version override detected: ${CHART_VERSION} (latest tag is ${LATEST_VERSION})"
+              exit 0
+            fi
           fi
 
           BUMP="none"

--- a/.github/workflows/release-pr-validation.yaml
+++ b/.github/workflows/release-pr-validation.yaml
@@ -21,7 +21,7 @@ jobs:
           BRANCH="${GITHUB_REF_NAME}"
           VERSION="$(printf '%s' "$BRANCH" | sed -n 's/^release\/v\([0-9][0-9.]*\)$/\1/p')"
           if [ -z "$VERSION" ]; then
-            echo "expected release branch like release/v0.26.0, got: $BRANCH"
+            echo "expected release branch like release/v1.0.0, got: $BRANCH"
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- make auto-release honor forward chart version overrides so published tags/images/charts can jump directly to `1.0.0` (and future explicit major/minor targets) instead of always patch-bumping from the latest tag
+
+### Documentation
+
+- update release and security policy docs for the `1.x` support line and release branch examples
+
 ## [0.27.43] - 2026-04-13
 
 ### Documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.27.x  | Yes       |
-| < 0.27  | No        |
+| 1.x     | Yes       |
+| < 1.0   | No        |
 
 ## Reporting a Vulnerability
 

--- a/charts/loki-vl-proxy/Chart.yaml
+++ b/charts/loki-vl-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki-vl-proxy
 description: HTTP proxy translating Loki API to VictoriaLogs
 type: application
-version: 0.27.43
-appVersion: "0.27.43"
+version: 1.0.0
+appVersion: "1.0.0"
 home: https://github.com/ReliablyObserve/Loki-VL-proxy
 sources:
   - https://github.com/ReliablyObserve/Loki-VL-proxy

--- a/docs/release-info.md
+++ b/docs/release-info.md
@@ -4,10 +4,11 @@
 
 `Auto Release` on `main` uses this precedence order:
 
-1. explicit release labels on merged PR: `release:major`, `release:minor`, `release:patch`, `no-release`
-2. semantic PR labels: `breaking-change`, `feature`, `bugfix`, `performance`
-3. conventional commit subjects (`feat`, `fix`, `perf`, `refactor`, `revert`, breaking markers)
-4. fallback patch bump for non-doc/non-ci changes when no explicit signal is present
+1. explicit chart version override: if `charts/loki-vl-proxy/Chart.yaml` `version` is ahead of the latest git tag, release exactly that chart version
+2. explicit release labels on merged PR: `release:major`, `release:minor`, `release:patch`, `no-release`
+3. semantic PR labels: `breaking-change`, `feature`, `bugfix`, `performance`
+4. conventional commit subjects (`feat`, `fix`, `perf`, `refactor`, `revert`, breaking markers)
+5. fallback patch bump for non-doc/non-ci changes when no explicit signal is present
 
 ## Skip Rules
 


### PR DESCRIPTION
## Summary
- restore Helm chart/app version to `1.0.0` so release artifacts align with the intended stable version
- update auto-release to honor forward chart-version overrides (when chart version is ahead of latest tag, release that exact version)
- update release/security docs and release branch validation example for the `1.x` line
- add unreleased changelog entries documenting the release-path fix

## Why
Recent artifacts continued at `0.27.43` because auto-release patch-bumped from latest tag and ignored an explicit forward chart version. This patch makes `1.0.0` (and future intentional major/minor jumps) authoritative when set in chart metadata.

## Validation
- `python3 -m unittest scripts/ci/tests/test_check_changelog_pr.py`
