### PR TITLE
Fix drilldown service_name no-data and transient empty field states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown: fix `service_name` label values intermittently returning empty by preserving detected-label summaries and using selector-only context for service discovery fallbacks
+- drilldown: treat non-2xx discovery responses as errors (instead of silent empty success) for fields/labels/value discovery paths to prevent false `no data`
+- proxy: stop caching transient empty fallback payloads for detected fields/labels endpoints, reducing sticky post-error empty states until manual refresh
+
 ## [1.0.0] - 2026-04-13
 
 ### CI

--- a/internal/metrics/otlp.go
+++ b/internal/metrics/otlp.go
@@ -50,6 +50,7 @@ type OTLPPusher struct {
 	prevProcCPU           processCPUStat
 	prevSystemAt          time.Time
 	hasPrevSystem         bool
+	wg                    sync.WaitGroup
 }
 
 // OTLPConfig configures the OTLP metrics pusher.
@@ -121,7 +122,9 @@ func (p *OTLPPusher) Start() {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 
+	p.wg.Add(1)
 	go func() {
+		defer p.wg.Done()
 		ticker := time.NewTicker(p.interval)
 		defer ticker.Stop()
 		for {
@@ -142,6 +145,7 @@ func (p *OTLPPusher) Stop() {
 	if p.cancel != nil {
 		p.cancel()
 	}
+	p.wg.Wait()
 }
 
 // push sends current metrics as OTLP JSON.

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -3,7 +3,9 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"regexp"
 	"sort"
@@ -267,11 +269,13 @@ func formatDetectedLabelSummaries(summaries map[string]*detectedLabelSummary) []
 			"label":       summary.label,
 			"cardinality": len(summary.values),
 		})
-		delete(summaries, "service_name")
 	}
 
 	names := make([]string, 0, len(summaries))
 	for label := range summaries {
+		if label == "service_name" {
+			continue
+		}
 		names = append(names, label)
 	}
 	sort.Strings(names)
@@ -287,7 +291,12 @@ func formatDetectedLabelSummaries(summaries map[string]*detectedLabelSummary) []
 }
 
 func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string) ([]string, error) {
-	logsqlQuery, err := p.translateQuery(defaultQuery(query))
+	selectorQuery := streamSelectorPrefix(query)
+	if selectorQuery == "" {
+		selectorQuery = defaultFieldDetectionQuery(query)
+	}
+	detectionQuery := defaultQuery(selectorQuery)
+	logsqlQuery, err := p.translateQuery(detectionQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -303,11 +312,14 @@ func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string)
 
 	resp, err := p.vlGet(ctx, "/select/logsql/streams", params)
 	if err != nil {
-		return nil, err
+		return p.serviceNameValuesFromDetectedLabels(ctx, detectionQuery, start, end)
 	}
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		return p.serviceNameValuesFromDetectedLabels(ctx, detectionQuery, start, end)
+	}
 	var vlResp struct {
 		Values []struct {
 			Value string `json:"value"`
@@ -328,6 +340,63 @@ func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string)
 		}
 		seen[serviceName] = struct{}{}
 		values = append(values, serviceName)
+	}
+	sort.Strings(values)
+	if len(values) == 0 {
+		return p.serviceNameValuesFromDetectedLabels(ctx, detectionQuery, start, end)
+	}
+	return values, nil
+}
+
+func streamSelectorPrefix(query string) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return ""
+	}
+	inQuote := byte(0)
+	escape := false
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+		if escape {
+			escape = false
+			continue
+		}
+		if inQuote != 0 {
+			if ch == '\\' && inQuote == '"' {
+				escape = true
+				continue
+			}
+			if ch == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if ch == '"' || ch == '`' {
+			inQuote = ch
+			continue
+		}
+		if ch == '|' {
+			return strings.TrimSpace(query[:i])
+		}
+	}
+	return query
+}
+
+func (p *Proxy) serviceNameValuesFromDetectedLabels(ctx context.Context, query, start, end string) ([]string, error) {
+	_, summaries, err := p.detectLabels(ctx, query, start, end, detectedFieldsSampleLimit)
+	if err != nil {
+		return nil, err
+	}
+	summary := summaries["service_name"]
+	if summary == nil {
+		return []string{}, nil
+	}
+	values := make([]string, 0, len(summary.values))
+	for value := range summary.values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		values = append(values, value)
 	}
 	sort.Strings(values)
 	return values, nil
@@ -856,6 +925,13 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+		}
+		return nil, nil, fmt.Errorf("%s", msg)
+	}
 	fieldList, fieldValues := p.detectFieldsFromBody(body)
 	fieldList, fieldValues = mergeNativeDetectedFields(fieldList, fieldValues, nativeFields)
 	p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
@@ -1154,6 +1230,13 @@ func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, f
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
 	var parsed vlFieldValuesResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, err
@@ -1204,6 +1287,13 @@ func (p *Proxy) detectNativeLabels(ctx context.Context, query, start, end string
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
 	var parsed vlStreamsResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, err
@@ -1254,6 +1344,13 @@ func (p *Proxy) detectScannedLabels(ctx context.Context, query, start, end strin
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
 	return scanDetectedLabelSummaries(body, p.labelTranslator), nil
 }
 

--- a/internal/proxy/perf_hardening_test.go
+++ b/internal/proxy/perf_hardening_test.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -112,6 +114,203 @@ func TestHandleDetectedLabels_BackendErrorReturnsEmptySuccess(t *testing.T) {
 	}
 	if resp.Status != "success" || len(resp.Data) != 0 || len(resp.DetectedLabels) != 0 || resp.Limit != 17 {
 		t.Fatalf("expected empty detected_labels success response, got %#v", resp)
+	}
+}
+
+func TestHandleDetectedLabels_DoesNotCacheTransientErrorFallback(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	var streamCalls atomic.Int32
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, `{"error":"transient backend failure"}`, http.StatusBadGateway)
+			return
+		}
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			streamCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"values":[{"value":"{service.name=\"api\",level=\"info\"}","hits":1}]}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	reqPath := `/loki/api/v1/detected_labels?query={service_name="api"}&start=1&end=2&limit=25`
+
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, reqPath, nil)
+	p.handleDetectedLabels(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first call expected 200, got %d body=%s", w1.Code, w1.Body.String())
+	}
+
+	fail.Store(false)
+
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, reqPath, nil)
+	p.handleDetectedLabels(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second call expected 200, got %d body=%s", w2.Code, w2.Body.String())
+	}
+
+	var resp struct {
+		DetectedLabels []struct {
+			Label string `json:"label"`
+		} `json:"detectedLabels"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.DetectedLabels) == 0 {
+		t.Fatalf("expected detected labels after backend recovery, got empty: %s (stream_calls=%d)", w2.Body.String(), streamCalls.Load())
+	}
+	foundService := false
+	for _, item := range resp.DetectedLabels {
+		if item.Label == "service_name" {
+			foundService = true
+			break
+		}
+	}
+	if !foundService {
+		t.Fatalf("expected service_name detected label after recovery, got %s", w2.Body.String())
+	}
+}
+
+func TestHandleDetectedFields_DoesNotCacheTransientErrorFallback(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, `{"error":"transient backend failure"}`, http.StatusBadGateway)
+			return
+		}
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"values":[{"value":"service.name","hits":1},{"value":"trace_id","hits":1}]}`)
+		case "/select/logsql/query":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			fmt.Fprintln(w, `{"_time":"2024-01-15T10:30:00Z","_msg":"ok","service.name":"api","trace_id":"abc123"}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	reqPath := `/loki/api/v1/detected_fields?query={service_name="api"}&start=1&end=2&limit=25`
+
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, reqPath, nil)
+	p.handleDetectedFields(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first call expected 200, got %d body=%s", w1.Code, w1.Body.String())
+	}
+
+	fail.Store(false)
+
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, reqPath, nil)
+	p.handleDetectedFields(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second call expected 200, got %d body=%s", w2.Code, w2.Body.String())
+	}
+
+	var resp struct {
+		Fields []struct {
+			Label string `json:"label"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Fields) == 0 {
+		t.Fatalf("expected detected fields after backend recovery, got empty: %s", w2.Body.String())
+	}
+}
+
+func TestLabelValuesServiceName_StripsFieldStagesForDrilldownQueries(t *testing.T) {
+	var receivedQuery string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			receivedQuery = r.URL.Query().Get("query")
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(receivedQuery, "source_message_bytes") || strings.Contains(receivedQuery, "unpack_json") || strings.Contains(receivedQuery, "logfmt") {
+				fmt.Fprintln(w, `{"values":[]}`)
+				return
+			}
+			fmt.Fprintln(w, `{"values":[{"value":"{service=\"grafana\"}","hits":1}]}`)
+		case "/select/logsql/query":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			fmt.Fprintln(w, `{"_time":"2024-01-15T10:30:00Z","_msg":"ok","_stream":"{service=\"grafana\"}"}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		http.MethodGet,
+		`/loki/api/v1/label/service_name/values?query=%7Bdeployment_environment%3D%22dev%22%7D+%7C+json+%7C+source_message_bytes%3D%2289%22&start=1&end=2`,
+		nil,
+	)
+	p.handleLabelValues(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(receivedQuery, "source_message_bytes") || strings.Contains(receivedQuery, "unpack_json") || strings.Contains(receivedQuery, "logfmt") {
+		t.Fatalf("service_name lookup should strip field-detection stages, got query %q", receivedQuery)
+	}
+
+	var resp struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data) == 0 || resp.Data[0] != "grafana" {
+		t.Fatalf("expected derived service_name value, got %#v (query=%q)", resp.Data, receivedQuery)
+	}
+}
+
+func TestDetectedLabelValuesForServiceName_SurviveDetectedLabelsCache(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"values":[{"value":"{service.name=\"api\",level=\"info\"}","hits":1}]}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	ctx := context.Background()
+	query := `{service_name="api"}`
+	start := "1"
+	end := "2"
+	limit := 25
+
+	labels, _, err := p.detectLabels(ctx, query, start, end, limit)
+	if err != nil {
+		t.Fatalf("detectLabels returned error: %v", err)
+	}
+	if len(labels) == 0 {
+		t.Fatalf("detectLabels returned no labels")
+	}
+
+	values := p.detectedLabelValuesForField(ctx, "service_name", query, start, end, limit)
+	if len(values) != 1 || values[0] != "api" {
+		t.Fatalf("expected cached service_name values to contain api, got %v", values)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3188,7 +3188,6 @@ func (p *Proxy) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 			"fields": []interface{}{},
 			"limit":  lineLimit,
 		}
-		p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_fields"], payload)
 		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_fields", http.StatusOK, time.Since(start))
 		return
@@ -3268,7 +3267,6 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 			"values": []string{},
 			"limit":  lineLimit,
 		}
-		p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
 		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
 		return
@@ -3480,7 +3478,6 @@ func (p *Proxy) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
 			"detectedLabels": []interface{}{},
 			"limit":          lineLimit,
 		}
-		p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_labels"], payload)
 		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_labels", http.StatusOK, time.Since(start))
 		return

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -894,6 +895,24 @@ func TestTranslation_MalformedSpacedDottedTripletNormalizedForDatasourceOps(t *t
 	}
 	if strings.Contains(receivedQuery, "custom . `") {
 		t.Fatalf("expected malformed spaced dotted syntax to be removed, got %q", receivedQuery)
+	}
+}
+
+func TestTranslation_DottedFieldComplexLiteralIsQuoted(t *testing.T) {
+	var receivedQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		receivedQuery = r.FormValue("query")
+		w.Write([]byte{})
+	}))
+	defer vlBackend.Close()
+
+	stack := `golang.a2z.com/EKSNodeMonitoringAgent/internal/monitor/kernel.(*KernelMonitor).handleEnvironment`
+	logql := `{deployment_environment="dev"} | code.stacktrace = ` + "`" + stack + "`"
+	doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query="+url.QueryEscape(logql)+"&start=1&end=2&limit=10")
+
+	if !strings.Contains(receivedQuery, `"code.stacktrace":="`+stack+`"`) {
+		t.Fatalf("expected complex dotted field value to be quoted in backend query, got %q", receivedQuery)
 	}
 }
 

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -215,6 +215,11 @@ func TestTranslateSingleLabelFilter_DottedTripletKeyOperatorValue(t *testing.T) 
 			stage: "custom . `pipeline.processing.` = `vector-processing`",
 			want:  `"custom.pipeline.processing":=vector-processing`,
 		},
+		{
+			name:  "complex dotted value is quoted for valid logsql",
+			stage: "code.stacktrace = `golang.a2z.com/EKSNodeMonitoringAgent/internal/monitor/kernel.(*KernelMonitor).handleEnvironment`",
+			want:  `"code.stacktrace":="golang.a2z.com/EKSNodeMonitoringAgent/internal/monitor/kernel.(*KernelMonitor).handleEnvironment"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -227,5 +232,17 @@ func TestTranslateSingleLabelFilter_DottedTripletKeyOperatorValue(t *testing.T) 
 				t.Fatalf("translateSingleLabelFilter(%q) = %q, want %q", tt.stage, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTranslateSingleLabelFilter_DottedTripletComplexMultilineValueQuoted(t *testing.T) {
+	stage := "code.stacktrace = `first line\n\tsecond line`"
+	got, ok := translateSingleLabelFilter(stage, nil)
+	if !ok {
+		t.Fatalf("expected stage to be parsed as label/operator/value triplet: %q", stage)
+	}
+	want := `"code.stacktrace":="first line\n\tsecond line"`
+	if got != want {
+		t.Fatalf("translateSingleLabelFilter multiline literal = %q, want %q", got, want)
 	}
 }

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // LabelTranslateFunc translates a Loki label name to a VL field name (query direction).
@@ -518,10 +519,17 @@ func translateSingleLabelFilter(stage string, labelFn LabelTranslateFunc) (strin
 				}
 				return fmt.Sprintf(`%s:=""`, label), true
 			}
-			if strings.HasPrefix(op.logsql, "-") {
-				return fmt.Sprintf("-%s%s%s", label, op.logsql[1:], value), true
+			formattedValue := value
+			if op.logsql == ":=" || op.logsql == "-:=" {
+				// Equality filters can carry arbitrary string payloads
+				// (for example stacktraces). Keep simple tokens bare and
+				// quote/escape complex values to preserve valid LogsQL.
+				formattedValue = formatLogsQLEqualityValue(value)
 			}
-			return fmt.Sprintf("%s%s%s", label, op.logsql, value), true
+			if strings.HasPrefix(op.logsql, "-") {
+				return fmt.Sprintf("-%s%s%s", label, op.logsql[1:], formattedValue), true
+			}
+			return fmt.Sprintf("%s%s%s", label, op.logsql, formattedValue), true
 		}
 	}
 
@@ -539,6 +547,36 @@ func quoteLogsQLFieldNameIfNeeded(label string) string {
 		return `"` + label + `"`
 	}
 	return label
+}
+
+func formatLogsQLEqualityValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return `""`
+	}
+	if logsQLEqualityValueNeedsQuoting(value) {
+		return strconv.Quote(value)
+	}
+	return value
+}
+
+func logsQLEqualityValueNeedsQuoting(value string) bool {
+	if value == "" {
+		return true
+	}
+	for _, r := range value {
+		if unicode.IsSpace(r) {
+			return true
+		}
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '_' || r == '-' || r == '.' || r == '/' {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func translateMalformedDottedStage(stage string, labelFn LabelTranslateFunc) (string, bool) {
@@ -1348,10 +1386,14 @@ func streamMatcherToFieldFilter(matcher string, labelFn LabelTranslateFunc) stri
 				}
 				return fmt.Sprintf(`%s:=""`, label)
 			}
-			if op.neg {
-				return fmt.Sprintf("-%s%s%s", label, op.logsql, value)
+			formattedValue := value
+			if op.logsql == ":=" {
+				formattedValue = formatLogsQLEqualityValue(value)
 			}
-			return fmt.Sprintf("%s%s%s", label, op.logsql, value)
+			if op.neg {
+				return fmt.Sprintf("-%s%s%s", label, op.logsql, formattedValue)
+			}
+			return fmt.Sprintf("%s%s%s", label, op.logsql, formattedValue)
 		}
 	}
 	return ""
@@ -1410,6 +1452,10 @@ var syntheticServiceNameFields = []string{
 
 func serviceNameMatcherFilter(op, value string, neg, isRegex bool) string {
 	value = strings.TrimSpace(strings.Trim(value, "\"`"))
+	formattedValue := value
+	if !isRegex {
+		formattedValue = formatLogsQLEqualityValue(value)
+	}
 	parts := make([]string, 0, len(syntheticServiceNameFields))
 	for _, field := range syntheticServiceNameFields {
 		name := field
@@ -1433,9 +1479,9 @@ func serviceNameMatcherFilter(op, value string, neg, isRegex bool) string {
 			continue
 		}
 		if neg {
-			parts = append(parts, fmt.Sprintf(`-%s%s%s`, name, op, value))
+			parts = append(parts, fmt.Sprintf(`-%s%s%s`, name, op, formattedValue))
 		} else {
-			parts = append(parts, fmt.Sprintf(`%s%s%s`, name, op, value))
+			parts = append(parts, fmt.Sprintf(`%s%s%s`, name, op, formattedValue))
 		}
 	}
 	if neg {


### PR DESCRIPTION
## Summary
- fix service_name value resolution for drilldown by using selector-only query context (pipeline stages no longer suppress service suggestions)
- preserve service_name in detected-label summaries (removed in-place map mutation that dropped it from cached summaries)
- treat non-2xx responses from VL drilldown discovery paths as errors instead of silently parsing them as empty success payloads
- avoid caching empty fallback payloads on transient errors for detected_labels, detected_fields, and detected_field_values

## Why
Two user-facing regressions were reproducible:
1. service_name in drilldown could show no values while related labels were present.
2. fields/labels endpoints intermittently returned empty data and recovered only after refresh.

Both were tied to cache/translation behavior and non-2xx upstream handling in drilldown discovery code paths.

## Tests
- added TestHandleDetectedLabels_DoesNotCacheTransientErrorFallback
- added TestHandleDetectedFields_DoesNotCacheTransientErrorFallback
- added TestLabelValuesServiceName_StripsFieldStagesForDrilldownQueries
- added TestDetectedLabelValuesForServiceName_SurviveDetectedLabelsCache
- full package run: go test ./internal/proxy (passes)
