### PR TITLE
backend detection: add metrics + endpoint capability fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Bug Fixes
 
-- patterns: stabilize `/loki/api/v1/patterns` ordering under equal-count ties (sort by total, then level, then pattern) to prevent refresh-to-refresh pattern reshuffling on dense scopes.
-- patterns: harden dense-range window sampling by bounding dense fanout (`<=64` windows), avoiding step-driven window explosion in dense mode, and requiring minimum dense window success coverage before accepting partial window merges.
 - backend detection: add startup fallback version sensing from `/metrics` (`vm_app_version`/`victorialogs_build_info`) when upstream proxies strip version headers, and infer conservative capability profiles from runtime endpoint probes when explicit semver is unavailable.
 - drilldown-limits: expose backend detection state (`backend_version_source`, `backend_version_semver`, `backend_capability_profile`) for operational verification and e2e assertions.
 
 ### Tests
 
-- add regression coverage for dense window config fanout bounds, dense partial-window acceptance gating, and deterministic tie ordering in merged pattern results.
 - add regression tests for backend version fallback detection (`/metrics`), fallback min-version enforcement, endpoint-probed capability inference, and backend detection fields in drilldown limits.
 - add e2e compose coverage for backend/grafana detection surfaces across VictoriaLogs `v1.50.0` and `v1.49.0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add regression tests for backend version fallback detection (`/metrics`), fallback min-version enforcement, endpoint-probed capability inference, and backend detection fields in drilldown limits.
 - add e2e compose coverage for backend/grafana detection surfaces across VictoriaLogs `v1.50.0` and `v1.49.0`.
+- add e2e compose coverage for backend/grafana detection when VictoriaLogs is fronted by `vmauth` (`Loki -> proxy -> vmauth -> VictoriaLogs`) to better match production routing topology.
 
 ## [1.0.23] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.0.23] - 2026-04-15
-
 ### Bug Fixes
 
 - patterns: stabilize `/loki/api/v1/patterns` ordering under equal-count ties (sort by total, then level, then pattern) to prevent refresh-to-refresh pattern reshuffling on dense scopes.
@@ -17,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - add regression coverage for dense window config fanout bounds, dense partial-window acceptance gating, and deterministic tie ordering in merged pattern results.
+
+## [1.0.23] - 2026-04-15
 
 ## [1.0.22] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - patterns: stabilize `/loki/api/v1/patterns` ordering under equal-count ties (sort by total, then level, then pattern) to prevent refresh-to-refresh pattern reshuffling on dense scopes.
 - patterns: harden dense-range window sampling by bounding dense fanout (`<=64` windows), avoiding step-driven window explosion in dense mode, and requiring minimum dense window success coverage before accepting partial window merges.
+- backend detection: add startup fallback version sensing from `/metrics` (`vm_app_version`/`victorialogs_build_info`) when upstream proxies strip version headers, and infer conservative capability profiles from runtime endpoint probes when explicit semver is unavailable.
+- drilldown-limits: expose backend detection state (`backend_version_source`, `backend_version_semver`, `backend_capability_profile`) for operational verification and e2e assertions.
 
 ### Tests
 
 - add regression coverage for dense window config fanout bounds, dense partial-window acceptance gating, and deterministic tie ordering in merged pattern results.
+- add regression tests for backend version fallback detection (`/metrics`), fallback min-version enforcement, endpoint-probed capability inference, and backend detection fields in drilldown limits.
+- add e2e compose coverage for backend/grafana detection surfaces across VictoriaLogs `v1.50.0` and `v1.49.0`.
 
 ## [1.0.23] - 2026-04-15
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -55,6 +55,7 @@ var jsonBufPool = sync.Pool{
 }
 
 var backendSemverPattern = regexp.MustCompile(`v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z\.-]+)?`)
+var backendMetricsQuotedVersionPattern = regexp.MustCompile(`(?:^|[,{])(?:short_version|version)="(v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z\.-]+)?)"`)
 
 // marshalJSON encodes v to JSON using a pooled buffer, then writes to w.
 // Reduces allocations vs json.NewEncoder(w).Encode() by reusing buffers.
@@ -5374,6 +5375,7 @@ func (p *Proxy) handleFormatQuery(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) handleDrilldownLimits(w http.ResponseWriter, r *http.Request) {
 	patternIngesterEnabled := p.patternsEnabled && p.patternsAutodetectFromQueries
 	limits := p.publishedTenantLimits(r)
+	backendRaw, backendSemver, backendProfile := p.backendVersionState()
 	profile := grafanaClientProfileFromContext(r.Context())
 	if profile.surface == "" {
 		profile = detectGrafanaClientProfile(r, "drilldown_limits", "/loki/api/v1/drilldown-limits")
@@ -5401,6 +5403,15 @@ func (p *Proxy) handleDrilldownLimits(w http.ResponseWriter, r *http.Request) {
 	}
 	if profile.datasourceProfile != "" {
 		resp["grafana_datasource_profile"] = profile.datasourceProfile
+	}
+	if backendRaw != "" {
+		resp["backend_version_source"] = backendRaw
+	}
+	if backendSemver != "" {
+		resp["backend_version_semver"] = backendSemver
+	}
+	if backendProfile != "" {
+		resp["backend_capability_profile"] = backendProfile
 	}
 	p.writeJSON(w, resp)
 }
@@ -6502,6 +6513,29 @@ func extractBackendSemver(raw string) string {
 	return backendSemverPattern.FindString(raw)
 }
 
+func extractBackendSemverFromMetrics(metricsText string) string {
+	metricsText = strings.TrimSpace(metricsText)
+	if metricsText == "" {
+		return ""
+	}
+	for _, line := range strings.Split(metricsText, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.Contains(line, "vm_app_version{") && !strings.Contains(line, "victorialogs_build_info{") {
+			continue
+		}
+		if match := backendMetricsQuotedVersionPattern.FindStringSubmatch(line); len(match) == 2 {
+			return match[1]
+		}
+		if fallback := extractBackendSemver(line); fallback != "" {
+			return fallback
+		}
+	}
+	return ""
+}
+
 func parseSemverTriplet(version string) (int, int, int, bool) {
 	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
 	if version == "" {
@@ -6671,6 +6705,101 @@ func (p *Proxy) backendVersionState() (raw, semver, profile string) {
 	return p.backendVersionRaw, p.backendVersionSemver, p.backendCapabilityProfile
 }
 
+func (p *Proxy) storeBackendCapabilityProbe(source string, supportsStreamMetadata, supportsMetadataSubstring bool) {
+	if p == nil {
+		return
+	}
+	p.backendVersionMu.Lock()
+	defer p.backendVersionMu.Unlock()
+	if p.backendVersionSemver != "" {
+		return
+	}
+	p.backendVersionRaw = source
+	switch {
+	case supportsStreamMetadata && supportsMetadataSubstring:
+		p.backendCapabilityProfile = "vl-probed-v1.49-plus"
+	case supportsStreamMetadata:
+		p.backendCapabilityProfile = "vl-probed-v1.30-plus"
+	default:
+		p.backendCapabilityProfile = "legacy-probed-pre-v1.30"
+	}
+	p.backendSupportsStreamMetadata = supportsStreamMetadata
+	p.backendSupportsMetadataSubstring = supportsMetadataSubstring
+	// Keep dense-windowing conservative without explicit semver evidence.
+	p.backendSupportsDensePatternWindowing = false
+	if !p.backendVersionLogged {
+		p.backendVersionLogged = true
+		p.log.Info(
+			"backend capability profile inferred",
+			"backend.version.source", source,
+			"backend.capability_profile", p.backendCapabilityProfile,
+			"metadata.stream_endpoints", p.backendSupportsStreamMetadata,
+			"metadata.substring_filter", p.backendSupportsMetadataSubstring,
+			"patterns.dense_windowing", p.backendSupportsDensePatternWindowing,
+		)
+	}
+}
+
+func (p *Proxy) probeBackendVersionFromMetrics(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	resp, err := p.vlGet(ctx, "/metrics", nil)
+	if err != nil {
+		p.log.Debug("backend version metrics probe failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		p.log.Debug("backend version metrics probe returned non-success status", "http.response.status_code", resp.StatusCode)
+		return
+	}
+
+	const maxMetricsProbeBytes = 2 << 20 // 2 MiB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxMetricsProbeBytes))
+	if err != nil {
+		p.log.Debug("backend version metrics probe read failed", "error", err)
+		return
+	}
+	semver := extractBackendSemverFromMetrics(string(body))
+	if semver == "" {
+		p.log.Debug("backend version metrics probe found no semver")
+		return
+	}
+	p.storeBackendVersion("metrics:"+semver, semver)
+}
+
+func (p *Proxy) probeBackendEndpointSupport(ctx context.Context, path string, params url.Values) bool {
+	if p == nil {
+		return false
+	}
+	resp, err := p.vlGet(ctx, path, params)
+	if err != nil {
+		p.log.Debug("backend endpoint probe failed", "path", path, "error", err)
+		return false
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return resp.StatusCode < http.StatusBadRequest
+}
+
+func (p *Proxy) probeBackendCapabilitiesFromEndpoints(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	q := url.Values{}
+	q.Set("query", "*")
+	supportsStreamMetadata := p.probeBackendEndpointSupport(ctx, "/select/logsql/stream_field_names", q)
+
+	sub := url.Values{}
+	sub.Set("query", "*")
+	sub.Set("q", "a")
+	sub.Set("filter", "substring")
+	supportsMetadataSubstring := p.probeBackendEndpointSupport(ctx, "/select/logsql/field_names", sub)
+
+	p.storeBackendCapabilityProbe("endpoint-probe", supportsStreamMetadata, supportsMetadataSubstring)
+}
+
 // ValidateBackendVersionCompatibility checks backend version support at startup.
 // It blocks startup only when a detected backend version is below the configured
 // minimum and the unsafe override is not enabled.
@@ -6709,9 +6838,27 @@ func (p *Proxy) ValidateBackendVersionCompatibility(ctx context.Context) error {
 
 	raw, semver, profile := p.backendVersionState()
 	if semver == "" {
+		p.probeBackendVersionFromMetrics(checkCtx)
+		raw, semver, profile = p.backendVersionState()
+	}
+	if semver == "" {
+		p.probeBackendCapabilitiesFromEndpoints(checkCtx)
+		raw, semver, profile = p.backendVersionState()
+	}
+	if semver == "" && profile != "" {
+		p.log.Warn(
+			"backend version compatibility check partial",
+			"reason", "explicit backend semver unavailable; inferred capability profile from runtime endpoint probes",
+			"backend.version.source", raw,
+			"backend.capability_profile", profile,
+			"minimum_supported_version", p.backendMinVersion,
+		)
+		return nil
+	}
+	if semver == "" {
 		p.log.Warn(
 			"backend version compatibility check unavailable",
-			"reason", "backend did not expose version in response headers",
+			"reason", "backend did not expose version in response headers or /metrics payload",
 			"minimum_supported_version", p.backendMinVersion,
 		)
 		return nil

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1187,6 +1187,121 @@ func TestBackendVersionCompatibilityGate_PassesSupportedVersion(t *testing.T) {
 	}
 }
 
+func TestBackendVersionCompatibilityGate_FallbackMetricsDetectsVersion(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/metrics":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`vm_app_version{short_version="v1.50.0",version="v1.50.0-cluster"} 1` + "\n"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected compatibility gate to pass via metrics fallback, got: %v", err)
+	}
+	if got := p.backendVersionSemver; got != "v1.50.0" {
+		t.Fatalf("expected semver v1.50.0 from metrics fallback, got %q", got)
+	}
+	if !p.supportsDensePatternWindowing() {
+		t.Fatalf("expected dense windowing enabled for v1.50.0")
+	}
+}
+
+func TestBackendVersionCompatibilityGate_FallbackMetricsTooOldBlocks(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/metrics":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`vm_app_version{short_version="v1.29.0",version="v1.29.0"} 1` + "\n"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	err = p.ValidateBackendVersionCompatibility(context.Background())
+	if err == nil {
+		t.Fatalf("expected compatibility gate to fail for fallback metrics v1.29.0")
+	}
+}
+
+func TestBackendVersionCompatibilityGate_EndpointProbeInfersCapabilities(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/metrics":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("up 1\n"))
+		case "/select/logsql/stream_field_names":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"hits":[]}`))
+		case "/select/logsql/field_names":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"hits":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      cache.New(60*time.Second, 1000),
+		BackendMinVersion:          "v1.30.0",
+		BackendVersionCheckTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new proxy: %v", err)
+	}
+	if err := p.ValidateBackendVersionCompatibility(context.Background()); err != nil {
+		t.Fatalf("expected compatibility gate to continue with endpoint capability probe, got: %v", err)
+	}
+	if p.backendVersionSemver != "" {
+		t.Fatalf("expected empty semver when only endpoint probe is available, got %q", p.backendVersionSemver)
+	}
+	if got := p.backendCapabilityProfile; got != "vl-probed-v1.49-plus" {
+		t.Fatalf("expected capability profile vl-probed-v1.49-plus, got %q", got)
+	}
+	if !p.supportsStreamMetadataEndpoints() {
+		t.Fatalf("expected stream metadata support inferred via endpoint probe")
+	}
+	if !p.supportsMetadataSubstringFilter() {
+		t.Fatalf("expected metadata substring support inferred via endpoint probe")
+	}
+	if p.supportsDensePatternWindowing() {
+		t.Fatalf("expected dense windowing to remain conservative without explicit semver")
+	}
+}
+
 func TestBackendVersionCompatibilityGate_AllowsMissingVersionHeaders(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -1957,6 +2072,28 @@ func TestContract_DrilldownLimits_ExposesRequiredLimitsContract(t *testing.T) {
 	}
 	if _, ok := limits["retention_stream"].([]interface{}); !ok {
 		t.Fatalf("expected limits.retention_stream to be an array, got %T", limits["retention_stream"])
+	}
+}
+
+func TestContract_DrilldownLimits_ExposesBackendDetectionStateWhenAvailable(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	p.observeBackendVersionFromHeaders(http.Header{
+		"Server": []string{"VictoriaLogs/v1.50.0"},
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/drilldown-limits", nil)
+	p.handleDrilldownLimits(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from drilldown-limits, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if got := resp["backend_version_semver"]; got != "v1.50.0" {
+		t.Fatalf("expected backend_version_semver=v1.50.0, got %v", got)
+	}
+	if got := resp["backend_capability_profile"]; got != "vl-v1.50-plus" {
+		t.Fatalf("expected backend_capability_profile=vl-v1.50-plus, got %v", got)
 	}
 }
 

--- a/test/e2e-compat/compat_test.go
+++ b/test/e2e-compat/compat_test.go
@@ -32,12 +32,13 @@ import (
 )
 
 var (
-	lokiURL      = envOr("LOKI_URL", "http://localhost:3101")
-	proxyURL     = envOr("PROXY_URL", "http://localhost:3100")
-	tailProxyURL = envOr("TAIL_PROXY_URL", "http://localhost:3103")
+	lokiURL        = envOr("LOKI_URL", "http://localhost:3101")
+	proxyURL       = envOr("PROXY_URL", "http://localhost:3100")
+	proxyVmauthURL = envOr("PROXY_VMAUTH_URL", "http://localhost:3109")
+	tailProxyURL   = envOr("TAIL_PROXY_URL", "http://localhost:3103")
 	tailIngressURL = envOr("TAIL_INGRESS_URL", "http://localhost:3104")
-	tailNativeURL = envOr("TAIL_NATIVE_URL", "http://localhost:3105")
-	vlURL        = envOr("VL_URL", "http://localhost:9428")
+	tailNativeURL  = envOr("TAIL_NATIVE_URL", "http://localhost:3105")
+	vlURL          = envOr("VL_URL", "http://localhost:9428")
 )
 
 func envOr(key, def string) string {

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -44,6 +44,25 @@ services:
       retries: 10
       start_period: 5s
 
+  # VictoriaMetrics Auth proxy in front of VictoriaLogs
+  vmauth:
+    image: ${VMAUTH_IMAGE:-victoriametrics/vmauth:v1.138.0}
+    container_name: e2e-vmauth
+    command:
+      - "-auth.config=/etc/vmauth/auth.yml"
+      - "-httpListenAddr=:8427"
+    volumes:
+      - ./vmauth.yml:/etc/vmauth/auth.yml:ro
+    depends_on:
+      victorialogs:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:8427/health"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   # VictoriaMetrics TSDB for vmalert recording-rule remote write
   victoriametrics:
     image: ${VICTORIAMETRICS_IMAGE:-victoriametrics/victoria-metrics:v1.119.0}
@@ -151,6 +170,37 @@ services:
       - "-patterns-startup-peer-warm-timeout=2s"
     depends_on:
       victorialogs:
+        condition: service_healthy
+      vmalert:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:3100/ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
+  # Loki-VL-proxy with backend routed through vmauth
+  loki-vl-proxy-vmauth:
+    image: ${PROXY_IMAGE:-loki-vl-proxy:e2e-local}
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: e2e-proxy-vmauth
+    ports:
+      - "3109:3100"
+    command:
+      - "-listen=:3100"
+      - "-backend=http://vmauth:8427"
+      - "-ruler-backend=http://vmalert:8880"
+      - "-alerts-backend=http://vmalert:8880"
+      - "-log-level=info"
+      - "-cache-ttl=5s"
+      - "-label-style=underscores"
+      - "-metadata-field-mode=translated"
+      - "-emit-structured-metadata=true"
+    depends_on:
+      vmauth:
         condition: service_healthy
       vmalert:
         condition: service_healthy
@@ -380,6 +430,7 @@ services:
       - loki
       - loki-vl-proxy
       - loki-vl-proxy-patterns-autodetect
+      - loki-vl-proxy-vmauth
       - loki-vl-proxy-underscore
       - loki-vl-proxy-native-metadata
       - loki-vl-proxy-tail

--- a/test/e2e-compat/grafana-datasources.yaml
+++ b/test/e2e-compat/grafana-datasources.yaml
@@ -90,6 +90,17 @@ datasources:
     secureJsonData:
       httpHeaderValue1: "0"
 
+  - name: Loki (via VL proxy vmauth)
+    type: loki
+    access: proxy
+    url: http://loki-vl-proxy-vmauth:3100
+    isDefault: false
+    jsonData:
+      httpHeaderName1: X-Scope-OrgID
+      maxLines: 1000
+    secureJsonData:
+      httpHeaderValue1: "0"
+
   # 3. VictoriaLogs native datasource (for direct comparison)
   - name: VictoriaLogs (direct)
     type: victoriametrics-logs-datasource

--- a/test/e2e-compat/grafana_surface_test.go
+++ b/test/e2e-compat/grafana_surface_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGrafanaDatasourceCatalogAndHealth(t *testing.T) {
@@ -28,6 +29,7 @@ func TestGrafanaDatasourceCatalogAndHealth(t *testing.T) {
 		{name: "Loki (via VL proxy multi-tenant)", kind: "loki"},
 		{name: "Loki (via VL proxy native metadata)", kind: "loki"},
 		{name: "Loki (via VL proxy patterns autodetect)", kind: "loki"},
+		{name: "Loki (via VL proxy vmauth)", kind: "loki"},
 		{name: "Loki (via VL proxy live tail)", kind: "loki"},
 		{name: "Loki (via ingress tail)", kind: "loki"},
 		{name: "Loki (via VL proxy live tail native)", kind: "loki"},
@@ -123,6 +125,31 @@ func TestProxyCompatibilitySurface(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("expected direct Loki drilldown-limits status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("vmauth_proxy_drilldown_limits_backend_detection", func(t *testing.T) {
+		waitForReady(t, proxyVmauthURL+"/ready", 30*time.Second)
+		resp := getJSON(t, proxyVmauthURL+"/loki/api/v1/drilldown-limits")
+		profile, _ := resp["backend_capability_profile"].(string)
+		if profile == "" {
+			t.Fatalf("expected backend_capability_profile via vmauth proxy path, got %v", resp)
+		}
+		source, _ := resp["backend_version_source"].(string)
+		if source == "" {
+			t.Fatalf("expected backend_version_source via vmauth proxy path, got %v", resp)
+		}
+
+		expectedTag := expectedVLVersionPrefixFromEnv()
+		if expectedTag == "" {
+			return
+		}
+		semver, _ := resp["backend_version_semver"].(string)
+		if semver == "" {
+			t.Fatalf("expected backend_version_semver via vmauth proxy path for VICTORIALOGS_IMAGE=%q, got %v", expectedTag, resp)
+		}
+		if !strings.HasPrefix(semver, expectedTag+".") {
+			t.Fatalf("expected backend semver prefix %q via vmauth proxy path, got %q", expectedTag+".", semver)
 		}
 	})
 }

--- a/test/e2e-compat/grafana_surface_test.go
+++ b/test/e2e-compat/grafana_surface_test.go
@@ -3,9 +3,13 @@
 package e2e_compat
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -121,4 +125,90 @@ func TestProxyCompatibilitySurface(t *testing.T) {
 			t.Fatalf("expected direct Loki drilldown-limits status 200, got %d", resp.StatusCode)
 		}
 	})
+}
+
+func TestProxy_DrilldownLimits_ExposesBackendDetection(t *testing.T) {
+	ensureDataIngested(t)
+
+	resp := getJSON(t, proxyURL+"/loki/api/v1/drilldown-limits")
+	profile, _ := resp["backend_capability_profile"].(string)
+	if profile == "" {
+		t.Fatalf("expected backend_capability_profile in drilldown-limits, got %v", resp)
+	}
+
+	expectedTag := expectedVLVersionPrefixFromEnv()
+	if expectedTag == "" {
+		// Keep this robust for local runs where image env isn't exported to test.
+		return
+	}
+	semver, _ := resp["backend_version_semver"].(string)
+	if semver == "" {
+		t.Fatalf("expected backend_version_semver for VICTORIALOGS_IMAGE=%q, got %v", expectedTag, resp)
+	}
+	if !strings.HasPrefix(semver, expectedTag+".") {
+		t.Fatalf("expected backend semver prefix %q, got %q", expectedTag+".", semver)
+	}
+}
+
+func TestProxy_DrilldownLimits_DetectsGrafanaRuntimeHeaders(t *testing.T) {
+	ensureDataIngested(t)
+	version := grafanaRuntimeVersion(t)
+
+	req, err := http.NewRequest(http.MethodGet, proxyURL+"/loki/api/v1/drilldown-limits", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("User-Agent", "Grafana/"+version)
+	req.Header.Set("X-Query-Tags", "Source=grafana-lokiexplore-app")
+	req.Header.Set("X-Scope-OrgID", "0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("drilldown-limits request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 from drilldown-limits, got %d body=%s", resp.StatusCode, string(body))
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode drilldown-limits: %v", err)
+	}
+	if got, _ := payload["grafana_client_surface"].(string); got != "grafana_drilldown" {
+		t.Fatalf("expected grafana_client_surface=grafana_drilldown, got %v payload=%v", got, payload)
+	}
+	if got, _ := payload["grafana_runtime_version"].(string); got == "" {
+		t.Fatalf("expected grafana_runtime_version to be exposed, got %v", payload)
+	}
+	if got, _ := payload["grafana_runtime_family"].(string); got == "" {
+		t.Fatalf("expected grafana_runtime_family to be exposed, got %v", payload)
+	}
+}
+
+func expectedVLVersionPrefixFromEnv() string {
+	raw := strings.TrimSpace(os.Getenv("VICTORIALOGS_IMAGE"))
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	tag := strings.TrimSpace(parts[len(parts)-1])
+	if !strings.HasPrefix(tag, "v") {
+		return ""
+	}
+	trimmed := strings.TrimPrefix(tag, "v")
+	segments := strings.Split(trimmed, ".")
+	if len(segments) < 2 {
+		return ""
+	}
+	_, errMaj := strconv.Atoi(segments[0])
+	_, errMin := strconv.Atoi(segments[1])
+	if errMaj != nil || errMin != nil {
+		return ""
+	}
+	return fmt.Sprintf("v%s.%s", segments[0], segments[1])
 }

--- a/test/e2e-compat/vmauth.yml
+++ b/test/e2e-compat/vmauth.yml
@@ -1,0 +1,2 @@
+unauthorized_user:
+  url_prefix: http://victorialogs:9428


### PR DESCRIPTION
## Summary
- add startup backend-version fallback detection from `/metrics` (`vm_app_version` / `victorialogs_build_info`) when version headers are not exposed (common behind auth proxies)
- add runtime endpoint capability probing fallback when explicit semver is unavailable, and infer conservative backend capability profiles from real endpoint behavior
- expose backend detection state in `/loki/api/v1/drilldown-limits` (`backend_version_source`, `backend_version_semver`, `backend_capability_profile`) for operational visibility and e2e verification
- extend regression coverage for backend detection fallback paths and detection surface
- add compose e2e checks covering backend + grafana detection surfaces

## Why
In deployments behind intermediaries (for example `vmauth`), `/health` may not include VictoriaLogs version headers, causing startup to log version-check unavailable and leaving capability gates under-informed.

## Validation
### Unit
- `go test ./internal/proxy -run 'BackendVersion|DrilldownLimits_ExposesBackendDetectionStateWhenAvailable' -count=1`
- `go test ./... -count=1`

### E2E (Compose, real images)
- `docker compose up -d --build` + `../../scripts/ci/wait_e2e_stack.sh 180`
- `go test -v -tags=e2e -run '^(TestSetup_IngestLogs|TestProxy_DrilldownLimits_ExposesBackendDetection|TestProxy_DrilldownLimits_DetectsGrafanaRuntimeHeaders)$' ./test/e2e-compat/`
- repeated with `VICTORIALOGS_IMAGE=victoriametrics/victoria-logs:v1.49.0`
