### PR TITLE
Refresh 1.0.x docs and observability guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- refresh the README, API reference, observability guide, operations guide, and operational-resources runbook for the `1.0.0` through `1.0.6` release line, including patterns support, route-aware request dimensions, and the renamed `Operational Resources` dashboard section
+
 ### CI
 
 - stabilize the label/field benchmark regression guard by raising only the catastrophic threshold for `BenchmarkProxy_LabelKeys_Scale_CacheBypass/keys_10000`, preventing flaky failures on shared GitHub runners while preserving strict bounds for other scale rows

--- a/README.md
+++ b/README.md
@@ -28,14 +28,6 @@ No custom Grafana datasource plugin. No sidecar translation service. One small s
 
 Related docs: [Architecture](docs/architecture.md), [Compatibility Matrix](docs/compatibility-matrix.md), [Operations](docs/operations.md)
 
-## 1.0.x Release Line
-
-The `1.0.x` line tightened the product around stable read compatibility, operator visibility, and safer release hygiene without changing the core scope.
-
-- **`1.0.0`**: established the stable `1.x` line with production-focused compatibility, long-range query hardening, and documented support/release policy.
-- **`1.0.1` to `1.0.3`**: fixed Drilldown edge cases, improved metadata path caching, and added route-aware upstream/downstream request telemetry aligned to OTel HTTP semantics.
-- **`1.0.4` to `1.0.6`**: refreshed the packaged operations dashboard, added prefixed process disk-operation metrics plus a CI guard against new unprefixed metrics, and introduced the Loki-compatible `/loki/api/v1/patterns` API with explicit runtime gating.
-
 ## Key Features
 
 ### Compatibility

--- a/README.md
+++ b/README.md
@@ -28,12 +28,21 @@ No custom Grafana datasource plugin. No sidecar translation service. One small s
 
 Related docs: [Architecture](docs/architecture.md), [Compatibility Matrix](docs/compatibility-matrix.md), [Operations](docs/operations.md)
 
+## 1.0.x Release Line
+
+The `1.0.x` line tightened the product around stable read compatibility, operator visibility, and safer release hygiene without changing the core scope.
+
+- **`1.0.0`**: established the stable `1.x` line with production-focused compatibility, long-range query hardening, and documented support/release policy.
+- **`1.0.1` to `1.0.3`**: fixed Drilldown edge cases, improved metadata path caching, and added route-aware upstream/downstream request telemetry aligned to OTel HTTP semantics.
+- **`1.0.4` to `1.0.6`**: refreshed the packaged operations dashboard, added prefixed process disk-operation metrics plus a CI guard against new unprefixed metrics, and introduced the Loki-compatible `/loki/api/v1/patterns` API with explicit runtime gating.
+
 ## Key Features
 
 ### Compatibility
 
 - Loki-compatible read API for Grafana datasource, Explore, Drilldown, and API clients.
 - Strict tuple contracts: default 2-tuple, explicit 3-tuple only via `categorize-labels`.
+- Grafana Logs Drilldown patterns support through `/loki/api/v1/patterns`, with explicit `-patterns-enabled` control when deployments need it disabled.
 - Multi-tenant read fanout with tenant isolation guardrails.
 - Rules and alerts read compatibility from `vmalert`.
 
@@ -46,9 +55,11 @@ Related docs: [Architecture](docs/architecture.md), [Compatibility Matrix](docs/
 
 ### Operations
 
-- Structured metrics and logs for cache, latency, fanout, tenant/client visibility.
+- Route-aware upstream/downstream metrics and semconv-aligned structured logs for client, proxy, and VictoriaLogs visibility.
+- Packaged operator dashboard covering `Client -> Proxy -> VictoriaLogs`, query-range resilience, cache behavior, and operational resources.
 - Helm-ready deployment model for production clusters.
 - Compatibility CI tracks for Loki, Logs Drilldown, and VictoriaLogs.
+- CI guardrails to keep new app metrics under the `loki_vl_proxy_*` prefix.
 - Runbook-backed alerting assets for operational response.
 
 Related docs: [Compatibility Matrix](docs/compatibility-matrix.md), [Observability](docs/observability.md), [Testing](docs/testing.md)
@@ -202,6 +213,15 @@ helm install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-vl-proxy \
   --set extraArgs.backend=http://victorialogs:9428
 ```
 
+For Grafana Logs Drilldown pattern discovery, keep the default `patterns-enabled=true` or set it explicitly during rollout:
+
+```bash
+helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-vl-proxy \
+  --version <release> \
+  --set extraArgs.backend=http://victorialogs:9428 \
+  --set extraArgs.patterns-enabled=true
+```
+
 For high-cardinality label-value browsing, tune indexed browse cache directly via chart flags:
 
 ```bash
@@ -332,7 +352,7 @@ See [Performance](docs/performance.md), [Fleet Cache](docs/fleet-cache.md), [Sca
 - [High Error Rate](docs/runbooks/loki-vl-proxy-high-error-rate.md)
 - [High Latency](docs/runbooks/loki-vl-proxy-high-latency.md)
 - [Rate Limiting](docs/runbooks/loki-vl-proxy-rate-limiting.md)
-- [System Resources](docs/runbooks/loki-vl-proxy-system-resources.md)
+- [Operational Resources](docs/runbooks/loki-vl-proxy-system-resources.md)
 - [Tenant High Error Rate](docs/runbooks/loki-vl-proxy-tenant-high-error-rate.md)
 
 ### Testing and Release

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,13 +10,13 @@
 | `GET /loki/api/v1/labels` | Implemented | `/select/logsql/stream_field_names` with fallback to `/select/logsql/field_names` | 60s | 3 |
 | `GET /loki/api/v1/label/{name}/values` | Implemented | `/select/logsql/stream_field_values` with fallback to `/select/logsql/field_values` | 60s | 3 |
 | `GET /loki/api/v1/series` | Implemented | `/select/logsql/streams` | 30s | 2 |
-| `GET /loki/api/v1/index/stats` | Implemented | `/select/logsql/hits` | - | 2 |
-| `GET /loki/api/v1/index/volume` | Implemented | `/select/logsql/hits` (field grouping) | - | 2 |
-| `GET /loki/api/v1/index/volume_range` | Implemented | `/select/logsql/hits` (step) | - | 2 |
+| `GET /loki/api/v1/index/stats` | Implemented | `/select/logsql/hits` | 10s | 2 |
+| `GET /loki/api/v1/index/volume` | Implemented | `/select/logsql/hits` (field grouping) | 10s | 2 |
+| `GET /loki/api/v1/index/volume_range` | Implemented | `/select/logsql/hits` (step) | 10s | 2 |
 | `GET /loki/api/v1/detected_fields` | Implemented | `/select/logsql/field_names` | 30s | 1 |
-| `GET /loki/api/v1/detected_field/{name}/values` | Implemented | `/select/logsql/field_values` | - | 1 |
-| `GET /loki/api/v1/detected_labels` | Implemented | `/select/logsql/field_names` | - | 1 |
-| `GET /loki/api/v1/patterns` | Implemented (toggleable) | `/select/logsql/query` + Drain-like token clustering | - | 4 |
+| `GET /loki/api/v1/detected_field/{name}/values` | Implemented | `/select/logsql/field_values` | 30s | 1 |
+| `GET /loki/api/v1/detected_labels` | Implemented | `/select/logsql/field_names` | 30s | 1 |
+| `GET /loki/api/v1/patterns` | Implemented (toggleable) | `/select/logsql/query` + Drain-like token clustering | 20s | 4 |
 | `GET /loki/api/v1/format_query` | Implemented | - (passthrough) | - | 1 |
 | `WS /loki/api/v1/tail` | Implemented | `/select/logsql/tail` (WebSocket->NDJSON) | - | 2 |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,7 +8,9 @@ Loki-VL-proxy emits the same core operational signals in two forms:
 | Metrics | Push | OTLP HTTP JSON to `/v1/metrics` | OpenTelemetry Collector, vendor OTLP gateways |
 | Logs | Stream | Structured JSON on stdout/stderr | Fluent Bit, Vector, OpenTelemetry Collector, Docker/Kubernetes log agents |
 
-The intent is parity, not two separate products. Prometheus scrape and OTLP push carry the same proxy-centric metrics with the same names, labels, and units for the important operational paths:
+The intent is parity, not two separate products. Prometheus scrape and OTLP push carry the same proxy-centric metric families, units, and low-cardinality request dimensions for the important operational paths. Prometheus uses label keys such as `system`, `direction`, `endpoint`, `route`, and `status`; OTLP exports the same dimensions as semantically aligned attributes such as `loki.api.system`, `proxy.direction`, `loki.request.type`, `http.route`, and `http.response.status_code`.
+
+That shared model is what makes the packaged dashboard portable across scrape-backed and OTLP-backed setups without rewriting the operator view:
 
 - request volume and latency
 - backend latency
@@ -48,16 +50,21 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
   },
   "body": "request",
   "component": "proxy",
-  "http.route": "query_range",
+  "http.route": "/loki/api/v1/query_range",
+  "url.path": "/loki/api/v1/query_range",
   "http.request.method": "GET",
   "http.response.status_code": 200,
-  "event.duration_ms": 42,
+  "loki.request.type": "query_range",
+  "loki.api.system": "loki",
+  "proxy.direction": "downstream",
+  "event.duration": 42000000,
   "loki.tenant.id": "team-a",
   "loki.query": "{service_name=\"api\"} |= \"error\"",
   "client.address": "10.0.0.12:51884",
   "enduser.id": "grafana-user@example.com",
   "enduser.source": "grafana_user",
   "cache.result": "miss",
+  "proxy.duration_ms": 42,
   "upstream.calls": 1,
   "upstream.status_code": 200,
   "upstream.duration_ms": 31,
@@ -89,13 +96,15 @@ The proxy writes structured logs for:
 | `severity.text` / `severity.number` | log severity |
 | `body` | message body |
 | `component` | internal subsystem (`proxy`, `disk_cache`, `cache_warmer`, `otlp_metrics`) |
-| `http.*` | request semantics |
+| `http.*` / `url.path` | request semantics and normalized route vs actual request path |
+| `event.duration` | request or upstream call duration in nanoseconds |
 | `client.address` | remote address |
 | `enduser.id` | stable trusted user/client identity when available |
 | `enduser.name` | display/login user name from trusted user headers when available |
 | `enduser.source` | trusted header source for end-user attribution (`grafana_user`, `forwarded_user`, etc.) |
 | `auth.*` | datasource/auth principal context (separate from `enduser.id`) |
 | `cache.result` | compatibility cache result (`hit`, `miss`, `bypass`) |
+| `proxy.*` | proxy-facing convenience fields such as total request duration and measured proxy overhead |
 | `upstream.*` | backend call count, status, and latency |
 | `loki.*` | Loki/proxy-specific attributes |
 
@@ -140,17 +149,31 @@ resource metadata to avoid `message.service.*` duplication in storage.
 | `-otel-service-instance-id` | `service.instance.id` |
 | `-deployment-environment` | `deployment.environment.name` |
 
+### Request Dimensions
+
+Request-oriented metrics use stable low-cardinality dimensions so dashboards can slice by user-visible API shape without leaking raw paths or query content.
+
+| Dimension | Prometheus scrape | OTLP push | Example |
+|---|---|---|---|
+| API system | `system` | `loki.api.system` | `loki`, `vl` |
+| Direction | `direction` | `proxy.direction` | `downstream`, `upstream` |
+| Request type | `endpoint` | `loki.request.type` | `query_range`, `labels`, `patterns` |
+| Route template | `route` | `http.route` | `/loki/api/v1/query_range`, `/select/logsql/query` |
+| Final status | `status` | `http.response.status_code` | `200`, `429`, `500` |
+
+Downstream routes are the normalized Loki API templates registered by the proxy. Upstream routes are the stable VictoriaLogs or rules/alerts backend path templates used by the proxy itself. Raw request paths and query strings stay in logs, not in metric labels.
+
 ### Core Proxy Metrics
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `loki_vl_proxy_requests_total` | counter | `endpoint`, `status` | all proxied requests |
-| `loki_vl_proxy_request_duration_seconds` | histogram | `endpoint` | end-to-end request latency |
-| `loki_vl_proxy_backend_duration_seconds` | histogram | `endpoint` | upstream VictoriaLogs latency only |
+| `loki_vl_proxy_requests_total` | counter | `system`, `direction`, `endpoint`, `route`, `status` | all proxied requests, sliced by downstream Loki path or upstream backend path |
+| `loki_vl_proxy_request_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | end-to-end request latency |
+| `loki_vl_proxy_backend_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | upstream backend latency only (`system="vl"`, `direction="upstream"`) |
 | `loki_vl_proxy_cache_hits_total` | counter | none | global cache hits |
 | `loki_vl_proxy_cache_misses_total` | counter | none | global cache misses |
-| `loki_vl_proxy_cache_hits_by_endpoint` | counter | `endpoint` | cache hits per endpoint |
-| `loki_vl_proxy_cache_misses_by_endpoint` | counter | `endpoint` | cache misses per endpoint |
+| `loki_vl_proxy_cache_hits_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | cache hits per normalized route |
+| `loki_vl_proxy_cache_misses_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | cache misses per normalized route |
 | `loki_vl_proxy_translations_total` | counter | none | successful LogQL to LogsQL translations |
 | `loki_vl_proxy_translation_errors_total` | counter | none | failed translations |
 | `loki_vl_proxy_coalesced_total` | counter | none | requests served from coalesced results |
@@ -195,15 +218,15 @@ These are the metrics to use when you want to identify the users or tenants actu
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `loki_vl_proxy_tenant_requests_total` | counter | `tenant`, `endpoint`, `status` | request volume by tenant |
-| `loki_vl_proxy_tenant_request_duration_seconds` | histogram | `tenant`, `endpoint` | latency by tenant |
-| `loki_vl_proxy_client_requests_total` | counter | `client`, `endpoint` | request volume by client identity |
+| `loki_vl_proxy_tenant_requests_total` | counter | `system`, `direction`, `tenant`, `endpoint`, `route`, `status` | request volume by tenant |
+| `loki_vl_proxy_tenant_request_duration_seconds` | histogram | `system`, `direction`, `tenant`, `endpoint`, `route` | latency by tenant |
+| `loki_vl_proxy_client_requests_total` | counter | `system`, `direction`, `client`, `endpoint`, `route` | request volume by client identity |
 | `loki_vl_proxy_client_response_bytes_total` | counter | `client` | response bytes by client |
-| `loki_vl_proxy_client_status_total` | counter | `client`, `endpoint`, `status` | final status breakdown by client |
+| `loki_vl_proxy_client_status_total` | counter | `system`, `direction`, `client`, `endpoint`, `route`, `status` | final status breakdown by client |
 | `loki_vl_proxy_client_inflight_requests` | gauge | `client` | current parallelism by client |
-| `loki_vl_proxy_client_request_duration_seconds` | histogram | `client`, `endpoint` | request latency by client |
-| `loki_vl_proxy_client_query_length_chars` | histogram | `client`, `endpoint` | query size outliers by client |
-| `loki_vl_proxy_client_errors_total` | counter | `endpoint`, `reason` | categorized 4xx-style client errors |
+| `loki_vl_proxy_client_request_duration_seconds` | histogram | `system`, `direction`, `client`, `endpoint`, `route` | request latency by client |
+| `loki_vl_proxy_client_query_length_chars` | histogram | `system`, `direction`, `client`, `endpoint`, `route` | query size outliers by client |
+| `loki_vl_proxy_client_errors_total` | counter | `system`, `direction`, `endpoint`, `route`, `reason` | categorized downstream client errors |
 
 ### Runtime and Process Metrics
 
@@ -217,6 +240,7 @@ App-scoped aliases are emitted with the `loki_vl_proxy_` prefix, while legacy `g
 | `loki_vl_proxy_process_cpu_usage_ratio` (`process_cpu_usage_ratio` alias) | CPU pressure split by `mode` |
 | `loki_vl_proxy_process_memory_*` (`process_memory_*` aliases) | total, free, available, usage ratio |
 | `loki_vl_proxy_process_disk_*_bytes_total` (`process_disk_*_bytes_total` aliases) | disk I/O counters |
+| `loki_vl_proxy_process_disk_*_operations_total` | disk read/write operation counters |
 | `loki_vl_proxy_process_network_*_bytes_total` (`process_network_*_bytes_total` aliases) | network I/O counters |
 | `loki_vl_proxy_process_pressure_*` (`process_pressure_*` aliases) | Linux PSI gauges when available |
 
@@ -226,29 +250,38 @@ Kubernetes notes:
 - On startup, the proxy logs a system-metrics readiness check with missing families and remediation hints instead of failing silently.
 - If you mount host `/proc` (`-proc-root=/host/proc`), these metrics will reflect host scope; keep default pod `/proc` for pod/container scope.
 - For per-pod attribution in OTLP backends, set `OTEL_SERVICE_INSTANCE_ID` from pod name and `OTEL_SERVICE_NAMESPACE` from pod namespace (the upstream chart now injects these by default).
+- CI includes a metric-name guard so new app metrics must stay under the `loki_vl_proxy_*` prefix unless explicitly allowlisted for compatibility.
 
 ### PromQL Drilldowns For Slowness And Client Errors
 
-Use these queries to quickly isolate backend slowness vs proxy/client-side failures:
+Use these queries to quickly isolate downstream client pain, upstream slowness, and route-specific cache efficiency:
 
 | Goal | Query |
 |---|---|
-| Backend p95 latency by endpoint | `histogram_quantile(0.95, sum(rate(loki_vl_proxy_backend_duration_seconds_bucket[5m])) by (le, endpoint))` |
-| Proxy p99 end-to-end latency by endpoint | `histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket[5m])) by (le, endpoint))` |
-| Tenant p99 latency | `histogram_quantile(0.99, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_bucket[5m])) by (le, tenant, endpoint))` |
-| 5xx rate by endpoint | `sum(rate(loki_vl_proxy_requests_total{status=~"5.."}[5m])) by (endpoint)` |
-| Client bad_request by client+endpoint | `sum(rate(loki_vl_proxy_client_errors_total{reason="bad_request"}[5m])) by (client, endpoint)` |
-| Client rate_limited by client+endpoint | `sum(rate(loki_vl_proxy_client_errors_total{reason="rate_limited"}[5m])) by (client, endpoint)` |
+| Downstream p95 latency by route | `histogram_quantile(0.95, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{system="loki",direction="downstream"}[5m])) by (le, endpoint, route))` |
+| Upstream p95 latency by route | `histogram_quantile(0.95, sum(rate(loki_vl_proxy_backend_duration_seconds_bucket{system="vl",direction="upstream"}[5m])) by (le, endpoint, route))` |
+| Downstream 5xx rate by route | `sum(rate(loki_vl_proxy_requests_total{system="loki",direction="downstream",status=~"5.."}[5m])) by (endpoint, route)` |
+| Tenant p99 latency by route | `histogram_quantile(0.99, sum(rate(loki_vl_proxy_tenant_request_duration_seconds_bucket{system="loki",direction="downstream"}[5m])) by (le, tenant, endpoint, route))` |
+| Route cache hit ratio | `sum(rate(loki_vl_proxy_cache_hits_by_endpoint{system="loki",direction="downstream"}[5m])) by (endpoint, route) / clamp_min(sum(rate(loki_vl_proxy_cache_hits_by_endpoint{system="loki",direction="downstream"}[5m])) by (endpoint, route) + sum(rate(loki_vl_proxy_cache_misses_by_endpoint{system="loki",direction="downstream"}[5m])) by (endpoint, route), 1)` |
+| Client bad_request by route | `sum(rate(loki_vl_proxy_client_errors_total{system="loki",direction="downstream",reason="bad_request"}[5m])) by (endpoint, route)` |
 
-For latency histograms, keep dashboards on `p50`, `p95`, and `p99` rather than averages. Averages hide tail latency incidents.
+For latency histograms, keep dashboards on `p50`, `p95`, and `p99` rather than averages. Averages hide tail latency incidents. For exact proxy-only overhead, use structured logs (`proxy.overhead_ms`) alongside the latency histograms; subtracting histogram quantiles is not mathematically reliable.
 
-The packaged `Loki-VL-Proxy` dashboard also includes a `System Resources` section with:
+The packaged `Loki-VL-Proxy` dashboard includes an `Operational Resources` section with:
 
-- memory usage ratio
+- memory saturation and memory footprint/headroom
 - CPU usage split by mode
+- disk IOPS up/down and disk throughput up/down
+- network up/down
 - PSI pressure (cpu/memory/io)
-- disk and network throughput
-- process RSS and open file descriptors
+- process RSS and open file descriptors by pod
+
+The top of the dashboard is organized as a left-to-right operator flow:
+
+- `Main Overview - Client -> Proxy -> VictoriaLogs`
+- `Client Edge - Request Quality & Shape`
+- `Heavy Consumers - Client Load Drivers`
+- `Proxy -> VictoriaLogs Query Pipeline`
 
 It also includes a `Query-Range Windowing` section for cache/tuning signals:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,6 +28,15 @@ helm install loki-vl-proxy ./charts/loki-vl-proxy \
 
 For multi-replica fleets with HPA, prefer `peerCache.enabled=true` over static peer lists. The chart creates a headless service and the proxy refreshes DNS-discovered peers automatically, so scaling events do not require manual replica or peer updates.
 
+For Grafana Logs Drilldown pattern discovery, keep the default `extraArgs.patterns-enabled=true` or set it explicitly during rollout if you need to control the surface area:
+
+```yaml
+extraArgs:
+  backend: http://victorialogs:9428
+  label-style: underscores
+  patterns-enabled: "true"
+```
+
 ### Required Configuration
 
 | Flag | Required | Description |
@@ -62,7 +71,7 @@ Treat these as one versioned operational package:
 
 | Asset | Canonical source | Purpose |
 |------|------------------|---------|
-| Grafana operations dashboard | [`dashboard/loki-vl-proxy.json`](../dashboard/loki-vl-proxy.json) | SLO and troubleshooting views for request, cache, tenant, and backend signals from proxy metrics |
+| Grafana operations dashboard | [`dashboard/loki-vl-proxy.json`](../dashboard/loki-vl-proxy.json) | Operator view for `Client -> Proxy -> VictoriaLogs`, route-aware RED signals, cache behavior, long-range query tuning, and operational resources |
 | Alert rules | [`alerting/loki-vl-proxy-prometheusrule.yaml`](../alerting/loki-vl-proxy-prometheusrule.yaml) | PrometheusRule/vmalert-oriented alert set with standardized labels and annotations |
 | SRE runbooks | [`docs/runbooks/alerts.md`](runbooks/alerts.md) | Index plus per-alert runbook files referenced directly from alert `runbook_url` |
 
@@ -206,21 +215,21 @@ See the dedicated [Observability Guide](observability.md) for the full metrics c
 
 The proxy exposes Prometheus metrics at `/metrics`:
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `loki_vl_proxy_requests_total{endpoint,status}` | counter | Total requests by endpoint and HTTP status |
-| `loki_vl_proxy_request_duration_seconds{endpoint}` | histogram | Request latency by endpoint |
-| `loki_vl_proxy_cache_hits_total` | counter | L1 cache hits |
-| `loki_vl_proxy_cache_misses_total` | counter | L1 cache misses |
-| `loki_vl_proxy_translations_total` | counter | LogQL→LogsQL translations |
-| `loki_vl_proxy_translation_errors_total` | counter | Failed translations |
-| `loki_vl_proxy_uptime_seconds` | gauge | Process uptime |
+| Metric | Type | Primary dimensions | Description |
+|--------|------|--------------------|-------------|
+| `loki_vl_proxy_requests_total` | counter | `system`, `direction`, `endpoint`, `route`, `status` | Total requests by downstream Loki route or upstream backend route |
+| `loki_vl_proxy_request_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | End-to-end request latency |
+| `loki_vl_proxy_backend_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | Upstream-only latency for VictoriaLogs and rules/alerts backends |
+| `loki_vl_proxy_cache_hits_by_endpoint` / `loki_vl_proxy_cache_misses_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | Cache efficiency by normalized route |
+| `loki_vl_proxy_tenant_requests_total` / `loki_vl_proxy_client_requests_total` | counter | tenant/client plus route dimensions | Hot tenants and clients per route |
+| `loki_vl_proxy_process_*` | gauges/counters | metric family specific | Runtime, CPU, memory, disk, network, and PSI health |
 
 ### Key Ratios to Monitor
 
-- **Cache hit ratio**: `cache_hits / (cache_hits + cache_misses)` — target >80%
-- **Error rate**: `requests_total{status=~"5.."} / requests_total` — target <1%
-- **P99 latency**: from histogram — target <2s for queries, <100ms for labels
+- **Route cache hit ratio**: `cache_hits_by_endpoint / (cache_hits_by_endpoint + cache_misses_by_endpoint)` by `endpoint,route` — target >80% on stable metadata paths
+- **Downstream error rate**: `requests_total{system="loki",direction="downstream",status=~"5.."}` over total downstream requests — target <1%
+- **Upstream latency**: `backend_duration_seconds` by `endpoint,route` — use this to separate VictoriaLogs slowness from proxy-side work
+- **End-to-end latency**: `request_duration_seconds{system="loki",direction="downstream"}` by `endpoint,route` — compare with upstream latency and request logs
 
 ### OTLP Push
 
@@ -233,6 +242,8 @@ Push metrics to an OTLP collector:
 ```
 
 The OTLP exporter reuses the same core proxy metric names that `/metrics` exposes, so dashboards and alert logic can stay aligned across scrape and push modes.
+
+For exact proxy-only overhead on translated paths, use structured request logs with `proxy.overhead_ms`, `proxy.duration_ms`, and `upstream.duration_ms`. The metrics intentionally keep route-aware end-to-end and upstream histograms, while logs carry the per-request decomposition.
 
 ---
 

--- a/docs/runbooks/loki-vl-proxy-system-resources.md
+++ b/docs/runbooks/loki-vl-proxy-system-resources.md
@@ -1,4 +1,4 @@
-# LokiVLProxy System Resources
+# LokiVLProxy Operational Resources
 
 ## Alerts Covered
 
@@ -19,9 +19,9 @@
 1. Confirm proxy health:
    - `curl -fsS http://<proxy>:3100/ready`
 2. Confirm metrics endpoint includes system families:
-   - `curl -fsS http://<proxy>:3100/metrics | rg "process_memory_usage_ratio|process_cpu_usage_ratio|process_pressure_"`
+   - `curl -fsS http://<proxy>:3100/metrics | rg "loki_vl_proxy_process_memory_usage_ratio|loki_vl_proxy_process_cpu_usage_ratio|loki_vl_proxy_process_pressure_|loki_vl_proxy_process_disk_(read|write)_operations_total"`
 3. Inspect startup diagnostics in proxy logs for system-metrics check output.
-4. Check dashboard section `System Resources` for memory, PSI, disk, and network trends.
+4. Check dashboard section `Operational Resources` for memory, CPU, PSI, disk IOPS/throughput, and network trends.
 
 ## Kubernetes-Specific Checks
 
@@ -41,7 +41,7 @@
    - move to nodes with higher memory/IO capacity when sustained pressure persists
 3. Validate backend health:
    - correlate with VictoriaLogs latency and error metrics
-   - inspect backend disk/network saturation
+   - inspect backend disk/network saturation and compare with proxy-side disk/network direction graphs
 
 ## Recovery Criteria
 


### PR DESCRIPTION
## Summary
- refresh the README for the 1.0.0 through 1.0.6 release line and add explicit patterns support and operator-visibility highlights
- align the API reference, observability guide, operations guide, and operational-resources runbook with the shipped route-aware telemetry model
- replace stale System Resources wording with Operational Resources and document the current dashboard and resource view

## Validation
- git diff --check
- python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD
- changelog gate: skipped (no releasable changes detected)