### PR TITLE
Fix drilldown-core patterns UI CI failure on missing seed stream

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,17 @@ jobs:
       - name: Start e2e stack
         working-directory: test/e2e-compat
         run: |
-          docker compose up -d --no-build
+          for attempt in 1 2 3; do
+            if docker compose up -d --no-build; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "docker compose up failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "docker compose up failed (attempt ${attempt}), retrying in 10s..."
+            sleep 10
+          done
           ../../scripts/ci/wait_e2e_stack.sh 180
 
       - name: Seed smoke data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - e2e compat: add Drilldown contract coverage for pattern flags and query-range-seeded autodetection through Grafana datasource resources
 - e2e compat: add dedicated autodetect proxy verification (`localhost:3110`) asserting `patterns_detected_total` increases after `query_range`
 - e2e UI: add Playwright Drilldown regression test proving `/resources/patterns` returns non-empty data for autodetect-enabled datasource
+- e2e UI: stabilize Drilldown patterns autodetect test by seeding and validating against the guaranteed `api-gateway` stream in CI stacks
 
 ## [1.0.10] - 2026-04-14
 

--- a/scripts/ci/check_changelog_pr.py
+++ b/scripts/ci/check_changelog_pr.py
@@ -160,7 +160,10 @@ def main() -> int:
     commits = run_git("log", "--pretty=format:%s", f"{args.base}..{args.head}").splitlines()
 
     base_text = run_git("show", f"{args.base}:CHANGELOG.md")
-    head_text = CHANGELOG.read_text(encoding="utf-8")
+    # In PR workflows, checkout can point at the synthetic merge ref instead of
+    # the PR head commit. Read changelog directly from --head to avoid false
+    # negatives when base moved after the PR was opened.
+    head_text = run_git("show", f"{args.head}:CHANGELOG.md")
     base_unreleased = extract_unreleased_section(base_text)
     head_unreleased = extract_unreleased_section(head_text)
 

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -79,6 +79,89 @@ function nsRangeLastDay() {
   return { start, end };
 }
 
+function uniqueQueries(queries: string[]) {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const query of queries) {
+    const normalized = query.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+async function seedPatternsStream(page: Page, uid: string) {
+  const nowNs = BigInt(Date.now()) * 1_000_000n;
+  const payload = {
+    streams: [
+      {
+        stream: {
+          app: "pattern-test",
+          service_name: "pattern-test",
+          level: "info",
+          cluster: "e2e",
+        },
+        values: [
+          [
+            (nowNs - 2_000_000_000n).toString(),
+            'time="2026-04-14T11:00:00Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=GetThing grpc.service=DemoService grpc.start_time="2026-04-14T11:00:00Z" grpc.time_ms=7 span.kind=server system=grpc',
+          ],
+          [
+            nowNs.toString(),
+            'time="2026-04-14T11:00:01Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=ListThings grpc.service=DemoService grpc.start_time="2026-04-14T11:00:01Z" grpc.time_ms=9 span.kind=server system=grpc',
+          ],
+        ],
+      },
+    ],
+  };
+
+  await page.request.post(`/api/datasources/proxy/uid/${uid}/loki/api/v1/push`, {
+    data: payload,
+  });
+}
+
+async function discoverLabelValueQueries(
+  page: Page,
+  uid: string,
+  start: number,
+  end: number
+) {
+  const labels = ["service_name", "app", "service", "job", "namespace", "pod", "container"];
+  const discovered: string[] = [];
+
+  for (const label of labels) {
+    const params = new URLSearchParams();
+    params.set("start", String(start));
+    params.set("end", String(end));
+    const response = await page.request.get(
+      `/api/datasources/proxy/uid/${uid}/loki/api/v1/label/${encodeURIComponent(label)}/values?${params.toString()}`
+    );
+    if (!response.ok()) {
+      continue;
+    }
+    const payload = (await response.json().catch(() => null)) as {
+      status?: string;
+      data?: unknown[];
+    } | null;
+    if (payload?.status !== "success" || !Array.isArray(payload.data)) {
+      continue;
+    }
+    for (const rawValue of payload.data) {
+      if (typeof rawValue !== "string" || rawValue.trim().length === 0) {
+        continue;
+      }
+      const value = rawValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      discovered.push(`{${label}="${value}"}`);
+      break;
+    }
+  }
+
+  return discovered;
+}
+
 async function waitForAutodetectedPatterns(
   page: Page,
   datasource: string,
@@ -91,7 +174,16 @@ async function waitForAutodetectedPatterns(
   let lastSeedPayload: unknown = null;
   let lastQuery = "";
   const { start, end } = nsRangeLastDay();
-  const fallbackQueries = [...queries];
+  await seedPatternsStream(page, uid);
+  const discoveredQueries = await discoverLabelValueQueries(page, uid, start, end);
+  const fallbackQueries = uniqueQueries([
+    '{app="pattern-test"}',
+    '{service_name="pattern-test"}',
+    ...queries,
+    ...discoveredQueries,
+    '{service_name=~".+"}',
+    '{app=~".+"}',
+  ]);
   const serviceKeys = [
     "service_name",
     "service.name",

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -65,10 +65,11 @@ async function openServiceDrilldown(
   page: Page,
   datasource: string,
   serviceName: string,
-  view: "logs" | "fields" = "logs"
+  view: "logs" | "fields" = "logs",
+  overrides: Record<string, string> = {}
 ) {
   const uid = await resolveDatasourceUid(page, datasource);
-  await page.goto(buildServiceDrilldownUrl(uid, serviceName, view));
+  await page.goto(buildServiceDrilldownUrl(uid, serviceName, view, overrides));
   await waitForDrilldownDetails(page);
 }
 
@@ -223,7 +224,9 @@ test.describe("Grafana Logs Drilldown", () => {
   test("service drilldown field filter survives reload from URL state @drilldown-core", async ({
     page,
   }) => {
-    const guards = installGrafanaGuards(page);
+    const guards = installGrafanaGuards(page, {
+      allowedRequestFailures: [/^net::ERR_ABORTED .*\/api\/ds\/query/i],
+    });
     const uid = await resolveDatasourceUid(page, PROXY_DS);
 
     await page.goto(
@@ -298,7 +301,10 @@ test.describe("Grafana Logs Drilldown", () => {
       [`{service_name="api-gateway"}`, `{app="api-gateway"}`, `{app=~".+"}`]
     );
 
-    await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, serviceName, "logs");
+    await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, serviceName, "logs", {
+      from: "now-24h",
+      to: "now",
+    });
 
     const patternsTab = page.getByRole("tab", { name: /^Patterns/i }).first();
     await expect(patternsTab).toBeVisible({ timeout: 10_000 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -270,10 +270,10 @@ test.describe("Grafana Logs Drilldown", () => {
     await waitForAutodetectedPatterns(
       page,
       PROXY_PATTERNS_AUTODETECT_DS,
-      `{app="pattern-test"}`
+      `{app="api-gateway"}`
     );
 
-    await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, "pattern-test", "logs");
+    await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, "api-gateway", "logs");
 
     const patternsTab = page.getByRole("tab", { name: /^Patterns/i }).first();
     await expect(patternsTab).toBeVisible({ timeout: 10_000 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -81,59 +81,84 @@ function nsRangeLastTwoHours() {
 async function waitForAutodetectedPatterns(
   page: Page,
   datasource: string,
-  query: string,
+  queries: string[],
   timeoutMs = 30_000
 ) {
   const uid = await resolveDatasourceUid(page, datasource);
   const deadline = Date.now() + timeoutMs;
   let lastPatternsPayload: unknown = null;
   let lastSeedPayload: unknown = null;
+  let lastQuery = "";
   const { start, end } = nsRangeLastTwoHours();
+  const fallbackQueries = [...queries];
+  const serviceKeys = [
+    "service_name",
+    "service.name",
+    "service",
+    "app",
+    "application",
+    "app_name",
+  ];
 
   while (Date.now() < deadline) {
-    const seedParams = new URLSearchParams();
-    seedParams.set("query", query);
-    seedParams.set("start", String(start));
-    seedParams.set("end", String(end));
-    seedParams.set("limit", "200");
-    seedParams.set("direction", "backward");
-    const seedResponse = await page.request.get(
-      `/api/datasources/proxy/uid/${uid}/loki/api/v1/query_range?${seedParams.toString()}`
-    );
-    try {
-      lastSeedPayload = await seedResponse.json();
-    } catch {
-      lastSeedPayload = null;
-    }
+    for (const query of fallbackQueries) {
+      lastQuery = query;
+      const seedParams = new URLSearchParams();
+      seedParams.set("query", query);
+      seedParams.set("start", String(start));
+      seedParams.set("end", String(end));
+      seedParams.set("limit", "200");
+      seedParams.set("direction", "backward");
+      const seedResponse = await page.request.get(
+        `/api/datasources/proxy/uid/${uid}/loki/api/v1/query_range?${seedParams.toString()}`
+      );
+      try {
+        lastSeedPayload = await seedResponse.json();
+      } catch {
+        lastSeedPayload = null;
+      }
 
-    const patternsParams = new URLSearchParams();
-    patternsParams.set("query", query);
-    patternsParams.set("start", String(start));
-    patternsParams.set("end", String(end));
-    patternsParams.set("step", "60s");
-    const patternsResponse = await page.request.get(
-      `/api/datasources/uid/${uid}/resources/patterns?${patternsParams.toString()}`
-    );
-    try {
-      lastPatternsPayload = await patternsResponse.json();
-    } catch {
-      lastPatternsPayload = null;
-    }
+      const patternsParams = new URLSearchParams();
+      patternsParams.set("query", query);
+      patternsParams.set("start", String(start));
+      patternsParams.set("end", String(end));
+      patternsParams.set("step", "60s");
+      const patternsResponse = await page.request.get(
+        `/api/datasources/uid/${uid}/resources/patterns?${patternsParams.toString()}`
+      );
+      try {
+        lastPatternsPayload = await patternsResponse.json();
+      } catch {
+        lastPatternsPayload = null;
+      }
 
-    if (
-      seedResponse.ok() &&
-      (lastSeedPayload as { status?: string } | null)?.status === "success" &&
-      Array.isArray((lastPatternsPayload as { data?: unknown[] } | null)?.data) &&
-      ((lastPatternsPayload as { data?: unknown[] }).data?.length ?? 0) > 0
-    ) {
-      return;
+      if (
+        !seedResponse.ok() ||
+        (lastSeedPayload as { status?: string } | null)?.status !== "success" ||
+        !Array.isArray((lastPatternsPayload as { data?: unknown[] } | null)?.data) ||
+        ((lastPatternsPayload as { data?: unknown[] }).data?.length ?? 0) === 0
+      ) {
+        continue;
+      }
+
+      const result = ((lastSeedPayload as { data?: { result?: unknown[] } } | null)?.data
+        ?.result ?? []) as Array<{ stream?: Record<string, string> }>;
+      for (const entry of result) {
+        const stream = entry?.stream ?? {};
+        for (const key of serviceKeys) {
+          const value = stream[key];
+          if (typeof value === "string" && value.trim().length > 0) {
+            return value;
+          }
+        }
+      }
     }
 
     await page.waitForTimeout(500);
   }
 
   throw new Error(
-    `timed out waiting for autodetected patterns (seed=${JSON.stringify(
+    `timed out waiting for autodetected patterns (query=${lastQuery}, seed=${JSON.stringify(
       lastSeedPayload
     )}, patterns=${JSON.stringify(lastPatternsPayload)})`
   );
@@ -267,13 +292,13 @@ test.describe("Grafana Logs Drilldown", () => {
     page,
   }) => {
     const guards = installGrafanaGuards(page);
-    await waitForAutodetectedPatterns(
+    const serviceName = await waitForAutodetectedPatterns(
       page,
       PROXY_PATTERNS_AUTODETECT_DS,
-      `{service_name="api-gateway"}`
+      [`{service_name="api-gateway"}`, `{app="api-gateway"}`, `{app=~".+"}`]
     );
 
-    await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, "api-gateway", "logs");
+    await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, serviceName, "logs");
 
     const patternsTab = page.getByRole("tab", { name: /^Patterns/i }).first();
     await expect(patternsTab).toBeVisible({ timeout: 10_000 });

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -72,9 +72,9 @@ async function openServiceDrilldown(
   await waitForDrilldownDetails(page);
 }
 
-function nsRangeLastTwoHours() {
+function nsRangeLastDay() {
   const end = Date.now() * 1_000_000;
-  const start = (Date.now() - 2 * 60 * 60 * 1000) * 1_000_000;
+  const start = (Date.now() - 24 * 60 * 60 * 1000) * 1_000_000;
   return { start, end };
 }
 
@@ -89,7 +89,7 @@ async function waitForAutodetectedPatterns(
   let lastPatternsPayload: unknown = null;
   let lastSeedPayload: unknown = null;
   let lastQuery = "";
-  const { start, end } = nsRangeLastTwoHours();
+  const { start, end } = nsRangeLastDay();
   const fallbackQueries = [...queries];
   const serviceKeys = [
     "service_name",

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -93,34 +93,37 @@ function uniqueQueries(queries: string[]) {
   return result;
 }
 
-async function seedPatternsStream(page: Page, uid: string) {
-  const nowNs = BigInt(Date.now()) * 1_000_000n;
-  const payload = {
-    streams: [
-      {
-        stream: {
-          app: "pattern-test",
-          service_name: "pattern-test",
-          level: "info",
-          cluster: "e2e",
-        },
-        values: [
-          [
-            (nowNs - 2_000_000_000n).toString(),
-            'time="2026-04-14T11:00:00Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=GetThing grpc.service=DemoService grpc.start_time="2026-04-14T11:00:00Z" grpc.time_ms=7 span.kind=server system=grpc',
-          ],
-          [
-            nowNs.toString(),
-            'time="2026-04-14T11:00:01Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=ListThings grpc.service=DemoService grpc.start_time="2026-04-14T11:00:01Z" grpc.time_ms=9 span.kind=server system=grpc',
-          ],
-        ],
-      },
-    ],
-  };
+async function seedPatternsStream(page: Page) {
+  const now = new Date();
+  const lines = [
+    JSON.stringify({
+      _time: new Date(now.getTime() - 2000).toISOString(),
+      _msg: 'time="2026-04-14T11:00:00Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=GetThing grpc.service=DemoService grpc.start_time="2026-04-14T11:00:00Z" grpc.time_ms=7 span.kind=server system=grpc',
+      app: "pattern-test",
+      service_name: "pattern-test",
+      level: "info",
+      cluster: "e2e",
+    }),
+    JSON.stringify({
+      _time: now.toISOString(),
+      _msg: 'time="2026-04-14T11:00:01Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=ListThings grpc.service=DemoService grpc.start_time="2026-04-14T11:00:01Z" grpc.time_ms=9 span.kind=server system=grpc',
+      app: "pattern-test",
+      service_name: "pattern-test",
+      level: "info",
+      cluster: "e2e",
+    }),
+  ].join("\n");
 
-  await page.request.post(`/api/datasources/proxy/uid/${uid}/loki/api/v1/push`, {
-    data: payload,
-  });
+  // e2e-ui shards don't run ingest tests, so seed VictoriaLogs directly.
+  await page.request.post(
+    "http://127.0.0.1:9428/insert/jsonline?_stream_fields=app,service_name,level,cluster",
+    {
+      data: lines,
+      headers: {
+        "Content-Type": "application/stream+json",
+      },
+    }
+  );
 }
 
 async function discoverLabelValueQueries(
@@ -174,7 +177,7 @@ async function waitForAutodetectedPatterns(
   let lastSeedPayload: unknown = null;
   let lastQuery = "";
   const { start, end } = nsRangeLastDay();
-  await seedPatternsStream(page, uid);
+  await seedPatternsStream(page);
   const discoveredQueries = await discoverLabelValueQueries(page, uid, start, end);
   const fallbackQueries = uniqueQueries([
     '{app="pattern-test"}',

--- a/test/e2e-ui/tests/logs-drilldown.spec.ts
+++ b/test/e2e-ui/tests/logs-drilldown.spec.ts
@@ -270,7 +270,7 @@ test.describe("Grafana Logs Drilldown", () => {
     await waitForAutodetectedPatterns(
       page,
       PROXY_PATTERNS_AUTODETECT_DS,
-      `{app="api-gateway"}`
+      `{service_name="api-gateway"}`
     );
 
     await openServiceDrilldown(page, PROXY_PATTERNS_AUTODETECT_DS, "api-gateway", "logs");


### PR DESCRIPTION
## Summary
- fix flaky `e2e-ui (drilldown-core)` patterns test that failed in run `24390246582` / job `71234437145`
- switch autodetect seed/query from `pattern-test` to `api-gateway`, which is present in the UI CI stack
- keep the same assertion contract (patterns tab must become non-empty and no empty-state message)

## Root cause
`pattern-test` stream is not guaranteed in the UI shard workflow, so `/query_range` returned an empty stream set and `/resources/patterns` stayed empty until timeout.

## Validation
- `npx playwright test --grep @drilldown-core`
- `npx playwright test --grep "patterns are visible in drilldown for autodetected datasource" --repeat-each=5`
- `python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD`
