### PR TITLE
patterns: stabilize dense refresh behavior and window fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- patterns: stabilize `/loki/api/v1/patterns` ordering under equal-count ties (sort by total, then level, then pattern) to prevent refresh-to-refresh pattern reshuffling on dense scopes.
+- patterns: harden dense-range window sampling by bounding dense fanout (`<=64` windows), avoiding step-driven window explosion in dense mode, and requiring minimum dense window success coverage before accepting partial window merges.
+
+### Tests
+
+- add regression coverage for dense window config fanout bounds, dense partial-window acceptance gating, and deterministic tie ordering in merged pattern results.
+
 ## [1.0.22] - 2026-04-14
 
 ### Bug Fixes

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"bufio"
 	"bytes"
-	"container/heap"
 	"encoding/json"
 	"net"
 	"regexp"
@@ -409,40 +408,26 @@ func buildPatternResponse(miner *patternMiner, limit int) []map[string]interface
 		limit = maxPatternResponseLimit
 	}
 	clusters := miner.AllClusters()
-	entryCap := len(clusters)
-	if entryCap > maxPatternResponseLimit {
-		entryCap = maxPatternResponseLimit
+	entries := make([]*patternBucket, 0, len(clusters))
+	entries = append(entries, clusters...)
+	for _, e := range entries {
+		e.pattern = miner.tokenizer.Join(e.tokens, e.spacesAfter)
 	}
-	entries := make([]*patternBucket, 0, entryCap)
-	if len(clusters) <= limit {
-		entries = append(entries, clusters...)
-		sort.Slice(entries, func(i, j int) bool {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].total != entries[j].total {
 			return entries[i].total > entries[j].total
-		})
-	} else {
-		h := &patternBucketHeap{}
-		heap.Init(h)
-		for _, entry := range clusters {
-			if h.Len() < limit {
-				heap.Push(h, entry)
-				continue
-			}
-			if (*h)[0].total < entry.total {
-				(*h)[0] = entry
-				heap.Fix(h, 0)
-			}
 		}
-		for h.Len() > 0 {
-			entries = append(entries, heap.Pop(h).(*patternBucket))
+		if entries[i].level != entries[j].level {
+			return entries[i].level < entries[j].level
 		}
-		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].total > entries[j].total
-		})
+		return entries[i].pattern < entries[j].pattern
+	})
+	if len(entries) > limit {
+		entries = entries[:limit]
 	}
 
 	result := make([]map[string]interface{}, 0, len(entries))
 	for _, e := range entries {
-		e.pattern = miner.tokenizer.Join(e.tokens, e.spacesAfter)
 		sampleTimes := make([]int64, 0, len(e.buckets))
 		for bucket := range e.buckets {
 			sampleTimes = append(sampleTimes, bucket)

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -667,22 +667,6 @@ func cloneInts(src []int) []int {
 	return out
 }
 
-type patternBucketHeap []*patternBucket
-
-func (h patternBucketHeap) Len() int           { return len(h) }
-func (h patternBucketHeap) Less(i, j int) bool { return h[i].total < h[j].total }
-func (h patternBucketHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-func (h *patternBucketHeap) Push(x interface{}) {
-	*h = append(*h, x.(*patternBucket))
-}
-func (h *patternBucketHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	item := old[n-1]
-	*h = old[:n-1]
-	return item
-}
-
 // tokenizeToPattern converts a log line into a pattern by replacing variable parts with <_>.
 // This is a simplified version of the drain log pattern mining algorithm.
 func tokenizeToPattern(line string) string {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4590,12 +4590,13 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if endpoint == "/select/logsql/query_range" {
-			startNs, endNs, splitInterval, perWindowLimit, ok := patternWindowedSamplingConfig(startParam, endParam, stepParam, sourceLimit, p.supportsDensePatternWindowingForRequest(r))
+			denseWindowing := p.supportsDensePatternWindowingForRequest(r)
+			startNs, endNs, splitInterval, perWindowLimit, ok := patternWindowedSamplingConfig(startParam, endParam, stepParam, sourceLimit, denseWindowing)
 			if ok {
 				windows := splitQueryRangeWindowsWithOptions(startNs, endNs, splitInterval, "backward", true)
 				if len(windows) > 1 {
 					windowEntries, windowSuccesses := p.fetchPatternsFromWindows(r, logsqlQuery, sourceLimit, perWindowLimit, windows, stepParam, patternLimit)
-					if windowSuccesses > 0 && len(windowEntries) > 0 {
+					if shouldAcceptWindowedPatternResults(windowSuccesses, len(windows), denseWindowing) && len(windowEntries) > 0 {
 						// Prefer distributed stratified windows so dense ranges keep full-range
 						// visibility instead of collapsing to a recent-tail sample.
 						return windowEntries, true
@@ -4894,22 +4895,26 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 	maxWindowSourceLimit := 1_000
 	maxPatternWindowSamples := 96
 	if denseWindowing {
-		targetWindowSpan = 10 * time.Minute
-		minWindowSourceLimit = 100
-		maxWindowSourceLimit = 2_000
-		maxPatternWindowSamples = 240
+		// Dense ranges can otherwise explode into hundreds of windows and produce
+		// short/unstable tails under backend pressure. Keep fanout bounded.
+		targetWindowSpan = 45 * time.Minute
+		minWindowSourceLimit = 200
+		maxWindowSourceLimit = 4_000
+		maxPatternWindowSamples = 64
 	}
 	if span < minWindowedSpan {
 		return 0, 0, 0, 0, false
 	}
 
 	windowCount := int(span/targetWindowSpan) + 1
-	if stepSeconds := parsePatternStepSeconds(stepParam); stepSeconds > 0 {
-		stepNs := stepSeconds * int64(time.Second)
-		if stepNs > 0 {
-			stepBasedCount := int(((endNs - startNs) / stepNs) + 1)
-			if stepBasedCount > windowCount {
-				windowCount = stepBasedCount
+	if !denseWindowing {
+		if stepSeconds := parsePatternStepSeconds(stepParam); stepSeconds > 0 {
+			stepNs := stepSeconds * int64(time.Second)
+			if stepNs > 0 {
+				stepBasedCount := int(((endNs - startNs) / stepNs) + 1)
+				if stepBasedCount > windowCount {
+					windowCount = stepBasedCount
+				}
 			}
 		}
 	}
@@ -4935,6 +4940,21 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 	}
 
 	return startNs, endNs, interval, perWindowLimit, true
+}
+
+func shouldAcceptWindowedPatternResults(successes, total int, denseWindowing bool) bool {
+	if successes <= 0 || total <= 0 {
+		return false
+	}
+	if successes >= total {
+		return true
+	}
+	if !denseWindowing {
+		return true
+	}
+	// For dense mode, avoid returning highly partial window samples; they tend
+	// to collapse to short recent tails and churn on refresh.
+	return successes*2 >= total
 }
 
 func limitPatternPayload(payload []byte, limit int) []byte {
@@ -5061,7 +5081,15 @@ func mergePatternResultEntries(base, extra []patternResultEntry) []patternResult
 	for _, item := range merged {
 		items = append(items, item)
 	}
-	sort.Slice(items, func(i, j int) bool { return items[i].total > items[j].total })
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].total != items[j].total {
+			return items[i].total > items[j].total
+		}
+		if items[i].level != items[j].level {
+			return items[i].level < items[j].level
+		}
+		return items[i].pattern < items[j].pattern
+	})
 
 	out := make([]patternResultEntry, 0, len(items))
 	for _, item := range items {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1986,6 +1987,74 @@ func TestContract_SupportsDensePatternWindowingForRequest_GrafanaRuntimeAware(t 
 
 	if !p.supportsDensePatternWindowingForRequest(baseReq) {
 		t.Fatal("expected dense windowing enabled for non-grafana request context")
+	}
+}
+
+func TestPatternWindowedSamplingConfig_DenseIgnoresStepInflationAndCapsFanout(t *testing.T) {
+	start := strconv.FormatInt(0, 10)
+	end := strconv.FormatInt(int64((24*time.Hour)/time.Second), 10)
+
+	startNsA, endNsA, intervalA, perWindowA, okA := patternWindowedSamplingConfig(start, end, "1s", 10000, true)
+	startNsB, endNsB, intervalB, perWindowB, okB := patternWindowedSamplingConfig(start, end, "30m", 10000, true)
+	if !okA || !okB {
+		t.Fatal("expected dense windowed config to be enabled for long ranges")
+	}
+	if startNsA != startNsB || endNsA != endNsB {
+		t.Fatalf("expected identical dense range bounds, got A=%d..%d B=%d..%d", startNsA, endNsA, startNsB, endNsB)
+	}
+	if intervalA != intervalB {
+		t.Fatalf("expected dense mode to ignore step-driven inflation, got intervalA=%s intervalB=%s", intervalA, intervalB)
+	}
+	if perWindowA != perWindowB {
+		t.Fatalf("expected dense mode per-window limit to remain stable across steps, got %d vs %d", perWindowA, perWindowB)
+	}
+
+	span := time.Duration(endNsA - startNsA)
+	windowCount := int(span/intervalA) + 1
+	if windowCount > 64 {
+		t.Fatalf("expected dense mode window cap <=64, got %d", windowCount)
+	}
+	if perWindowA < 200 {
+		t.Fatalf("expected dense mode per-window lower bound >=200, got %d", perWindowA)
+	}
+}
+
+func TestShouldAcceptWindowedPatternResults(t *testing.T) {
+	if shouldAcceptWindowedPatternResults(1, 4, true) {
+		t.Fatal("expected dense mode to reject highly partial window coverage")
+	}
+	if !shouldAcceptWindowedPatternResults(2, 4, true) {
+		t.Fatal("expected dense mode to accept >=50% window coverage")
+	}
+	if !shouldAcceptWindowedPatternResults(1, 4, false) {
+		t.Fatal("expected non-dense mode to accept partial coverage when there is at least one successful window")
+	}
+	if shouldAcceptWindowedPatternResults(0, 4, false) {
+		t.Fatal("expected zero successful windows to be rejected")
+	}
+}
+
+func TestMergePatternResultEntries_DeterministicTieOrder(t *testing.T) {
+	base := []patternResultEntry{
+		{Level: "warn", Pattern: "zeta", Samples: [][]interface{}{{int64(1), 1}}},
+		{Level: "info", Pattern: "beta", Samples: [][]interface{}{{int64(1), 1}}},
+	}
+	extra := []patternResultEntry{
+		{Level: "info", Pattern: "alpha", Samples: [][]interface{}{{int64(2), 1}}},
+	}
+
+	merged := mergePatternResultEntries(base, extra)
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 merged patterns, got %d", len(merged))
+	}
+	got := []string{
+		merged[0].Level + "/" + merged[0].Pattern,
+		merged[1].Level + "/" + merged[1].Pattern,
+		merged[2].Level + "/" + merged[2].Pattern,
+	}
+	want := []string{"info/alpha", "info/beta", "warn/zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected deterministic order: got=%v want=%v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stabilize pattern ordering under equal totals so refreshes stop reshuffling patterns on dense scopes
- harden dense `/loki/api/v1/patterns` window sampling by bounding fanout and avoiding step-driven window explosion
- reject highly partial dense window merges (fallback to non-window path) to reduce short recent-tail results
- add regression tests for dense window config behavior, dense partial-window acceptance gating, and deterministic merge ordering

## Root Cause Addressed
On dense cluster-wide queries, the window fanout path could produce partial/unstable coverage and tie-order churn. That manifested as pattern graph data changing on refresh and collapsing to short recent windows.

## Validation
- `go test ./internal/proxy -run 'Pattern|Patterns|DrilldownLimits' -count=1`
- `go test ./... -count=1`
