### PR TITLE
Add Grafana runtime-aware compatibility profiles and request-surface gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - patterns: keep `/loki/api/v1/patterns` charts full-range on large scopes by parsing relative range boundaries and adaptively coarsening overly dense bucket grids instead of returning sparse short-tail samples.
+- patterns: harden long-range windowed extraction by using direct `query_range` fanout per window and bounded per-window limits, avoiding helper-path stalls and preserving deterministic dense-range coverage.
+- compatibility gate: enforce minimum supported VictoriaLogs version at startup (with explicit unsafe bypass flag) and add version-sensed runtime capability profiles for stream metadata and dense pattern windowing paths.
+- metadata browse: add version-gated (`v1.49+`) forwarding of `q` + `filter=substring` to VictoriaLogs `field_*`/`stream_field_*` endpoints, with safe fallback behavior for older versions.
+- cache freshness: add near-now stale-cache bypass controls (`recent-tail-refresh-*`) for `query_range`, `index/volume`, and `index/volume_range` to reduce refresh gaps without sacrificing long-lived historical cache reuse.
+
+### Tests
+
+- add regression coverage for VictoriaLogs version compatibility gate edge paths (missing version headers, health probe failure, non-success health status).
+- add cache freshness and persistence hardening tests for near-now cache bypass decisions, volume cache bypass behavior, patterns snapshot compaction, and patterns persistence loop startup/shutdown.
+
+### Documentation
+
+- compatibility matrix: bump Logs Drilldown contract coverage to `2.0.3` and VictoriaLogs pinned runtime coverage to `v1.50.0`, including updated support-band notes and pinned commit references.
+- compatibility matrix/docs: add VictoriaLogs runtime capability profiles (version-sensed feature gates) and document which LogSQL optimizations are enabled per version family.
+- compatibility matrix/docs: add Grafana Loki datasource compatibility profiles and Drilldown `v1`/`v2` capability profiles, including runtime detection limits (`X-Query-Tags` + `User-Agent`) and release-family watchlists for forward support planning.
 
 ## [1.0.20] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- ci: remove an unused Grafana surface helper that triggered lint failure.
+- tests: harden long-range patterns contract tests against race conditions under parallel window fanout (`-race`).
+
 ## [1.0.21] - 2026-04-14
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Operational note:
 - Grafana Loki query builder UI may tokenize dotted keys as `label=host`, `operator=.`, `value=id` for `host.id`. Query execution still works in code mode, but builder editing is safest with underscore aliases (`label-style=underscores`, `metadata-field-mode=translated`).
 - `extra-label-fields` can extend `/labels` and alias resolution for custom VL fields while keeping Loki-facing labels underscore-safe in conservative mode.
 
-Related docs: [Compatibility Matrix](docs/compatibility-matrix.md), [Loki Compatibility](docs/compatibility-loki.md), [Logs Drilldown Compatibility](docs/compatibility-drilldown.md), [VictoriaLogs Compatibility](docs/compatibility-victorialogs.md)
+Related docs: [Compatibility Matrix](docs/compatibility-matrix.md), [Loki Compatibility](docs/compatibility-loki.md), [Logs Drilldown Compatibility](docs/compatibility-drilldown.md), [Grafana Loki Datasource Compatibility](docs/compatibility-grafana-datasource.md), [VictoriaLogs Compatibility](docs/compatibility-victorialogs.md)
 
 ## LogQL Compatibility
 
@@ -348,6 +348,7 @@ See [Performance](docs/performance.md), [Fleet Cache](docs/fleet-cache.md), [Sca
 - [Compatibility Matrix](docs/compatibility-matrix.md)
 - [Loki Compatibility](docs/compatibility-loki.md)
 - [Logs Drilldown Compatibility](docs/compatibility-drilldown.md)
+- [Grafana Loki Datasource Compatibility](docs/compatibility-grafana-datasource.md)
 - [VictoriaLogs Compatibility](docs/compatibility-victorialogs.md)
 - [Translation Modes Guide](docs/translation-modes.md)
 - [Translation Reference](docs/translation-reference.md)

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -73,6 +73,9 @@ extraArgs:
   query-range-freshness: "10m"
   query-range-recent-cache-ttl: "0s"
   query-range-history-cache-ttl: "24h"
+  recent-tail-refresh-enabled: "true"
+  recent-tail-refresh-window: "2m"
+  recent-tail-refresh-max-staleness: "15s"
   # Long-range phase controls (defaults shown here; uncomment to override quickly):
   # query-range-prefilter-index-stats: "true"          # preflight /select/logsql/hits to skip empty windows
   # query-range-prefilter-min-windows: "8"             # prefilter engages only when split windows >= this threshold
@@ -84,6 +87,9 @@ extraArgs:
   # query-range-partial-responses: "false"             # return partial response on retryable backend failures
   # query-range-background-warm: "true"                # continue warming failed windows in background
   # query-range-background-warm-max-windows: "24"      # cap background warm fanout
+  # recent-tail-refresh-enabled: "true"                # bypass stale near-now cache hits and fetch latest backend data
+  # recent-tail-refresh-window: "2m"                   # only near-now ranges (end within window) are refreshed
+  # recent-tail-refresh-max-staleness: "15s"           # max near-now cache age before bypass
   # Indexed label-values browse cache (high-cardinality label UX).
   # Keep disabled by default; enable when label value lists are large and you
   # want hotset-first responses with optional offset/search.
@@ -92,6 +98,9 @@ extraArgs:
   label-values-index-max-entries: "200000"
   patterns-enabled: "true"
   patterns-autodetect-from-queries: "false"
+  backend-min-version: "v1.30.0"
+  backend-allow-unsupported-version: "false"
+  backend-version-check-timeout: "5s"
   log-level: "info"
   # Hardening
   http-read-timeout: "30s"
@@ -169,6 +178,9 @@ extraArgs:
   # compat-cache-enabled: "true"                # enable Tier0 compatibility-edge cache
   # compat-cache-max-percent: "10"              # Tier0 share of L1 cache budget (max 50)
   # backend-timeout: "120s"                     # upstream request timeout
+  # backend-min-version: "v1.30.0"              # startup minimum supported VictoriaLogs version
+  # backend-allow-unsupported-version: "false"  # allow older backend at your own risk
+  # backend-version-check-timeout: "5s"         # startup backend version check timeout
   # backend-tls-skip-verify: "false"
   # deployment-environment: ""                  # OTel deployment.environment.name
   # otel-service-name: "loki-vl-proxy"

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -63,6 +63,9 @@ type proxyRuntimeConfig struct {
 	tenantLimitsJSON                   string
 	maxLines                           int
 	backendTimeout                     time.Duration
+	backendMinVersion                  string
+	backendAllowUnsupportedVersion     bool
+	backendVersionCheckTimeout         time.Duration
 	backendBasicAuth                   string
 	backendCompression                 string
 	backendTLSSkip                     bool
@@ -99,6 +102,9 @@ type proxyRuntimeConfig struct {
 	queryRangePartialResponses         bool
 	queryRangeBackgroundWarm           bool
 	queryRangeBackgroundWarmMaxWindows int
+	recentTailRefreshEnabled           bool
+	recentTailRefreshWindow            time.Duration
+	recentTailRefreshMaxStaleness      time.Duration
 	authEnabled                        bool
 	allowGlobalTenant                  bool
 	registerInstrumentation            *bool
@@ -335,6 +341,9 @@ func run(
 	// Grafana datasource compatibility
 	maxLines := fs.Int("max-lines", 1000, "Default max lines per query")
 	backendTimeout := fs.Duration("backend-timeout", 120*time.Second, "Timeout for non-streaming requests to the VictoriaLogs backend")
+	backendMinVersion := fs.String("backend-min-version", "v1.30.0", "Minimum VictoriaLogs version considered fully supported at startup")
+	backendAllowUnsupportedVersion := fs.Bool("backend-allow-unsupported-version", false, "Allow startup with backend versions lower than -backend-min-version (at your own risk)")
+	backendVersionCheckTimeout := fs.Duration("backend-version-check-timeout", 5*time.Second, "Timeout for startup backend version compatibility check")
 	backendBasicAuth := fs.String("backend-basic-auth", "", "Basic auth for VL backend (user:password)")
 	backendCompression := fs.String("backend-compression", "auto", "Backend HTTP compression preference: auto, gzip, zstd, none")
 	backendTLSSkip := fs.Bool("backend-tls-skip-verify", false, "Skip TLS verification for VL backend")
@@ -371,6 +380,9 @@ func run(
 	queryRangePartialResponses := fs.Bool("query-range-partial-responses", false, "Allow partial query_range responses on retryable backend failures")
 	queryRangeBackgroundWarm := fs.Bool("query-range-background-warm", true, "Warm failed query_range windows in background after partial response")
 	queryRangeBackgroundWarmMaxWindows := fs.Int("query-range-background-warm-max-windows", 24, "Maximum query_range windows warmed in background after partial response")
+	recentTailRefreshEnabled := fs.Bool("recent-tail-refresh-enabled", true, "Bypass stale near-now cache hits and fetch latest backend data while preserving historical cache")
+	recentTailRefreshWindow := fs.Duration("recent-tail-refresh-window", 2*time.Minute, "How close request end must be to now to enable near-now cache freshness bypass")
+	recentTailRefreshMaxStaleness := fs.Duration("recent-tail-refresh-max-staleness", 15*time.Second, "Maximum acceptable cache age for near-now requests before cache bypass")
 
 	// Loki-style auth / instrumentation controls
 	authEnabled := fs.Bool("auth.enabled", false, "Require X-Scope-OrgID on query requests. When false, requests without a tenant header use the backend default tenant.")
@@ -492,6 +504,9 @@ func run(
 			tenantLimitsJSON:                   envCfg.tenantLimitsJSON,
 			maxLines:                           *maxLines,
 			backendTimeout:                     *backendTimeout,
+			backendMinVersion:                  *backendMinVersion,
+			backendAllowUnsupportedVersion:     *backendAllowUnsupportedVersion,
+			backendVersionCheckTimeout:         *backendVersionCheckTimeout,
 			backendBasicAuth:                   *backendBasicAuth,
 			backendCompression:                 resolvedBackendCompression,
 			backendTLSSkip:                     *backendTLSSkip,
@@ -528,6 +543,9 @@ func run(
 			queryRangePartialResponses:         *queryRangePartialResponses,
 			queryRangeBackgroundWarm:           *queryRangeBackgroundWarm,
 			queryRangeBackgroundWarmMaxWindows: *queryRangeBackgroundWarmMaxWindows,
+			recentTailRefreshEnabled:           *recentTailRefreshEnabled,
+			recentTailRefreshWindow:            *recentTailRefreshWindow,
+			recentTailRefreshMaxStaleness:      *recentTailRefreshMaxStaleness,
 			authEnabled:                        *authEnabled,
 			allowGlobalTenant:                  *allowGlobalTenant,
 			registerInstrumentation:            registerInstrumentation,
@@ -698,6 +716,11 @@ func buildRuntime(opts runtimeOptions, logger *slog.Logger, notify signalNotifie
 		cacheCleanup()
 		compatCleanup()
 		return nil, fmt.Errorf("create proxy: %w", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		cacheCleanup()
+		compatCleanup()
+		return nil, fmt.Errorf("backend compatibility gate: %w", err)
 	}
 	p.Init()
 
@@ -1188,6 +1211,9 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		TenantLimits:                       tenantLimits,
 		MaxLines:                           cfg.maxLines,
 		BackendTimeout:                     cfg.backendTimeout,
+		BackendMinVersion:                  cfg.backendMinVersion,
+		BackendAllowUnsupportedVersion:     cfg.backendAllowUnsupportedVersion,
+		BackendVersionCheckTimeout:         cfg.backendVersionCheckTimeout,
 		BackendBasicAuth:                   cfg.backendBasicAuth,
 		BackendCompression:                 cfg.backendCompression,
 		BackendTLSSkip:                     cfg.backendTLSSkip,
@@ -1222,6 +1248,9 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		QueryRangePartialResponses:         cfg.queryRangePartialResponses,
 		QueryRangeBackgroundWarm:           cfg.queryRangeBackgroundWarm,
 		QueryRangeBackgroundWarmMaxWindows: cfg.queryRangeBackgroundWarmMaxWindows,
+		RecentTailRefreshEnabled:           cfg.recentTailRefreshEnabled,
+		RecentTailRefreshWindow:            cfg.recentTailRefreshWindow,
+		RecentTailRefreshMaxStaleness:      cfg.recentTailRefreshMaxStaleness,
 		AuthEnabled:                        cfg.authEnabled,
 		AllowGlobalTenant:                  cfg.allowGlobalTenant,
 		RegisterInstrumentation:            cfg.registerInstrumentation,

--- a/docs/compatibility-drilldown.md
+++ b/docs/compatibility-drilldown.md
@@ -31,7 +31,9 @@ The Drilldown matrix is also a moving window. We support the current app family 
 
 | Logs Drilldown version | Coverage path | Version-specific focus |
 |---|---|---|
-| `2.0.1` | PR/main pinned runtime + scheduled/manual contract matrix | Current pinned contract |
+| `2.0.3` | PR/main pinned runtime + scheduled/manual contract matrix | Current pinned contract |
+| `2.0.2` | Scheduled and manual contract matrix | `detected_level` coloring, service-detail panels |
+| `2.0.1` | Scheduled and manual contract matrix | `detected_level` coloring, service-detail panels |
 | `2.0.0` | Scheduled and manual contract matrix | `detected_level` coloring, service-detail panels |
 | `1.0.41` | PR/main previous-family Grafana smoke + scheduled/manual contract matrix | Service buckets, detected-fields filtering, labels field parsing |
 | `1.0.40` | Scheduled and manual contract matrix | Service buckets, detected-fields filtering, labels field parsing |
@@ -41,6 +43,45 @@ The Drilldown matrix is also a moving window. We support the current app family 
 | `1.0.36` | Scheduled and manual contract matrix | Service buckets, detected-fields filtering, labels field parsing |
 | `1.0.35` | Scheduled and manual contract matrix | Service buckets, detected-fields filtering, labels field parsing |
 | `1.0.34` | Scheduled and manual contract matrix | Service buckets, detected-fields filtering, labels field parsing |
+
+## Runtime Detection And Version Coupling
+
+Proxy-side Drilldown detection is based on deterministic request signals:
+
+- `X-Query-Tags: Source=grafana-lokiexplore-app` identifies Drilldown-origin resource calls
+- `User-Agent: Grafana/<version>` provides Grafana runtime version family
+
+Important limit:
+
+- exact Drilldown app semver is not emitted on the datasource HTTP request path by default
+
+Because of that, version-specific behavior should be gated by:
+
+1. explicit request source tag,
+2. Grafana runtime family (`11.x`, `12.x`),
+3. compatibility matrix contract version bands (`1.0.x`, `2.0.x`), validated in CI.
+
+## Drilldown Capability Profiles
+
+| Drilldown version family | Capability profile | Proxy handling focus |
+|---|---|---|
+| `2.0.x` | `drilldown-v2` | detected-level defaults, modern service-detail scenes, patterns and field-value drill flows |
+| `1.0.x` | `drilldown-v1` | legacy service buckets, filtered detected-fields path, prior labels/field rendering behavior |
+
+These profiles are matrix-level compatibility profiles (contract and CI guidance). Runtime request handling must stay Loki-compatible and should not depend on guessed app build strings.
+
+## Release Watchlist
+
+Potential next family move:
+
+- current: `2.0.x`
+- next expected family to evaluate: `2.1.x` (then `3.0.x` when released)
+
+Promotion criteria for a new family:
+
+1. add versions to matrix manifest,
+2. verify `TestDrilldownTrackScore` and `TestDrilldown_RuntimeFamilyContracts` on pinned + smoke runtimes,
+3. confirm no regressions in patterns, labels/fields, and service detail flows.
 
 ## Contracts We Enforce
 

--- a/docs/compatibility-grafana-datasource.md
+++ b/docs/compatibility-grafana-datasource.md
@@ -1,0 +1,80 @@
+# Grafana Loki Datasource Compatibility
+
+This track focuses on the built-in Grafana Loki datasource contract (`/api/datasources/.../resources` and datasource proxy calls), separate from app-specific Drilldown behavior.
+
+## Scope
+
+- datasource catalog and health checks
+- datasource resource endpoints (`labels`, `label/<name>/values`, `detected_*`, `index/volume*`, `patterns`, `drilldown-limits`)
+- datasource proxy API path shape (`/api/datasources/proxy/uid/<uid>/loki/api/v1/...`)
+
+## CI Coverage
+
+- workflow: `compat-drilldown.yaml` (runtime smoke path)
+- primary runtime contract test: `TestGrafanaDatasourceCatalogAndHealth`
+- additional resource contract tests: `TestDrilldown_GrafanaResourceContracts`
+
+## Runtime Version Matrix
+
+| Grafana runtime version | Coverage path | Focus |
+|---|---|---|
+| `12.4.2` | pinned runtime CI | current-family datasource + Drilldown runtime contract |
+| `12.4.1` | PR smoke + scheduled/manual matrix | current-family datasource contract drift detection |
+| `11.6.6` | PR smoke + scheduled/manual matrix | previous-family datasource contract drift detection |
+
+## Client Detection Signals
+
+Runtime detection is signal-based, not guess-based:
+
+- Grafana runtime version: parsed from `User-Agent` (`Grafana/<version>`)
+- Drilldown caller surface: `X-Query-Tags: Source=grafana-lokiexplore-app`
+- Loki datasource caller surface: inferred from Grafana runtime request shape when no Drilldown source tag is present
+
+On-wire limitation:
+
+- Built-in Loki datasource plugin exact semver is not emitted on requests by default.
+- Proxy can reliably detect runtime family and client surface, but not the datasource plugin build number.
+
+## Version Handling Policy
+
+Use runtime-family capability profiles (like backend capability profiles for VictoriaLogs):
+
+- `grafana-runtime-v12-plus`
+  - treat as current-family behavior
+  - enable current contract assumptions verified by runtime-family tests
+- `grafana-runtime-v11`
+  - keep previous-family compatibility behavior
+  - preserve contract assumptions verified by runtime-family tests
+
+When a new Grafana family becomes current:
+
+1. add runtime to matrix,
+2. run datasource + Drilldown runtime contract tests,
+3. add/update profile row and focused edge cases,
+4. then slide support window forward.
+
+## What Can Differ By Family
+
+The proxy should keep Loki API behavior stable, but client request patterns can differ by runtime family:
+
+- default scene/query mixes and request ordering
+- Drilldown resource call density and timing
+- field/value follow-up query patterns
+- request retries and cancellation timing
+
+These are handled by strict contract tests and conservative runtime-family gating, not by ad-hoc heuristics.
+
+## Release Watchlist
+
+Potential next runtime family move:
+
+- current: `12.x`
+- previous supported: `11.x`
+- next expected family to evaluate: `13.x`
+
+Promotion criteria for runtime family updates:
+
+1. add runtime versions in `test/e2e-compat/compatibility-matrix.json`,
+2. pass `TestGrafanaDatasourceCatalogAndHealth` and `TestDrilldown_RuntimeFamilyContracts`,
+3. verify proxy request-surface detection logs stay stable (`grafana.version`, `grafana.client.surface`, `grafana.client.source_tag`),
+4. then slide support window and drop oldest family.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-This project tracks compatibility on three separate layers. They are intentionally split because each layer has different contracts, failure modes, and supported version ranges.
+This project tracks compatibility on four separate layers. They are intentionally split because each layer has different contracts, failure modes, and supported version ranges.
 
 ## Tracks
 
@@ -8,33 +8,53 @@ This project tracks compatibility on three separate layers. They are intentional
 |---|---|---|---|---|
 | Loki | Does the proxy behave like Loki for Loki clients and LogQL? | `compat-loki.yaml` | `TestLokiTrackScore` | [compatibility-loki.md](compatibility-loki.md) |
 | Logs Drilldown | Does Grafana Logs Drilldown still work through the Loki datasource proxy path? | `compat-drilldown.yaml` | `TestDrilldownTrackScore` | [compatibility-drilldown.md](compatibility-drilldown.md) |
+| Grafana Loki Datasource | Does the built-in Grafana Loki datasource contract stay stable across supported Grafana runtime families? | `compat-drilldown.yaml` | `TestGrafanaDatasourceCatalogAndHealth` | [compatibility-grafana-datasource.md](compatibility-grafana-datasource.md) |
 | VictoriaLogs | Does the proxy keep VictoriaLogs backend behavior stable while translating to Loki semantics? | `compat-vl.yaml` | `TestVLTrackScore` | [compatibility-victorialogs.md](compatibility-victorialogs.md) |
 
 The tracked versions live in [compatibility-matrix.json](../test/e2e-compat/compatibility-matrix.json).
 The GitHub Actions compatibility workflows read their matrix lists directly from that manifest, so the repo has a single source of truth for supported versions.
+VictoriaLogs capability profiles (used by runtime version sensing in proxy code) are tracked in the same manifest under `stack.victorialogs.capability_profiles`.
+Grafana runtime and client-surface capability profiles are tracked under `stack.grafana_loki_datasource_contract.capability_profiles` and `stack.logs_drilldown_contract.capability_profiles`.
 
 ## Support Window Policy
 
 The matrix is intentionally not open-ended. For every upstream we support a moving window that advances as new releases land:
 
 - Loki: current minor family plus one minor family behind, including patch releases in those two families
-- VictoriaLogs: the `v1.3x.x` and `v1.4x.x` support bands
+- VictoriaLogs: transitional support across `v1.3x.x` through `v1.5x.x`
 - Logs Drilldown: current release family plus one family behind, including patch releases in those two families
+- Grafana runtime (for built-in Loki datasource): current runtime family plus one family behind
 
-When a new upstream family becomes current, the oldest family drops out of the matrix. VictoriaLogs is the one exception right now: we intentionally keep the broader `v1.3x.x` and `v1.4x.x` band because backend upgrades lag more often during migrations. This keeps the compatibility budget focused on versions we can realistically support.
+When a new upstream family becomes current, the oldest family drops out of the matrix. VictoriaLogs is the one exception right now: we intentionally keep the broader `v1.3x.x` through `v1.5x.x` band because backend upgrades lag more often during migrations. This keeps the compatibility budget focused on versions we can realistically support.
 
 ## Matrix Summary
 
 | Component family | Versions tracked | Coverage mode |
 |---|---|---|
 | Loki | `3.6.x` and `3.7.x` | Real runtime matrix in GitHub Actions |
+| Grafana Loki datasource runtime | `11.x` and `12.x` | Runtime contracts through Grafana datasource API in GitHub Actions |
 | Logs Drilldown | `1.0.x` and `2.0.x` | Pinned runtime e2e plus source-contract matrix |
-| VictoriaLogs | `v1.30.x` through `v1.49.x` | Real runtime matrix in GitHub Actions |
+| VictoriaLogs | `v1.30.x` through `v1.50.x` | Real runtime matrix in GitHub Actions |
+
+## Grafana Version Sensing Model
+
+Proxy-side client sensing is intentionally conservative:
+
+- Drilldown client detection: `X-Query-Tags: Source=grafana-lokiexplore-app`
+- Grafana runtime version detection: `User-Agent` (`Grafana/<version>`)
+- Built-in Loki datasource plugin exact semver: not exposed on wire by default
+
+Because datasource semver is not emitted in requests, proxy behavior should gate by:
+
+1. deterministic request signals (`X-Query-Tags`, endpoint family)
+2. Grafana runtime family (`11.x`, `12.x`, future `13.x`)
+3. compatibility matrix and e2e contracts, not guessed plugin build strings
 
 ## Why The Tracks Are Separate
 
 - Loki compatibility is about frontend semantics: query results, labels, streams, and LogQL behavior.
 - Drilldown compatibility is about Grafana app contracts: datasource resources, log frame labels, level coloring, and breakdown panels.
+- Grafana datasource compatibility is about Grafana-to-proxy request shape and resource/API contract stability across runtime families.
 - VictoriaLogs compatibility is about backend assumptions: how the proxy uses `field_names`, `field_values`, `hits`, `_stream`, and structured fields.
 
 Blending those into one percentage hides which layer actually regressed. The repo now treats them as separate compatibility products.

--- a/docs/compatibility-victorialogs.md
+++ b/docs/compatibility-victorialogs.md
@@ -13,15 +13,16 @@ This track measures whether the proxy keeps VictoriaLogs behavior usable and sta
 
 - Workflow: `compat-vl.yaml`
 - Score test: `TestVLTrackScore`
-- Runtime matrix: real VictoriaLogs images from the `v1.3x.x` and `v1.4x.x` bands
+- Runtime matrix: real VictoriaLogs images from the `v1.3x.x` through `v1.5x.x` bands
 
-VictoriaLogs is intentionally broader than the Loki support window. We support `v1.3x.x` and `v1.4x.x` because backend upgrades often lag behind proxy upgrades during migrations. When the backend support band moves forward, the oldest decade-band drops out.
+VictoriaLogs is intentionally broader than the Loki support window. We support `v1.3x.x` through `v1.5x.x` because backend upgrades often lag behind proxy upgrades during migrations. When the backend support band moves forward, the oldest decade-band drops out.
 
 ## Version Matrix
 
 | VictoriaLogs version | Coverage path | Version-specific focus |
 |---|---|---|
-| `v1.49.0` | PR and main CI pinned runtime | Current pinned backend |
+| `v1.50.0` | PR and main CI pinned runtime | Current pinned backend |
+| `v1.49.0` | Scheduled and manual matrix | Structured metadata shaping, volume endpoints |
 | `v1.48.0` | Scheduled and manual matrix | Structured metadata shaping, volume endpoints |
 | `v1.47.0` | Scheduled and manual matrix | Structured metadata shaping, volume endpoints |
 | `v1.46.0` | Scheduled and manual matrix | Structured metadata shaping, volume endpoints |
@@ -48,3 +49,47 @@ VictoriaLogs is intentionally broader than the Loki support window. We support `
 - `detected_fields` and `detected_field/<name>/values` derived from VictoriaLogs field content
 - Loki `index/stats`, `index/volume`, and `index/volume_range` backed by VictoriaLogs `hits` and stats endpoints
 - Raw VictoriaLogs fields mapped into parsed fields or structured metadata without polluting stream labels
+
+## Runtime Capability Profiles
+
+The proxy passively detects backend version from upstream response headers and selects a capability profile. This keeps one binary safe across mixed backend versions while enabling newer LogSQL optimizations where available.
+
+| VictoriaLogs version family | Capability profile | Stream metadata endpoints fast path (`stream_field_*`) | Metadata substring filter (`q` + `filter=substring`) | Dense patterns windowing profile |
+|---|---|---|---|---|
+| `v1.50.x+` | `vl-v1.50-plus` | enabled | enabled | enabled |
+| `v1.49.x` | `vl-v1.49-plus` | enabled | enabled | disabled (conservative profile) |
+| `v1.30.x` to `v1.48.x` | `vl-v1.30-plus` | enabled | disabled | disabled (conservative profile) |
+| `< v1.30.0` | `legacy-pre-v1.30` | disabled (fallback to generic `field_*`) | disabled | disabled |
+| unknown (before first upstream response) | `unknown` | enabled (optimistic default) | disabled (safe default) | disabled (safe default) |
+
+Current code gates:
+
+- pattern extraction window density for `/loki/api/v1/patterns`
+- stream-metadata-first label inventory/value lookups (`/select/logsql/stream_field_names`, `/select/logsql/stream_field_values`)
+- metadata search fan-in via `q` + `filter=substring` on `field_*` and `stream_field_*` endpoints
+
+As new LogSQL backend features land, this table and the capability derivation in proxy code should be updated together, with explicit tests per profile.
+
+## Feature Capability Matrix (v1.30.0 To v1.50.0)
+
+The table below tracks changelog-relevant LogSQL and metadata behavior between `v1.30.0` and `v1.50.0`, and how the proxy should treat each band.
+
+| Version band | Backend capability signals | Limitations / risks to account for | Proxy handling policy |
+|---|---|---|---|
+| `v1.30.x` to `v1.33.x` | baseline stable `field_*`, `stream_field_*`, `hits`, and core query endpoints | older query-path edge cases; use conservative behavior for expensive pattern extraction | keep stream metadata fast-path enabled; keep conservative (non-dense) pattern windowing |
+| `v1.34.x` to `v1.48.x` | improved cluster query behavior and partial-response handling in VictoriaLogs changelog line | still treat dense pattern extraction as opt-in to avoid long-range overload in mixed backends | same runtime profile as `vl-v1.30-plus`; prefer conservative pattern sampling |
+| `v1.49.x` | adds `filter=substring` support for `field_names` / `field_values` and stream metadata browse endpoints | older versions do not support this parameter reliably | gate substring server-side filtering by backend capability; keep fallback filtering in proxy for older versions |
+| `v1.50.x+` | parser/query fixes and latest metadata/query behavior; current pinned target | none specific beyond normal backend saturation limits | enable `vl-v1.50-plus` profile, including dense patterns windowing and newest metadata behavior |
+| `< v1.30.0` | legacy behavior only | higher compatibility risk for modern drilldown/explore contracts | block startup by default (`backend-min-version`), allow override with `backend-allow-unsupported-version=true` |
+
+### Capability Profile Guidance
+
+- `vl-v1.50-plus`: use for latest backend capabilities and densest safe pattern windowing.
+- `vl-v1.30-plus`: compatibility-first profile across transitional fleets.
+- `legacy-pre-v1.30`: fallback-only profile, intended for temporary migrations.
+
+When adding a new profile or changing a gate, update three places in the same PR:
+
+- runtime derivation in `internal/proxy/proxy.go`
+- capability metadata in `test/e2e-compat/compatibility-matrix.json`
+- this document section

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,6 +289,9 @@ These flags control Loki-compatible `query_range` split/merge execution with per
 | `-query-range-partial-responses` | — | `false` | Allow partial `query_range` responses on retryable backend failures |
 | `-query-range-background-warm` | — | `true` | Continue warming failed windows in background after a partial response |
 | `-query-range-background-warm-max-windows` | — | `24` | Cap background warm fanout after a partial response |
+| `-recent-tail-refresh-enabled` | — | `true` | Enable near-now stale-cache bypass for `query_range`, `index/volume`, and `index/volume_range` |
+| `-recent-tail-refresh-window` | — | `2m` | Treat requests ending within this window from `now` as near-now |
+| `-recent-tail-refresh-max-staleness` | — | `15s` | Maximum acceptable cache age for near-now requests before forcing a fresh backend fetch |
 
 ### Loki-Aligned Defaults
 
@@ -500,6 +503,9 @@ Operational notes:
 |---|---|---|---|
 | `-max-lines` | — | `1000` | Default max lines per query |
 | `-backend-timeout` | — | `120s` | Timeout for non-streaming VL backend requests |
+| `-backend-min-version` | — | `v1.30.0` | Minimum VictoriaLogs version considered fully supported at startup compatibility gate |
+| `-backend-allow-unsupported-version` | — | `false` | Allow startup when detected backend version is lower than `-backend-min-version` (unsafe override) |
+| `-backend-version-check-timeout` | — | `5s` | Timeout for startup backend version compatibility check (`/health`) |
 | `-stream-response` | — | `false` | Stream via chunked transfer |
 | `-response-compression` | — | `auto` | Response compression codec: `auto`, `gzip`, `zstd`, `none` |
 | `-response-gzip` | — | `true` | Deprecated compatibility switch; `false` disables response compression when `-response-compression` is unset |
@@ -522,6 +528,13 @@ Compression notes:
 - `-backend-compression=auto` advertises `zstd, gzip` upstream and the proxy safely decodes either on the way back.
 - current VictoriaLogs docs describe HTTP response compression in general terms, not a guaranteed `zstd` select-query path, so in practice many deployments will still observe `gzip` or identity from stock VictoriaLogs today.
 - Grafana `12.4.2` datasource proxy requests advertised `Accept-Encoding: deflate, gzip`, not `zstd`, in local verification, so `auto` will not magically turn standard Grafana datasource traffic into `zstd` today.
+
+Backend version gate notes:
+
+- On startup, proxy probes backend `/health` and inspects response headers for a VictoriaLogs semver.
+- If detected version is below `-backend-min-version`, startup is blocked by default.
+- Set `-backend-allow-unsupported-version=true` to bypass the gate at your own risk.
+- If version cannot be detected from headers, proxy logs a warning and continues startup.
 
 ## Built-In Protection Defaults
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -235,21 +235,22 @@ Moved out of Playwright:
 
 ## Compatibility Tracks
 
-The repo now keeps three separate compatibility tracks:
+The repo now keeps four separate compatibility tracks/contracts:
 
 | Track | Local score test | Matrix coverage |
 |---|---|---|
 | Loki | `TestLokiTrackScore` | Loki `3.6.x` and `3.7.x` |
 | Logs Drilldown | `TestDrilldownTrackScore` | Logs Drilldown `1.0.x` and `2.0.x` families |
-| VictoriaLogs | `TestVLTrackScore` | VictoriaLogs `v1.3x.x` and `v1.4x.x` bands |
+| Grafana Loki datasource | `TestGrafanaDatasourceCatalogAndHealth` | Grafana runtime `11.x` and `12.x` families |
+| VictoriaLogs | `TestVLTrackScore` | VictoriaLogs `v1.3x.x` through `v1.5x.x` transition band |
 
 The default local stack is pinned to:
 
 - Loki `3.7.1`
-- VictoriaLogs `v1.49.0`
+- VictoriaLogs `v1.50.0`
 - vmalert `v1.138.0` (with local VictoriaMetrics remote-write target for recording-rule evaluation)
 - Grafana `12.4.2`
-- Logs Drilldown contract `2.0.1` from `grafana/logs-drilldown` commit `4463f56047de75da95251086d1906fb902ad53a7`
+- Logs Drilldown contract `2.0.3` from `grafana/logs-drilldown` commit `c22fae24f533a36ec2173933d2c303804cb7e814`
 
 Field-surface defaults in the pinned stack:
 
@@ -269,7 +270,7 @@ Support window policy:
 - Loki: current minor family plus one minor behind
 - Grafana runtime: pinned current family gets the fuller Drilldown runtime contract, and pull requests also run smaller current-family and previous-family smoke profiles; the full runtime matrix stays on scheduled/manual coverage
 - Logs Drilldown: current family plus one family behind
-- VictoriaLogs: `v1.3x.x` and `v1.4x.x`
+- VictoriaLogs: `v1.3x.x` through `v1.5x.x` (transition band)
 
 Grafana runtime profiles from the manifest:
 

--- a/internal/proxy/label_surface_test.go
+++ b/internal/proxy/label_surface_test.go
@@ -574,7 +574,7 @@ func TestLabelSurface_AsyncRefreshPathsPopulateCache(t *testing.T) {
 		t.Fatalf("failed to create proxy: %v", err)
 	}
 
-	p.refreshLabelValuesCacheAsync("", "label_values:async", "app", "", "", "", "")
+	p.refreshLabelValuesCacheAsync("", "label_values:async", "app", "", "", "", "", "")
 	waitForCachedKey(t, c, "label_values:async")
 
 	p.refreshDetectedFieldsCacheAsync("", "detected_fields:async", `{service_name="svc-a"}`, "", "", 100)
@@ -650,7 +650,7 @@ func TestLabelSurface_RefreshLabelsCacheAsyncPopulatesCache(t *testing.T) {
 	}
 
 	cacheKey := "labels:async"
-	p.refreshLabelsCacheAsync("", cacheKey, `{service_name="svc-a"}`, "", "")
+	p.refreshLabelsCacheAsync("", cacheKey, `{service_name="svc-a"}`, "", "", "")
 	raw := waitForCachedKey(t, c, cacheKey)
 
 	if streamFieldNamesCalls.Load() == 0 {
@@ -668,6 +668,87 @@ func TestLabelSurface_RefreshLabelsCacheAsyncPopulatesCache(t *testing.T) {
 	}
 	if contains(resp.Data, "_msg") {
 		t.Fatalf("expected internal labels to be filtered, got %v", resp.Data)
+	}
+}
+
+func TestLabelSurface_RefreshLabelsCacheAsync_ForwardsSubstringFilterWhenSupported(t *testing.T) {
+	var gotQ, gotFilter atomic.Value
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stream_field_names" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		gotQ.Store(r.URL.Query().Get("q"))
+		gotFilter.Store(r.URL.Query().Get("filter"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"values":[{"value":"service.name","hits":2}]}`))
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:        vlBackend.URL,
+		Cache:             c,
+		LogLevel:          "error",
+		LabelStyle:        LabelStyleUnderscores,
+		MetadataFieldMode: MetadataFieldModeTranslated,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	p.observeBackendVersionFromHeaders(http.Header{"Server": []string{"VictoriaLogs/v1.49.0"}})
+
+	cacheKey := "labels:async:substring"
+	p.refreshLabelsCacheAsync("", cacheKey, `{service_name="svc-a"}`, "", "", "svc")
+	_ = waitForCachedKey(t, c, cacheKey)
+
+	if v, _ := gotQ.Load().(string); v != "svc" {
+		t.Fatalf("expected q=svc for async labels refresh, got %q", v)
+	}
+	if v, _ := gotFilter.Load().(string); v != "substring" {
+		t.Fatalf("expected filter=substring for async labels refresh, got %q", v)
+	}
+}
+
+func TestLabelSurface_RefreshLabelValuesCacheAsync_ForwardsSubstringFilterWhenSupported(t *testing.T) {
+	var gotQ, gotFilter atomic.Value
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"app","hits":2}]}`))
+		case "/select/logsql/stream_field_values":
+			gotQ.Store(r.URL.Query().Get("q"))
+			gotFilter.Store(r.URL.Query().Get("filter"))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"svc-a","hits":2}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL:        vlBackend.URL,
+		Cache:             c,
+		LogLevel:          "error",
+		LabelStyle:        LabelStyleUnderscores,
+		MetadataFieldMode: MetadataFieldModeTranslated,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	p.observeBackendVersionFromHeaders(http.Header{"Server": []string{"VictoriaLogs/v1.49.0"}})
+
+	cacheKey := "label_values:async:substring"
+	p.refreshLabelValuesCacheAsync("", cacheKey, "app", `{service_name="svc-a"}`, "", "", "", "svc")
+	_ = waitForCachedKey(t, c, cacheKey)
+
+	if v, _ := gotQ.Load().(string); v != "svc" {
+		t.Fatalf("expected q=svc for async label values refresh, got %q", v)
+	}
+	if v, _ := gotFilter.Load().(string); v != "substring" {
+		t.Fatalf("expected filter=substring for async label values refresh, got %q", v)
 	}
 }
 

--- a/internal/proxy/labels_fields_scale_bench_test.go
+++ b/internal/proxy/labels_fields_scale_bench_test.go
@@ -140,11 +140,11 @@ func BenchmarkProxy_LabelValues_Scale_CacheHit(b *testing.B) {
 
 			rawURL := "/loki/api/v1/label/app/values?query=%7Bapp%3D%22api%22%7D&start=1&end=2"
 			warmRoute(mux, rawURL, nil)
-			req := benchmarkRequest(rawURL)
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
+				req := benchmarkRequest(rawURL)
 				w := newBenchmarkResponseWriter()
 				for pb.Next() {
 					w.reset()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -54,6 +54,8 @@ var jsonBufPool = sync.Pool{
 	},
 }
 
+var backendSemverPattern = regexp.MustCompile(`v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z\.-]+)?`)
+
 // marshalJSON encodes v to JSON using a pooled buffer, then writes to w.
 // Reduces allocations vs json.NewEncoder(w).Encode() by reusing buffers.
 func marshalJSON(w http.ResponseWriter, v interface{}) {
@@ -81,6 +83,7 @@ const (
 	origRequestKey
 	requestTelemetryKey
 	requestRouteMetaKey
+	requestGrafanaClientKey
 )
 
 type requestTelemetry struct {
@@ -104,6 +107,16 @@ type requestTelemetrySnapshot struct {
 type requestRouteMeta struct {
 	endpoint string
 	route    string
+}
+
+type grafanaClientProfile struct {
+	surface           string
+	sourceTag         string
+	version           string
+	runtimeMajor      int
+	runtimeFamily     string
+	drilldownProfile  string
+	datasourceProfile string
 }
 
 var upstreamRequestTypeByRoute = map[string]string{
@@ -199,6 +212,11 @@ func requestRouteMetaFromContext(ctx context.Context) requestRouteMeta {
 	return meta
 }
 
+func grafanaClientProfileFromContext(ctx context.Context) grafanaClientProfile {
+	profile, _ := ctx.Value(requestGrafanaClientKey).(grafanaClientProfile)
+	return profile
+}
+
 // withOrgID stores the X-Scope-OrgID and original request in the request context (request-scoped, no shared state).
 func withOrgID(r *http.Request) *http.Request {
 	ctx := r.Context()
@@ -258,8 +276,16 @@ type Config struct {
 	BackendCompression string            // upstream HTTP compression preference: auto, gzip, zstd, none
 	BackendTimeout     time.Duration     // bounded timeout for non-streaming backend requests
 	BackendTLSSkip     bool              // skip TLS verification for VL backend
-	DerivedFields      []DerivedField    // derived fields for trace/link extraction
-	StreamResponse     bool              // stream responses via chunked transfer (default: false)
+	// BackendMinVersion defines the minimum VictoriaLogs version considered
+	// fully supported at startup compatibility check time.
+	BackendMinVersion string
+	// BackendAllowUnsupportedVersion allows startup to continue when detected
+	// backend version is lower than BackendMinVersion. Use at your own risk.
+	BackendAllowUnsupportedVersion bool
+	// BackendVersionCheckTimeout bounds startup backend version checks.
+	BackendVersionCheckTimeout time.Duration
+	DerivedFields              []DerivedField // derived fields for trace/link extraction
+	StreamResponse             bool           // stream responses via chunked transfer (default: false)
 	// EmitStructuredMetadata enables Loki 3-tuple stream values [ts, line, metadata].
 	// Disabled by default for conservative datasource compatibility.
 	EmitStructuredMetadata bool
@@ -298,6 +324,16 @@ type Config struct {
 	QueryRangePartialResponses         bool
 	QueryRangeBackgroundWarm           bool
 	QueryRangeBackgroundWarmMaxWindows int
+	// RecentTailRefreshEnabled enables near-now cache freshness bypass for selected endpoints.
+	// When enabled, stale cache hits near current time are bypassed so the proxy refetches
+	// latest data while still caching historical ranges.
+	RecentTailRefreshEnabled bool
+	// RecentTailRefreshWindow defines how close query end time must be to "now" to be
+	// considered near-now for freshness bypass.
+	RecentTailRefreshWindow time.Duration
+	// RecentTailRefreshMaxStaleness defines max acceptable cache age for near-now requests.
+	// Older cache hits are bypassed and recomputed.
+	RecentTailRefreshMaxStaleness time.Duration
 
 	// Label translation
 	LabelStyle        LabelStyle        // how to translate VL field names to Loki labels
@@ -435,6 +471,9 @@ type Proxy struct {
 	forwardCookies                        map[string]bool   // cookie names to copy from client request to VL
 	backendHeaders                        map[string]string // static headers on all VL requests
 	backendCompression                    string
+	backendMinVersion                     string
+	backendAllowUnsupportedVersion        bool
+	backendVersionCheckTimeout            time.Duration
 	derivedFields                         []DerivedField
 	streamResponse                        bool
 	emitStructuredMetadata                bool
@@ -486,6 +525,9 @@ type Proxy struct {
 	queryRangePartialResponses            bool
 	queryRangeBackgroundWarm              bool
 	queryRangeBackgroundWarmMaxWindows    int
+	recentTailRefreshEnabled              bool
+	recentTailRefreshWindow               time.Duration
+	recentTailRefreshMaxStaleness         time.Duration
 	labelRefreshGroup                     singleflight.Group
 	labelValuesIndexedCache               bool
 	labelValuesHotLimit                   int
@@ -507,6 +549,14 @@ type Proxy struct {
 	patternsSnapshotEntries               map[string]patternSnapshotEntry
 	patternsSnapshotPatternCount          int64
 	patternsSnapshotPayloadBytes          int64
+	backendVersionMu                      sync.RWMutex
+	backendVersionRaw                     string
+	backendVersionSemver                  string
+	backendCapabilityProfile              string
+	backendSupportsStreamMetadata         bool
+	backendSupportsDensePatternWindowing  bool
+	backendSupportsMetadataSubstring      bool
+	backendVersionLogged                  bool
 	labelValuesIndexWarmReady             atomic.Bool
 	labelValuesIndexPersistStarted        atomic.Bool
 	labelValuesIndexPersistDirty          atomic.Bool
@@ -698,6 +748,17 @@ func New(cfg Config) (*Proxy, error) {
 	if backendTimeout <= 0 {
 		backendTimeout = 120 * time.Second
 	}
+	backendMinVersion := normalizeSemverString(cfg.BackendMinVersion)
+	if backendMinVersion == "" {
+		backendMinVersion = "v1.30.0"
+	}
+	if _, _, _, ok := parseSemverTriplet(backendMinVersion); !ok {
+		return nil, fmt.Errorf("invalid backend minimum version %q", backendMinVersion)
+	}
+	backendVersionCheckTimeout := cfg.BackendVersionCheckTimeout
+	if backendVersionCheckTimeout <= 0 {
+		backendVersionCheckTimeout = 5 * time.Second
+	}
 	transport.ResponseHeaderTimeout = backendTimeout
 	transport.DisableCompression = false // accept gzip from VL if available
 	if cfg.BackendTLSSkip {
@@ -815,6 +876,14 @@ func New(cfg Config) (*Proxy, error) {
 	if queryRangeBackgroundWarmMaxWindows <= 0 {
 		queryRangeBackgroundWarmMaxWindows = 24
 	}
+	recentTailRefreshWindow := cfg.RecentTailRefreshWindow
+	if recentTailRefreshWindow <= 0 {
+		recentTailRefreshWindow = 2 * time.Minute
+	}
+	recentTailRefreshMaxStaleness := cfg.RecentTailRefreshMaxStaleness
+	if recentTailRefreshMaxStaleness <= 0 {
+		recentTailRefreshMaxStaleness = 15 * time.Second
+	}
 	tailMode := cfg.TailMode
 	if tailMode == "" {
 		tailMode = TailModeAuto
@@ -909,6 +978,9 @@ func New(cfg Config) (*Proxy, error) {
 		forwardCookies:                        forwardCookies,
 		backendHeaders:                        backendHeaders,
 		backendCompression:                    normalizeBackendCompression(cfg.BackendCompression),
+		backendMinVersion:                     backendMinVersion,
+		backendAllowUnsupportedVersion:        cfg.BackendAllowUnsupportedVersion,
+		backendVersionCheckTimeout:            backendVersionCheckTimeout,
 		derivedFields:                         cfg.DerivedFields,
 		streamResponse:                        cfg.StreamResponse,
 		emitStructuredMetadata:                cfg.EmitStructuredMetadata,
@@ -956,6 +1028,9 @@ func New(cfg Config) (*Proxy, error) {
 		queryRangePartialResponses:            cfg.QueryRangePartialResponses,
 		queryRangeBackgroundWarm:              cfg.QueryRangeBackgroundWarm,
 		queryRangeBackgroundWarmMaxWindows:    queryRangeBackgroundWarmMaxWindows,
+		recentTailRefreshEnabled:              cfg.RecentTailRefreshEnabled,
+		recentTailRefreshWindow:               recentTailRefreshWindow,
+		recentTailRefreshMaxStaleness:         recentTailRefreshMaxStaleness,
 		labelValuesIndexedCache:               cfg.LabelValuesIndexedCache,
 		labelValuesHotLimit:                   labelValuesHotLimit,
 		labelValuesIndexMaxEntries:            labelValuesIndexMaxEntries,
@@ -1636,15 +1711,17 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	cacheable := !p.streamResponse
 	if cacheable {
 		cacheKey = p.queryRangeCacheKey(r, logqlQuery)
-		if cached, ok := p.cache.Get(cacheKey); ok {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write(cached)
-			elapsed := time.Since(start)
-			p.metrics.RecordRequest("query_range", http.StatusOK, elapsed)
-			p.metrics.RecordTupleMode(tupleMode)
-			p.metrics.RecordCacheHit()
-			p.queryTracker.Record("query_range", logqlQuery, elapsed, false)
-			return
+		if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
+			if !p.shouldBypassRecentTailCache("query_range", remaining, r) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(cached)
+				elapsed := time.Since(start)
+				p.metrics.RecordRequest("query_range", http.StatusOK, elapsed)
+				p.metrics.RecordTupleMode(tupleMode)
+				p.metrics.RecordCacheHit()
+				p.queryTracker.Record("query_range", logqlQuery, elapsed, false)
+				return
+			}
 		}
 		p.metrics.RecordCacheMiss()
 	}
@@ -1999,20 +2076,22 @@ func (p *Proxy) fetchVLFieldValues(ctx context.Context, path string, params url.
 }
 
 func (p *Proxy) fetchPreferredLabelNames(ctx context.Context, params url.Values) ([]string, error) {
-	labels, err := p.fetchVLFieldNames(ctx, "/select/logsql/stream_field_names", params)
-	if err == nil {
-		labels = appendUniqueStrings(labels, p.snapshotDeclaredLabelFields()...)
-		return labels, nil
-	}
-	if shouldFallbackToGenericMetadata(err) {
-		fallback, fallbackErr := p.fetchVLFieldNames(ctx, "/select/logsql/field_names", params)
-		if fallbackErr != nil {
-			return nil, fallbackErr
+	if p.supportsStreamMetadataEndpoints() {
+		labels, err := p.fetchVLFieldNames(ctx, "/select/logsql/stream_field_names", params)
+		if err == nil {
+			labels = appendUniqueStrings(labels, p.snapshotDeclaredLabelFields()...)
+			return labels, nil
 		}
-		fallback = appendUniqueStrings(fallback, p.snapshotDeclaredLabelFields()...)
-		return fallback, nil
+		if !shouldFallbackToGenericMetadata(err) {
+			return nil, err
+		}
 	}
-	return nil, err
+	fallback, fallbackErr := p.fetchVLFieldNames(ctx, "/select/logsql/field_names", params)
+	if fallbackErr != nil {
+		return nil, fallbackErr
+	}
+	fallback = appendUniqueStrings(fallback, p.snapshotDeclaredLabelFields()...)
+	return fallback, nil
 }
 
 func (p *Proxy) fetchPreferredLabelNamesCached(ctx context.Context, params url.Values) ([]string, error) {
@@ -2039,10 +2118,15 @@ func (p *Proxy) fetchPreferredLabelNamesCached(ctx context.Context, params url.V
 }
 
 func (p *Proxy) fetchPreferredLabelValues(ctx context.Context, labelName string, params url.Values) ([]string, error) {
-	streamFields, err := p.fetchVLFieldNames(ctx, "/select/logsql/stream_field_names", params)
-	useStreamEndpoint := err == nil
-	if err != nil && !shouldFallbackToGenericMetadata(err) {
-		return nil, err
+	useStreamEndpoint := p.supportsStreamMetadataEndpoints()
+	streamFields := []string{}
+	if useStreamEndpoint {
+		var err error
+		streamFields, err = p.fetchVLFieldNames(ctx, "/select/logsql/stream_field_names", params)
+		useStreamEndpoint = err == nil
+		if err != nil && !shouldFallbackToGenericMetadata(err) {
+			return nil, err
+		}
 	}
 	streamFields = appendUniqueStrings(streamFields, p.snapshotDeclaredLabelFields()...)
 
@@ -2107,6 +2191,41 @@ func (p *Proxy) shouldRefreshLabelsInBackground(remaining, ttl time.Duration) bo
 	return remaining <= threshold
 }
 
+func (p *Proxy) requestEndsNearNow(r *http.Request) bool {
+	if p == nil || r == nil || p.recentTailRefreshWindow <= 0 {
+		return false
+	}
+	endRaw := strings.TrimSpace(firstNonEmpty(r.FormValue("end"), r.FormValue("to")))
+	if endRaw == "" {
+		// Loki defaults to "now" when end is omitted.
+		return true
+	}
+	endNs, ok := parseLokiTimeToUnixNano(endRaw)
+	if !ok {
+		return false
+	}
+	nowNs := time.Now().UnixNano()
+	if endNs > nowNs {
+		endNs = nowNs
+	}
+	return nowNs-endNs <= p.recentTailRefreshWindow.Nanoseconds()
+}
+
+func (p *Proxy) shouldBypassRecentTailCache(endpoint string, remaining time.Duration, r *http.Request) bool {
+	if p == nil || !p.recentTailRefreshEnabled {
+		return false
+	}
+	ttl := CacheTTLs[endpoint]
+	if ttl <= 0 || remaining <= 0 {
+		return false
+	}
+	cacheAge := ttl - remaining
+	if cacheAge < p.recentTailRefreshMaxStaleness {
+		return false
+	}
+	return p.requestEndsNearNow(r)
+}
+
 func (p *Proxy) labelBackgroundTimeout() time.Duration {
 	if p.client != nil && p.client.Timeout > 0 && p.client.Timeout < 10*time.Second {
 		return p.client.Timeout
@@ -2114,7 +2233,7 @@ func (p *Proxy) labelBackgroundTimeout() time.Duration {
 	return 10 * time.Second
 }
 
-func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end string) {
+func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end, search string) {
 	refreshKey := "refresh:labels:" + cacheKey
 	go func() {
 		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
@@ -2141,6 +2260,10 @@ func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end st
 			if strings.TrimSpace(end) != "" {
 				params.Set("end", end)
 			}
+			if search = strings.TrimSpace(search); search != "" && p.supportsMetadataSubstringFilter() {
+				params.Set("q", search)
+				params.Set("filter", "substring")
+			}
 
 			labels, fetchErr := p.fetchPreferredLabelNames(ctx, params)
 			if fetchErr != nil {
@@ -2165,7 +2288,7 @@ func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end st
 	}()
 }
 
-func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuery, start, end, limit string) {
+func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuery, start, end, limit, search string) {
 	refreshKey := "refresh:label_values:" + cacheKey
 	go func() {
 		_, err, _ := p.labelRefreshGroup.Do(refreshKey, func() (interface{}, error) {
@@ -2202,6 +2325,10 @@ func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuer
 				}
 				if strings.TrimSpace(limit) != "" {
 					params.Set("limit", limit)
+				}
+				if search = strings.TrimSpace(search); search != "" && p.supportsMetadataSubstringFilter() {
+					params.Set("q", search)
+					params.Set("filter", "substring")
 				}
 				values, fetchErr = p.fetchPreferredLabelValues(ctx, labelName, params)
 			}
@@ -3541,7 +3668,11 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordRequest("labels", http.StatusOK, time.Since(start))
 		p.metrics.RecordCacheHit()
 		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["labels"]) {
-			p.refreshLabelsCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"))
+			search := strings.TrimSpace(r.FormValue("search"))
+			if search == "" {
+				search = strings.TrimSpace(r.FormValue("q"))
+			}
+			p.refreshLabelsCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), search)
 		}
 		return
 	}
@@ -3565,6 +3696,14 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	}
 	if e := r.FormValue("end"); e != "" {
 		params.Set("end", e)
+	}
+	search := strings.TrimSpace(r.FormValue("search"))
+	if search == "" {
+		search = strings.TrimSpace(r.FormValue("q"))
+	}
+	if search != "" && p.supportsMetadataSubstringFilter() {
+		params.Set("q", search)
+		params.Set("filter", "substring")
 	}
 
 	labels, err := p.fetchPreferredLabelNamesCached(r.Context(), params)
@@ -3650,6 +3789,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 				r.FormValue("start"),
 				r.FormValue("end"),
 				r.FormValue("limit"),
+				search,
 			)
 		}
 		return
@@ -3710,6 +3850,10 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	}
 	if l := r.FormValue("limit"); l != "" {
 		params.Set("limit", l)
+	}
+	if search != "" && p.supportsMetadataSubstringFilter() {
+		params.Set("q", search)
+		params.Set("filter", "substring")
 	}
 
 	values, err := p.fetchPreferredLabelValues(r.Context(), labelName, params)
@@ -3943,14 +4087,16 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 	orgID := r.Header.Get("X-Scope-OrgID")
 	cacheKey := "volume:" + orgID + ":" + r.URL.RawQuery
 	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(cached)
-		p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
-		p.metrics.RecordCacheHit()
-		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume"]) {
-			p.refreshVolumeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("targetLabels"))
+		if !p.shouldBypassRecentTailCache("volume", remaining, r) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(cached)
+			p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
+			p.metrics.RecordCacheHit()
+			if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume"]) {
+				p.refreshVolumeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("targetLabels"))
+			}
+			return
 		}
-		return
 	}
 	p.metrics.RecordCacheMiss()
 
@@ -4044,14 +4190,16 @@ func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 	orgID := r.Header.Get("X-Scope-OrgID")
 	cacheKey := "volume_range:" + orgID + ":" + r.URL.RawQuery
 	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(cached)
-		p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
-		p.metrics.RecordCacheHit()
-		if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume_range"]) {
-			p.refreshVolumeRangeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"), r.FormValue("targetLabels"))
+		if !p.shouldBypassRecentTailCache("volume_range", remaining, r) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(cached)
+			p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
+			p.metrics.RecordCacheHit()
+			if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume_range"]) {
+				p.refreshVolumeRangeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"), r.FormValue("targetLabels"))
+			}
+			return
 		}
-		return
 	}
 	p.metrics.RecordCacheMiss()
 
@@ -4441,36 +4589,26 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 			return entries, true
 		}
 
+		if endpoint == "/select/logsql/query_range" {
+			startNs, endNs, splitInterval, perWindowLimit, ok := patternWindowedSamplingConfig(startParam, endParam, stepParam, sourceLimit, p.supportsDensePatternWindowingForRequest(r))
+			if ok {
+				windows := splitQueryRangeWindowsWithOptions(startNs, endNs, splitInterval, "backward", true)
+				if len(windows) > 1 {
+					windowEntries, windowSuccesses := p.fetchPatternsFromWindows(r, logsqlQuery, sourceLimit, perWindowLimit, windows, stepParam, patternLimit)
+					if windowSuccesses > 0 && len(windowEntries) > 0 {
+						// Prefer distributed stratified windows so dense ranges keep full-range
+						// visibility instead of collapsing to a recent-tail sample.
+						return windowEntries, true
+					}
+				}
+			}
+		}
+
 		entries, ok := fetchFromParams(params)
 		if !ok {
 			return nil, false
 		}
-		if endpoint != "/select/logsql/query_range" {
-			return entries, true
-		}
-
-		startNs, endNs, splitInterval, perWindowLimit, ok := patternWindowedSamplingConfig(startParam, endParam, sourceLimit)
-		if !ok {
-			return entries, true
-		}
-		windows := splitQueryRangeWindowsWithOptions(startNs, endNs, splitInterval, "backward", true)
-		if len(windows) <= 1 {
-			return entries, true
-		}
-
-		merged := entries
-		for _, window := range windows {
-			windowParams := cloneURLValues(params)
-			windowParams.Set("start", strconv.FormatInt(window.startNs, 10))
-			windowParams.Set("end", strconv.FormatInt(window.endNs, 10))
-			windowParams.Set("limit", strconv.Itoa(perWindowLimit))
-			windowEntries, ok := fetchFromParams(windowParams)
-			if !ok {
-				continue
-			}
-			merged = mergePatternResultEntries(merged, windowEntries)
-		}
-		return merged, true
+		return entries, true
 	}
 
 	// Prefer query_range to preserve full selected-range buckets in Drilldown graphs.
@@ -4506,6 +4644,107 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(resultBody)
 	p.metrics.RecordRequest("patterns", http.StatusOK, time.Since(start))
+}
+
+func (p *Proxy) fetchPatternsFromWindows(
+	r *http.Request,
+	logsqlQuery string,
+	sourceLimit int,
+	perWindowLimit int,
+	windows []queryRangeWindow,
+	stepParam string,
+	patternLimit int,
+) ([]patternResultEntry, int) {
+	if len(windows) == 0 {
+		return nil, 0
+	}
+	if perWindowLimit <= 0 {
+		perWindowLimit = 1
+	}
+	effectiveLimit := perWindowLimit
+	if sourceLimit > 0 && sourceLimit < effectiveLimit {
+		effectiveLimit = sourceLimit
+	}
+
+	maxParallel := min(8, max(1, p.queryRangeWindowParallelLimit()))
+	if maxParallel > len(windows) {
+		maxParallel = len(windows)
+	}
+
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+
+	baseParams := url.Values{}
+	baseParams.Set("query", logsqlQuery)
+	if s := strings.TrimSpace(stepParam); s != "" {
+		baseParams.Set("step", formatVLStep(s))
+	}
+
+	collected := make([]patternResultEntry, 0, len(windows))
+	successes := 0
+	var mu sync.Mutex
+
+	for _, window := range windows {
+		window := window
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-r.Context().Done():
+				return
+			case sem <- struct{}{}:
+			}
+			defer func() { <-sem }()
+
+			params := cloneURLValues(baseParams)
+			params.Set("start", strconv.FormatInt(window.startNs, 10))
+			params.Set("end", strconv.FormatInt(window.endNs, 10))
+			params.Set("limit", strconv.Itoa(effectiveLimit))
+			resp, err := p.vlPost(r.Context(), "/select/logsql/query_range", params)
+			if err != nil {
+				p.log.Debug(
+					"patterns window fetch failed",
+					"start_ns", window.startNs,
+					"end_ns", window.endNs,
+					"error", err,
+				)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode >= http.StatusBadRequest {
+				p.log.Debug(
+					"patterns window fetch non-success status",
+					"start_ns", window.startNs,
+					"end_ns", window.endNs,
+					"status_code", resp.StatusCode,
+				)
+				return
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return
+			}
+			extracted := extractLogPatterns(body, stepParam, patternLimit)
+			if len(extracted) == 0 {
+				return
+			}
+			entries := patternResultEntriesFromMaps(extracted)
+			if len(entries) == 0 {
+				return
+			}
+
+			mu.Lock()
+			successes++
+			collected = mergePatternResultEntries(collected, entries)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(collected) == 0 {
+		return nil, successes
+	}
+	return collected, successes
 }
 
 func patternScopeQuery(query string) string {
@@ -4642,25 +4881,38 @@ func derivePatternStep(startParam, endParam string) string {
 	return strconv.FormatInt(stepSeconds, 10) + "s"
 }
 
-func patternWindowedSamplingConfig(startParam, endParam string, sourceLimit int) (int64, int64, time.Duration, int, bool) {
+func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourceLimit int, denseWindowing bool) (int64, int64, time.Duration, int, bool) {
 	startNs, endNs, ok := parseLokiTimeRangeToUnixNano(startParam, endParam)
 	if !ok || sourceLimit <= 0 || endNs <= startNs {
 		return 0, 0, 0, 0, false
 	}
 
 	span := time.Duration(endNs - startNs)
-	const (
-		minWindowedSpan         = 30 * time.Minute
-		targetWindowSpan        = 15 * time.Minute
-		minWindowSourceLimit    = 500
-		maxWindowSourceLimit    = 10_000
-		maxPatternWindowSamples = 24
-	)
+	minWindowedSpan := 20 * time.Minute
+	targetWindowSpan := 20 * time.Minute
+	minWindowSourceLimit := 200
+	maxWindowSourceLimit := 1_000
+	maxPatternWindowSamples := 96
+	if denseWindowing {
+		targetWindowSpan = 10 * time.Minute
+		minWindowSourceLimit = 100
+		maxWindowSourceLimit = 2_000
+		maxPatternWindowSamples = 240
+	}
 	if span < minWindowedSpan {
 		return 0, 0, 0, 0, false
 	}
 
 	windowCount := int(span/targetWindowSpan) + 1
+	if stepSeconds := parsePatternStepSeconds(stepParam); stepSeconds > 0 {
+		stepNs := stepSeconds * int64(time.Second)
+		if stepNs > 0 {
+			stepBasedCount := int(((endNs - startNs) / stepNs) + 1)
+			if stepBasedCount > windowCount {
+				windowCount = stepBasedCount
+			}
+		}
+	}
 	if windowCount < 2 {
 		windowCount = 2
 	}
@@ -5094,7 +5346,11 @@ func (p *Proxy) handleFormatQuery(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) handleDrilldownLimits(w http.ResponseWriter, r *http.Request) {
 	patternIngesterEnabled := p.patternsEnabled && p.patternsAutodetectFromQueries
 	limits := p.publishedTenantLimits(r)
-	p.writeJSON(w, map[string]interface{}{
+	profile := grafanaClientProfileFromContext(r.Context())
+	if profile.surface == "" {
+		profile = detectGrafanaClientProfile(r, "drilldown_limits", "/loki/api/v1/drilldown-limits")
+	}
+	resp := map[string]interface{}{
 		"limits":                   limits,
 		"pattern_ingester_enabled": patternIngesterEnabled,
 		"version":                  "unknown",
@@ -5102,7 +5358,23 @@ func (p *Proxy) handleDrilldownLimits(w http.ResponseWriter, r *http.Request) {
 		"maxDetectedValues":        1000,
 		"maxLabelValues":           1000,
 		"maxLines":                 p.maxLines,
-	})
+	}
+	if profile.surface != "" && profile.surface != "unknown" {
+		resp["grafana_client_surface"] = profile.surface
+	}
+	if profile.version != "" {
+		resp["grafana_runtime_version"] = profile.version
+	}
+	if profile.runtimeFamily != "" {
+		resp["grafana_runtime_family"] = profile.runtimeFamily
+	}
+	if profile.drilldownProfile != "" {
+		resp["drilldown_profile"] = profile.drilldownProfile
+	}
+	if profile.datasourceProfile != "" {
+		resp["grafana_datasource_profile"] = profile.datasourceProfile
+	}
+	p.writeJSON(w, resp)
 }
 
 func (p *Proxy) publishedTenantLimits(r *http.Request) map[string]any {
@@ -6174,6 +6446,278 @@ func (p *Proxy) recordUpstreamObservation(ctx context.Context, system, method, r
 	p.log.Log(ctx, level, "upstream_request", logAttrs...)
 }
 
+func (p *Proxy) observeBackendVersionFromHeaders(headers http.Header) {
+	if headers == nil {
+		return
+	}
+	candidates := []string{
+		headers.Get("Server"),
+		headers.Get("X-App-Version"),
+		headers.Get("X-Backend-Version"),
+		headers.Get("X-Victoriametrics-Build"),
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		semver := extractBackendSemver(candidate)
+		if semver == "" {
+			continue
+		}
+		p.storeBackendVersion(candidate, semver)
+		return
+	}
+}
+
+func extractBackendSemver(raw string) string {
+	return backendSemverPattern.FindString(raw)
+}
+
+func parseSemverTriplet(version string) (int, int, int, bool) {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	if version == "" {
+		return 0, 0, 0, false
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) < 3 {
+		return 0, 0, 0, false
+	}
+	major, err := strconv.Atoi(numericPrefix(parts[0]))
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	minor, err := strconv.Atoi(numericPrefix(parts[1]))
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	patch, err := strconv.Atoi(numericPrefix(parts[2]))
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}
+
+func normalizeSemverString(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	if version[0] >= '0' && version[0] <= '9' {
+		return "v" + version
+	}
+	return version
+}
+
+func numericPrefix(in string) string {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range in {
+		if r < '0' || r > '9' {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func semverAtLeastSemver(version, minVersion string) bool {
+	vMaj, vMin, vPatch, vok := parseSemverTriplet(version)
+	mMaj, mMin, mPatch, mok := parseSemverTriplet(minVersion)
+	if !vok || !mok {
+		return false
+	}
+	if vMaj != mMaj {
+		return vMaj > mMaj
+	}
+	if vMin != mMin {
+		return vMin > mMin
+	}
+	return vPatch >= mPatch
+}
+
+func semverAtLeast(semver string, major, minor, patch int) bool {
+	mj, mn, pt, ok := parseSemverTriplet(semver)
+	if !ok {
+		return false
+	}
+	if mj != major {
+		return mj > major
+	}
+	if mn != minor {
+		return mn > minor
+	}
+	return pt >= patch
+}
+
+func deriveBackendCapabilities(semver string) (profile string, supportsStreamMetadata bool, supportsDensePatternWindowing bool, supportsMetadataSubstring bool) {
+	switch {
+	case semverAtLeast(semver, 1, 50, 0):
+		return "vl-v1.50-plus", true, true, true
+	case semverAtLeast(semver, 1, 49, 0):
+		return "vl-v1.49-plus", true, false, true
+	case semverAtLeast(semver, 1, 30, 0):
+		return "vl-v1.30-plus", true, false, false
+	default:
+		return "legacy-pre-v1.30", false, false, false
+	}
+}
+
+func (p *Proxy) storeBackendVersion(raw, semver string) {
+	if semver == "" {
+		return
+	}
+	p.backendVersionMu.Lock()
+	defer p.backendVersionMu.Unlock()
+	// Keep first detected version to avoid churn from intermediaries rewriting headers.
+	if p.backendVersionSemver != "" {
+		return
+	}
+	profile, supportsStreamMetadata, supportsDensePatternWindowing, supportsMetadataSubstring := deriveBackendCapabilities(semver)
+	p.backendVersionRaw = raw
+	p.backendVersionSemver = semver
+	p.backendCapabilityProfile = profile
+	p.backendSupportsStreamMetadata = supportsStreamMetadata
+	p.backendSupportsDensePatternWindowing = supportsDensePatternWindowing
+	p.backendSupportsMetadataSubstring = supportsMetadataSubstring
+	if !p.backendVersionLogged {
+		p.backendVersionLogged = true
+		p.log.Info(
+			"backend version detected",
+			"backend.version.raw", raw,
+			"backend.version.semver", semver,
+			"backend.capability_profile", p.backendCapabilityProfile,
+			"metadata.stream_endpoints", p.backendSupportsStreamMetadata,
+			"metadata.substring_filter", p.backendSupportsMetadataSubstring,
+			"patterns.dense_windowing", p.backendSupportsDensePatternWindowing,
+		)
+	}
+}
+
+func (p *Proxy) supportsStreamMetadataEndpoints() bool {
+	p.backendVersionMu.RLock()
+	defer p.backendVersionMu.RUnlock()
+	// Before first backend version observation, optimistically keep stream-first
+	// behavior so we don't regress newer deployments.
+	if p.backendVersionSemver == "" {
+		return true
+	}
+	return p.backendSupportsStreamMetadata
+}
+
+func (p *Proxy) supportsDensePatternWindowing() bool {
+	p.backendVersionMu.RLock()
+	defer p.backendVersionMu.RUnlock()
+	return p.backendSupportsDensePatternWindowing
+}
+
+func (p *Proxy) supportsDensePatternWindowingForRequest(r *http.Request) bool {
+	if !p.supportsDensePatternWindowing() {
+		return false
+	}
+	if r == nil {
+		return true
+	}
+	profile := grafanaClientProfileFromContext(r.Context())
+	// Keep legacy Drilldown runtime family on conservative windowing even when backend
+	// can do denser extraction. This mirrors 1.x behavior and avoids over-rendering
+	// surprises on older Grafana runtimes.
+	if profile.surface == "grafana_drilldown" && profile.runtimeMajor > 0 && profile.runtimeMajor < 12 {
+		return false
+	}
+	return true
+}
+
+func (p *Proxy) supportsMetadataSubstringFilter() bool {
+	p.backendVersionMu.RLock()
+	defer p.backendVersionMu.RUnlock()
+	return p.backendSupportsMetadataSubstring
+}
+
+func (p *Proxy) backendVersionState() (raw, semver, profile string) {
+	p.backendVersionMu.RLock()
+	defer p.backendVersionMu.RUnlock()
+	return p.backendVersionRaw, p.backendVersionSemver, p.backendCapabilityProfile
+}
+
+// ValidateBackendVersionCompatibility checks backend version support at startup.
+// It blocks startup only when a detected backend version is below the configured
+// minimum and the unsafe override is not enabled.
+func (p *Proxy) ValidateBackendVersionCompatibility(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	timeout := p.backendVersionCheckTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	resp, err := p.vlGet(checkCtx, "/health", nil)
+	if err != nil {
+		p.log.Warn(
+			"backend version compatibility check skipped",
+			"reason", "health probe failed",
+			"error", err,
+			"minimum_supported_version", p.backendMinVersion,
+		)
+		return nil
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		p.log.Warn(
+			"backend version compatibility check skipped",
+			"reason", "health probe returned non-success status",
+			"http.response.status_code", resp.StatusCode,
+			"minimum_supported_version", p.backendMinVersion,
+		)
+		return nil
+	}
+
+	raw, semver, profile := p.backendVersionState()
+	if semver == "" {
+		p.log.Warn(
+			"backend version compatibility check unavailable",
+			"reason", "backend did not expose version in response headers",
+			"minimum_supported_version", p.backendMinVersion,
+		)
+		return nil
+	}
+	if !semverAtLeastSemver(semver, p.backendMinVersion) {
+		if p.backendAllowUnsupportedVersion {
+			p.log.Warn(
+				"unsupported backend version allowed by override",
+				"backend.version.raw", raw,
+				"backend.version.semver", semver,
+				"backend.capability_profile", profile,
+				"minimum_supported_version", p.backendMinVersion,
+				"flag", "backend-allow-unsupported-version",
+			)
+			return nil
+		}
+		return fmt.Errorf(
+			"detected backend version %s (%s) is below minimum supported %s; compatibility may be incomplete. Set -backend-allow-unsupported-version=true to bypass at your own risk",
+			semver,
+			raw,
+			p.backendMinVersion,
+		)
+	}
+
+	p.log.Info(
+		"backend version compatibility check passed",
+		"backend.version.raw", raw,
+		"backend.version.semver", semver,
+		"backend.capability_profile", profile,
+		"minimum_supported_version", p.backendMinVersion,
+	)
+	return nil
+}
+
 func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*http.Response, error) {
 	if !p.breaker.Allow() {
 		return nil, fmt.Errorf("circuit breaker open — backend unavailable")
@@ -6203,6 +6747,7 @@ func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*htt
 		}
 		return nil, err
 	}
+	p.observeBackendVersionFromHeaders(resp.Header)
 	if err := decodeCompressedHTTPResponse(resp); err != nil {
 		_ = resp.Body.Close()
 		recordUpstreamCall(ctx, http.StatusBadGateway, duration, true)
@@ -6245,6 +6790,7 @@ func (p *Proxy) vlPost(ctx context.Context, path string, params url.Values) (*ht
 		}
 		return nil, err
 	}
+	p.observeBackendVersionFromHeaders(resp.Header)
 	if err := decodeCompressedHTTPResponse(resp); err != nil {
 		_ = resp.Body.Close()
 		recordUpstreamCall(ctx, http.StatusBadGateway, duration, true)
@@ -8885,6 +9431,19 @@ func (p *Proxy) applyBackendHeaders(vlReq *http.Request) {
 		clientID, clientSource := metrics.ResolveClientContext(origReq, p.metricsTrustProxyHeaders)
 		vlReq.Header.Set("X-Loki-VL-Client-ID", clientID)
 		vlReq.Header.Set("X-Loki-VL-Client-Source", clientSource)
+		gp := grafanaClientProfileFromContext(origReq.Context())
+		if gp.surface != "" {
+			vlReq.Header.Set("X-Loki-VL-Grafana-Surface", gp.surface)
+		}
+		if gp.version != "" {
+			vlReq.Header.Set("X-Loki-VL-Grafana-Version", gp.version)
+		}
+		if gp.runtimeFamily != "" {
+			vlReq.Header.Set("X-Loki-VL-Grafana-Runtime-Family", gp.runtimeFamily)
+		}
+		if gp.drilldownProfile != "" {
+			vlReq.Header.Set("X-Loki-VL-Drilldown-Profile", gp.drilldownProfile)
+		}
 		if authUser, authSource := metrics.ResolveAuthContext(origReq); authUser != "" {
 			vlReq.Header.Set("X-Loki-VL-Auth-User", authUser)
 			vlReq.Header.Set("X-Loki-VL-Auth-Source", authSource)
@@ -9031,6 +9590,8 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 		rt := newRequestTelemetry()
 		ctx := context.WithValue(r.Context(), requestTelemetryKey, rt)
 		ctx = context.WithValue(ctx, requestRouteMetaKey, requestRouteMeta{endpoint: endpoint, route: route})
+		grafanaProfile := detectGrafanaClientProfile(r, endpoint, route)
+		ctx = context.WithValue(ctx, requestGrafanaClientKey, grafanaProfile)
 		reqWithTelemetry := r.WithContext(ctx)
 		sc := &statusCapture{ResponseWriter: w, code: 200}
 		next.ServeHTTP(sc, reqWithTelemetry)
@@ -9081,6 +9642,9 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 		authUser, authSource := metrics.ResolveAuthContext(r)
 		clientAddr := forwardedClientAddress(r, p.metricsTrustProxyHeaders)
 		peerAddr, _ := splitHostPortValue(r.RemoteAddr)
+		grafanaSurface := grafanaProfile.surface
+		grafanaSourceTag := grafanaProfile.sourceTag
+		grafanaVersion := grafanaProfile.version
 		logAttrs := []interface{}{
 			"http.route", route,
 			"url.path", r.URL.Path,
@@ -9111,6 +9675,24 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 		if userAgent := strings.TrimSpace(r.Header.Get("User-Agent")); userAgent != "" {
 			logAttrs = append(logAttrs, "user_agent.original", userAgent)
 		}
+		if grafanaVersion != "" {
+			logAttrs = append(logAttrs, "grafana.version", grafanaVersion)
+		}
+		if grafanaSourceTag != "" {
+			logAttrs = append(logAttrs, "grafana.client.source_tag", grafanaSourceTag)
+		}
+		if grafanaSurface != "unknown" {
+			logAttrs = append(logAttrs, "grafana.client.surface", grafanaSurface)
+		}
+		if grafanaProfile.runtimeFamily != "" {
+			logAttrs = append(logAttrs, "grafana.runtime.family", grafanaProfile.runtimeFamily)
+		}
+		if grafanaProfile.drilldownProfile != "" {
+			logAttrs = append(logAttrs, "grafana.drilldown.profile", grafanaProfile.drilldownProfile)
+		}
+		if grafanaProfile.datasourceProfile != "" {
+			logAttrs = append(logAttrs, "grafana.datasource.profile", grafanaProfile.datasourceProfile)
+		}
 		if enduserName := deriveEnduserName(clientID, clientSource); enduserName != "" {
 			logAttrs = append(logAttrs, "enduser.name", enduserName)
 		}
@@ -9129,6 +9711,140 @@ func truncateQuery(q string, maxLen int) string {
 		return q
 	}
 	return q[:maxLen] + "..."
+}
+
+func detectGrafanaClientProfile(r *http.Request, endpoint, route string) grafanaClientProfile {
+	version := parseGrafanaVersionFromUserAgent(r.Header.Get("User-Agent"))
+	sourceTag := parseGrafanaSourceTag(r.Header.Values("X-Query-Tags"))
+	surface := "unknown"
+
+	sourceLower := strings.ToLower(sourceTag)
+	switch {
+	case strings.Contains(sourceLower, "lokiexplore"), strings.Contains(sourceLower, "drilldown"):
+		surface = "grafana_drilldown"
+	case strings.Contains(sourceLower, "loki"):
+		surface = "grafana_loki_datasource"
+	}
+
+	// Fallback: infer surface from endpoint family when request is known to come from Grafana.
+	if surface == "unknown" && version != "" {
+		switch endpoint {
+		case "patterns", "detected_fields", "detected_labels", "volume", "volume_range", "drilldown_limits":
+			surface = "grafana_drilldown"
+		default:
+			if strings.HasPrefix(route, "/loki/api/") {
+				surface = "grafana_loki_datasource"
+			}
+		}
+	}
+
+	major := parseGrafanaRuntimeMajor(version)
+	runtimeFamily := ""
+	switch {
+	case major >= 12:
+		runtimeFamily = "12.x+"
+	case major == 11:
+		runtimeFamily = "11.x"
+	case major > 0:
+		runtimeFamily = strconv.Itoa(major) + ".x"
+	}
+
+	drilldownProfile := ""
+	if surface == "grafana_drilldown" {
+		switch {
+		case major >= 12:
+			drilldownProfile = "drilldown-v2"
+		case major == 11:
+			drilldownProfile = "drilldown-v1"
+		}
+	}
+
+	datasourceProfile := ""
+	if surface == "grafana_loki_datasource" {
+		switch {
+		case major >= 12:
+			datasourceProfile = "grafana-datasource-v12"
+		case major == 11:
+			datasourceProfile = "grafana-datasource-v11"
+		}
+	}
+
+	return grafanaClientProfile{
+		surface:           surface,
+		sourceTag:         sourceTag,
+		version:           version,
+		runtimeMajor:      major,
+		runtimeFamily:     runtimeFamily,
+		drilldownProfile:  drilldownProfile,
+		datasourceProfile: datasourceProfile,
+	}
+}
+
+func detectGrafanaClientSurface(r *http.Request, endpoint, route string) (surface, sourceTag, version string) {
+	profile := detectGrafanaClientProfile(r, endpoint, route)
+	return profile.surface, profile.sourceTag, profile.version
+}
+
+func parseGrafanaSourceTag(values []string) string {
+	for _, raw := range values {
+		for _, part := range strings.Split(raw, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			key, val, ok := strings.Cut(part, "=")
+			if !ok {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(key), "source") {
+				continue
+			}
+			clean := strings.Trim(strings.TrimSpace(val), `"`)
+			if clean != "" {
+				return clean
+			}
+		}
+	}
+	return ""
+}
+
+func parseGrafanaVersionFromUserAgent(userAgent string) string {
+	userAgent = strings.TrimSpace(userAgent)
+	if userAgent == "" {
+		return ""
+	}
+	lower := strings.ToLower(userAgent)
+	idx := strings.Index(lower, "grafana/")
+	if idx < 0 {
+		return ""
+	}
+	rest := userAgent[idx+len("grafana/"):]
+	end := 0
+	for end < len(rest) {
+		ch := rest[end]
+		if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '.' || ch == '-' {
+			end++
+			continue
+		}
+		break
+	}
+	version := strings.Trim(rest[:end], ".-")
+	return version
+}
+
+func parseGrafanaRuntimeMajor(version string) int {
+	if version == "" {
+		return 0
+	}
+	majorPart := version
+	if idx := strings.IndexByte(majorPart, '.'); idx >= 0 {
+		majorPart = majorPart[:idx]
+	}
+	major, err := strconv.Atoi(majorPart)
+	if err != nil {
+		return 0
+	}
+	return major
 }
 
 func deriveEnduserName(clientID, clientSource string) string {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9780,11 +9780,6 @@ func detectGrafanaClientProfile(r *http.Request, endpoint, route string) grafana
 	}
 }
 
-func detectGrafanaClientSurface(r *http.Request, endpoint, route string) (surface, sourceTag, version string) {
-	profile := detectGrafanaClientProfile(r, endpoint, route)
-	return profile.surface, profile.sourceTag, profile.version
-}
-
 func parseGrafanaSourceTag(values []string) string {
 	for _, raw := range values {
 		for _, part := range strings.Split(raw, ",") {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -880,6 +881,7 @@ func TestContract_Patterns_UsesFromToWhenStartEndMissing(t *testing.T) {
 
 func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 	receivedLimits := make([]string, 0, 32)
+	var limitsMu sync.Mutex
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/select/logsql/query_range" {
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
@@ -887,7 +889,9 @@ func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("parse form: %v", err)
 		}
+		limitsMu.Lock()
 		receivedLimits = append(receivedLimits, r.FormValue("limit"))
+		limitsMu.Unlock()
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"GET /api/users 200 15ms","level":"info"}` + "\n"))
 	}))
@@ -905,10 +909,13 @@ func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
 	}
-	if len(receivedLimits) < 2 {
-		t.Fatalf("expected windowed query_range fanout for long range, got %d backend calls", len(receivedLimits))
+	limitsMu.Lock()
+	limitsSnapshot := append([]string(nil), receivedLimits...)
+	limitsMu.Unlock()
+	if len(limitsSnapshot) < 2 {
+		t.Fatalf("expected windowed query_range fanout for long range, got %d backend calls", len(limitsSnapshot))
 	}
-	for i, limit := range receivedLimits {
+	for i, limit := range limitsSnapshot {
 		n, err := strconv.Atoi(limit)
 		if err != nil {
 			t.Fatalf("expected numeric per-window limit at call %d, got %q", i+1, limit)
@@ -921,6 +928,7 @@ func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 
 func TestContract_Patterns_DerivesStepWhenMissing(t *testing.T) {
 	var receivedStep string
+	var stepMu sync.Mutex
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/select/logsql/query_range" {
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
@@ -928,7 +936,11 @@ func TestContract_Patterns_DerivesStepWhenMissing(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("parse form: %v", err)
 		}
-		receivedStep = r.FormValue("step")
+		stepMu.Lock()
+		if strings.TrimSpace(receivedStep) == "" {
+			receivedStep = r.FormValue("step")
+		}
+		stepMu.Unlock()
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"GET /api/users 200 15ms","level":"info"}` + "\n"))
 	}))
@@ -946,7 +958,10 @@ func TestContract_Patterns_DerivesStepWhenMissing(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
 	}
-	if strings.TrimSpace(receivedStep) == "" {
+	stepMu.Lock()
+	stepSnapshot := receivedStep
+	stepMu.Unlock()
+	if strings.TrimSpace(stepSnapshot) == "" {
 		t.Fatalf("expected derived step to be forwarded when request step is missing")
 	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -234,6 +236,72 @@ func TestContract_LabelValues_PrefersStreamFieldValues(t *testing.T) {
 	assertContains(t, data, "prod")
 	if streamNameCalls != 1 || streamValueCalls != 1 || genericValueCalls != 0 {
 		t.Fatalf("expected stream metadata path only, got names=%d streamValues=%d genericValues=%d", streamNameCalls, streamValueCalls, genericValueCalls)
+	}
+}
+
+func TestContract_LabelValues_ForwardsSubstringFilter_OnV149Plus(t *testing.T) {
+	var receivedQ, receivedFilter string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			writeVLFieldNames(w, []fieldHit{{"app", 1}})
+		case "/select/logsql/stream_field_values":
+			receivedQ = r.URL.Query().Get("q")
+			receivedFilter = r.URL.Query().Get("filter")
+			writeVLFieldValues(w, []fieldHit{{"argocd", 1}})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	h := http.Header{}
+	h.Set("Server", "VictoriaLogs/v1.49.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/label/app/values?search=arg", nil)
+	p.handleLabelValues(w, r)
+
+	if receivedQ != "arg" {
+		t.Fatalf("expected q=arg to be forwarded for substring filter, got %q", receivedQ)
+	}
+	if receivedFilter != "substring" {
+		t.Fatalf("expected filter=substring for VictoriaLogs >= v1.49.0, got %q", receivedFilter)
+	}
+}
+
+func TestContract_LabelValues_DoesNotForwardSubstringFilter_OnV148(t *testing.T) {
+	var receivedQ, receivedFilter string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			writeVLFieldNames(w, []fieldHit{{"app", 1}})
+		case "/select/logsql/stream_field_values":
+			receivedQ = r.URL.Query().Get("q")
+			receivedFilter = r.URL.Query().Get("filter")
+			writeVLFieldValues(w, []fieldHit{{"argocd", 1}})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	h := http.Header{}
+	h.Set("Server", "VictoriaLogs/v1.48.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/label/app/values?search=arg", nil)
+	p.handleLabelValues(w, r)
+
+	if receivedQ != "" {
+		t.Fatalf("expected q to stay unset for VictoriaLogs < v1.49.0, got %q", receivedQ)
+	}
+	if receivedFilter != "" {
+		t.Fatalf("expected filter to stay unset for VictoriaLogs < v1.49.0, got %q", receivedFilter)
 	}
 }
 
@@ -840,16 +908,13 @@ func TestContract_Patterns_AdaptiveSourceLimitForLongRanges(t *testing.T) {
 	if len(receivedLimits) < 2 {
 		t.Fatalf("expected windowed query_range fanout for long range, got %d backend calls", len(receivedLimits))
 	}
-	if receivedLimits[0] != "50000" {
-		t.Fatalf("expected initial adaptive source limit capped at 50000 for long range, got %q", receivedLimits[0])
-	}
-	for i, limit := range receivedLimits[1:] {
+	for i, limit := range receivedLimits {
 		n, err := strconv.Atoi(limit)
 		if err != nil {
-			t.Fatalf("expected numeric per-window limit at call %d, got %q", i+2, limit)
+			t.Fatalf("expected numeric per-window limit at call %d, got %q", i+1, limit)
 		}
-		if n <= 0 || n > 10000 {
-			t.Fatalf("expected per-window limit in range 1..10000 at call %d, got %d", i+2, n)
+		if n <= 0 || n > 2000 {
+			t.Fatalf("expected per-window limit in range 1..2000 at call %d, got %d", i+1, n)
 		}
 	}
 }
@@ -938,6 +1003,385 @@ func TestContract_Patterns_WindowedSamplingCoversWholeRange(t *testing.T) {
 	}
 	if firstTS >= lastTS {
 		t.Fatalf("expected increasing sample timestamps across range, got first=%d last=%d", firstTS, lastTS)
+	}
+}
+
+func TestBackendVersionDetection_FromResponseHeaders(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	if p.supportsDensePatternWindowing() {
+		t.Fatalf("expected dense windowing disabled before backend version is detected")
+	}
+	if !p.supportsStreamMetadataEndpoints() {
+		t.Fatalf("expected stream metadata endpoints enabled before version detection")
+	}
+
+	h := http.Header{}
+	h.Set("Server", "VictoriaLogs/v1.50.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	if got := p.backendVersionSemver; got != "v1.50.0" {
+		t.Fatalf("expected semver v1.50.0 from headers, got %q", got)
+	}
+	if !p.supportsDensePatternWindowing() {
+		t.Fatalf("expected dense pattern windowing to be enabled for VictoriaLogs >= v1.50.0")
+	}
+	if !p.supportsStreamMetadataEndpoints() {
+		t.Fatalf("expected stream metadata endpoints to stay enabled for VictoriaLogs >= v1.50.0")
+	}
+	if got := p.backendCapabilityProfile; got != "vl-v1.50-plus" {
+		t.Fatalf("expected capability profile vl-v1.50-plus, got %q", got)
+	}
+}
+
+func TestBackendVersionDetection_OlderVersionKeepsConservativeProfile(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+
+	h := http.Header{}
+	h.Set("X-App-Version", "victoria-logs v1.49.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	if got := p.backendVersionSemver; got != "v1.49.0" {
+		t.Fatalf("expected semver v1.49.0 from headers, got %q", got)
+	}
+	if p.supportsDensePatternWindowing() {
+		t.Fatalf("expected dense pattern windowing to stay disabled for VictoriaLogs < v1.50.0")
+	}
+	if !p.supportsStreamMetadataEndpoints() {
+		t.Fatalf("expected stream metadata endpoints enabled for VictoriaLogs >= v1.30.0")
+	}
+	if !p.supportsMetadataSubstringFilter() {
+		t.Fatalf("expected metadata substring filter enabled for VictoriaLogs >= v1.49.0")
+	}
+	if got := p.backendCapabilityProfile; got != "vl-v1.49-plus" {
+		t.Fatalf("expected capability profile vl-v1.49-plus, got %q", got)
+	}
+}
+
+func TestBackendVersionDetection_V148KeepsSubstringFilterDisabled(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+
+	h := http.Header{}
+	h.Set("Server", "VictoriaLogs/v1.48.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	if got := p.backendVersionSemver; got != "v1.48.0" {
+		t.Fatalf("expected semver v1.48.0 from headers, got %q", got)
+	}
+	if p.supportsMetadataSubstringFilter() {
+		t.Fatalf("expected metadata substring filter disabled for VictoriaLogs < v1.49.0")
+	}
+	if got := p.backendCapabilityProfile; got != "vl-v1.30-plus" {
+		t.Fatalf("expected capability profile vl-v1.30-plus, got %q", got)
+	}
+}
+
+func TestBackendVersionDetection_LegacyVersionDisablesStreamMetadataFastPath(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+
+	h := http.Header{}
+	h.Set("Server", "VictoriaLogs/v1.29.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	if got := p.backendVersionSemver; got != "v1.29.0" {
+		t.Fatalf("expected semver v1.29.0 from headers, got %q", got)
+	}
+	if p.supportsStreamMetadataEndpoints() {
+		t.Fatalf("expected stream metadata endpoints disabled for legacy VictoriaLogs versions")
+	}
+	if p.supportsDensePatternWindowing() {
+		t.Fatalf("expected dense pattern windowing disabled for legacy VictoriaLogs versions")
+	}
+	if got := p.backendCapabilityProfile; got != "legacy-pre-v1.30" {
+		t.Fatalf("expected capability profile legacy-pre-v1.30, got %q", got)
+	}
+}
+
+func TestBackendVersionCompatibilityGate_BlocksTooOldVersion(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Server", "VictoriaLogs/v1.29.0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+
+	err = p.ValidateBackendVersionCompatibility(context.Background())
+	if err == nil {
+		t.Fatalf("expected compatibility gate to fail for backend v1.29.0")
+	}
+	if !strings.Contains(err.Error(), "backend-allow-unsupported-version") {
+		t.Fatalf("expected bypass hint in error, got: %v", err)
+	}
+}
+
+func TestBackendVersionCompatibilityGate_AllowsBypassForTooOldVersion(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "VictoriaLogs/v1.29.0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                     backend.URL,
+		Cache:                          cache.New(60*time.Second, 1000),
+		BackendMinVersion:              "v1.30.0",
+		BackendAllowUnsupportedVersion: true,
+		BackendVersionCheckTimeout:     time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected bypassed compatibility gate, got: %v", err)
+	}
+}
+
+func TestBackendVersionCompatibilityGate_PassesSupportedVersion(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "VictoriaLogs/v1.50.0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected compatibility gate to pass, got: %v", err)
+	}
+}
+
+func TestBackendVersionCompatibilityGate_AllowsMissingVersionHeaders(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected compatibility gate to skip missing version headers, got: %v", err)
+	}
+}
+
+func TestBackendVersionCompatibilityGate_AllowsHealthProbeFailure(t *testing.T) {
+	p, err := New(Config{
+		BackendURL:                 "http://127.0.0.1:65535",
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected compatibility gate to skip health probe failure, got: %v", err)
+	}
+}
+
+func TestBackendVersionCompatibilityGate_AllowsNonSuccessHealthStatus(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "VictoriaLogs/v1.10.0")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unavailable"))
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected compatibility gate to skip non-success health status, got: %v", err)
+	}
+}
+
+func TestBackendVersionCompatibilityConfig_InvalidMinVersion(t *testing.T) {
+	_, err := New(Config{
+		BackendURL:        "http://example.com",
+		Cache:             cache.New(60*time.Second, 1000),
+		BackendMinVersion: "not-a-semver",
+	})
+	if err == nil {
+		t.Fatalf("expected invalid backend minimum version error")
+	}
+}
+
+func TestPatternsSnapshotCompaction_DeduplicatesEquivalentScopes(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	p.patternsSnapshotEntries = map[string]patternSnapshotEntry{}
+	now := time.Now().UnixNano()
+
+	payloadA := []byte(`{"status":"success","data":[{"pattern":"a","samples":[[1,2]]}]}`)
+	payloadB := []byte(`{"status":"success","data":[{"pattern":"b","samples":[[1,3]]}]}`)
+
+	keyOld := "patterns:org-a:query=%7Bapp%3D%22api%22%7D&start=1&end=10&step=60"
+	keyNew := "patterns:org-a:query=%7Bapp%3D%22api%22%7D&start=5&end=15&step=60"
+	keyOther := "patterns:org-a:query=%7Bapp%3D%22worker%22%7D&start=1&end=10&step=60"
+
+	p.patternsSnapshotEntries[keyOld] = patternSnapshotEntry{Value: append([]byte(nil), payloadA...), UpdatedAtUnixNano: now - 10, PatternCount: 1}
+	p.patternsSnapshotEntries[keyNew] = patternSnapshotEntry{Value: append([]byte(nil), payloadA...), UpdatedAtUnixNano: now, PatternCount: 1}
+	p.patternsSnapshotEntries[keyOther] = patternSnapshotEntry{Value: append([]byte(nil), payloadB...), UpdatedAtUnixNano: now, PatternCount: 1}
+
+	p.cache.SetWithTTL(keyOld, payloadA, time.Minute)
+	p.cache.SetWithTTL(keyNew, payloadA, time.Minute)
+	p.cache.SetWithTTL(keyOther, payloadB, time.Minute)
+
+	droppedEntries, droppedPatterns := p.compactPatternsSnapshot(patternDedupSourceMemory, "test")
+	if droppedEntries != 1 {
+		t.Fatalf("expected one deduplicated entry, got %d", droppedEntries)
+	}
+	if droppedPatterns < 0 {
+		t.Fatalf("expected non-negative dropped pattern count, got %d", droppedPatterns)
+	}
+	if _, ok := p.patternsSnapshotEntries[keyOld]; ok {
+		t.Fatalf("expected older equivalent key to be dropped")
+	}
+	if _, ok := p.patternsSnapshotEntries[keyNew]; !ok {
+		t.Fatalf("expected newer equivalent key to be kept")
+	}
+	if _, ok := p.patternsSnapshotEntries[keyOther]; !ok {
+		t.Fatalf("expected different-scope key to stay")
+	}
+	if _, ok := p.cache.Get(keyOld); ok {
+		t.Fatalf("expected dropped key to be invalidated from cache")
+	}
+}
+
+func TestPatternsPersistenceLoop_PersistsAndStopsOnShutdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	persistPath := filepath.Join(tmpDir, "patterns-snapshot.json")
+
+	p, err := New(Config{
+		BackendURL:              "http://127.0.0.1:65535",
+		Cache:                   cache.New(60*time.Second, 1000),
+		LogLevel:                "error",
+		PatternsPersistPath:     persistPath,
+		PatternsPersistInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	p.Init()
+
+	payload := []byte(`{"status":"success","data":[{"pattern":"sample","samples":[[1,1]]}]}`)
+	p.recordPatternSnapshotEntry("patterns:org-a:query=%7Bapp%3D%22api%22%7D&start=1&end=2", payload, time.Now())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, readErr := os.ReadFile(persistPath)
+		if readErr == nil && len(data) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	data, readErr := os.ReadFile(persistPath)
+	if readErr != nil {
+		t.Fatalf("expected persisted snapshot file: %v", readErr)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected persisted snapshot file to be non-empty")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	p.Shutdown(ctx)
+
+	select {
+	case <-p.patternsPersistDone:
+	default:
+		t.Fatalf("expected patterns persistence loop to be stopped after shutdown")
+	}
+}
+
+func TestRecentTailCacheBypass_Decision(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	p.recentTailRefreshEnabled = true
+	p.recentTailRefreshWindow = 2 * time.Minute
+	p.recentTailRefreshMaxStaleness = 2 * time.Second
+
+	nearNow := httptest.NewRequest("GET", "/loki/api/v1/query_range?end=now", nil)
+	if !p.shouldBypassRecentTailCache("query_range", 5*time.Second, nearNow) {
+		t.Fatalf("expected near-now stale cache to be bypassed")
+	}
+
+	oldRange := httptest.NewRequest("GET", "/loki/api/v1/query_range?end=now-10m", nil)
+	if p.shouldBypassRecentTailCache("query_range", 5*time.Second, oldRange) {
+		t.Fatalf("expected old-range cache hit to be retained")
+	}
+
+	fresh := httptest.NewRequest("GET", "/loki/api/v1/query_range?end=now", nil)
+	if p.shouldBypassRecentTailCache("query_range", 9*time.Second, fresh) {
+		t.Fatalf("expected fresh near-now cache hit to be retained")
+	}
+
+	p.recentTailRefreshEnabled = false
+	if p.shouldBypassRecentTailCache("query_range", 5*time.Second, nearNow) {
+		t.Fatalf("expected disabled tail-refresh to retain cache")
+	}
+}
+
+func TestContract_Volume_BypassesNearNowStaleCache(t *testing.T) {
+	var backendCalls int
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		backendCalls++
+		_, _ = w.Write([]byte(`{"hits":[{"fields":{"service.name":"api"},"timestamps":["2026-01-01T00:00:00Z"],"values":[3]}]}`))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	p.recentTailRefreshEnabled = true
+	p.recentTailRefreshWindow = time.Hour
+	p.recentTailRefreshMaxStaleness = time.Nanosecond
+
+	uri := "/loki/api/v1/index/volume?query=%7Bapp%3D%22api%22%7D&end=now"
+	w1 := httptest.NewRecorder()
+	p.handleVolume(w1, httptest.NewRequest("GET", uri, nil))
+	if backendCalls != 1 {
+		t.Fatalf("expected first call to hit backend once, got %d", backendCalls)
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	w2 := httptest.NewRecorder()
+	p.handleVolume(w2, httptest.NewRequest("GET", uri, nil))
+	if backendCalls < 2 {
+		t.Fatalf("expected stale near-now cache to be bypassed, backend calls=%d", backendCalls)
 	}
 }
 
@@ -1402,6 +1846,33 @@ func TestContract_DrilldownLimits_PatternsDisabledAdvertised(t *testing.T) {
 	}
 }
 
+func TestContract_DrilldownLimits_AdvertisesGrafanaProfilesWhenDetected(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/drilldown-limits", nil)
+	r.Header.Set("User-Agent", "Grafana/11.6.6")
+	r.Header.Set("X-Query-Tags", "Source=grafana-lokiexplore-app")
+	p.handleDrilldownLimits(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from drilldown-limits, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if got := resp["grafana_client_surface"]; got != "grafana_drilldown" {
+		t.Fatalf("expected grafana_client_surface=grafana_drilldown, got %v", got)
+	}
+	if got := resp["grafana_runtime_version"]; got != "11.6.6" {
+		t.Fatalf("expected grafana_runtime_version=11.6.6, got %v", got)
+	}
+	if got := resp["grafana_runtime_family"]; got != "11.x" {
+		t.Fatalf("expected grafana_runtime_family=11.x, got %v", got)
+	}
+	if got := resp["drilldown_profile"]; got != "drilldown-v1" {
+		t.Fatalf("expected drilldown_profile=drilldown-v1, got %v", got)
+	}
+}
+
 func TestContract_DrilldownLimits_ExposesRequiredLimitsContract(t *testing.T) {
 	p := newTestProxy(t, "http://unused")
 	w := httptest.NewRecorder()
@@ -1470,6 +1941,36 @@ func TestContract_DrilldownLimits_ExposesRequiredLimitsContract(t *testing.T) {
 	}
 	if _, ok := limits["retention_stream"].([]interface{}); !ok {
 		t.Fatalf("expected limits.retention_stream to be an array, got %T", limits["retention_stream"])
+	}
+}
+
+func TestContract_SupportsDensePatternWindowingForRequest_GrafanaRuntimeAware(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	p.backendVersionMu.Lock()
+	p.backendSupportsDensePatternWindowing = true
+	p.backendVersionSemver = "v1.50.0"
+	p.backendVersionMu.Unlock()
+
+	baseReq := httptest.NewRequest("GET", "/loki/api/v1/patterns?query=%7Bapp%3D%22api%22%7D", nil)
+
+	legacyCtx := context.WithValue(baseReq.Context(), requestGrafanaClientKey, grafanaClientProfile{
+		surface:      "grafana_drilldown",
+		runtimeMajor: 11,
+	})
+	if p.supportsDensePatternWindowingForRequest(baseReq.WithContext(legacyCtx)) {
+		t.Fatal("expected dense windowing disabled for legacy drilldown runtime family")
+	}
+
+	modernCtx := context.WithValue(baseReq.Context(), requestGrafanaClientKey, grafanaClientProfile{
+		surface:      "grafana_drilldown",
+		runtimeMajor: 12,
+	})
+	if !p.supportsDensePatternWindowingForRequest(baseReq.WithContext(modernCtx)) {
+		t.Fatal("expected dense windowing enabled for modern drilldown runtime family")
+	}
+
+	if !p.supportsDensePatternWindowingForRequest(baseReq) {
+		t.Fatal("expected dense windowing enabled for non-grafana request context")
 	}
 }
 
@@ -2410,6 +2911,32 @@ func TestContract_Labels_ForwardsQueryParam(t *testing.T) {
 	}
 	if !strings.Contains(receivedQuery, "app") {
 		t.Errorf("expected translated query to contain 'app', got %q", receivedQuery)
+	}
+}
+
+func TestContract_Labels_ForwardsSubstringFilter_OnV149Plus(t *testing.T) {
+	var receivedQ, receivedFilter string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQ = r.URL.Query().Get("q")
+		receivedFilter = r.URL.Query().Get("filter")
+		writeVLFieldNames(w, []fieldHit{{"app", 1}, {"level", 1}})
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	h := http.Header{}
+	h.Set("Server", "VictoriaLogs/v1.49.0")
+	p.observeBackendVersionFromHeaders(h)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", `/loki/api/v1/labels?query={app="nginx"}&search=app`, nil)
+	p.handleLabels(w, r)
+
+	if receivedQ != "app" {
+		t.Fatalf("expected q=app to be forwarded for substring filter, got %q", receivedQ)
+	}
+	if receivedFilter != "substring" {
+		t.Fatalf("expected filter=substring for VictoriaLogs >= v1.49.0, got %q", receivedFilter)
 	}
 }
 

--- a/internal/proxy/request_logger_semconv_test.go
+++ b/internal/proxy/request_logger_semconv_test.go
@@ -108,3 +108,98 @@ func TestRequestLogger_MetricsUseTemplateRoutes(t *testing.T) {
 		}
 	}
 }
+
+func TestRequestLogger_DetectsGrafanaDrilldownSurface(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Proxy{
+		log:                      slog.New(slog.NewJSONHandler(&buf, nil)),
+		metrics:                  metrics.NewMetrics(),
+		metricsTrustProxyHeaders: true,
+	}
+
+	h := p.requestLogger("detected_fields", "/loki/api/v1/detected_fields", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/detected_fields?query=%7Bservice_name%3D%22api%22%7D", nil)
+	req.Header.Set("User-Agent", "Grafana/12.3.3")
+	req.Header.Set("X-Query-Tags", "Source=grafana-lokiexplore-app")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid request log json: %v", err)
+	}
+	if got := payload["grafana.client.surface"]; got != "grafana_drilldown" {
+		t.Fatalf("expected drilldown surface, got %#v", got)
+	}
+	if got := payload["grafana.client.source_tag"]; got != "grafana-lokiexplore-app" {
+		t.Fatalf("expected source tag, got %#v", got)
+	}
+	if got := payload["grafana.version"]; got != "12.3.3" {
+		t.Fatalf("expected grafana version, got %#v", got)
+	}
+	if got := payload["grafana.runtime.family"]; got != "12.x+" {
+		t.Fatalf("expected grafana runtime family, got %#v", got)
+	}
+	if got := payload["grafana.drilldown.profile"]; got != "drilldown-v2" {
+		t.Fatalf("expected drilldown profile, got %#v", got)
+	}
+}
+
+func TestRequestLogger_DetectsGrafanaDatasourceSurface(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Proxy{
+		log:     slog.New(slog.NewJSONHandler(&buf, nil)),
+		metrics: metrics.NewMetrics(),
+	}
+
+	h := p.requestLogger("labels", "/loki/api/v1/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/labels", nil)
+	req.Header.Set("User-Agent", "Grafana/12.4.1")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid request log json: %v", err)
+	}
+	if got := payload["grafana.client.surface"]; got != "grafana_loki_datasource" {
+		t.Fatalf("expected datasource surface, got %#v", got)
+	}
+	if got := payload["grafana.version"]; got != "12.4.1" {
+		t.Fatalf("expected grafana version, got %#v", got)
+	}
+	if got := payload["grafana.runtime.family"]; got != "12.x+" {
+		t.Fatalf("expected grafana runtime family, got %#v", got)
+	}
+	if got := payload["grafana.datasource.profile"]; got != "grafana-datasource-v12" {
+		t.Fatalf("expected datasource profile, got %#v", got)
+	}
+}
+
+func TestParseGrafanaSourceTag(t *testing.T) {
+	got := parseGrafanaSourceTag([]string{`foo=bar, Source="grafana-lokiexplore-app"`})
+	if got != "grafana-lokiexplore-app" {
+		t.Fatalf("unexpected source tag: %q", got)
+	}
+	if empty := parseGrafanaSourceTag([]string{"foo=bar"}); empty != "" {
+		t.Fatalf("expected empty source tag, got %q", empty)
+	}
+}
+
+func TestParseGrafanaRuntimeMajor(t *testing.T) {
+	if got := parseGrafanaRuntimeMajor("12.4.1"); got != 12 {
+		t.Fatalf("expected 12, got %d", got)
+	}
+	if got := parseGrafanaRuntimeMajor("11.6.6-beta1"); got != 11 {
+		t.Fatalf("expected 11, got %d", got)
+	}
+	if got := parseGrafanaRuntimeMajor("dev"); got != 0 {
+		t.Fatalf("expected 0 for non-semver token, got %d", got)
+	}
+}

--- a/test/e2e-compat/compatibility-matrix.json
+++ b/test/e2e-compat/compatibility-matrix.json
@@ -33,7 +33,10 @@
         "policy": "v1_3x_to_v1_5x_transition",
         "description": "Support VictoriaLogs releases across v1.3x.x through v1.5x.x during migration windows. The current family is v1.5x.x, but we intentionally retain older bands to avoid backend upgrade lockstep.",
         "current_family": "v1.5x.x",
-        "previous_family": "v1.4x.x"
+        "previous_family": "v1.4x.x",
+        "additional_families": [
+          "v1.3x.x"
+        ]
       },
       "matrix_versions": [
         "v1.30.0",

--- a/test/e2e-compat/compatibility-matrix.json
+++ b/test/e2e-compat/compatibility-matrix.json
@@ -28,12 +28,12 @@
     },
     "victorialogs": {
       "image_repo": "victoriametrics/victoria-logs",
-      "pinned_version": "v1.49.0",
+      "pinned_version": "v1.50.0",
       "support_window": {
-        "policy": "v1_3x_and_v1_4x",
-        "description": "Support VictoriaLogs releases in the v1.3x.x and v1.4x.x bands. This is intentionally broader than Loki because users commonly run older VictoriaLogs backends during migration windows.",
-        "current_family": "v1.4x.x",
-        "previous_family": "v1.3x.x"
+        "policy": "v1_3x_to_v1_5x_transition",
+        "description": "Support VictoriaLogs releases across v1.3x.x through v1.5x.x during migration windows. The current family is v1.5x.x, but we intentionally retain older bands to avoid backend upgrade lockstep.",
+        "current_family": "v1.5x.x",
+        "previous_family": "v1.4x.x"
       },
       "matrix_versions": [
         "v1.30.0",
@@ -55,7 +55,39 @@
         "v1.46.0",
         "v1.47.0",
         "v1.48.0",
-        "v1.49.0"
+        "v1.49.0",
+        "v1.50.0"
+      ],
+    "capability_profiles": [
+      {
+        "profile": "vl-v1.50-plus",
+        "version_range": ">= v1.50.0",
+        "capabilities": [
+          "stream_metadata_endpoints",
+          "dense_patterns_windowing",
+          "metadata_substring_filter"
+        ]
+      },
+      {
+        "profile": "vl-v1.49-plus",
+        "version_range": ">= v1.49.0 < v1.50.0",
+        "capabilities": [
+          "stream_metadata_endpoints",
+          "metadata_substring_filter"
+        ]
+      },
+      {
+        "profile": "vl-v1.30-plus",
+        "version_range": ">= v1.30.0 < v1.49.0",
+        "capabilities": [
+          "stream_metadata_endpoints"
+        ]
+      },
+        {
+          "profile": "legacy-pre-v1.30",
+          "version_range": "< v1.30.0",
+          "capabilities": []
+        }
       ],
       "role": "backend under translation"
     },
@@ -87,12 +119,67 @@
           "run_on_pr": true,
           "test_regex": "^(TestGrafanaDatasourceCatalogAndHealth|TestDrilldown_GrafanaResourceContracts|TestDrilldown_RuntimeFamilyContracts)$"
         }
+      ],
+      "capability_profiles": [
+        {
+          "profile": "grafana-runtime-v12-plus",
+          "version_range": ">= 12.0.0",
+          "capabilities": [
+            "drilldown_source_tag",
+            "runtime_family_v12_contracts"
+          ]
+        },
+        {
+          "profile": "grafana-runtime-v11",
+          "version_range": ">= 11.0.0 < 12.0.0",
+          "capabilities": [
+            "drilldown_source_tag",
+            "runtime_family_v11_contracts"
+          ]
+        }
+      ]
+    },
+    "grafana_loki_datasource_contract": {
+      "repo": "https://github.com/grafana/grafana",
+      "path": "public/app/plugins/datasource/loki",
+      "support_window": {
+        "policy": "current_runtime_family_plus_previous_family",
+        "description": "Track built-in Loki datasource contract behavior for current Grafana runtime family and one family behind.",
+        "current_family": "12.x",
+        "previous_family": "11.x"
+      },
+      "matrix_versions": [
+        "12.4.2",
+        "12.4.1",
+        "11.6.6"
+      ],
+      "capability_profiles": [
+        {
+          "profile": "grafana-datasource-v12",
+          "version_range": ">= 12.0.0",
+          "capabilities": [
+            "runtime_v12_contract_assertions",
+            "structured_resource_flow"
+          ]
+        },
+        {
+          "profile": "grafana-datasource-v11",
+          "version_range": ">= 11.0.0 < 12.0.0",
+          "capabilities": [
+            "runtime_v11_contract_assertions",
+            "legacy_runtime_flow"
+          ]
+        }
+      ],
+      "notes": [
+        "Datasource plugin exact semver is not emitted on request headers by default.",
+        "Proxy runtime sensing uses Grafana User-Agent version family and endpoint/source-tag request shape."
       ]
     },
     "logs_drilldown_contract": {
       "repo": "https://github.com/grafana/logs-drilldown",
-      "pinned_version": "2.0.1",
-      "pinned_commit": "4463f56047de75da95251086d1906fb902ad53a7",
+      "pinned_version": "2.0.3",
+      "pinned_commit": "c22fae24f533a36ec2173933d2c303804cb7e814",
       "support_window": {
         "policy": "current_family_plus_previous_family",
         "description": "Support the current Logs Drilldown release family and one family behind. The contract matrix moves forward as upstream releases advance; we do not keep an open-ended history of older families.",
@@ -100,6 +187,8 @@
         "previous_family": "1.0.x"
       },
       "matrix_versions": [
+        "2.0.3",
+        "2.0.2",
         "2.0.1",
         "2.0.0",
         "1.0.41",
@@ -116,6 +205,42 @@
         "Service detail logs use a mixed parser selector: json + logfmt + drop __error__ stages",
         "detected_fields is post-processed by the app datasource wrapper to drop detected_level, level, and level_extracted",
         "Patterns are label-scoped; parsed fields, metadata, and line filters are not expected to constrain the pattern list"
+      ],
+      "capability_profiles": [
+        {
+          "profile": "drilldown-v2",
+          "version_range": ">= 2.0.0 < 3.0.0",
+          "capabilities": [
+            "detected_level_default_columns",
+            "service_detail_field_value_breakdowns"
+          ]
+        },
+        {
+          "profile": "drilldown-v1",
+          "version_range": ">= 1.0.34 < 2.0.0",
+          "capabilities": [
+            "legacy_service_selection_buckets",
+            "legacy_detected_fields_filtering"
+          ]
+        }
+      ],
+      "runtime_detection": {
+        "source_header": "X-Query-Tags",
+        "source_tag_key": "Source",
+        "source_tag_value": "grafana-lokiexplore-app",
+        "runtime_version_source": "User-Agent: Grafana/<version>",
+        "app_semver_exposed_on_wire": false
+      }
+    },
+    "grafana_client_detection": {
+      "signals": [
+        "User-Agent: Grafana/<version>",
+        "X-Query-Tags: Source=grafana-lokiexplore-app"
+      ],
+      "surfaces": [
+        "grafana_drilldown",
+        "grafana_loki_datasource",
+        "unknown"
       ]
     }
   },
@@ -172,7 +297,9 @@
         {
           "versions": [
             "2.0.0",
-            "2.0.1"
+            "2.0.1",
+            "2.0.2",
+            "2.0.3"
           ],
           "focus": [
             "detected_level coloring series names",
@@ -217,7 +344,8 @@
             "v1.46.x",
             "v1.47.x",
             "v1.48.x",
-            "v1.49.x"
+            "v1.49.x",
+            "v1.50.x"
           ],
           "focus": [
             "stats_query_range shape",

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   # VictoriaLogs backend
   victorialogs:
-    image: ${VICTORIALOGS_IMAGE:-victoriametrics/victoria-logs:v1.49.0}
+    image: ${VICTORIALOGS_IMAGE:-victoriametrics/victoria-logs:v1.50.0}
     container_name: e2e-victorialogs
     ports:
       - "9428:9428"

--- a/test/e2e-compat/matrix_manifest_test.go
+++ b/test/e2e-compat/matrix_manifest_test.go
@@ -26,9 +26,10 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 				ImageRepo     string `json:"image_repo"`
 				PinnedVersion string `json:"pinned_version"`
 				SupportWindow struct {
-					Policy         string `json:"policy"`
-					CurrentFamily  string `json:"current_family"`
-					PreviousFamily string `json:"previous_family"`
+					Policy             string   `json:"policy"`
+					CurrentFamily      string   `json:"current_family"`
+					PreviousFamily     string   `json:"previous_family"`
+					AdditionalFamilies []string `json:"additional_families"`
 				} `json:"support_window"`
 				MatrixVersions []string `json:"matrix_versions"`
 			} `json:"loki"`
@@ -36,9 +37,10 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 				ImageRepo     string `json:"image_repo"`
 				PinnedVersion string `json:"pinned_version"`
 				SupportWindow struct {
-					Policy         string `json:"policy"`
-					CurrentFamily  string `json:"current_family"`
-					PreviousFamily string `json:"previous_family"`
+					Policy             string   `json:"policy"`
+					CurrentFamily      string   `json:"current_family"`
+					PreviousFamily     string   `json:"previous_family"`
+					AdditionalFamilies []string `json:"additional_families"`
 				} `json:"support_window"`
 				MatrixVersions []string `json:"matrix_versions"`
 			} `json:"victorialogs"`
@@ -46,9 +48,10 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 				ImageRepo     string `json:"image_repo"`
 				PinnedVersion string `json:"pinned_version"`
 				SupportWindow struct {
-					Policy         string `json:"policy"`
-					CurrentFamily  string `json:"current_family"`
-					PreviousFamily string `json:"previous_family"`
+					Policy             string   `json:"policy"`
+					CurrentFamily      string   `json:"current_family"`
+					PreviousFamily     string   `json:"previous_family"`
+					AdditionalFamilies []string `json:"additional_families"`
 				} `json:"support_window"`
 				RuntimeProfiles []struct {
 					Version   string `json:"version"`
@@ -61,9 +64,10 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 				PinnedVersion string `json:"pinned_version"`
 				PinnedCommit  string `json:"pinned_commit"`
 				SupportWindow struct {
-					Policy         string `json:"policy"`
-					CurrentFamily  string `json:"current_family"`
-					PreviousFamily string `json:"previous_family"`
+					Policy             string   `json:"policy"`
+					CurrentFamily      string   `json:"current_family"`
+					PreviousFamily     string   `json:"previous_family"`
+					AdditionalFamilies []string `json:"additional_families"`
 				} `json:"support_window"`
 				MatrixVersions []string `json:"matrix_versions"`
 			} `json:"logs_drilldown_contract"`
@@ -145,7 +149,7 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 	if len(matrix.Stack.Loki.MatrixVersions) == 0 || len(matrix.Stack.VictoriaLogs.MatrixVersions) == 0 {
 		t.Fatalf("runtime matrices must not be empty")
 	}
-	assertSupportWindow := func(name, policyName, currentFamily, previousFamily string, versions []string) {
+	assertSupportWindow := func(name, policyName, currentFamily, previousFamily string, additionalFamilies, versions []string) {
 		t.Helper()
 		if policyName == "" || currentFamily == "" || previousFamily == "" {
 			t.Fatalf("%s support window must define policy, current family, and previous family", name)
@@ -155,15 +159,29 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 		}
 		currentPrefix := familyPrefix(currentFamily)
 		previousPrefix := familyPrefix(previousFamily)
+		allowedPrefixes := []string{currentPrefix, previousPrefix}
+		for _, family := range additionalFamilies {
+			if family == "" {
+				continue
+			}
+			allowedPrefixes = append(allowedPrefixes, familyPrefix(family))
+		}
 		foundCurrent := false
 		foundPrevious := false
 		for _, version := range versions {
+			matched := false
+			for _, prefix := range allowedPrefixes {
+				if strings.HasPrefix(version, prefix) {
+					matched = true
+					break
+				}
+			}
 			switch {
 			case strings.HasPrefix(version, currentPrefix):
 				foundCurrent = true
 			case strings.HasPrefix(version, previousPrefix):
 				foundPrevious = true
-			default:
+			case !matched:
 				t.Fatalf("%s version %q falls outside support window %q / %q", name, version, currentFamily, previousFamily)
 			}
 		}
@@ -179,6 +197,7 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 		matrix.Stack.Loki.SupportWindow.Policy,
 		matrix.Stack.Loki.SupportWindow.CurrentFamily,
 		matrix.Stack.Loki.SupportWindow.PreviousFamily,
+		matrix.Stack.Loki.SupportWindow.AdditionalFamilies,
 		matrix.Stack.Loki.MatrixVersions,
 	)
 	assertSupportWindow(
@@ -186,6 +205,7 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 		matrix.Stack.VictoriaLogs.SupportWindow.Policy,
 		matrix.Stack.VictoriaLogs.SupportWindow.CurrentFamily,
 		matrix.Stack.VictoriaLogs.SupportWindow.PreviousFamily,
+		matrix.Stack.VictoriaLogs.SupportWindow.AdditionalFamilies,
 		matrix.Stack.VictoriaLogs.MatrixVersions,
 	)
 	assertSupportWindow(
@@ -193,6 +213,7 @@ func TestPinnedCompatibilityMatrixMatchesCompose(t *testing.T) {
 		matrix.Stack.LogsDrilldownContract.SupportWindow.Policy,
 		matrix.Stack.LogsDrilldownContract.SupportWindow.CurrentFamily,
 		matrix.Stack.LogsDrilldownContract.SupportWindow.PreviousFamily,
+		matrix.Stack.LogsDrilldownContract.SupportWindow.AdditionalFamilies,
 		matrix.Stack.LogsDrilldownContract.MatrixVersions,
 	)
 	if !strings.HasPrefix(matrix.Stack.Loki.PinnedVersion, familyPrefix(matrix.Stack.Loki.SupportWindow.CurrentFamily)) {


### PR DESCRIPTION
## Summary
- add request-surface/runtime detection for Grafana clients using deterministic signals:
  - X-Query-Tags: Source=grafana-lokiexplore-app (Drilldown surface)
  - User-Agent: Grafana/<version> (runtime family)
- add runtime capability profiles in proxy request context and expose them in structured request logs
  - grafana.runtime.family
  - grafana.drilldown.profile
  - grafana.datasource.profile
- gate dense pattern windowing by runtime family for Drilldown requests (keep conservative behavior for legacy runtime, modern behavior for 12.x+)
- enrich /loki/api/v1/drilldown-limits response with detected Grafana runtime/profile metadata
- forward Grafana surface/profile headers upstream for backend-aware observability

## Compatibility/Docs
- add Grafana Loki datasource compatibility guide
- extend compatibility matrix with Grafana runtime + datasource profile track
- extend Drilldown compatibility doc with runtime detection model and profile bands
- update README/testing/changelog references

## Tests
- add request logger tests for Drilldown and datasource surface detection + runtime family/profile fields
- add parser test for Grafana runtime major extraction
- add contract tests for drilldown limits profile exposure and runtime-aware dense pattern windowing
- verified locally:
  - go test ./internal/proxy -count=1
  - go test ./cmd/proxy -count=1

## Notes
- exact built-in Loki datasource plugin semver is not available on request path by default; runtime-family + deterministic request signals are used for behavior gating.
