### PR TITLE
Fix Drilldown patterns refresh window scope and long-range sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- patterns: honor `from`/`to` when `start`/`end` are not provided so Drilldown refresh requests keep the selected range scope
+- patterns: replace fixed upstream source fetch limit (`1000`) with bounded adaptive sampling for longer ranges to prevent near-now-only pattern results after refresh
+
 ## [1.0.12] - 2026-04-14
 
 ### Features

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4331,10 +4331,11 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	r = withOrgID(r)
 	orgID := r.Header.Get("X-Scope-OrgID")
 	query := patternScopeQuery(r.FormValue("query"))
-	startParam := r.FormValue("start")
-	endParam := r.FormValue("end")
+	startParam := strings.TrimSpace(firstNonEmpty(r.FormValue("start"), r.FormValue("from")))
+	endParam := strings.TrimSpace(firstNonEmpty(r.FormValue("end"), r.FormValue("to")))
 	stepParam := r.FormValue("step")
 	patternLimit := parsePatternLimit(r.FormValue("limit"))
+	sourceLimit := parsePatternSourceLineLimit(r.FormValue("line_limit"), startParam, endParam, stepParam)
 	cacheKey := p.patternsAutodetectCacheKey(orgID, query, startParam, endParam, stepParam)
 	if cacheKey == "" {
 		cacheKey = "patterns:" + orgID + ":" + r.URL.RawQuery
@@ -4367,7 +4368,7 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	if e := endParam; e != "" {
 		params.Set("end", formatVLTimestamp(e))
 	}
-	params.Set("limit", "1000")
+	params.Set("limit", strconv.Itoa(sourceLimit))
 
 	fetchPatterns := func(endpoint string) ([]map[string]interface{}, bool) {
 		resp, err := p.vlPost(r.Context(), endpoint, params)
@@ -4469,6 +4470,54 @@ func parsePatternLimit(raw string) int {
 		return maxPatternResponseLimit
 	}
 	return patternLimit
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func parsePatternSourceLineLimit(raw, startParam, endParam, stepParam string) int {
+	const (
+		defaultPatternSourceLimit = 10_000
+		minPatternSourceLimit     = 2_000
+		maxPatternSourceLimit     = 50_000
+		bucketSampleMultiplier    = 20
+	)
+
+	if raw = strings.TrimSpace(raw); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			if parsed > maxPatternSourceLimit {
+				return maxPatternSourceLimit
+			}
+			return parsed
+		}
+	}
+
+	startUnix, okStart := parsePatternUnixSeconds(startParam)
+	endUnix, okEnd := parsePatternUnixSeconds(endParam)
+	if !okStart || !okEnd || endUnix <= startUnix {
+		return defaultPatternSourceLimit
+	}
+
+	stepSeconds := parsePatternStepSeconds(stepParam)
+	if stepSeconds <= 0 {
+		stepSeconds = 60
+	}
+
+	buckets := int(((endUnix - startUnix) / stepSeconds) + 1)
+	estimate := buckets * bucketSampleMultiplier
+	if estimate < minPatternSourceLimit {
+		return minPatternSourceLimit
+	}
+	if estimate > maxPatternSourceLimit {
+		return maxPatternSourceLimit
+	}
+	return estimate
 }
 
 func limitPatternPayload(payload []byte, limit int) []byte {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -772,6 +772,71 @@ func TestContract_Patterns_PrefersQueryRangeForSelectedRange(t *testing.T) {
 	}
 }
 
+func TestContract_Patterns_UsesFromToWhenStartEndMissing(t *testing.T) {
+	var receivedStart, receivedEnd string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query_range" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		receivedStart = r.FormValue("start")
+		receivedEnd = r.FormValue("end")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"GET /api/users 200 15ms","level":"info"}` + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		"GET",
+		"/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&from=1712311200&to=1712311800&step=1m",
+		nil,
+	)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+	if receivedStart != "1712311200" || receivedEnd != "1712311800" {
+		t.Fatalf("expected from/to to be forwarded as start/end, got start=%q end=%q", receivedStart, receivedEnd)
+	}
+}
+
+func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
+	var receivedLimit string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query_range" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		receivedLimit = r.FormValue("limit")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"GET /api/users 200 15ms","level":"info"}` + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		"GET",
+		"/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=1712311200&end=1712916000&step=60",
+		nil,
+	)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+	if receivedLimit != "50000" {
+		t.Fatalf("expected adaptive source limit capped at 50000 for long range, got %q", receivedLimit)
+	}
+}
+
 func TestContract_Patterns_DisabledReturnsNotFound(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- fix /loki/api/v1/patterns to honor from/to when start/end are missing (Grafana refresh compatibility)
- replace fixed backend source fetch limit (1000) with adaptive long-range sampling limits to avoid near-now bias after refresh
- keep strict caps for safety and predictable load

## Changes
- internal/proxy/proxy.go
  - read start from start || from
  - read end from end || to
  - add parsePatternSourceLineLimit(...) with bounded adaptive scaling
  - use adaptive value for upstream /select/logsql/query_range|query limit
- internal/proxy/proxy_test.go
  - add TestContract_Patterns_UsesFromToWhenStartEndMissing
  - add TestContract_Patterns_AdaptiveSourceLimitForLongRanges

## Validation
- go test ./internal/proxy -run 'TestContract_Patterns_(UsesFromToWhenStartEndMissing|AdaptiveSourceLimitForLongRanges|PrefersQueryRangeForSelectedRange|ResponseFormat)' -count=1
- go test ./internal/proxy -run 'TestHandlePatterns|TestContract_Patterns|TestContract_Patterns_' -count=1
- go test ./internal/proxy -count=1
