### PR TITLE
Improve Loki patterns parity and add patterns regression guards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,6 +203,66 @@ jobs:
             awk -F'\t' '{printf "| `%s` | %s | %s | %s |\n", $1, $2, $3, $4}' bench-label-fields.tsv
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Run patterns scale benchmarks (regression guard)
+        run: |
+          go test ./internal/proxy/ -run "^$" -bench 'BenchmarkProxy_Patterns_Scale_' -benchmem -count=1 -benchtime=200ms \
+            | tee bench-patterns.txt
+
+          awk '
+            /^BenchmarkProxy_Patterns_Scale_.*ns\/op/ {
+              bench=$1
+              sub(/-[0-9]+$/, "", bench)
+              printf "%s\t%s\t%s\t%s\n", bench, $3, $5, $7
+            }
+          ' bench-patterns.txt > bench-patterns.tsv
+
+          expected=6
+          actual=$(wc -l < bench-patterns.tsv | tr -d " ")
+          if [ "$actual" -ne "$expected" ]; then
+            echo "FAIL: expected ${expected} parsed pattern benchmark rows, got ${actual}"
+            cat bench-patterns.tsv
+            exit 1
+          fi
+
+          awk -F'\t' '
+            BEGIN { fail=0 }
+            {
+              name=$1
+              ns=$2+0
+              scale=name
+              sub(/^.*\/lines_/, "", scale)
+              if (name ~ /CacheBypass/) {
+                bypass[scale]=ns
+              } else if (name ~ /CacheHit/) {
+                hit[scale]=ns
+              }
+            }
+            END {
+              for (s in bypass) {
+                if (!(s in hit)) {
+                  printf "FAIL: missing cache-hit benchmark for lines_%s\n", s
+                  fail=1
+                  continue
+                }
+                if (hit[s] >= bypass[s]) {
+                  printf "FAIL: cache hit should be faster than bypass for lines_%s (hit=%.2f ns/op bypass=%.2f ns/op)\n", s, hit[s], bypass[s]
+                  fail=1
+                }
+              }
+              exit fail
+            }
+          ' bench-patterns.tsv
+
+      - name: Publish patterns benchmark summary
+        run: |
+          {
+            echo "### Patterns Scale Benchmarks"
+            echo ""
+            echo "| Benchmark | ns/op | B/op | allocs/op |"
+            echo "|---|---:|---:|---:|"
+            awk -F'\t' '{printf "| `%s` | %s | %s | %s |\n", $1, $2, $3, $4}' bench-patterns.tsv
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Run load tests
         run: |
           go test ./internal/proxy/ -run "TestLoad" -v -timeout=120s -count=1 \
@@ -216,6 +276,8 @@ jobs:
             bench-results.txt
             bench-label-fields.txt
             bench-label-fields.tsv
+            bench-patterns.txt
+            bench-patterns.tsv
             load-results.txt
 
       - name: Check for performance regressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- patterns: add Loki-compatible `/loki/api/v1/patterns` extraction flow with canonicalized token clustering and low-signal line filtering for better parity on repeated dynamic log messages
+
+### Configuration
+
+- proxy: add `-patterns-enabled` runtime flag to explicitly enable/disable patterns API behavior
+- chart: expose `extraArgs.patterns-enabled` in Helm values for straightforward deployment-time control
+
+### Tests
+
+- patterns: add benchmark scale coverage (`10/100/1000/10000`) with CI regression gates to keep cache-assisted patterns extraction from regressing in latency-sensitive paths
+
 ## [1.0.5] - 2026-04-13
 
 ### Observability

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -90,6 +90,7 @@ extraArgs:
   label-values-indexed-cache: "false"
   label-values-hot-limit: "200"
   label-values-index-max-entries: "200000"
+  patterns-enabled: "true"
   log-level: "info"
   # Hardening
   http-read-timeout: "30s"
@@ -119,6 +120,7 @@ extraArgs:
   # - label-style: passthrough | underscores
   # - metadata-field-mode: native | translated | hybrid
   # - emit-structured-metadata: true | false
+  # - patterns-enabled: true | false
   #
   # Common profile examples:
   # 1) Loki/Grafana conservative:

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -65,6 +65,7 @@ type proxyRuntimeConfig struct {
 	derivedFieldsJSON                  string
 	streamResponse                     bool
 	emitStructuredMetadata             bool
+	patternsEnabled                    bool
 	queryRangeWindowing                bool
 	queryRangeSplitInterval            time.Duration
 	queryRangeMaxParallel              int
@@ -324,6 +325,7 @@ func run(
 	derivedFieldsJSON := fs.String("derived-fields", "", `JSON derived fields: [{"name":"traceID","matcherRegex":"trace_id=([a-f0-9]+)","url":"http://tempo/trace/${__value.raw}"}]`)
 	streamResponse := fs.Bool("stream-response", false, "Stream log responses via chunked transfer encoding")
 	emitStructuredMetadata := fs.Bool("emit-structured-metadata", true, "Include Loki 3-tuple stream values [timestamp, line, metadata] in query responses")
+	patternsEnabled := fs.Bool("patterns-enabled", true, "Enable /loki/api/v1/patterns endpoint (Grafana Logs Drilldown patterns)")
 	queryRangeWindowing := fs.Bool("query-range-windowing", true, "Enable query_range window splitting and window-level cache reuse for log queries")
 	queryRangeSplitInterval := fs.Duration("query-range-split-interval", time.Hour, "Time window size used for query_range split/merge (for example 15m, 1h, 24h)")
 	queryRangeMaxParallel := fs.Int("query-range-max-parallel", 2, "Maximum number of query_range windows fetched in parallel when adaptive parallelism is disabled")
@@ -457,6 +459,7 @@ func run(
 			derivedFieldsJSON:                  *derivedFieldsJSON,
 			streamResponse:                     *streamResponse,
 			emitStructuredMetadata:             *emitStructuredMetadata,
+			patternsEnabled:                    *patternsEnabled,
 			queryRangeWindowing:                *queryRangeWindowing,
 			queryRangeSplitInterval:            *queryRangeSplitInterval,
 			queryRangeMaxParallel:              *queryRangeMaxParallel,
@@ -909,6 +912,10 @@ func parseHeaderMapCSV(s string) map[string]string {
 	return headers
 }
 
+func boolPointer(v bool) *bool {
+	return &v
+}
+
 func buildOTLPConfig(cfg otlpRuntimeConfig) metrics.OTLPConfig {
 	return metrics.OTLPConfig{
 		Endpoint:              cfg.endpoint,
@@ -997,6 +1004,7 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		DerivedFields:                      derivedFields,
 		StreamResponse:                     cfg.streamResponse,
 		EmitStructuredMetadata:             cfg.emitStructuredMetadata,
+		PatternsEnabled:                    boolPointer(cfg.patternsEnabled),
 		QueryRangeWindowingEnabled:         cfg.queryRangeWindowing,
 		QueryRangeSplitInterval:            cfg.queryRangeSplitInterval,
 		QueryRangeMaxParallel:              cfg.queryRangeMaxParallel,
@@ -1139,6 +1147,9 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 	}
 	if proxyCfg.FieldMappings != nil {
 		logger.Info("loaded field mappings", "count", len(proxyCfg.FieldMappings))
+	}
+	if proxyCfg.PatternsEnabled != nil && !*proxyCfg.PatternsEnabled {
+		logger.Info("patterns endpoint disabled", "flag", "patterns-enabled")
 	}
 	if proxyCfg.LabelStyle == proxy.LabelStyleUnderscores {
 		logger.Info("label translation enabled", "label_style", "underscores", "metadata_field_mode", string(proxyCfg.MetadataFieldMode))

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -355,6 +355,9 @@ func TestRun_DefaultEnablesStructuredMetadata(t *testing.T) {
 	if !captured.proxyCfg.emitStructuredMetadata {
 		t.Fatal("expected -emit-structured-metadata to default to true")
 	}
+	if !captured.proxyCfg.patternsEnabled {
+		t.Fatal("expected -patterns-enabled to default to true")
+	}
 }
 
 func TestBuildServerTLSConfig_RequiresCAWhenClientCertsRequired(t *testing.T) {
@@ -806,6 +809,7 @@ func TestBuildProxyConfig(t *testing.T) {
 		derivedFieldsJSON:               `[{"name":"traceID","matcherRegex":"trace_id=(\\w+)","url":"http://tempo/${__value.raw}"}]`,
 		streamResponse:                  true,
 		emitStructuredMetadata:          true,
+		patternsEnabled:                 false,
 		queryRangeWindowing:             true,
 		queryRangeSplitInterval:         30 * time.Minute,
 		queryRangeMaxParallel:           4,
@@ -880,6 +884,9 @@ func TestBuildProxyConfig(t *testing.T) {
 	}
 	if !got.EmitStructuredMetadata {
 		t.Fatalf("expected emit structured metadata to be enabled")
+	}
+	if got.PatternsEnabled == nil || *got.PatternsEnabled {
+		t.Fatalf("expected patterns endpoint to be disabled in built config")
 	}
 	if !got.QueryRangeWindowingEnabled {
 		t.Fatalf("expected query range windowing to be enabled")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,7 +16,7 @@
 | `GET /loki/api/v1/detected_fields` | Implemented | `/select/logsql/field_names` | 30s | 1 |
 | `GET /loki/api/v1/detected_field/{name}/values` | Implemented | `/select/logsql/field_values` | - | 1 |
 | `GET /loki/api/v1/detected_labels` | Implemented | `/select/logsql/field_names` | - | 1 |
-| `GET /loki/api/v1/patterns` | Implemented | `/select/logsql/query` + pattern extraction | - | 3 |
+| `GET /loki/api/v1/patterns` | Implemented (toggleable) | `/select/logsql/query` + Drain-like token clustering | - | 4 |
 | `GET /loki/api/v1/format_query` | Implemented | - (passthrough) | - | 1 |
 | `WS /loki/api/v1/tail` | Implemented | `/select/logsql/tail` (WebSocket->NDJSON) | - | 2 |
 
@@ -32,6 +32,7 @@ For Grafana Logs Drilldown and Explore compatibility:
 - Label APIs prefer VictoriaLogs stream metadata so parsed fields do not leak into Loki label pickers when the backend supports the stream-only endpoints.
 - `-extra-label-fields` extends label-facing APIs (`/labels`, `/label/{name}/values`) with explicit VL fields and improves custom dot/underscore alias resolution.
 - Optional indexed browse mode for label values (`-label-values-indexed-cache=true`) supports hotset-first responses and optional `offset`/`search` (`search` or `q`) on `GET /loki/api/v1/label/{name}/values`.
+- Patterns API can be explicitly gated via `-patterns-enabled` (default `true`) to match deployments that do not expose Drilldown pattern discovery.
 - Indexed label-values cache snapshots can be persisted to disk (`-label-values-index-persist-path`) and restored at startup.
 - On stale/missing disk snapshot, startup can warm from peer cache before serving (`-label-values-index-startup-stale-threshold`, `-label-values-index-startup-peer-warm-timeout`).
 - Peer cache payload fetches (`/_cache/get`) support gzip response compression for lower network latency/cost on large cache objects.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ See [Translation Modes Guide](translation-modes.md) for mode-selection profiles 
 | `-label-style` | `LABEL_STYLE` | `passthrough` | `passthrough` or `underscores` |
 | `-metadata-field-mode` | `METADATA_FIELD_MODE` | `hybrid` | `native`, `translated`, or `hybrid` for `detected_fields` and structured metadata exposure |
 | `-emit-structured-metadata` | — | `true` | Enable Loki `categorize-labels` response encoding: requests with `X-Loki-Response-Encoding-Flags: categorize-labels` emit 3-tuples `[timestamp, line, metadata]`, while default/no-flag requests stay canonical 2-tuples |
+| `-patterns-enabled` | — | `true` | Enable `GET /loki/api/v1/patterns` (Grafana Logs Drilldown patterns view). When `false`, the endpoint returns `404 not_found` |
 | `-field-mapping` | `FIELD_MAPPING` | — | JSON custom field mappings |
 | `-stream-fields` | — | — | Comma-separated `_stream_fields` labels used for stream selector optimization and label-surface hints |
 | `-extra-label-fields` | `EXTRA_LABEL_FIELDS` | — | Comma-separated additional VL fields to expose on label-facing APIs and alias resolution paths (for example `host.id,k8s.cluster.name`) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@
 - [x] Per-endpoint cache/backend metrics, CB state gauge
 - [x] Fuzz testing (1.2M+ executions, no panics)
 - [x] Nested binary metric queries (`sum(rate(...)) / sum(rate(...))`)
-- [x] `/loki/api/v1/patterns` proxy-side drain-like pattern extraction
+- [x] `/loki/api/v1/patterns` proxy-side Loki-style Drain tokenizer/clustering extraction
 - [x] `direction` parameter (forward/backward sort)
 - [x] `quantile_over_time()` mapped to VL quantile
 - [x] `label_format` multi-rename (comma-separated)

--- a/internal/proxy/patterns_scale_bench_test.go
+++ b/internal/proxy/patterns_scale_bench_test.go
@@ -1,0 +1,123 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func buildPatternNDJSON(lines int) []byte {
+	if lines < 1 {
+		lines = 1
+	}
+	var b strings.Builder
+	b.Grow(lines * 140)
+	for i := range lines {
+		method := []string{"GET", "POST", "PUT", "DELETE"}[i%4]
+		status := []int{200, 201, 400, 500}[i%4]
+		msg := fmt.Sprintf(
+			"level=info msg=request method=%s route=/api/item/%d status=%d duration_ms=%d",
+			method,
+			i%2000,
+			status,
+			10+(i%900),
+		)
+		_, _ = fmt.Fprintf(
+			&b,
+			`{"_time":"2026-04-04T10:%02d:%02dZ","_msg":%q,"level":"info"}`+"\n",
+			(i/60)%60,
+			i%60,
+			msg,
+		)
+	}
+	return []byte(b.String())
+}
+
+func patternBypassRequests(requestCount int) []*http.Request {
+	if requestCount < 1 {
+		requestCount = 1
+	}
+	requests := make([]*http.Request, 0, requestCount)
+	for i := range requestCount {
+		req := benchmarkRequest(
+			fmt.Sprintf(
+				`/loki/api/v1/patterns?query={app="api"}&start=%d&end=%d&step=1m&limit=50`,
+				i+1,
+				i+2,
+			),
+		)
+		_ = req.ParseForm()
+		requests = append(requests, req)
+	}
+	return requests
+}
+
+func BenchmarkProxy_Patterns_Scale_CacheBypass(b *testing.B) {
+	scales := []int{100, 1000, 10000}
+	for _, scale := range scales {
+		scale := scale
+		b.Run("lines_"+strconv.Itoa(scale), func(b *testing.B) {
+			body := buildPatternNDJSON(scale)
+			mux, _ := newCompatBenchmarkProxy(b, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/select/logsql/query" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				_, _ = w.Write(body)
+			}, false)
+
+			// Keep a wide unique-request set so cache bypass remains representative
+			// under parallel benchmark load.
+			requests := patternBypassRequests(8192)
+			var idx atomic.Uint64
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				w := newBenchmarkResponseWriter()
+				for pb.Next() {
+					r := requests[int(idx.Add(1)-1)%len(requests)]
+					w.reset()
+					mux.ServeHTTP(w, r)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkProxy_Patterns_Scale_CacheHit(b *testing.B) {
+	scales := []int{100, 1000, 10000}
+	for _, scale := range scales {
+		scale := scale
+		b.Run("lines_"+strconv.Itoa(scale), func(b *testing.B) {
+			body := buildPatternNDJSON(scale)
+			mux, _ := newCompatBenchmarkProxy(b, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/select/logsql/query" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				_, _ = w.Write(body)
+			}, false)
+
+			rawURL := `/loki/api/v1/patterns?query={app="api"}&start=1&end=2&step=1m&limit=50`
+			warmRoute(mux, rawURL, nil)
+			req := benchmarkRequest(rawURL)
+			_ = req.ParseForm()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				w := newBenchmarkResponseWriter()
+				for pb.Next() {
+					w.reset()
+					mux.ServeHTTP(w, req)
+				}
+			})
+		})
+	}
+}

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -238,9 +238,7 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 	}
 	entries := make([]*patternBucket, 0, entryCap)
 	if len(clusters) <= limit {
-		for _, entry := range clusters {
-			entries = append(entries, entry)
-		}
+		entries = append(entries, clusters...)
 		sort.Slice(entries, func(i, j int) bool {
 			return entries[i].total > entries[j].total
 		})

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -17,12 +17,21 @@ import (
 var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 const maxPatternResponseLimit = 1000
+const (
+	patternVarPlaceholder = "<_>"
+	patternMinTokens      = 4
+	patternMaxTokens      = 80
+	patternSimThreshold   = 0.3
+	patternMaxLineLength  = 3000
+)
 
 type patternBucket struct {
-	pattern string
-	level   string
-	buckets map[int64]int
-	total   int
+	pattern     string
+	level       string
+	buckets     map[int64]int
+	total       int
+	tokens      []string
+	spacesAfter []int
 }
 
 // decolorizeStreams strips ANSI escape sequences from all log lines in streams.
@@ -166,9 +175,9 @@ func extractLineFormatTemplate(query string) string {
 	return ""
 }
 
-// extractLogPatterns implements a simplified drain-like pattern extraction.
-// Groups log lines by structural pattern and time bucket, returning the response
-// shape expected by Grafana Logs Drilldown's patterns resource.
+// extractLogPatterns implements Loki-style Drain-inspired pattern extraction.
+// It tokenizes lines with punctuation-aware splitting, clusters by similarity,
+// and returns Grafana Logs Drilldown compatible pattern buckets.
 func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]interface{} {
 	stepSeconds := int64(60)
 	if step != "" {
@@ -180,7 +189,7 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 	}
 
 	lines := strings.Split(string(vlBody), "\n")
-	patterns := make(map[string]*patternBucket)
+	miner := newPatternMiner()
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -203,8 +212,6 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 				continue
 			}
 		}
-
-		pattern := tokenizeToPattern(msg)
 		labels := buildEntryLabels(entry)
 		level := strings.TrimSpace(labels["detected_level"])
 		if level == "" {
@@ -214,18 +221,7 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 		if stepSeconds > 0 {
 			bucket = (bucket / stepSeconds) * stepSeconds
 		}
-		key := level + "\x00" + pattern
-		entryBucket := patterns[key]
-		if entryBucket == nil {
-			entryBucket = &patternBucket{
-				pattern: pattern,
-				level:   level,
-				buckets: map[int64]int{},
-			}
-			patterns[key] = entryBucket
-		}
-		entryBucket.buckets[bucket]++
-		entryBucket.total++
+		miner.Observe(level, msg, bucket)
 	}
 
 	// Sort by count descending
@@ -235,13 +231,14 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 	if limit > maxPatternResponseLimit {
 		limit = maxPatternResponseLimit
 	}
-	entryCap := len(patterns)
+	clusters := miner.AllClusters()
+	entryCap := len(clusters)
 	if entryCap > maxPatternResponseLimit {
 		entryCap = maxPatternResponseLimit
 	}
 	entries := make([]*patternBucket, 0, entryCap)
-	if len(patterns) <= limit {
-		for _, entry := range patterns {
+	if len(clusters) <= limit {
+		for _, entry := range clusters {
 			entries = append(entries, entry)
 		}
 		sort.Slice(entries, func(i, j int) bool {
@@ -250,7 +247,7 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 	} else {
 		h := &patternBucketHeap{}
 		heap.Init(h)
-		for _, entry := range patterns {
+		for _, entry := range clusters {
 			if h.Len() < limit {
 				heap.Push(h, entry)
 				continue
@@ -270,6 +267,7 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 
 	result := make([]map[string]interface{}, 0, len(entries))
 	for _, e := range entries {
+		e.pattern = miner.tokenizer.Join(e.tokens, e.spacesAfter)
 		sampleTimes := make([]int64, 0, len(e.buckets))
 		for bucket := range e.buckets {
 			sampleTimes = append(sampleTimes, bucket)
@@ -291,6 +289,222 @@ func extractLogPatterns(vlBody []byte, step string, limit int) []map[string]inte
 		result = append(result, item)
 	}
 	return result
+}
+
+type patternMiner struct {
+	tokenizer *patternLineTokenizer
+	// level -> tokenCount -> clusters
+	groups map[string]map[int][]*patternBucket
+}
+
+func newPatternMiner() *patternMiner {
+	return &patternMiner{
+		tokenizer: newPatternLineTokenizer(),
+		groups:    make(map[string]map[int][]*patternBucket),
+	}
+}
+
+func (m *patternMiner) Observe(level, line string, bucket int64) {
+	tokens, spacesAfter, ok := m.tokenizer.Tokenize(line)
+	if !ok {
+		return
+	}
+	tokenCount := len(tokens)
+
+	levelGroups := m.groups[level]
+	if levelGroups == nil {
+		levelGroups = make(map[int][]*patternBucket)
+		m.groups[level] = levelGroups
+	}
+	candidates := levelGroups[tokenCount]
+	cluster := bestPatternCluster(candidates, tokens)
+	if cluster == nil {
+		cluster = &patternBucket{
+			level:       level,
+			buckets:     make(map[int64]int),
+			tokens:      cloneTokens(tokens),
+			spacesAfter: cloneInts(spacesAfter),
+		}
+		levelGroups[tokenCount] = append(levelGroups[tokenCount], cluster)
+	} else {
+		cluster.tokens = mergePatternTemplate(cluster.tokens, tokens)
+	}
+	cluster.buckets[bucket]++
+	cluster.total++
+}
+
+func (m *patternMiner) AllClusters() []*patternBucket {
+	out := make([]*patternBucket, 0)
+	for _, byCount := range m.groups {
+		for _, clusters := range byCount {
+			out = append(out, clusters...)
+		}
+	}
+	return out
+}
+
+func bestPatternCluster(candidates []*patternBucket, tokens []string) *patternBucket {
+	var match *patternBucket
+	maxSim := -1.0
+	maxParamCount := -1
+
+	for _, cluster := range candidates {
+		curSim, paramCount := getPatternSimilarity(cluster.tokens, tokens)
+		if paramCount < 0 {
+			continue
+		}
+		if curSim > maxSim || (curSim == maxSim && paramCount > maxParamCount) {
+			maxSim = curSim
+			maxParamCount = paramCount
+			match = cluster
+		}
+	}
+	if maxSim >= patternSimThreshold {
+		return match
+	}
+	return nil
+}
+
+func getPatternSimilarity(templateTokens, tokens []string) (float64, int) {
+	if len(templateTokens) != len(tokens) || len(templateTokens) == 0 {
+		return 0, -1
+	}
+	simTokens := 0
+	paramCount := 0
+	for i := range templateTokens {
+		switch templateTokens[i] {
+		case patternVarPlaceholder:
+			paramCount++
+		case tokens[i]:
+			simTokens++
+		}
+	}
+	return float64(simTokens) / float64(len(templateTokens)), paramCount
+}
+
+func mergePatternTemplate(templateTokens, tokens []string) []string {
+	if len(templateTokens) != len(tokens) {
+		return templateTokens
+	}
+	for i := range templateTokens {
+		if templateTokens[i] != tokens[i] {
+			templateTokens[i] = patternVarPlaceholder
+		}
+	}
+	return templateTokens
+}
+
+type patternLineTokenizer struct {
+	includeDelimiters [128]rune
+	excludeDelimiters [128]rune
+}
+
+func newPatternLineTokenizer() *patternLineTokenizer {
+	var included [128]rune
+	var excluded [128]rune
+	included['='] = 1
+	excluded['_'] = 1
+	excluded['-'] = 1
+	excluded['.'] = 1
+	excluded[':'] = 1
+	excluded['/'] = 1
+	return &patternLineTokenizer{
+		includeDelimiters: included,
+		excludeDelimiters: excluded,
+	}
+}
+
+func (p *patternLineTokenizer) Tokenize(line string) ([]string, []int, bool) {
+	if len(line) == 0 || len(line) > patternMaxLineLength {
+		return nil, nil, false
+	}
+	tokens := make([]string, 0, 128)
+	spacesAfter := make([]int, 0, 64)
+
+	start := 0
+	for i, char := range line {
+		if len(tokens) >= 127 {
+			break
+		}
+		if unicode.IsLetter(char) || unicode.IsNumber(char) || (char < 128 && p.excludeDelimiters[char] != 0) {
+			continue
+		}
+		included := char < 128 && p.includeDelimiters[char] != 0
+		if char == ' ' || included || unicode.IsPunct(char) {
+			if i > start {
+				tokens = append(tokens, line[start:i])
+			}
+			if char == ' ' {
+				spacesAfter = append(spacesAfter, len(tokens)-1)
+			} else {
+				tokens = append(tokens, line[i:i+1])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(line) {
+		tokens = append(tokens, line[start:])
+	}
+
+	if len(tokens) < patternMinTokens || len(tokens) > patternMaxTokens {
+		return nil, nil, false
+	}
+	return tokens, spacesAfter, true
+}
+
+func (p *patternLineTokenizer) Join(tokens []string, spacesAfter []int) string {
+	if len(tokens) == 0 {
+		return ""
+	}
+	strBuilder := strings.Builder{}
+	spacesIdx := 0
+	for i, token := range tokens {
+		out := token
+		if token == patternVarPlaceholder {
+			out = patternVarPlaceholder
+		}
+		strBuilder.WriteString(out)
+		for spacesIdx < len(spacesAfter) && i == spacesAfter[spacesIdx] {
+			strBuilder.WriteByte(' ')
+			spacesIdx++
+		}
+	}
+	return deduplicatePlaceholders(strBuilder.String(), patternVarPlaceholder)
+}
+
+func deduplicatePlaceholders(line, placeholder string) string {
+	first := strings.Index(line, placeholder+placeholder)
+	if first == -1 {
+		return line
+	}
+	var b strings.Builder
+	b.Grow(len(line))
+	i := 0
+	for i < len(line) {
+		if strings.HasPrefix(line[i:], placeholder+placeholder) {
+			b.WriteString(placeholder)
+			i += len(placeholder)
+			for i < len(line) && strings.HasPrefix(line[i:], placeholder) {
+				i += len(placeholder)
+			}
+			continue
+		}
+		b.WriteByte(line[i])
+		i++
+	}
+	return b.String()
+}
+
+func cloneTokens(tokens []string) []string {
+	out := make([]string, len(tokens))
+	copy(out, tokens)
+	return out
+}
+
+func cloneInts(src []int) []int {
+	out := make([]int, len(src))
+	copy(out, src)
+	return out
 }
 
 type patternBucketHeap []*patternBucket

--- a/internal/proxy/postprocess_test.go
+++ b/internal/proxy/postprocess_test.go
@@ -309,7 +309,7 @@ func TestExtractLogPatternsRespectsLimit(t *testing.T) {
 func TestExtractLogPatterns_DefaultAndMaxLimitPaths(t *testing.T) {
 	lines := make([]string, 0, maxPatternResponseLimit+25)
 	for i := 0; i < maxPatternResponseLimit+25; i++ {
-		lines = append(lines, `{"_time":"2026-04-04T10:00:00Z","_msg":"route /item-`+strconv.Itoa(i)+` 200","level":"info"}`)
+		lines = append(lines, `{"_time":"2026-04-04T10:00:00Z","_msg":"tokA`+strconv.Itoa(i)+` tokB`+strconv.Itoa(i)+` tokC`+strconv.Itoa(i)+` tokD`+strconv.Itoa(i)+`","level":"info"}`)
 	}
 	vlBody := []byte(strings.Join(lines, "\n"))
 
@@ -346,6 +346,35 @@ func TestExtractLogPatterns_GroupsByBucketAndDetectedLevel(t *testing.T) {
 	}
 	if got := samples[0][1]; got != 2 {
 		t.Fatalf("expected warn bucket count 2, got %#v", got)
+	}
+}
+
+func TestExtractLogPatterns_DrainLikeTemplateMerging(t *testing.T) {
+	vlBody := []byte(strings.Join([]string{
+		`{"_time":"2026-04-04T10:00:01Z","_msg":"level=info msg=request id=1 user=alice"}`,
+		`{"_time":"2026-04-04T10:00:02Z","_msg":"level=info msg=request id=2 user=bob"}`,
+		`{"_time":"2026-04-04T10:00:03Z","_msg":"level=info msg=request id=3 user=carol"}`,
+	}, "\n"))
+
+	patterns := extractLogPatterns(vlBody, "1m", 10)
+	if len(patterns) != 1 {
+		t.Fatalf("expected one merged drain-like pattern, got %d", len(patterns))
+	}
+	got, _ := patterns[0]["pattern"].(string)
+	if got != "level=info msg=request id=<_> user=<_>" {
+		t.Fatalf("unexpected merged pattern: %q", got)
+	}
+}
+
+func TestExtractLogPatterns_SkipsTooShortMessagesLikeLokiDrain(t *testing.T) {
+	vlBody := []byte(strings.Join([]string{
+		`{"_time":"2026-04-04T10:00:01Z","_msg":"ok done"}`,
+		`{"_time":"2026-04-04T10:00:02Z","_msg":"still ok"}`,
+	}, "\n"))
+
+	patterns := extractLogPatterns(vlBody, "1m", 10)
+	if len(patterns) != 0 {
+		t.Fatalf("expected no patterns for messages below minimum token length, got %d", len(patterns))
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -254,6 +254,9 @@ type Config struct {
 	// EmitStructuredMetadata enables Loki 3-tuple stream values [ts, line, metadata].
 	// Disabled by default for conservative datasource compatibility.
 	EmitStructuredMetadata bool
+	// PatternsEnabled controls /loki/api/v1/patterns availability.
+	// Nil defaults to true for backward compatibility.
+	PatternsEnabled *bool
 	// Query range windowing/cache options.
 	// When enabled, eligible log query_range requests are split into time windows,
 	// fetched with bounded parallelism, and merged in Loki-compatible direction order.
@@ -396,6 +399,7 @@ type Proxy struct {
 	derivedFields                         []DerivedField
 	streamResponse                        bool
 	emitStructuredMetadata                bool
+	patternsEnabled                       bool
 	labelTranslator                       *LabelTranslator
 	metadataFieldMode                     MetadataFieldMode
 	streamFieldsMap                       map[string]bool  // known _stream_fields for VL stream selector optimization
@@ -707,6 +711,10 @@ func New(cfg Config) (*Proxy, error) {
 
 	labelTranslator := NewLabelTranslator(cfg.LabelStyle, cfg.FieldMappings)
 	declaredLabelFields := buildDeclaredLabelFields(cfg.StreamFields, cfg.ExtraLabelFields, labelTranslator)
+	patternsEnabled := true
+	if cfg.PatternsEnabled != nil {
+		patternsEnabled = *cfg.PatternsEnabled
+	}
 
 	return &Proxy{
 		backend:       u,
@@ -737,6 +745,7 @@ func New(cfg Config) (*Proxy, error) {
 		derivedFields:                         cfg.DerivedFields,
 		streamResponse:                        cfg.StreamResponse,
 		emitStructuredMetadata:                cfg.EmitStructuredMetadata,
+		patternsEnabled:                       patternsEnabled,
 		labelTranslator:                       labelTranslator,
 		metadataFieldMode:                     metadataFieldMode,
 		streamFieldsMap:                       buildStreamFieldsMap(cfg.StreamFields),
@@ -3406,6 +3415,11 @@ func (p *Proxy) detectedLabelValuesForField(ctx context.Context, fieldName, quer
 // handlePatterns returns log patterns for Grafana Logs Drilldown.
 func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
+	if !p.patternsEnabled {
+		p.writeError(w, http.StatusNotFound, "patterns endpoint is disabled")
+		p.metrics.RecordRequest("patterns", http.StatusNotFound, time.Since(start))
+		return
+	}
 	if p.handleMultiTenantFanout(w, r, "patterns", p.handlePatterns) {
 		return
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -600,6 +600,35 @@ func TestContract_Patterns_ResponseFormat(t *testing.T) {
 	}
 }
 
+func TestContract_Patterns_DisabledReturnsNotFound(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer vlBackend.Close()
+
+	disabled := false
+	p, err := New(Config{
+		BackendURL:      vlBackend.URL,
+		PatternsEnabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/patterns?query=%7B%7D&start=1&end=2", nil)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when patterns endpoint is disabled, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp["errorType"] != "not_found" {
+		t.Fatalf("expected not_found errorType, got %v", resp["errorType"])
+	}
+}
+
 // --- /loki/api/v1/tail ---
 
 func TestContract_Tail_RequiresQuery(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace simplified /loki/api/v1/patterns extraction with Loki-style Drain-inspired tokenization/similarity clustering
- add explicit -patterns-enabled flag (default true) and endpoint gating (404 not_found when disabled)
- add patterns behavior tests and new scale benchmarks with CI regression guard
- expose patterns-enabled in Helm chart extraArgs and update docs

## Validation
- go test ./cmd/proxy ./internal/proxy
- go test ./internal/proxy -run "TestExtractLogPatterns|TestContract_Patterns|TestHandlePatternsReuseCachedResponse"
- go test ./internal/proxy -run '^$' -bench 'BenchmarkProxy_Patterns_Scale_' -benchmem -count=1 -benchtime=200ms