### PR TITLE
Patterns: custom overlays, query_range extraction, and chart wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- patterns: support static custom pattern overlays via inline JSON/text (`-patterns-custom`) and file-backed input (`-patterns-custom-file`) for deterministic Drilldown pattern suggestions
+- patterns: prefer `query_range` during pattern extraction with `query` fallback so Drilldown pattern graphs align with selected time windows instead of only recent tail data
+
+### Chart
+
+- add Helm wiring for custom patterns via `patternsCustom.inline` and `patternsCustom.file.*` (including optional ConfigMap generation and mount wiring)
+
+### Tests
+
+- extend proxy unit coverage for custom pattern parsing, file loading, and merged `/patterns` response behavior
+
 ## [1.0.11] - 2026-04-14
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Related docs: [Architecture](docs/architecture.md), [Compatibility Matrix](docs/
 - Strict tuple contracts: default 2-tuple, explicit 3-tuple only via `categorize-labels`.
 - Grafana Logs Drilldown patterns support through `/loki/api/v1/patterns`, with explicit `-patterns-enabled` control when deployments need it disabled.
 - Loki-compatible patterns endpoint with optional restart-safe persistence.
+- Automatic pattern autodetection from successful `query`/`query_range` responses (`-patterns-autodetect-from-queries`) to keep Drilldown patterns warm behind the scenes.
+- Custom pattern overlays via runtime flags or Helm ConfigMap/file wiring (`-patterns-custom`, `-patterns-custom-file`, `patternsCustom.*`).
 - Multi-tenant read fanout with tenant isolation guardrails.
 - Rules and alerts read compatibility from `vmalert`.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-v
   --set extraArgs.label-values-index-max-entries=200000
 ```
 
+For static custom Drilldown patterns (always prepended), configure inline values or a file-backed ConfigMap:
+
+```bash
+helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-vl-proxy \
+  --version <release> \
+  --set extraArgs.backend=http://victorialogs:9428 \
+  --set-json 'patternsCustom.inline=["time=\"<_>\" level=info msg=\"finished unary call\"","grpc.code=<_> grpc.method=<_>"]' \
+  --set patternsCustom.file.enabled=true
+```
+
 For deployment recipes (StatefulSet + persistence, peer-cache fleet setup, OTLP push wiring) and image source selection (GHCR vs Docker Hub vs custom registry), see:
 - [Getting Started](docs/getting-started.md)
 - [Operations](docs/operations.md)

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -138,6 +138,34 @@ Default disk cache path when persistence is enabled.
 {{- end }}
 
 {{/*
+Resolve ConfigMap name for file-based custom patterns.
+*/}}
+{{- define "loki-vl-proxy.customPatternsConfigMapName" -}}
+{{- if .Values.patternsCustom.file.existingConfigMap -}}
+{{- .Values.patternsCustom.file.existingConfigMap -}}
+{{- else -}}
+{{- default (printf "%s-custom-patterns" (include "loki-vl-proxy.fullname" .)) .Values.patternsCustom.file.configMapName -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render default custom patterns file content.
+Priority:
+1) explicit patternsCustom.file.content
+2) JSON from patternsCustom.inline
+3) empty JSON array
+*/}}
+{{- define "loki-vl-proxy.customPatternsFileContent" -}}
+{{- if .Values.patternsCustom.file.content -}}
+{{- .Values.patternsCustom.file.content -}}
+{{- else if gt (len .Values.patternsCustom.inline) 0 -}}
+{{- toJson .Values.patternsCustom.inline -}}
+{{- else -}}
+[]
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve effective GOMEMLIMIT value.
 Priority:
 1) explicit .Values.goMemLimit

--- a/charts/loki-vl-proxy/templates/custom-patterns-configmap.yaml
+++ b/charts/loki-vl-proxy/templates/custom-patterns-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.patternsCustom.file.enabled (eq (trim .Values.patternsCustom.file.existingConfigMap) "") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki-vl-proxy.customPatternsConfigMapName" . }}
+  labels:
+    {{- include "loki-vl-proxy.labels" . | nindent 4 }}
+data:
+  {{ default "custom-patterns.json" .Values.patternsCustom.file.key }}: |
+    {{- include "loki-vl-proxy.customPatternsFileContent" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
       {{- end }}
       {{- $hostProcEnabled := false }}
       {{- $hostProcMountPath := "/host/proc" }}
+      {{- $customPatternsFileEnabled := .Values.patternsCustom.file.enabled }}
+      {{- $customPatternsFilePath := default "/etc/loki-vl-proxy/patterns/custom-patterns.json" .Values.patternsCustom.file.path }}
+      {{- $customPatternsMountDir := dir $customPatternsFilePath }}
+      {{- $customPatternsFileName := base $customPatternsFilePath }}
       {{- if and (hasKey .Values "systemMetrics") (hasKey .Values.systemMetrics "hostProc") }}
       {{- $hostProcEnabled = .Values.systemMetrics.hostProc.enabled }}
       {{- if .Values.systemMetrics.hostProc.mountPath }}
@@ -98,6 +102,12 @@ spec:
             {{- end }}
             {{- if and .Values.persistence.enabled (not (hasKey .Values.extraArgs "disk-cache-path")) }}
             - "-disk-cache-path={{ include "loki-vl-proxy.diskCachePath" . }}"
+            {{- end }}
+            {{- if and (gt (len .Values.patternsCustom.inline) 0) (not (hasKey .Values.extraArgs "patterns-custom")) }}
+            - '-patterns-custom={{ toJson .Values.patternsCustom.inline }}'
+            {{- end }}
+            {{- if and $customPatternsFileEnabled (not (hasKey .Values.extraArgs "patterns-custom-file")) }}
+            - "-patterns-custom-file={{ $customPatternsFilePath }}"
             {{- end }}
             {{- if .Values.peerCache.enabled }}
             - "-peer-self=$(POD_IP):3100"
@@ -180,7 +190,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts $hostProcEnabled }}
+          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts $hostProcEnabled $customPatternsFileEnabled }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: cache-data
@@ -191,6 +201,11 @@ spec:
               mountPath: {{ $hostProcMountPath }}
               readOnly: true
             {{- end }}
+            {{- if $customPatternsFileEnabled }}
+            - name: custom-patterns
+              mountPath: {{ $customPatternsMountDir | quote }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -198,7 +213,7 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.extraVolumes $hostProcEnabled (and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet"))) }}
+      {{- if or .Values.extraVolumes $hostProcEnabled $customPatternsFileEnabled (and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet"))) }}
       volumes:
         {{- if and .Values.persistence.enabled (or .Values.persistence.existingClaim (ne (include "loki-vl-proxy.workloadKind" .) "StatefulSet")) }}
         - name: cache-data
@@ -210,6 +225,14 @@ spec:
           hostPath:
             path: /proc
             type: Directory
+        {{- end }}
+        {{- if $customPatternsFileEnabled }}
+        - name: custom-patterns
+          configMap:
+            name: {{ include "loki-vl-proxy.customPatternsConfigMapName" . }}
+            items:
+              - key: {{ default "custom-patterns.json" .Values.patternsCustom.file.key | quote }}
+                path: {{ $customPatternsFileName | quote }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -202,6 +202,34 @@ extraArgs:
   # tls-client-ca-file: ""
   # tls-require-client-cert: "false"
 
+# Custom Drilldown patterns always prepended to /loki/api/v1/patterns.
+# Runtime supports:
+# - inline JSON/newline config via -patterns-custom
+# - file-based config via -patterns-custom-file
+#
+# The chart can source file-based patterns from an existing ConfigMap or create
+# one from patternsCustom.file.content.
+patternsCustom:
+  # Inline patterns are rendered as a JSON array and passed via -patterns-custom.
+  inline: []
+  # - "time=\"<_>\" level=info msg=\"finished unary call\" grpc.code=OK"
+  # - "component=proxy http.route=<_> http.response.status_code=<_->"
+  file:
+    enabled: false
+    # Path inside the container passed to -patterns-custom-file.
+    path: /etc/loki-vl-proxy/patterns/custom-patterns.json
+    # Use an existing ConfigMap when set.
+    existingConfigMap: ""
+    # Optional override for chart-managed ConfigMap name (when existingConfigMap is empty).
+    configMapName: ""
+    # ConfigMap key mounted as the file basename from path.
+    key: custom-patterns.json
+    # File content used when chart creates the ConfigMap.
+    # Accepted by runtime:
+    # - JSON array of strings
+    # - newline-separated patterns (supports # comments)
+    content: ""
+
 # Go runtime tuning:
 # The chart exports GOMEMLIMIT into the container env.
 # Priority:

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -73,6 +73,8 @@ type proxyRuntimeConfig struct {
 	emitStructuredMetadata             bool
 	patternsEnabled                    bool
 	patternsAutodetectFromQueries      bool
+	patternsCustomRaw                  string
+	patternsCustomFile                 string
 	queryRangeWindowing                bool
 	queryRangeSplitInterval            time.Duration
 	queryRangeMaxParallel              int
@@ -341,6 +343,8 @@ func run(
 	emitStructuredMetadata := fs.Bool("emit-structured-metadata", true, "Include Loki 3-tuple stream values [timestamp, line, metadata] in query responses")
 	patternsEnabled := fs.Bool("patterns-enabled", true, "Enable /loki/api/v1/patterns endpoint (Grafana Logs Drilldown patterns)")
 	patternsAutodetectFromQueries := fs.Bool("patterns-autodetect-from-queries", false, "Warm /loki/api/v1/patterns cache from successful query/query_range log responses (opt-in global autodetect)")
+	patternsCustomRaw := fs.String("patterns-custom", "", `JSON array (or newline-separated text) of custom Drilldown patterns always prepended to /loki/api/v1/patterns responses`)
+	patternsCustomFile := fs.String("patterns-custom-file", "", "Path to custom Drilldown patterns file (JSON array or newline-separated text) loaded on startup")
 	queryRangeWindowing := fs.Bool("query-range-windowing", true, "Enable query_range window splitting and window-level cache reuse for log queries")
 	queryRangeSplitInterval := fs.Duration("query-range-split-interval", time.Hour, "Time window size used for query_range split/merge (for example 15m, 1h, 24h)")
 	queryRangeMaxParallel := fs.Int("query-range-max-parallel", 2, "Maximum number of query_range windows fetched in parallel when adaptive parallelism is disabled")
@@ -486,6 +490,8 @@ func run(
 			emitStructuredMetadata:             *emitStructuredMetadata,
 			patternsEnabled:                    *patternsEnabled,
 			patternsAutodetectFromQueries:      *patternsAutodetectFromQueries,
+			patternsCustomRaw:                  *patternsCustomRaw,
+			patternsCustomFile:                 *patternsCustomFile,
 			queryRangeWindowing:                *queryRangeWindowing,
 			queryRangeSplitInterval:            *queryRangeSplitInterval,
 			queryRangeMaxParallel:              *queryRangeMaxParallel,
@@ -930,6 +936,80 @@ func parseDerivedFieldsJSON(raw string) ([]proxy.DerivedField, error) {
 	return derivedFields, nil
 }
 
+func parseCustomPatternsSource(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	normalize := func(values []string) []string {
+		if len(values) == 0 {
+			return nil
+		}
+		seen := make(map[string]struct{}, len(values))
+		out := make([]string, 0, len(values))
+		for _, v := range values {
+			v = strings.TrimSpace(v)
+			if v == "" {
+				continue
+			}
+			if _, ok := seen[v]; ok {
+				continue
+			}
+			seen[v] = struct{}{}
+			out = append(out, v)
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+
+	var fromJSON []string
+	if err := json.Unmarshal([]byte(raw), &fromJSON); err == nil {
+		return normalize(fromJSON), nil
+	}
+	if strings.HasPrefix(raw, "[") {
+		return nil, fmt.Errorf("expected valid JSON string array")
+	}
+
+	lines := strings.Split(raw, "\n")
+	parsed := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parsed = append(parsed, line)
+	}
+	return normalize(parsed), nil
+}
+
+func parseCustomPatterns(inlineRaw, filePath string) ([]string, error) {
+	inlinePatterns, err := parseCustomPatternsSource(inlineRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse -patterns-custom: %w", err)
+	}
+
+	var filePatterns []string
+	filePath = strings.TrimSpace(filePath)
+	if filePath != "" {
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read -patterns-custom-file %q: %w", filePath, readErr)
+		}
+		filePatterns, err = parseCustomPatternsSource(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("parse -patterns-custom-file %q: %w", filePath, err)
+		}
+	}
+
+	combined := make([]string, 0, len(inlinePatterns)+len(filePatterns))
+	combined = append(combined, inlinePatterns...)
+	combined = append(combined, filePatterns...)
+	return parseCustomPatternsSource(strings.Join(combined, "\n"))
+}
+
 func parseLabelModes(labelStyle, metadataFieldMode string) (proxy.LabelStyle, proxy.MetadataFieldMode, error) {
 	ls := proxy.LabelStyle(labelStyle)
 	switch ls {
@@ -1036,6 +1116,10 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 	if err != nil {
 		return proxy.Config{}, fmt.Errorf("parse derived fields: %w", err)
 	}
+	customPatterns, err := parseCustomPatterns(cfg.patternsCustomRaw, cfg.patternsCustomFile)
+	if err != nil {
+		return proxy.Config{}, err
+	}
 	tailMode := proxy.TailMode(cfg.tailMode)
 	switch tailMode {
 	case "", proxy.TailModeAuto:
@@ -1078,6 +1162,7 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		EmitStructuredMetadata:             cfg.emitStructuredMetadata,
 		PatternsEnabled:                    boolPointer(cfg.patternsEnabled),
 		PatternsAutodetectFromQueries:      cfg.patternsAutodetectFromQueries,
+		PatternsCustom:                     customPatterns,
 		QueryRangeWindowingEnabled:         cfg.queryRangeWindowing,
 		QueryRangeSplitInterval:            cfg.queryRangeSplitInterval,
 		QueryRangeMaxParallel:              cfg.queryRangeMaxParallel,
@@ -1270,6 +1355,9 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 				"hint", "set -patterns-persist-path and use StatefulSet + PVC for restart-safe patterns cache",
 			)
 		}
+	}
+	if len(proxyCfg.PatternsCustom) > 0 {
+		logger.Info("custom drilldown patterns enabled", "count", len(proxyCfg.PatternsCustom))
 	}
 	if proxyCfg.DerivedFields != nil {
 		logger.Info("loaded derived fields", "count", len(proxyCfg.DerivedFields))

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -361,6 +361,12 @@ func TestRun_DefaultEnablesStructuredMetadata(t *testing.T) {
 	if captured.proxyCfg.patternsAutodetectFromQueries {
 		t.Fatal("expected -patterns-autodetect-from-queries to default to false")
 	}
+	if captured.proxyCfg.patternsCustomRaw != "" {
+		t.Fatalf("expected -patterns-custom default empty, got %q", captured.proxyCfg.patternsCustomRaw)
+	}
+	if captured.proxyCfg.patternsCustomFile != "" {
+		t.Fatalf("expected -patterns-custom-file default empty, got %q", captured.proxyCfg.patternsCustomFile)
+	}
 	if captured.proxyCfg.patternsPersistPath != "" {
 		t.Fatalf("expected -patterns-persist-path to default empty, got %q", captured.proxyCfg.patternsPersistPath)
 	}
@@ -867,6 +873,7 @@ func TestBuildProxyConfig(t *testing.T) {
 		emitStructuredMetadata:          true,
 		patternsEnabled:                 false,
 		patternsAutodetectFromQueries:   true,
+		patternsCustomRaw:               `["msg=error code=<_>", "grpc.code=<_>"]`,
 		queryRangeWindowing:             true,
 		queryRangeSplitInterval:         30 * time.Minute,
 		queryRangeMaxParallel:           4,
@@ -960,6 +967,9 @@ func TestBuildProxyConfig(t *testing.T) {
 	}
 	if !got.PatternsAutodetectFromQueries {
 		t.Fatalf("expected patterns autodetect from queries to be enabled")
+	}
+	if len(got.PatternsCustom) != 2 || got.PatternsCustom[0] != "msg=error code=<_>" || got.PatternsCustom[1] != "grpc.code=<_>" {
+		t.Fatalf("unexpected custom patterns: %+v", got.PatternsCustom)
 	}
 	if !got.QueryRangeWindowingEnabled {
 		t.Fatalf("expected query range windowing to be enabled")
@@ -1073,6 +1083,39 @@ func TestBuildProxyConfig_DefaultsAlertsBackendToRuler(t *testing.T) {
 	if got.AlertsBackendURL != "http://ruler" {
 		t.Fatalf("expected alerts backend to default to ruler backend, got %q", got.AlertsBackendURL)
 	}
+}
+
+func TestParseCustomPatterns(t *testing.T) {
+	t.Run("json-inline", func(t *testing.T) {
+		got, err := parseCustomPatterns(`["a"," b ","a"]`, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Fatalf("unexpected parsed patterns: %+v", got)
+		}
+	})
+
+	t.Run("newline-file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "patterns.txt")
+		content := "# comment\nfirst pattern\n\nsecond pattern\nfirst pattern\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write patterns file: %v", err)
+		}
+		got, err := parseCustomPatterns("", path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 || got[0] != "first pattern" || got[1] != "second pattern" {
+			t.Fatalf("unexpected parsed file patterns: %+v", got)
+		}
+	})
+
+	t.Run("invalid-json-inline", func(t *testing.T) {
+		if _, err := parseCustomPatterns("[not-valid]", ""); err == nil {
+			t.Fatal("expected invalid json error")
+		}
+	})
 }
 
 func TestBuildProxyConfig_InvalidInputs(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,8 @@ See [Translation Modes Guide](translation-modes.md) for mode-selection profiles 
 | `-emit-structured-metadata` | — | `true` | Enable Loki `categorize-labels` response encoding: requests with `X-Loki-Response-Encoding-Flags: categorize-labels` emit 3-tuples `[timestamp, line, metadata]`, while default/no-flag requests stay canonical 2-tuples |
 | `-patterns-enabled` | — | `true` | Enable `GET /loki/api/v1/patterns` (Grafana Logs Drilldown patterns view). When `false`, the endpoint returns `404 not_found` |
 | `-patterns-autodetect-from-queries` | — | `false` | Warm `/loki/api/v1/patterns` cache from successful `query` and `query_range` responses (global autodetect mode, opt-in) |
+| `-patterns-custom` | — | — | Static custom patterns prepended to every `/patterns` response. Accepts JSON string array or newline-separated text payload |
+| `-patterns-custom-file` | — | — | File path for static custom patterns prepended to every `/patterns` response. Supports JSON string array or newline-separated text with optional `#` comments |
 | `-patterns-persist-path` | — | — | Disk path for persisted patterns snapshot JSON file (empty disables persistence) |
 | `-patterns-persist-interval` | — | `30s` | Periodic flush interval for in-memory patterns snapshot |
 | `-patterns-startup-stale-threshold` | — | `60s` | Freshness threshold used by startup warm logic/peer snapshot cache |
@@ -48,6 +50,20 @@ See [Translation Modes Guide](translation-modes.md) for mode-selection profiles 
 ```bash
 ./loki-vl-proxy -label-style=underscores \
   -field-mapping='[{"vl_field":"my_trace_id","loki_label":"traceID"}]'
+```
+
+### Custom Drilldown Patterns
+
+Examples:
+
+```bash
+# Inline JSON list
+./loki-vl-proxy \
+  -patterns-custom='["time=\"<_>\" level=info msg=\"finished unary call\"","grpc.code=<_> grpc.method=<_>"]'
+
+# File-backed list (JSON array or newline-separated text)
+./loki-vl-proxy \
+  -patterns-custom-file=/etc/loki-vl-proxy/custom-patterns.json
 ```
 
 ### Extra Label Fields (`-extra-label-fields`)

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -18,6 +18,26 @@ Proxy behavior:
 - Patterns are derived from live query results, not from a static dictionary.
 - Optional global autodetect mode (`-patterns-autodetect-from-queries=true`) additionally warms pattern cache from successful `query` and `query_range` responses.
 - Maximum patterns returned per request are clamped to `1000`.
+- Pattern extraction prefers backend `query_range` first so Drilldown graphs use the selected time range buckets (not only recent tail windows), with `query` as fallback.
+
+## Static Custom Patterns
+
+You can prepend static patterns to every `/loki/api/v1/patterns` response:
+
+- `-patterns-custom` for inline config
+- `-patterns-custom-file` for file-based config (for example ConfigMap-mounted files)
+
+Accepted formats:
+
+- JSON string array
+- newline-separated text (`#` comments and empty lines are ignored)
+
+Custom patterns are prepended before autodetected patterns and de-duplicated by exact pattern string.
+
+Helm chart wiring:
+
+- `patternsCustom.inline` -> `-patterns-custom`
+- `patternsCustom.file.enabled=true` + ConfigMap mount -> `-patterns-custom-file`
 
 Loki behavior reference:
 
@@ -47,6 +67,8 @@ Retention model:
 
 - `-patterns-enabled`
 - `-patterns-autodetect-from-queries`
+- `-patterns-custom`
+- `-patterns-custom-file`
 - `-patterns-persist-path`
 - `-patterns-persist-interval`
 - `-patterns-startup-stale-threshold`

--- a/internal/proxy/perf_hardening_test.go
+++ b/internal/proxy/perf_hardening_test.go
@@ -353,7 +353,7 @@ func TestHandleDetectedFieldValues_LevelFallsBackToDetectedLevel(t *testing.T) {
 func TestHandlePatternsReuseCachedResponse(t *testing.T) {
 	var backendCalls int
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/select/logsql/query" {
+		if r.URL.Path != "/select/logsql/query_range" {
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
 		}
 		backendCalls++

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -266,6 +266,9 @@ type Config struct {
 	// PatternsAutodetectFromQueries passively extracts patterns from successful
 	// log query/query_range responses and warms /patterns cache entries.
 	PatternsAutodetectFromQueries bool
+	// PatternsCustom is a static list of patterns always prepended to
+	// /loki/api/v1/patterns responses.
+	PatternsCustom []string
 	// Query range windowing/cache options.
 	// When enabled, eligible log query_range requests are split into time windows,
 	// fetched with bounded parallelism, and merged in Loki-compatible direction order.
@@ -433,6 +436,7 @@ type Proxy struct {
 	emitStructuredMetadata                bool
 	patternsEnabled                       bool
 	patternsAutodetectFromQueries         bool
+	patternsCustom                        []string
 	labelTranslator                       *LabelTranslator
 	metadataFieldMode                     MetadataFieldMode
 	streamFieldsMap                       map[string]bool  // known _stream_fields for VL stream selector optimization
@@ -872,6 +876,7 @@ func New(cfg Config) (*Proxy, error) {
 	}
 	tenantDefaultLimits := cloneStringAnyMap(cfg.TenantDefaultLimits)
 	tenantLimits := cloneTenantLimitsMap(cfg.TenantLimits)
+	patternsCustom := normalizeCustomPatterns(cfg.PatternsCustom)
 
 	return &Proxy{
 		backend:       u,
@@ -904,6 +909,7 @@ func New(cfg Config) (*Proxy, error) {
 		emitStructuredMetadata:                cfg.EmitStructuredMetadata,
 		patternsEnabled:                       patternsEnabled,
 		patternsAutodetectFromQueries:         cfg.PatternsAutodetectFromQueries,
+		patternsCustom:                        patternsCustom,
 		labelTranslator:                       labelTranslator,
 		metadataFieldMode:                     metadataFieldMode,
 		streamFieldsMap:                       buildStreamFieldsMap(cfg.StreamFields),
@@ -1035,6 +1041,29 @@ func buildDeclaredLabelFields(streamFields, extraLabelFields []string, lt *Label
 		return nil
 	}
 	sort.Strings(out)
+	return out
+}
+
+func normalizeCustomPatterns(patterns []string) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(patterns))
+	out := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		if _, ok := seen[pattern]; ok {
+			continue
+		}
+		seen[pattern] = struct{}{}
+		out = append(out, pattern)
+	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
 }
 
@@ -4311,7 +4340,7 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		cacheKey = "patterns:" + orgID + ":" + r.URL.RawQuery
 	}
 	if cached, ok := p.cache.Get(cacheKey); ok {
-		body := limitPatternPayload(cached, patternLimit)
+		body := p.applyCustomPatternsToPayload(cached, startParam, stepParam, patternLimit)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 		p.metrics.RecordRequest("patterns", http.StatusOK, time.Since(start))
@@ -4340,66 +4369,48 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	}
 	params.Set("limit", "1000")
 
-	resp, err := p.vlPost(r.Context(), "/select/logsql/query", params)
-	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
-			"status": "success",
-			"data":   []interface{}{},
-		})
-		p.metrics.RecordRequest("patterns", http.StatusOK, time.Since(start))
-		return
+	fetchPatterns := func(endpoint string) ([]map[string]interface{}, bool) {
+		resp, err := p.vlPost(r.Context(), endpoint, params)
+		if err != nil {
+			return nil, false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= http.StatusBadRequest {
+			return nil, false
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, false
+		}
+		extracted := extractLogPatterns(body, stepParam, patternLimit)
+		if len(extracted) == 0 {
+			return nil, false
+		}
+		return extracted, true
 	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		p.writeJSON(w, map[string]interface{}{
-			"status": "success",
-			"data":   []interface{}{},
-		})
-		p.metrics.RecordRequest("patterns", http.StatusOK, time.Since(start))
-		return
-	}
-
-	patterns := extractLogPatterns(body, stepParam, patternLimit)
-	// Some VictoriaLogs builds may return a query payload shape that is valid (HTTP 200)
-	// but not pattern-extractable here; fall back to query_range in that case too.
-	if resp.StatusCode >= http.StatusBadRequest || len(patterns) == 0 {
-		rangeParams := url.Values{}
-		rangeParams.Set("query", logsqlQuery)
-		if s := startParam; s != "" {
-			rangeParams.Set("start", formatVLTimestamp(s))
-		}
-		if e := endParam; e != "" {
-			rangeParams.Set("end", formatVLTimestamp(e))
-		}
-		rangeParams.Set("limit", "1000")
-		rangeResp, rangeErr := p.vlPost(r.Context(), "/select/logsql/query_range", rangeParams)
-		if rangeErr == nil {
-			defer rangeResp.Body.Close()
-			if rangeBody, readErr := io.ReadAll(rangeResp.Body); readErr == nil && rangeResp.StatusCode < http.StatusBadRequest {
-				if fallbackPatterns := extractLogPatterns(rangeBody, stepParam, patternLimit); len(fallbackPatterns) > 0 {
-					patterns = fallbackPatterns
-				}
-			}
-		}
+	// Prefer query_range to preserve full selected-range buckets in Drilldown graphs.
+	patterns, ok := fetchPatterns("/select/logsql/query_range")
+	if !ok {
+		patterns, _ = fetchPatterns("/select/logsql/query")
 	}
 	if patterns == nil {
 		patterns = []map[string]interface{}{}
 	}
-	p.metrics.RecordPatternsDetected(len(patterns))
-	result := map[string]interface{}{
-		"status": "success",
-		"data":   patterns,
-	}
-	resultBody, err := json.Marshal(result)
+	entries := patternResultEntriesFromMaps(patterns)
+	p.metrics.RecordPatternsDetected(len(entries))
+	entries = p.prependCustomPatternEntries(entries, startParam, stepParam, patternLimit)
+	resultBody, err := json.Marshal(patternsResponse{
+		Status: "success",
+		Data:   entries,
+	})
 	if err != nil {
 		p.writeJSON(w, map[string]interface{}{"status": "success", "data": []interface{}{}})
 		p.metrics.RecordRequest("patterns", http.StatusOK, time.Since(start))
 		return
 	}
 	// Avoid sticky empty results: first-call empty probes should not poison long-lived pattern cache entries.
-	if len(patterns) > 0 {
+	if len(entries) > 0 {
 		p.cache.SetWithTTL(cacheKey, resultBody, patternsCacheRetention)
 		p.recordPatternSnapshotEntry(cacheKey, resultBody, time.Now().UTC())
 	}
@@ -4475,6 +4486,122 @@ func limitPatternPayload(payload []byte, limit int) []byte {
 	encoded, err := json.Marshal(resp)
 	if err != nil {
 		return payload
+	}
+	return encoded
+}
+
+func customPatternSeedBucket(startParam, stepParam string) int64 {
+	nowBucket := time.Now().UTC().Unix()
+	if parsed, ok := parsePatternUnixSeconds(strings.TrimSpace(startParam)); ok {
+		nowBucket = parsed
+	}
+	stepSeconds := parsePatternStepSeconds(stepParam)
+	if stepSeconds > 0 {
+		nowBucket = (nowBucket / stepSeconds) * stepSeconds
+	}
+	return nowBucket
+}
+
+func patternResultEntriesFromMaps(patterns []map[string]interface{}) []patternResultEntry {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]patternResultEntry, 0, len(patterns))
+	for _, item := range patterns {
+		pattern, _ := item["pattern"].(string)
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		entry := patternResultEntry{
+			Pattern: pattern,
+			Samples: [][]interface{}{},
+		}
+		if level, ok := item["level"].(string); ok {
+			entry.Level = strings.TrimSpace(level)
+		}
+		if rawSamples, ok := item["samples"].([][]interface{}); ok {
+			entry.Samples = rawSamples
+		} else if rawSamples, ok := item["samples"].([]interface{}); ok && len(rawSamples) > 0 {
+			samples := make([][]interface{}, 0, len(rawSamples))
+			for _, sample := range rawSamples {
+				pair, ok := sample.([]interface{})
+				if !ok || len(pair) != 2 {
+					continue
+				}
+				samples = append(samples, pair)
+			}
+			entry.Samples = samples
+		}
+		out = append(out, entry)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (p *Proxy) prependCustomPatternEntries(patterns []patternResultEntry, startParam, stepParam string, limit int) []patternResultEntry {
+	if len(p.patternsCustom) == 0 {
+		if limit > 0 && len(patterns) > limit {
+			return patterns[:limit]
+		}
+		return patterns
+	}
+
+	seedBucket := customPatternSeedBucket(startParam, stepParam)
+	out := make([]patternResultEntry, 0, len(p.patternsCustom)+len(patterns))
+	seen := make(map[string]struct{}, len(p.patternsCustom)+len(patterns))
+
+	for _, customPattern := range p.patternsCustom {
+		customPattern = strings.TrimSpace(customPattern)
+		if customPattern == "" {
+			continue
+		}
+		if _, ok := seen[customPattern]; ok {
+			continue
+		}
+		seen[customPattern] = struct{}{}
+		out = append(out, patternResultEntry{
+			Pattern: customPattern,
+			Samples: [][]interface{}{{seedBucket, 0}},
+		})
+	}
+
+	for _, entry := range patterns {
+		patternKey := strings.TrimSpace(entry.Pattern)
+		if patternKey == "" {
+			continue
+		}
+		if _, ok := seen[patternKey]; ok {
+			continue
+		}
+		seen[patternKey] = struct{}{}
+		out = append(out, entry)
+	}
+
+	if limit > 0 && len(out) > limit {
+		return out[:limit]
+	}
+	return out
+}
+
+func (p *Proxy) applyCustomPatternsToPayload(payload []byte, startParam, stepParam string, limit int) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+	if len(p.patternsCustom) == 0 {
+		return limitPatternPayload(payload, limit)
+	}
+
+	var resp patternsResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return limitPatternPayload(payload, limit)
+	}
+	resp.Data = p.prependCustomPatternEntries(resp.Data, startParam, stepParam, limit)
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		return limitPatternPayload(payload, limit)
 	}
 	return encoded
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -732,6 +732,46 @@ func TestContract_Patterns_FallsBackToQueryRangeWhenQueryHasNoExtractablePattern
 	}
 }
 
+func TestContract_Patterns_PrefersQueryRangeForSelectedRange(t *testing.T) {
+	var queryRangeCalls, queryCalls int
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/query_range":
+			queryRangeCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"level":"info"},"values":[["1712311200000000000","GET /api/users 200 15ms"],["1712311260000000000","GET /api/users 200 22ms"]]}]}}`))
+		case "/select/logsql/query":
+			queryCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=1712311200&end=1712311800&step=1m", nil)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+	if queryRangeCalls == 0 {
+		t.Fatalf("expected query_range to be used for patterns extraction")
+	}
+	if queryCalls != 0 {
+		t.Fatalf("expected query fallback to be skipped when query_range already returned patterns, got %d calls", queryCalls)
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data, _ := resp["data"].([]interface{})
+	if len(data) == 0 {
+		t.Fatalf("expected non-empty patterns response, got %v", resp)
+	}
+}
+
 func TestContract_Patterns_DisabledReturnsNotFound(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -833,6 +873,87 @@ func TestContract_PatternHelpers_ParseAndLimitPayload(t *testing.T) {
 	mustUnmarshal(t, limited, &resp)
 	if len(resp.Data) != 2 {
 		t.Fatalf("expected 2 limited patterns, got %d", len(resp.Data))
+	}
+}
+
+func TestContract_Patterns_CustomPatternsPrepended(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"GET /api/users 200 15ms","app":"web","level":"info"}` + "\n"))
+		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:01Z","_msg":"GET /api/users 200 22ms","app":"web","level":"info"}` + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:      vlBackend.URL,
+		Cache:           c,
+		LogLevel:        "error",
+		PatternsCustom:  []string{"always-top", "always-top", "second-custom"},
+		PatternsEnabled: nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=1&end=2&step=1m", nil)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp patternsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Data) < 2 {
+		t.Fatalf("expected prepended custom patterns, got %+v", resp.Data)
+	}
+	if resp.Data[0].Pattern != "always-top" || resp.Data[1].Pattern != "second-custom" {
+		t.Fatalf("expected custom patterns prepended, got %+v", resp.Data[:2])
+	}
+	if len(resp.Data[0].Samples) != 1 || len(resp.Data[0].Samples[0]) != 2 {
+		t.Fatalf("expected synthetic sample for custom pattern, got %+v", resp.Data[0].Samples)
+	}
+}
+
+func TestContract_Patterns_CachedPayloadStillPrependsCustomPatterns(t *testing.T) {
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:     "http://127.0.0.1:65535",
+		Cache:          c,
+		LogLevel:       "error",
+		PatternsCustom: []string{"cached-custom"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	cacheKey := p.patternsAutodetectCacheKey("", `{app="web"}`, "1", "2", "1m")
+	payload, err := json.Marshal(patternsResponse{
+		Status: "success",
+		Data: []patternResultEntry{
+			{Pattern: "auto-pattern", Samples: [][]interface{}{{int64(1), 3}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	p.cache.SetWithTTL(cacheKey, payload, patternsCacheRetention)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=1&end=2&step=1m&limit=2", nil)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp patternsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected custom+cached patterns with limit=2, got %+v", resp.Data)
+	}
+	if resp.Data[0].Pattern != "cached-custom" || resp.Data[1].Pattern != "auto-pattern" {
+		t.Fatalf("expected custom pattern prepended over cached payload, got %+v", resp.Data)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add custom Drilldown pattern overlays via runtime flags (`-patterns-custom`, `-patterns-custom-file`)
- add Helm support for custom patterns through `patternsCustom.inline` and `patternsCustom.file.*` (optional ConfigMap + mount + arg wiring)
- make pattern extraction prefer `query_range` with `query` fallback so Drilldown pattern graphs align with selected time ranges
- update docs for patterns/configuration and add an `Unreleased` changelog entry
- extend unit/perf coverage for custom pattern parsing/loading and merged `/patterns` behavior

## Validation
- `go test ./cmd/proxy ./internal/proxy`
- `helm template loki-vl-proxy charts/loki-vl-proxy`

## Notes
- commit is SSH-signed
