### PR TITLE
ci: enable Pages during docs-site deploy

### DIFF
--- a/.github/workflows/docs-site.yaml
+++ b/.github/workflows/docs-site.yaml
@@ -27,6 +27,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,6 +53,8 @@ jobs:
       - name: Configure Pages
         if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI
 
 - add a GitHub Pages workflow that builds and deploys the Docusaurus site from `website/`
+- let the Pages workflow auto-enable GitHub Pages on the first `main` deployment instead of failing when the site is not yet provisioned
 
 ## [1.0.15] - 2026-04-14
 


### PR DESCRIPTION
## Summary
- allow the docs-site workflow to auto-enable GitHub Pages on the first deployment
- give the build job the Pages permissions needed by actions/configure-pages
- record the workflow fix in the unreleased changelog

## Validation
- rtk npm --prefix website run build
- reviewed docs-site workflow change against the failing main-branch run 24411627423
