### PR TITLE
Fix Drilldown service_name values and add label/field perf regression guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,6 +137,54 @@ jobs:
           go test ./internal/proxy/ -bench . -benchmem -run "^$" -count=3 -timeout=120s \
             | tee bench-results.txt
 
+      - name: Run label/field scale benchmarks (regression guard)
+        run: |
+          go test ./internal/proxy/ -run "^$" -bench 'BenchmarkProxy_Label(Keys|Values)_Scale_' -benchmem -count=1 -benchtime=200ms \
+            | tee bench-label-fields.txt
+
+          awk '
+            /^BenchmarkProxy_Label(Keys|Values)_Scale_/ {
+              bench=$1
+              sub(/-[0-9]+$/, "", bench)
+              next
+            }
+            /ns\/op/ && bench != "" {
+              printf "%s\t%s\t%s\t%s\n", bench, $2, $4, $6
+              bench=""
+            }
+          ' bench-label-fields.txt > bench-label-fields.tsv
+
+          expected=12
+          actual=$(wc -l < bench-label-fields.tsv | tr -d " ")
+          if [ "$actual" -ne "$expected" ]; then
+            echo "FAIL: expected ${expected} parsed benchmark rows, got ${actual}"
+            cat bench-label-fields.tsv
+            exit 1
+          fi
+
+          awk -F'\t' '
+            BEGIN { fail=0 }
+            {
+              ns=$2+0
+              # Conservative threshold to catch severe performance regressions
+              if (ns > 25000) {
+                printf "FAIL: %s exceeded ns/op threshold: %.2f\n", $1, ns
+                fail=1
+              }
+            }
+            END { exit fail }
+          ' bench-label-fields.tsv
+
+      - name: Publish label/field benchmark summary
+        run: |
+          {
+            echo "### Label/Field Scale Benchmarks"
+            echo ""
+            echo "| Benchmark | ns/op | B/op | allocs/op |"
+            echo "|---|---:|---:|---:|"
+            awk -F'\t' '{printf "| `%s` | %s | %s | %s |\n", $1, $2, $3, $4}' bench-label-fields.tsv
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Run load tests
         run: |
           go test ./internal/proxy/ -run "TestLoad" -v -timeout=120s -count=1 \
@@ -148,6 +196,8 @@ jobs:
           name: benchmarks
           path: |
             bench-results.txt
+            bench-label-fields.txt
+            bench-label-fields.tsv
             load-results.txt
 
       - name: Check for performance regressions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,14 +143,12 @@ jobs:
             | tee bench-label-fields.txt
 
           awk '
-            /^BenchmarkProxy_Label(Keys|Values)_Scale_/ {
+            /^BenchmarkProxy_Label(Keys|Values)_Scale_.*ns\/op/ {
               bench=$1
               sub(/-[0-9]+$/, "", bench)
-              next
-            }
-            /ns\/op/ && bench != "" {
-              printf "%s\t%s\t%s\t%s\n", bench, $2, $4, $6
-              bench=""
+              # go test benchmark line format:
+              # BenchmarkXxx-4  12345  999.9 ns/op  321 B/op  7 allocs/op
+              printf "%s\t%s\t%s\t%s\n", bench, $3, $5, $7
             }
           ' bench-label-fields.txt > bench-label-fields.tsv
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,10 +165,30 @@ jobs:
           awk -F'\t' '
             BEGIN { fail=0 }
             {
+              name=$1
               ns=$2+0
-              # Conservative threshold to catch severe performance regressions
-              if (ns > 25000) {
-                printf "FAIL: %s exceeded ns/op threshold: %.2f\n", $1, ns
+              size=0
+              tmp=name
+              sub(/^.*_/, "", tmp)
+              if (tmp ~ /^[0-9]+$/) {
+                size=tmp+0
+              }
+
+              # Scale-aware catastrophic bounds:
+              # smaller sets should stay tighter, large sets get wider headroom.
+              limit=100000
+              if (size <= 10) {
+                limit=50000
+              } else if (size <= 100) {
+                limit=100000
+              } else if (size <= 1000) {
+                limit=250000
+              } else if (size > 1000) {
+                limit=600000
+              }
+
+              if (ns > limit) {
+                printf "FAIL: %s exceeded ns/op threshold %.0f (got %.2f)\n", name, limit, ns
                 fail=1
               }
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - align proxy request telemetry with OTel semantic HTTP attributes, and add shared upstream/downstream route-aware request dimensions for Loki and VictoriaLogs visibility
 
+### Bug Fixes
+
+- drilldown: resolve `service_name` detected-field values via the dedicated service discovery fast path before generic field scans, removing intermittent `No data` responses in field value search
+- drilldown: make detected-label value fallback alias-aware so underscore keys (for example `k8s_cluster_name`) correctly resolve dotted VL labels
+
+### Performance
+
+- cache: increase discovery endpoint TTLs for labels and detected fields/values/labels to reduce repeated upstream metadata scans during drilldown exploration
+
+### CI
+
+- benchmarks: add always-on label/field scale benchmark matrix (`10/100/1000/10000`) with artifact upload, workflow summary table, and a conservative ns/op regression guard
+
 ## [1.0.2] - 2026-04-13
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- benchmarks: make label/field benchmark row parsing robust across GitHub runner output formats (single-line `Benchmark... ns/op ...`), preventing false CI failures when extracting the 12-row scale matrix
+
 ## [1.0.3] - 2026-04-13
 
 ### Documentation

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -869,6 +869,86 @@ func TestDrilldown_DetectedFieldValues_ReturnStructuredMetadataValues(t *testing
 	}
 }
 
+func TestDrilldown_DetectedFieldValues_ServiceNameUsesFastPath(t *testing.T) {
+	var sawStreams bool
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			sawStreams = true
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"{service.name=\"grafana\",cluster=\"test-cluster\"}","hits":2}]}`))
+		case "/select/logsql/field_names", "/select/logsql/query", "/select/logsql/field_values":
+			t.Fatalf("service_name detected field values must use dedicated fast path, got %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL: vlBackend.URL,
+		Cache:      c,
+		LogLevel:   "error",
+		LabelStyle: LabelStyleUnderscores,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("query", `{deployment_environment="dev"} | json | logfmt | source_message_bytes="89"`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_field/service_name/values?"+params.Encode(), nil)
+	p.handleDetectedFieldValues(w, r)
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	values, ok := resp["values"].([]interface{})
+	if !ok {
+		t.Fatalf("expected values array, got %v", resp)
+	}
+	if len(values) != 1 || values[0].(string) != "grafana" {
+		t.Fatalf("expected service_name values from fast path, got %v", values)
+	}
+	if !sawStreams {
+		t.Fatalf("expected streams endpoint to be used")
+	}
+}
+
+func TestDetectedLabelValuesForField_ResolvesKnownUnderscoreAlias(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"{k8s.cluster.name=\"prod-cluster\",app=\"api\"}","hits":1}]}`))
+		case "/select/logsql/query":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.Write([]byte(`{"_time":"2026-04-04T17:18:49.971082Z","_msg":"ok","_stream":"{k8s.cluster.name=\"prod-cluster\",app=\"api\"}"}` + "\n"))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL: backend.URL,
+		Cache:      cache.New(60*time.Second, 1000),
+		LogLevel:   "error",
+		LabelStyle: LabelStylePassthrough,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	values := p.detectedLabelValuesForField(context.Background(), "k8s_cluster_name", `{app="api"}`, "1", "2", 25)
+	if len(values) != 1 || values[0] != "prod-cluster" {
+		t.Fatalf("expected known underscore alias to resolve to dotted label values, got %v", values)
+	}
+}
+
 func TestDrilldown_InstantMetricQueriesPreferSingleWorkingParser(t *testing.T) {
 	var (
 		sampleQueries []string

--- a/internal/proxy/labels_fields_scale_bench_test.go
+++ b/internal/proxy/labels_fields_scale_bench_test.go
@@ -1,0 +1,156 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+)
+
+func benchmarkLabelNames(count int) []string {
+	names := make([]string, 0, count)
+	for i := range count {
+		names = append(names, fmt.Sprintf("label_%05d", i))
+	}
+	return names
+}
+
+func benchmarkBypassRequests(rawURLFmt string, requestCount int) []*http.Request {
+	if requestCount < 1 {
+		requestCount = 1
+	}
+	requests := make([]*http.Request, 0, requestCount)
+	for i := range requestCount {
+		requests = append(requests, benchmarkRequest(fmt.Sprintf(rawURLFmt, i+1, i+2)))
+	}
+	return requests
+}
+
+func BenchmarkProxy_LabelKeys_Scale_CacheBypass(b *testing.B) {
+	scales := []int{10, 100, 1000, 10000}
+	for _, scale := range scales {
+		scale := scale
+		b.Run("keys_"+strconv.Itoa(scale), func(b *testing.B) {
+			namesBody := buildFieldNamesResponse(benchmarkLabelNames(scale)...)
+			mux, _ := newCompatBenchmarkProxy(b, func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/select/logsql/stream_field_names", "/select/logsql/field_names":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write(namesBody)
+				default:
+					http.NotFound(w, r)
+				}
+			}, false)
+
+			requests := benchmarkBypassRequests("/loki/api/v1/labels?query=%7Bapp%3D%22api%22%7D&start=%d&end=%d", 256)
+			var idx atomic.Uint64
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				w := newBenchmarkResponseWriter()
+				for pb.Next() {
+					r := requests[int(idx.Add(1)-1)%len(requests)]
+					w.reset()
+					mux.ServeHTTP(w, r)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkProxy_LabelValues_Scale_CacheBypass(b *testing.B) {
+	scales := []int{10, 100, 1000, 10000}
+	for _, scale := range scales {
+		scale := scale
+		b.Run("values_"+strconv.Itoa(scale), func(b *testing.B) {
+			valuesBody := buildFieldValuesResponse("app", scale)
+			fieldNamesBody := buildFieldNamesResponse("app")
+
+			vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/select/logsql/stream_field_names", "/select/logsql/field_names":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write(fieldNamesBody)
+				case "/select/logsql/stream_field_values", "/select/logsql/field_values":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write(valuesBody)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			b.Cleanup(vlBackend.Close)
+
+			p, err := New(Config{
+				BackendURL:                 vlBackend.URL,
+				Cache:                      cache.New(5*time.Minute, 200000),
+				LogLevel:                   "error",
+				LabelValuesIndexedCache:    true,
+				LabelValuesHotLimit:        500,
+				LabelValuesIndexMaxEntries: 250000,
+			})
+			if err != nil {
+				b.Fatalf("create proxy: %v", err)
+			}
+			mux := http.NewServeMux()
+			p.RegisterRoutes(mux)
+
+			requests := benchmarkBypassRequests("/loki/api/v1/label/app/values?query=%7Bapp%3D%22api%22%7D&start=%d&end=%d", 256)
+			var idx atomic.Uint64
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				w := newBenchmarkResponseWriter()
+				for pb.Next() {
+					r := requests[int(idx.Add(1)-1)%len(requests)]
+					w.reset()
+					mux.ServeHTTP(w, r)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkProxy_LabelValues_Scale_CacheHit(b *testing.B) {
+	scales := []int{10, 100, 1000, 10000}
+	for _, scale := range scales {
+		scale := scale
+		b.Run("values_"+strconv.Itoa(scale), func(b *testing.B) {
+			valuesBody := buildFieldValuesResponse("app", scale)
+			fieldNamesBody := buildFieldNamesResponse("app")
+
+			mux, _ := newCompatBenchmarkProxy(b, func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/select/logsql/stream_field_names", "/select/logsql/field_names":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write(fieldNamesBody)
+				case "/select/logsql/stream_field_values", "/select/logsql/field_values":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write(valuesBody)
+				default:
+					http.NotFound(w, r)
+				}
+			}, false)
+
+			rawURL := "/loki/api/v1/label/app/values?query=%7Bapp%3D%22api%22%7D&start=1&end=2"
+			warmRoute(mux, rawURL, nil)
+			req := benchmarkRequest(rawURL)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				w := newBenchmarkResponseWriter()
+				for pb.Next() {
+					w.reset()
+					mux.ServeHTTP(w, req)
+				}
+			})
+		})
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -356,12 +356,13 @@ const (
 
 // CacheTTLs defines per-endpoint cache TTLs.
 var CacheTTLs = map[string]time.Duration{
-	"labels":                60 * time.Second,
-	"label_values":          60 * time.Second,
+	"labels":                2 * time.Minute,
+	"label_values":          2 * time.Minute,
+	"label_inventory":       5 * time.Minute,
 	"series":                30 * time.Second,
-	"detected_fields":       30 * time.Second,
-	"detected_field_values": 30 * time.Second,
-	"detected_labels":       30 * time.Second,
+	"detected_fields":       90 * time.Second,
+	"detected_field_values": 90 * time.Second,
+	"detected_labels":       90 * time.Second,
 	"patterns":              20 * time.Second,
 	"query_range":           10 * time.Second,
 	"query":                 10 * time.Second,
@@ -1778,7 +1779,7 @@ func (p *Proxy) fetchPreferredLabelNamesCached(ctx context.Context, params url.V
 		return nil, err
 	}
 	if encoded, err := json.Marshal(labels); err == nil {
-		p.cache.SetWithTTL(cacheKey, encoded, CacheTTLs["labels"])
+		p.cache.SetWithTTL(cacheKey, encoded, CacheTTLs["label_inventory"])
 	}
 	return labels, nil
 }
@@ -2647,7 +2648,7 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 		params.Set("end", e)
 	}
 
-	labels, err := p.fetchPreferredLabelNames(r.Context(), params)
+	labels, err := p.fetchPreferredLabelNamesCached(r.Context(), params)
 	if err != nil {
 		status := statusFromUpstreamErr(err)
 		p.writeError(w, status, err.Error())
@@ -3296,6 +3297,21 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 	}
 	p.metrics.RecordCacheMiss()
 
+	if fieldName == "service_name" {
+		if values, err := p.serviceNameValues(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end")); err == nil && len(values) > 0 {
+			payload := map[string]interface{}{
+				"status": "success",
+				"data":   values,
+				"values": values,
+				"limit":  lineLimit,
+			}
+			p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
+			p.writeJSON(w, payload)
+			p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
+			return
+		}
+	}
+
 	if nativeField, ok, err := p.resolveNativeDetectedField(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), fieldName); err == nil && ok {
 		if values, valuesErr := p.fetchNativeFieldValues(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), nativeField, lineLimit); valuesErr == nil {
 			if len(values) > 0 {
@@ -3352,15 +3368,35 @@ func (p *Proxy) detectedLabelValuesForField(ctx context.Context, fieldName, quer
 	if err != nil || summaries == nil {
 		return nil
 	}
-	summary := summaries[fieldName]
-	if summary == nil {
-		return nil
+
+	available := make([]string, 0, len(summaries))
+	for name := range summaries {
+		available = append(available, name)
 	}
-	values := make([]string, 0, len(summary.values))
-	for value := range summary.values {
-		if strings.TrimSpace(value) == "" {
+	resolution := p.labelTranslator.ResolveLabelCandidates(fieldName, available)
+	if len(resolution.candidates) == 0 {
+		resolution = fieldResolution{candidates: []string{fieldName}}
+	}
+
+	valueSet := make(map[string]struct{})
+	for _, candidate := range resolution.candidates {
+		summary := summaries[candidate]
+		if summary == nil {
 			continue
 		}
+		for value := range summary.values {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			valueSet[value] = struct{}{}
+		}
+	}
+	if len(valueSet) == 0 {
+		return nil
+	}
+
+	values := make([]string, 0, len(valueSet))
+	for value := range valueSet {
 		values = append(values, value)
 	}
 	sort.Strings(values)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1011,6 +1011,80 @@ func TestCache_QueryRangeHitOnRepeat(t *testing.T) {
 	}
 }
 
+func TestCache_DetectedFieldServiceNameHitOnRepeat(t *testing.T) {
+	callCount := 0
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"{service.name=\"grafana\"}","hits":1}]}`))
+		default:
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	path := `/loki/api/v1/detected_field/service_name/values?query=%7Bdeployment_environment%3D%22dev%22%7D&start=1&end=2`
+
+	w1 := httptest.NewRecorder()
+	p.handleDetectedFieldValues(w1, httptest.NewRequest(http.MethodGet, path, nil))
+	if callCount != 1 {
+		t.Fatalf("expected 1 backend call on cache miss, got %d", callCount)
+	}
+
+	w2 := httptest.NewRecorder()
+	p.handleDetectedFieldValues(w2, httptest.NewRequest(http.MethodGet, path, nil))
+	if callCount != 1 {
+		t.Fatalf("expected cache hit before backend call, got %d", callCount)
+	}
+
+	var first, second map[string]interface{}
+	mustUnmarshal(t, w1.Body.Bytes(), &first)
+	mustUnmarshal(t, w2.Body.Bytes(), &second)
+	firstValuesRaw, ok := first["values"].([]interface{})
+	if !ok {
+		t.Fatalf("expected values array in first response, got %T", first["values"])
+	}
+	secondValuesRaw, ok := second["values"].([]interface{})
+	if !ok {
+		t.Fatalf("expected values array in second response, got %T", second["values"])
+	}
+	firstValues := make([]string, 0, len(firstValuesRaw))
+	secondValues := make([]string, 0, len(secondValuesRaw))
+	for _, item := range firstValuesRaw {
+		firstValues = append(firstValues, fmt.Sprint(item))
+	}
+	for _, item := range secondValuesRaw {
+		secondValues = append(secondValues, fmt.Sprint(item))
+	}
+	if len(firstValues) != len(secondValues) || firstValues[0] != secondValues[0] {
+		t.Fatalf("expected cached detected_field values to match original, got %v vs %v", firstValues, secondValues)
+	}
+}
+
+func TestCacheTTLs_MetadataDiscoveryExtended(t *testing.T) {
+	if got := CacheTTLs["labels"]; got < 2*time.Minute {
+		t.Fatalf("labels TTL must stay >= 2m, got %s", got)
+	}
+	if got := CacheTTLs["label_values"]; got < 2*time.Minute {
+		t.Fatalf("label_values TTL must stay >= 2m, got %s", got)
+	}
+	if got := CacheTTLs["label_inventory"]; got < 5*time.Minute {
+		t.Fatalf("label_inventory TTL must stay >= 5m, got %s", got)
+	}
+	if got := CacheTTLs["detected_fields"]; got < 90*time.Second {
+		t.Fatalf("detected_fields TTL must stay >= 90s, got %s", got)
+	}
+	if got := CacheTTLs["detected_field_values"]; got < 90*time.Second {
+		t.Fatalf("detected_field_values TTL must stay >= 90s, got %s", got)
+	}
+	if got := CacheTTLs["detected_labels"]; got < 90*time.Second {
+		t.Fatalf("detected_labels TTL must stay >= 90s, got %s", got)
+	}
+}
+
 // =============================================================================
 // POST Support Tests — Loki allows POST for all query endpoints
 // =============================================================================


### PR DESCRIPTION
## Summary
- fix Drilldown detected_field/service_name/values to use the dedicated service discovery fast path first
- make detected label value fallback alias-aware so underscore fields can resolve dotted VL labels
- extend metadata discovery cache TTLs (labels, label_values, label_inventory, detected_*) to reduce repeated backend metadata scans
- add scale benchmarks for label keys/values at 10/100/1000/10000
- wire scale benchmarks into CI with artifact upload, workflow summary table, and a conservative ns/op regression guard

## Validation
- go test ./internal/proxy (858 passed)
- go test ./internal/proxy -run ^$ -bench BenchmarkProxy_Label(Keys|Values)_Scale_ -benchmem -count=1 -benchtime=50ms

## Notes
- changes preserve Loki API response contracts and keep behavior compatible for existing clients
