### PR TITLE
chart: harden StatefulSet immutable serviceName handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- chart: decouple StatefulSet immutable `spec.serviceName` from peer-discovery alias settings by binding StatefulSet identity to `workload.statefulSet.serviceName` and rendering an additional DNS headless alias service when `peerCache.serviceName` differs
+
 ## [1.0.1] - 2026-04-13
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "loki-vl-proxy.labels" . | nindent 4 }}
 spec:
   {{- if eq (include "loki-vl-proxy.workloadKind" .) "StatefulSet" }}
-  serviceName: {{ include "loki-vl-proxy.peerServiceName" . }}
+  serviceName: {{ include "loki-vl-proxy.headlessServiceName" . }}
   podManagementPolicy: {{ .Values.workload.statefulSet.podManagementPolicy }}
   updateStrategy:
     {{- toYaml .Values.workload.statefulSet.updateStrategy | nindent 4 }}

--- a/charts/loki-vl-proxy/templates/peer-service.yaml
+++ b/charts/loki-vl-proxy/templates/peer-service.yaml
@@ -1,8 +1,10 @@
 {{- if or (eq (include "loki-vl-proxy.workloadKind" .) "StatefulSet") (and .Values.peerCache.enabled (eq .Values.peerCache.discovery "dns")) }}
+{{- $headlessName := include "loki-vl-proxy.headlessServiceName" . -}}
+{{- $peerName := include "loki-vl-proxy.peerServiceName" . -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "loki-vl-proxy.peerServiceName" . }}
+  name: {{ $headlessName }}
   labels:
     {{- include "loki-vl-proxy.labels" . | nindent 4 }}
     {{- with .Values.peerService.labels }}
@@ -23,4 +25,31 @@ spec:
       name: http
   selector:
     {{- include "loki-vl-proxy.selectorLabels" . | nindent 4 }}
+{{- if and .Values.peerCache.enabled (eq .Values.peerCache.discovery "dns") (ne $peerName $headlessName) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $peerName }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+    {{- with .Values.peerService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.peerService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  {{- include "loki-vl-proxy.renderTrafficDistribution" (dict "field" ".Values.peerService.trafficDistribution" "value" .Values.peerService.trafficDistribution) | nindent 2 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "loki-vl-proxy.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/loki-vl-proxy/templates/statefulset-immutable-guard.yaml
+++ b/charts/loki-vl-proxy/templates/statefulset-immutable-guard.yaml
@@ -9,7 +9,7 @@
 
 {{- if and $existing (eq $kind "StatefulSet") -}}
 {{- $existingServiceName := default "" $existing.spec.serviceName -}}
-{{- $desiredServiceName := include "loki-vl-proxy.peerServiceName" . -}}
+{{- $desiredServiceName := include "loki-vl-proxy.headlessServiceName" . -}}
 {{- if ne $existingServiceName $desiredServiceName -}}
 {{- fail (printf "statefulSetImmutableGuard: immutable StatefulSet field change detected for %q: spec.serviceName current=%q desired=%q" $name $existingServiceName $desiredServiceName) -}}
 {{- end -}}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -530,7 +530,9 @@ peerCache:
   enabled: false
   # Discovery: "dns" (headless service, recommended) or "static" (explicit peers list)
   discovery: "dns"
-  # Headless service name (defaults to release-name + "-headless")
+  # Optional DNS service name used for peer discovery.
+  # Does NOT change StatefulSet spec.serviceName (that is controlled by workload.statefulSet.serviceName).
+  # Empty = reuse StatefulSet headless service.
   serviceName: ""
   # Static peer addresses in host:port form (if discovery=static)
   peers: []


### PR DESCRIPTION
## Summary
- make StatefulSet `spec.serviceName` depend only on `workload.statefulSet.serviceName` (headless identity), not on peer discovery service selection
- keep peer discovery service configurable via `peerCache.serviceName` without mutating StatefulSet immutable fields
- when StatefulSet is used and peer DNS service differs from headless service, render a second headless Service for discovery alias
- update immutable guard to compare against the StatefulSet headless service name
- document the behavior in chart `values.yaml` comments

## Why
Some upgrades can fail with Kubernetes immutable StatefulSet errors when peer discovery service naming changes. This patch isolates immutable StatefulSet identity from peer discovery naming, preserving flexibility while avoiding forbidden updates.

## Validation
- `helm lint charts/loki-vl-proxy`
- `helm template lvp charts/loki-vl-proxy`
- `helm template lvp charts/loki-vl-proxy --set workload.kind=StatefulSet --set peerCache.enabled=true --set peerCache.discovery=dns --set peerCache.serviceName=peer-custom`
