### PR TITLE
ci: skip docs deploy until Pages is enabled

### DIFF
--- a/.github/workflows/docs-site.yaml
+++ b/.github/workflows/docs-site.yaml
@@ -27,6 +27,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      pages_site_exists: ${{ steps.pages_site.outputs.exists || 'false' }}
     permissions:
       contents: read
       pages: write
@@ -50,20 +52,40 @@ jobs:
         working-directory: website
         run: npm run build
 
-      - name: Configure Pages
+      - name: Detect Pages site
         if: github.event_name != 'pull_request'
+        id: pages_site
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if curl -fsS \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "### GitHub Pages not enabled"
+            echo ""
+            echo "Site build succeeded, but deployment was skipped because GitHub Pages is not enabled for this repository."
+            echo "Enable GitHub Pages in repository settings and select GitHub Actions as the source, then rerun this workflow."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Configure Pages
+        if: github.event_name != 'pull_request' && steps.pages_site.outputs.exists == 'true'
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.pages_site.outputs.exists == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: website/build
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && needs.build.outputs.pages_site_exists == 'true'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI
 
 - add a GitHub Pages workflow that builds and deploys the Docusaurus site from `website/`
-- let the Pages workflow auto-enable GitHub Pages on the first `main` deployment instead of failing when the site is not yet provisioned
+- skip docs-site deployment cleanly until GitHub Pages is enabled in repository settings, instead of failing `main` builds when the Pages site is not yet provisioned
 
 ## [1.0.15] - 2026-04-14
 


### PR DESCRIPTION
## Summary
- detect whether GitHub Pages is already enabled for the repository
- skip configure/deploy steps when the Pages site does not exist yet
- leave the website build green and add a clear workflow summary instead of failing main

## Why
- main-branch docs-site run 24411855015 failed because the GITHUB_TOKEN cannot create the Pages site for this repository
- this keeps CI green until a repo admin enables Pages in settings

## Validation
- rtk npm --prefix website run build
- reviewed failure in actions run 24411855015 / job 71310530744
