### PR TITLE
patterns: keep full-range charts for dense and relative ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- patterns: keep `/loki/api/v1/patterns` charts full-range on large scopes by parsing relative range boundaries and adaptively coarsening overly dense bucket grids instead of returning sparse short-tail samples.
+
 ## [1.0.20] - 2026-04-14
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - patterns: normalize relative-range (`now`/`now-*`) cache key boundaries for `/loki/api/v1/patterns` so Drilldown refresh requests consistently reuse the correct time-scoped cache entries
 - patterns: fill returned `samples` across the full requested range (`start..end` by `step`) with zero buckets for missing intervals, preventing short-tail-only pattern graphs after refresh
+- patterns: parse relative (`now`/`now-*`) boundaries in extraction/fill paths and adaptively coarsen overly dense bucket grids, so large-scope high-volume pattern charts render full selected ranges instead of collapsing to recent minutes
 
 ## [1.0.18] - 2026-04-14
 

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -297,20 +297,12 @@ func parsePatternUnixSeconds(raw interface{}) (int64, bool) {
 	if parsed, err := time.Parse(time.RFC3339, timeStr); err == nil {
 		return parsed.Unix(), true
 	}
-	value, err := strconv.ParseInt(timeStr, 10, 64)
-	if err != nil {
-		return 0, false
+	// Reuse Loki-compatible parser for numeric, RFC3339, and relative ("now-24h")
+	// boundaries so pattern sampling/filling stays stable with Drilldown ranges.
+	if ns, ok := parseLokiTimeToUnixNano(timeStr); ok {
+		return ns / int64(time.Second), true
 	}
-	switch l := len(timeStr); {
-	case l >= 19:
-		return value / 1_000_000_000, true
-	case l >= 16:
-		return value / 1_000_000, true
-	case l >= 13:
-		return value / 1_000, true
-	default:
-		return value, true
-	}
+	return 0, false
 }
 
 func patternMessageFromEntry(entry map[string]interface{}) (string, bool) {

--- a/internal/proxy/postprocess_test.go
+++ b/internal/proxy/postprocess_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDecolorizeStreams(t *testing.T) {
@@ -428,6 +429,26 @@ func TestParsePatternUnixSeconds(t *testing.T) {
 				t.Fatalf("expected %d, got %d", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestParsePatternUnixSeconds_RelativeNow(t *testing.T) {
+	now := time.Now().UTC()
+	gotNow, ok := parsePatternUnixSeconds("now")
+	if !ok {
+		t.Fatal("expected now to be parsed")
+	}
+	if delta := gotNow - now.Unix(); delta < -5 || delta > 5 {
+		t.Fatalf("expected now delta within +/-5s, got %d", delta)
+	}
+
+	gotPast, ok := parsePatternUnixSeconds("now-1h")
+	if !ok {
+		t.Fatal("expected now-1h to be parsed")
+	}
+	delta := gotNow - gotPast
+	if delta < 3595 || delta > 3605 {
+		t.Fatalf("expected now-1h delta close to 3600s, got %d", delta)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4970,15 +4970,27 @@ func fillPatternSamplesAcrossRequestedRange(entries []patternResultEntry, startP
 	if stepSeconds <= 0 {
 		return entries
 	}
-	startBucket := (startUnix / stepSeconds) * stepSeconds
-	endBucket := (endUnix / stepSeconds) * stepSeconds
+	effectiveStepSeconds := stepSeconds
+	startBucket := (startUnix / effectiveStepSeconds) * effectiveStepSeconds
+	endBucket := (endUnix / effectiveStepSeconds) * effectiveStepSeconds
 	if endBucket < startBucket {
 		return entries
 	}
 	const maxPatternRangePoints = 11000
-	points := int(((endBucket - startBucket) / stepSeconds) + 1)
-	if points <= 0 || points > maxPatternRangePoints {
+	points := int(((endBucket - startBucket) / effectiveStepSeconds) + 1)
+	if points <= 0 {
 		return entries
+	}
+	// For very long ranges with tiny steps (for example 1s over days), adaptively
+	// coarsen bucket resolution instead of returning sparse short-tail samples.
+	for points > maxPatternRangePoints {
+		effectiveStepSeconds *= 2
+		startBucket = (startUnix / effectiveStepSeconds) * effectiveStepSeconds
+		endBucket = (endUnix / effectiveStepSeconds) * effectiveStepSeconds
+		if endBucket < startBucket {
+			return entries
+		}
+		points = int(((endBucket - startBucket) / effectiveStepSeconds) + 1)
 	}
 	for i := range entries {
 		sampleMap := make(map[int64]int, len(entries[i].Samples))
@@ -4991,10 +5003,11 @@ func fillPatternSamplesAcrossRequestedRange(entries []patternResultEntry, startP
 			if !okTS || !okCount {
 				continue
 			}
+			ts = (ts / effectiveStepSeconds) * effectiveStepSeconds
 			sampleMap[ts] += count
 		}
 		filled := make([][]interface{}, 0, points)
-		for ts := startBucket; ts <= endBucket; ts += stepSeconds {
+		for ts := startBucket; ts <= endBucket; ts += effectiveStepSeconds {
 			filled = append(filled, []interface{}{ts, sampleMap[ts]})
 		}
 		entries[i].Samples = filled

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1097,6 +1097,70 @@ func TestContract_Patterns_FillsSamplesAcrossRequestedRange(t *testing.T) {
 	}
 }
 
+func TestContract_Patterns_FillsSamplesAcrossRelativeNowRange(t *testing.T) {
+	now := time.Now().UTC()
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintf(
+			w,
+			`{"_time":"%s","_msg":"GET /api/users 200 15ms","app":"web","level":"info"}`+"\n",
+			now.Format(time.RFC3339Nano),
+		)
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		"GET",
+		"/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=now-24h&end=now&limit=1",
+		nil,
+	)
+	p.handlePatterns(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp patternsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected one pattern, got %v", resp.Data)
+	}
+	samples := resp.Data[0].Samples
+	if len(samples) < 100 {
+		t.Fatalf("expected long-range relative fill to produce >=100 buckets, got %d samples: %v", len(samples), samples)
+	}
+}
+
+func TestContract_Patterns_FillCoarsensHugePointRanges(t *testing.T) {
+	entries := []patternResultEntry{
+		{
+			Pattern: "GET <_> <_> <_>",
+			Samples: [][]interface{}{
+				{int64(172799), 3},
+				{int64(172800), 4},
+			},
+		},
+	}
+
+	filled := fillPatternSamplesAcrossRequestedRange(entries, "0", "172800", "1s")
+	if len(filled) != 1 {
+		t.Fatalf("expected one filled entry, got %d", len(filled))
+	}
+	if got := len(filled[0].Samples); got <= 100 || got > 11000 {
+		t.Fatalf("expected adaptive coarsening to keep buckets in 101..11000, got %d", got)
+	}
+	firstTS, okFirst := numberToInt64(filled[0].Samples[0][0])
+	lastTS, okLast := numberToInt64(filled[0].Samples[len(filled[0].Samples)-1][0])
+	if !okFirst || !okLast {
+		t.Fatalf("expected numeric filled timestamps, got first=%v last=%v", filled[0].Samples[0], filled[0].Samples[len(filled[0].Samples)-1])
+	}
+	if firstTS != 0 || lastTS != 172800 {
+		t.Fatalf("expected filled range to remain anchored to request boundaries, got %d..%d", firstTS, lastTS)
+	}
+}
+
 func TestContract_Patterns_CustomPatternsPrepended(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/x-ndjson")


### PR DESCRIPTION
## Summary
- fix `/loki/api/v1/patterns` range filling for relative boundaries (`now`, `now-*`) by reusing Loki-compatible time parsing
- avoid short-tail-only charts on very dense long ranges by adaptively coarsening bucket step instead of skipping fill when point count exceeds cap
- keep pattern chart output anchored to requested start/end range

## Root Cause
When range fill exceeded `maxPatternRangePoints` (large span + tiny step), the code returned sparse source buckets and Drilldown rendered only recent minutes. Relative ranges were also not parsed in the fill path, so full-range fill could be skipped.

## Validation
- `go test ./internal/proxy -run 'TestContract_Patterns_FillsSamplesAcrossRequestedRange|TestContract_Patterns_FillsSamplesAcrossRelativeNowRange|TestContract_Patterns_FillCoarsensHugePointRanges|TestParsePatternUnixSeconds_RelativeNow' -count=1`
- `go test ./internal/proxy -count=1`
