### PR TITLE
patterns: window long-range extraction for drilldown compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- patterns: improve long-range `/loki/api/v1/patterns` extraction by windowing `query_range` sampling and merging samples across windows, so Drilldown pattern charts keep full-range visibility
+
 ## [1.0.14] - 2026-04-14
 
 ### Bug Fixes

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4411,35 +4411,71 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	}
 	params.Set("limit", strconv.Itoa(sourceLimit))
 
-	fetchPatterns := func(endpoint string) ([]map[string]interface{}, bool) {
-		resp, err := p.vlPost(r.Context(), endpoint, params)
-		if err != nil {
+	fetchPatterns := func(endpoint string) ([]patternResultEntry, bool) {
+		fetchFromParams := func(queryParams url.Values) ([]patternResultEntry, bool) {
+			resp, err := p.vlPost(r.Context(), endpoint, queryParams)
+			if err != nil {
+				return nil, false
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode >= http.StatusBadRequest {
+				return nil, false
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, false
+			}
+			extracted := extractLogPatterns(body, stepParam, patternLimit)
+			if len(extracted) == 0 {
+				return nil, false
+			}
+			entries := patternResultEntriesFromMaps(extracted)
+			if len(entries) == 0 {
+				return nil, false
+			}
+			return entries, true
+		}
+
+		entries, ok := fetchFromParams(params)
+		if !ok {
 			return nil, false
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode >= http.StatusBadRequest {
-			return nil, false
+		if endpoint != "/select/logsql/query_range" {
+			return entries, true
 		}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, false
+
+		startNs, endNs, splitInterval, perWindowLimit, ok := patternWindowedSamplingConfig(startParam, endParam, sourceLimit)
+		if !ok {
+			return entries, true
 		}
-		extracted := extractLogPatterns(body, stepParam, patternLimit)
-		if len(extracted) == 0 {
-			return nil, false
+		windows := splitQueryRangeWindowsWithOptions(startNs, endNs, splitInterval, "backward", true)
+		if len(windows) <= 1 {
+			return entries, true
 		}
-		return extracted, true
+
+		merged := entries
+		for _, window := range windows {
+			windowParams := cloneURLValues(params)
+			windowParams.Set("start", strconv.FormatInt(window.startNs, 10))
+			windowParams.Set("end", strconv.FormatInt(window.endNs, 10))
+			windowParams.Set("limit", strconv.Itoa(perWindowLimit))
+			windowEntries, ok := fetchFromParams(windowParams)
+			if !ok {
+				continue
+			}
+			merged = mergePatternResultEntries(merged, windowEntries)
+		}
+		return merged, true
 	}
 
 	// Prefer query_range to preserve full selected-range buckets in Drilldown graphs.
-	patterns, ok := fetchPatterns("/select/logsql/query_range")
+	entries, ok := fetchPatterns("/select/logsql/query_range")
 	if !ok {
-		patterns, _ = fetchPatterns("/select/logsql/query")
+		entries, _ = fetchPatterns("/select/logsql/query")
 	}
-	if patterns == nil {
-		patterns = []map[string]interface{}{}
+	if entries == nil {
+		entries = []patternResultEntry{}
 	}
-	entries := patternResultEntriesFromMaps(patterns)
 	p.metrics.RecordPatternsDetected(len(entries))
 	entries = p.prependCustomPatternEntries(entries, startParam, stepParam, patternLimit)
 	resultBody, err := json.Marshal(patternsResponse{
@@ -4527,6 +4563,16 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+func cloneURLValues(in url.Values) url.Values {
+	out := make(url.Values, len(in))
+	for k, vals := range in {
+		copied := make([]string, len(vals))
+		copy(copied, vals)
+		out[k] = copied
+	}
+	return out
+}
+
 func parsePatternSourceLineLimit(raw, startParam, endParam, stepParam string) int {
 	const (
 		defaultPatternSourceLimit = 10_000
@@ -4588,6 +4634,49 @@ func derivePatternStep(startParam, endParam string) string {
 		stepSeconds = maxStep
 	}
 	return strconv.FormatInt(stepSeconds, 10) + "s"
+}
+
+func patternWindowedSamplingConfig(startParam, endParam string, sourceLimit int) (int64, int64, time.Duration, int, bool) {
+	startNs, endNs, ok := parseLokiTimeRangeToUnixNano(startParam, endParam)
+	if !ok || sourceLimit <= 0 || endNs <= startNs {
+		return 0, 0, 0, 0, false
+	}
+
+	span := time.Duration(endNs - startNs)
+	const (
+		minWindowedSpan         = 30 * time.Minute
+		targetWindowSpan        = 15 * time.Minute
+		minWindowSourceLimit    = 500
+		maxWindowSourceLimit    = 10_000
+		maxPatternWindowSamples = 24
+	)
+	if span < minWindowedSpan {
+		return 0, 0, 0, 0, false
+	}
+
+	windowCount := int(span/targetWindowSpan) + 1
+	if windowCount < 2 {
+		windowCount = 2
+	}
+	if windowCount > maxPatternWindowSamples {
+		windowCount = maxPatternWindowSamples
+	}
+
+	intervalNs := (endNs - startNs) / int64(windowCount)
+	if intervalNs <= 0 {
+		return 0, 0, 0, 0, false
+	}
+	interval := time.Duration(intervalNs)
+
+	perWindowLimit := sourceLimit / windowCount
+	if perWindowLimit < minWindowSourceLimit {
+		perWindowLimit = minWindowSourceLimit
+	}
+	if perWindowLimit > maxWindowSourceLimit {
+		perWindowLimit = maxWindowSourceLimit
+	}
+
+	return startNs, endNs, interval, perWindowLimit, true
 }
 
 func limitPatternPayload(payload []byte, limit int) []byte {
@@ -4657,6 +4746,83 @@ func patternResultEntriesFromMaps(patterns []map[string]interface{}) []patternRe
 	if len(out) == 0 {
 		return nil
 	}
+	return out
+}
+
+func mergePatternResultEntries(base, extra []patternResultEntry) []patternResultEntry {
+	if len(base) == 0 {
+		return extra
+	}
+	if len(extra) == 0 {
+		return base
+	}
+
+	type bucket struct {
+		level   string
+		pattern string
+		samples map[int64]int
+		total   int
+	}
+
+	merged := map[string]*bucket{}
+	add := func(items []patternResultEntry) {
+		for _, item := range items {
+			pattern := strings.TrimSpace(item.Pattern)
+			if pattern == "" {
+				continue
+			}
+			key := item.Level + "\x00" + pattern
+			b := merged[key]
+			if b == nil {
+				b = &bucket{
+					level:   strings.TrimSpace(item.Level),
+					pattern: pattern,
+					samples: map[int64]int{},
+				}
+				merged[key] = b
+			}
+			for _, pair := range item.Samples {
+				if len(pair) < 2 {
+					continue
+				}
+				ts, okTS := numberToInt64(pair[0])
+				count, okCount := numberToInt(pair[1])
+				if !okTS || !okCount {
+					continue
+				}
+				b.samples[ts] += count
+				b.total += count
+			}
+		}
+	}
+
+	add(base)
+	add(extra)
+
+	items := make([]*bucket, 0, len(merged))
+	for _, item := range merged {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].total > items[j].total })
+
+	out := make([]patternResultEntry, 0, len(items))
+	for _, item := range items {
+		timestamps := make([]int64, 0, len(item.samples))
+		for ts := range item.samples {
+			timestamps = append(timestamps, ts)
+		}
+		sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
+		samples := make([][]interface{}, 0, len(timestamps))
+		for _, ts := range timestamps {
+			samples = append(samples, []interface{}{ts, item.samples[ts]})
+		}
+		entry := patternResultEntry{Pattern: item.pattern, Samples: samples}
+		if item.level != "" {
+			entry.Level = item.level
+		}
+		out = append(out, entry)
+	}
+
 	return out
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -810,7 +811,7 @@ func TestContract_Patterns_UsesFromToWhenStartEndMissing(t *testing.T) {
 }
 
 func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
-	var receivedLimit string
+	receivedLimits := make([]string, 0, 32)
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/select/logsql/query_range" {
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
@@ -818,7 +819,7 @@ func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("parse form: %v", err)
 		}
-		receivedLimit = r.FormValue("limit")
+		receivedLimits = append(receivedLimits, r.FormValue("limit"))
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"GET /api/users 200 15ms","level":"info"}` + "\n"))
 	}))
@@ -836,8 +837,20 @@ func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
 	}
-	if receivedLimit != "50000" {
-		t.Fatalf("expected adaptive source limit capped at 50000 for long range, got %q", receivedLimit)
+	if len(receivedLimits) < 2 {
+		t.Fatalf("expected windowed query_range fanout for long range, got %d backend calls", len(receivedLimits))
+	}
+	if receivedLimits[0] != "50000" {
+		t.Fatalf("expected initial adaptive source limit capped at 50000 for long range, got %q", receivedLimits[0])
+	}
+	for i, limit := range receivedLimits[1:] {
+		n, err := strconv.Atoi(limit)
+		if err != nil {
+			t.Fatalf("expected numeric per-window limit at call %d, got %q", i+2, limit)
+		}
+		if n <= 0 || n > 10000 {
+			t.Fatalf("expected per-window limit in range 1..10000 at call %d, got %d", i+2, n)
+		}
 	}
 }
 
@@ -870,6 +883,61 @@ func TestContract_Patterns_DerivesStepWhenMissing(t *testing.T) {
 	}
 	if strings.TrimSpace(receivedStep) == "" {
 		t.Fatalf("expected derived step to be forwarded when request step is missing")
+	}
+}
+
+func TestContract_Patterns_WindowedSamplingCoversWholeRange(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query_range" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		startRaw := strings.TrimSpace(r.FormValue("start"))
+		startVal, err := strconv.ParseInt(startRaw, 10, 64)
+		if err != nil {
+			t.Fatalf("expected numeric start timestamp, got %q: %v", startRaw, err)
+		}
+		startSec := startVal
+		if len(startRaw) > 10 {
+			startSec = startVal / int64(time.Second)
+		}
+		ts := time.Unix(startSec, 0).UTC().Format(time.RFC3339)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"_time":"%s","_msg":"finished_unary_call code=OK method=Fetch","level":"info"}`+"\n", ts)))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		"GET",
+		"/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=1712311200&end=1712484000&step=60s&line_limit=20",
+		nil,
+	)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp patternsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Data) == 0 {
+		t.Fatalf("expected non-empty patterns response")
+	}
+	samples := resp.Data[0].Samples
+	if len(samples) < 2 {
+		t.Fatalf("expected windowed sampling to produce samples across range, got %v", samples)
+	}
+	firstTS, okFirst := numberToInt64(samples[0][0])
+	lastTS, okLast := numberToInt64(samples[len(samples)-1][0])
+	if !okFirst || !okLast {
+		t.Fatalf("expected numeric sample timestamps, got first=%v last=%v", samples[0], samples[len(samples)-1])
+	}
+	if firstTS >= lastTS {
+		t.Fatalf("expected increasing sample timestamps across range, got first=%d last=%d", firstTS, lastTS)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -905,7 +905,7 @@ func TestContract_Patterns_WindowedSamplingCoversWholeRange(t *testing.T) {
 		}
 		ts := time.Unix(startSec, 0).UTC().Format(time.RFC3339)
 		w.Header().Set("Content-Type", "application/x-ndjson")
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"_time":"%s","_msg":"finished_unary_call code=OK method=Fetch","level":"info"}`+"\n", ts)))
+		_, _ = fmt.Fprintf(w, `{"_time":"%s","_msg":"finished_unary_call code=OK method=Fetch","level":"info"}`+"\n", ts)
 	}))
 	defer vlBackend.Close()
 


### PR DESCRIPTION
## Summary
- keep Loki-compatible limits surface (/config/tenant/v1/limits and /loki/api/v1/drilldown-limits) aligned with runtime-configured limits
- improve /loki/api/v1/patterns for long ranges by adding windowed query_range sampling and deterministic merge of pattern samples
- retain existing query_range-first behavior and fallback to query when needed

## Why
Drilldown pattern graphs were effectively short-lived for wide ranges because a single extraction pass could under-sample long windows. Loki compatibility requires robust wide-range behavior for pattern visualization.

## Implementation
- handlePatterns now:
  - fetches base pattern entries from /select/logsql/query_range
  - for large time ranges, splits range into bounded windows
  - re-fetches each window with bounded per-window limit
  - merges samples by (level, pattern, timestamp) and sums counts
- added helpers:
  - cloneURLValues
  - patternWindowedSamplingConfig
  - mergePatternResultEntries

## Tests
- updated TestContract_Patterns_AdaptiveSourceLimitForLongRanges to assert fanout and bounded per-window limits
- added TestContract_Patterns_WindowedSamplingCoversWholeRange
- local run:
  - go test ./internal/proxy -run 'TestContract_Patterns|TestDrilldown|TestFeature_Patterns|TestPatterns' -count=1
  - result: pass