### PR TITLE
Add drilldown fanout telemetry and chart flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- observability: add per-request fanout and proxy-internal operation telemetry to logs, Prometheus, OTLP export, bundled dashboard panels, and first-class Helm chart values for the new observability/runtime flags.
+
+### Bug Fixes
+
+- drilldown/patterns: keep long-range Drilldown patterns and volume queries dense across `>24h` windows by boosting dense per-window sampling and adding 48h regression coverage.
+
 ## [1.3.0] - 2026-04-16
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
+++ b/charts/loki-vl-proxy/dashboards/loki-vl-proxy.json
@@ -107,12 +107,12 @@
       "collapsed": false
     },
     {
-      "title": "P50 Latency by Endpoint",
+      "title": "Downstream P50 Latency by Endpoint",
       "type": "timeseries",
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p50 {{endpoint}}"
         }
       ],
@@ -121,12 +121,12 @@
       }
     },
     {
-      "title": "P99 Latency by Endpoint",
+      "title": "Downstream P99 Latency by Endpoint",
       "type": "timeseries",
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p99 {{endpoint}}"
         }
       ],
@@ -188,7 +188,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 0, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (endpoint)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ]
@@ -199,7 +199,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (status)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (status)",
           "legendFormat": "{{status}}"
         }
       ]
@@ -210,7 +210,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 28},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -826,6 +826,54 @@
       ],
       "fieldConfig": {
         "defaults": {"unit": "none", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Fanout & Internal Ops",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 137},
+      "collapsed": false
+    },
+    {
+      "title": "VL Child P99 Latency by Upstream Endpoint",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 138},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_backend_duration_seconds_bucket{system=\"vl\",direction=\"upstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "legendFormat": "p99 {{endpoint}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "s", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "P95 Upstream Calls per Downstream Request",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 138},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(loki_vl_proxy_upstream_calls_per_request_bucket{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "legendFormat": "p95 {{endpoint}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "short", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Internal Operations by Outcome",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 138},
+      "targets": [
+        {
+          "expr": "sum(rate(loki_vl_proxy_internal_operation_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (operation, outcome)",
+          "legendFormat": "{{operation}} {{outcome}}/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}
       }
     }
   ],

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -76,6 +76,11 @@ spec:
       {{- $customPatternsFilePath := default "/etc/loki-vl-proxy/patterns/custom-patterns.json" .Values.patternsCustom.file.path }}
       {{- $customPatternsMountDir := dir $customPatternsFilePath }}
       {{- $customPatternsFileName := base $customPatternsFilePath }}
+      {{- $observability := default (dict) .Values.observability }}
+      {{- $observabilityOTEL := default (dict) (get $observability "otel") }}
+      {{- $observabilityOTLP := default (dict) (get $observability "otlp") }}
+      {{- $observabilityMetrics := default (dict) (get $observability "metrics") }}
+      {{- $observabilityServer := default (dict) (get $observability "server") }}
       {{- if and (hasKey .Values "systemMetrics") (hasKey .Values.systemMetrics "hostProc") }}
       {{- $hostProcEnabled = .Values.systemMetrics.hostProc.enabled }}
       {{- if .Values.systemMetrics.hostProc.mountPath }}
@@ -96,6 +101,54 @@ spec:
           args:
             {{- range $key, $value := .Values.extraArgs }}
             - "-{{ $key }}={{ $value }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "deployment-environment")) (ne (default "" (get $observability "deploymentEnvironment")) "") }}
+            - "-deployment-environment={{ get $observability "deploymentEnvironment" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otel-service-name")) (ne (default "" (get $observabilityOTEL "serviceName")) "") }}
+            - "-otel-service-name={{ get $observabilityOTEL "serviceName" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otel-service-namespace")) (ne (default "" (get $observabilityOTEL "serviceNamespace")) "") }}
+            - "-otel-service-namespace={{ get $observabilityOTEL "serviceNamespace" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otel-service-instance-id")) (ne (default "" (get $observabilityOTEL "serviceInstanceId")) "") }}
+            - "-otel-service-instance-id={{ get $observabilityOTEL "serviceInstanceId" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otlp-endpoint")) (ne (default "" (get $observabilityOTLP "endpoint")) "") }}
+            - "-otlp-endpoint={{ get $observabilityOTLP "endpoint" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otlp-interval")) (ne (default "" (get $observabilityOTLP "interval")) "") }}
+            - "-otlp-interval={{ get $observabilityOTLP "interval" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otlp-compression")) (ne (default "" (get $observabilityOTLP "compression")) "") }}
+            - "-otlp-compression={{ get $observabilityOTLP "compression" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otlp-timeout")) (ne (default "" (get $observabilityOTLP "timeout")) "") }}
+            - "-otlp-timeout={{ get $observabilityOTLP "timeout" }}"
+            {{- end }}
+            {{- if and (not (hasKey .Values.extraArgs "otlp-headers")) (ne (default "" (get $observabilityOTLP "headers")) "") }}
+            - "-otlp-headers={{ get $observabilityOTLP "headers" }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "otlp-tls-skip-verify") }}
+            - "-otlp-tls-skip-verify={{ ternary "true" "false" (default false (get $observabilityOTLP "tlsSkipVerify")) }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "metrics.max-tenants") }}
+            - "-metrics.max-tenants={{ default 256 (get $observabilityMetrics "maxTenants") }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "metrics.max-clients") }}
+            - "-metrics.max-clients={{ default 256 (get $observabilityMetrics "maxClients") }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "metrics.trust-proxy-headers") }}
+            - "-metrics.trust-proxy-headers={{ ternary "true" "false" (default false (get $observabilityMetrics "trustProxyHeaders")) }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "metrics.export-sensitive-labels") }}
+            - "-metrics.export-sensitive-labels={{ ternary "true" "false" (default false (get $observabilityMetrics "exportSensitiveLabels")) }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "server.register-instrumentation") }}
+            - "-server.register-instrumentation={{ ternary "true" "false" (default true (get $observabilityServer "registerInstrumentation")) }}"
+            {{- end }}
+            {{- if not (hasKey .Values.extraArgs "server.metrics-max-concurrency") }}
+            - "-server.metrics-max-concurrency={{ default 1 (get $observabilityServer "metricsMaxConcurrency") }}"
             {{- end }}
             {{- if and $hostProcEnabled (not (hasKey .Values.extraArgs "proc-root")) }}
             - "-proc-root={{ $hostProcMountPath }}"

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -244,6 +244,36 @@ extraArgs:
   # tls-client-ca-file: ""
   # tls-require-client-cert: "false"
 
+# First-class observability flags.
+# The chart renders these as CLI args unless the same key is already set under
+# extraArgs, so existing extraArgs-based installs keep precedence.
+#
+# Use env / envFrom for secrets; keep these values for non-secret runtime knobs.
+observability:
+  # Empty keeps the binary default / env-based value.
+  deploymentEnvironment: ""
+  otel:
+    # Empty keeps the binary default or env-derived value.
+    serviceName: ""
+    serviceNamespace: ""
+    serviceInstanceId: ""
+  otlp:
+    # Empty endpoint disables OTLP export unless set elsewhere.
+    endpoint: ""
+    interval: ""
+    compression: ""
+    timeout: ""
+    headers: ""
+    tlsSkipVerify: false
+  metrics:
+    maxTenants: 256
+    maxClients: 256
+    trustProxyHeaders: false
+    exportSensitiveLabels: false
+  server:
+    registerInstrumentation: true
+    metricsMaxConcurrency: 1
+
 # Custom Drilldown patterns always prepended to /loki/api/v1/patterns.
 # Runtime supports:
 # - inline JSON/newline config via -patterns-custom

--- a/dashboard/loki-vl-proxy.json
+++ b/dashboard/loki-vl-proxy.json
@@ -107,12 +107,12 @@
       "collapsed": false
     },
     {
-      "title": "P50 Latency by Endpoint",
+      "title": "Downstream P50 Latency by Endpoint",
       "type": "timeseries",
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p50 {{endpoint}}"
         }
       ],
@@ -121,12 +121,12 @@
       }
     },
     {
-      "title": "P99 Latency by Endpoint",
+      "title": "Downstream P99 Latency by Endpoint",
       "type": "timeseries",
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_request_duration_seconds_bucket{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
           "legendFormat": "p99 {{endpoint}}"
         }
       ],
@@ -188,7 +188,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 0, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (endpoint)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ]
@@ -199,7 +199,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 28},
       "targets": [
         {
-          "expr": "sum(increase(loki_vl_proxy_requests_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (status)",
+          "expr": "sum(increase(loki_vl_proxy_requests_total{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__range])) by (status)",
           "legendFormat": "{{status}}"
         }
       ]
@@ -210,7 +210,7 @@
       "gridPos": {"h": 8, "w": 8, "x": 16, "y": 28},
       "targets": [
         {
-          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(loki_vl_proxy_request_duration_seconds_sum{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint) / sum(rate(loki_vl_proxy_request_duration_seconds_count{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -826,6 +826,54 @@
       ],
       "fieldConfig": {
         "defaults": {"unit": "none", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Fanout & Internal Ops",
+      "type": "row",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 137},
+      "collapsed": false
+    },
+    {
+      "title": "VL Child P99 Latency by Upstream Endpoint",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 138},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(loki_vl_proxy_backend_duration_seconds_bucket{system=\"vl\",direction=\"upstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "legendFormat": "p99 {{endpoint}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "s", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "P95 Upstream Calls per Downstream Request",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 138},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(loki_vl_proxy_upstream_calls_per_request_bucket{system=\"loki\",direction=\"downstream\",job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (endpoint, le))",
+          "legendFormat": "p95 {{endpoint}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "short", "custom": {"fillOpacity": 10}}
+      }
+    },
+    {
+      "title": "Internal Operations by Outcome",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 138},
+      "targets": [
+        {
+          "expr": "sum(rate(loki_vl_proxy_internal_operation_total{job=~\"${job:regex}|${job:regex}-headless\",cluster=~\"${cluster:regex}\",env=~\"${env:regex}\",namespace=~\"${namespace:regex}|loki-vl-proxy\",service=~\"${service:regex}|${service:regex}-headless|\",pod=~\"${pod:regex}\"}[$__rate_interval])) by (operation, outcome)",
+          "legendFormat": "{{operation}} {{outcome}}/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "reqps", "custom": {"fillOpacity": 10}}
       }
     }
   ],

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -66,8 +66,20 @@ Default logs are emitted as JSON and already use OTel-friendly top-level keys:
   "cache.result": "miss",
   "proxy.duration_ms": 42,
   "upstream.calls": 1,
+  "upstream.calls_by_type": {
+    "vl:select_logsql_query": 1
+  },
   "upstream.status_code": 200,
   "upstream.duration_ms": 31,
+  "upstream.duration_ms_by_type": {
+    "vl:select_logsql_query": 31
+  },
+  "proxy.operations_by_type": {
+    "translate_query:translated": 1
+  },
+  "proxy.operation_duration_ms_by_type": {
+    "translate_query:translated": 4
+  },
   "proxy.overhead_ms": 11
 }
 ```
@@ -97,6 +109,7 @@ The proxy writes structured logs for:
 | `body` | message body |
 | `component` | internal subsystem (`proxy`, `disk_cache`, `cache_warmer`, `otlp_metrics`) |
 | `http.*` / `url.path` | request semantics and normalized route vs actual request path |
+| `http.parent_route` | parent downstream route template on upstream child-call logs |
 | `event.duration` | request or upstream call duration in nanoseconds |
 | `client.address` | remote address |
 | `enduser.id` | stable trusted user/client identity when available |
@@ -107,6 +120,18 @@ The proxy writes structured logs for:
 | `proxy.*` | proxy-facing convenience fields such as total request duration and measured proxy overhead |
 | `upstream.*` | backend call count, status, and latency |
 | `loki.*` | Loki/proxy-specific attributes |
+
+Additional request-scope aggregate fields used for fanout visibility:
+
+| Field | Meaning |
+|---|---|
+| `loki.parent_request.type` | parent downstream request type on upstream child-call logs |
+| `upstream.calls_by_type` | per-parent aggregate map keyed by `<system>:<request_type>` |
+| `upstream.duration_ms_by_type` | per-parent aggregate latency map keyed by `<system>:<request_type>` |
+| `proxy.operations_by_type` | per-parent aggregate map keyed by `<operation>:<outcome>` for proxy-only work |
+| `proxy.operation_duration_ms_by_type` | per-parent aggregate latency map keyed by `<operation>:<outcome>` |
+
+These aggregate map keys are intentionally bounded by route templates and hardcoded operation/outcome enums. They are log fields, not metric labels.
 
 ## Metrics
 
@@ -163,24 +188,45 @@ Request-oriented metrics use stable low-cardinality dimensions so dashboards can
 
 Downstream routes are the normalized Loki API templates registered by the proxy. Upstream routes are the stable VictoriaLogs or rules/alerts backend path templates used by the proxy itself. Raw request paths and query strings stay in logs, not in metric labels.
 
+Tenant and client metric families are the only intentionally high-cardinality families, and even those are bounded with `-metrics.max-tenants` and `-metrics.max-clients`; excess identities collapse to `__overflow__`.
+
+Histogram helper series (`_bucket`, `_sum`, `_count`) inherit the same label set and cardinality as the parent metric family.
+
+### Cardinality Levels
+
+| Level | Meaning |
+|---|---|
+| `Low` | no labels or only fixed route templates / small enums (`status`, `direction`, `mode`, `reason`) |
+| `Medium` | bounded internal enums that may grow slowly with feature surface but not with traffic shape |
+| `High (capped)` | user or tenant identity dimensions; bounded by `-metrics.max-tenants` / `-metrics.max-clients` with `__overflow__` fallback |
+
 ### Core Proxy Metrics
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `loki_vl_proxy_requests_total` | counter | `system`, `direction`, `endpoint`, `route`, `status` | all proxied requests, sliced by downstream Loki path or upstream backend path |
-| `loki_vl_proxy_request_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | end-to-end request latency |
-| `loki_vl_proxy_backend_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | upstream backend latency only (`system="vl"`, `direction="upstream"`) |
-| `loki_vl_proxy_cache_hits_total` | counter | none | global cache hits |
-| `loki_vl_proxy_cache_misses_total` | counter | none | global cache misses |
-| `loki_vl_proxy_cache_hits_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | cache hits per normalized route |
-| `loki_vl_proxy_cache_misses_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | cache misses per normalized route |
-| `loki_vl_proxy_translations_total` | counter | none | successful LogQL to LogsQL translations |
-| `loki_vl_proxy_translation_errors_total` | counter | none | failed translations |
-| `loki_vl_proxy_coalesced_total` | counter | none | requests served from coalesced results |
-| `loki_vl_proxy_coalesced_saved_total` | counter | none | backend requests saved by coalescing |
-| `loki_vl_proxy_uptime_seconds` | gauge | none | process uptime |
-| `loki_vl_proxy_active_requests` | gauge | none | current in-flight requests |
-| `loki_vl_proxy_circuit_breaker_state` | gauge | none | `0=closed`, `1=open`, `2=half-open` |
+All rows below are exposed through Prometheus scrape and OTLP push unless noted otherwise.
+
+| Metric | Type | Labels | Cardinality | Description |
+|---|---|---|---|---|
+| `loki_vl_proxy_requests_total` | counter | `system`, `direction`, `endpoint`, `route`, `status` | `Low` | all proxied requests, sliced by downstream Loki path or upstream backend path |
+| `loki_vl_proxy_request_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | `Low` | end-to-end request latency |
+| `loki_vl_proxy_backend_duration_seconds` | histogram | `system`, `direction`, `endpoint`, `route` | `Low` | upstream backend latency only (`system="vl"`, `direction="upstream"`) |
+| `loki_vl_proxy_upstream_calls_per_request` | histogram | `system`, `direction`, `endpoint`, `route` | `Low` | number of upstream child requests fanned out under a single downstream request |
+| `loki_vl_proxy_cache_hits_total` | counter | none | `Low` | global cache hits |
+| `loki_vl_proxy_cache_misses_total` | counter | none | `Low` | global cache misses |
+| `loki_vl_proxy_cache_hits_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | `Low` | cache hits per normalized route |
+| `loki_vl_proxy_cache_misses_by_endpoint` | counter | `system`, `direction`, `endpoint`, `route` | `Low` | cache misses per normalized route |
+| `loki_vl_proxy_translations_total` | counter | none | `Low` | successful LogQL to LogsQL translations |
+| `loki_vl_proxy_translation_errors_total` | counter | none | `Low` | failed translations |
+| `loki_vl_proxy_internal_operation_total` | counter | `operation`, `outcome` | `Medium` | proxy-only work such as translation, parser preference, and response-label rewrites |
+| `loki_vl_proxy_internal_operation_duration_seconds` | histogram | `operation`, `outcome` | `Medium` | latency spent in proxy-only work not covered by backend timings |
+| `loki_vl_proxy_coalesced_total` | counter | none | `Low` | requests served from coalesced results |
+| `loki_vl_proxy_coalesced_saved_total` | counter | none | `Low` | backend requests saved by coalescing |
+| `loki_vl_proxy_response_tuple_mode_total` | counter | `mode` | `Low` | emitted log tuple contract mode by client behavior (Prometheus scrape only today) |
+| `loki_vl_proxy_uptime_seconds` | gauge | none | `Low` | process uptime |
+| `loki_vl_proxy_active_requests` | gauge | none | `Low` | current in-flight requests |
+| `loki_vl_proxy_circuit_breaker_state` | gauge | none | `Low` | `0=closed`, `1=open`, `2=half-open` |
+| `loki_vl_proxy_http_connections` | gauge | `state` | `Low` | current downstream HTTP server connections by state |
+| `loki_vl_proxy_http_connection_transitions_total` | counter | `state` | `Low` | downstream HTTP server connection state transitions |
+| `loki_vl_proxy_http_connection_rotations_total` | counter | `reason` | `Low` | downstream HTTP/1.x connection rotations triggered by the proxy |
 
 Operational notes for these hot paths:
 
@@ -192,41 +238,79 @@ Operational notes for these hot paths:
 
 These are the primary signals for long-range query performance and backend protection:
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `loki_vl_proxy_window_cache_hit_total` | counter | none | cached split windows served without backend scan |
-| `loki_vl_proxy_window_cache_miss_total` | counter | none | split windows requiring backend scan |
-| `loki_vl_proxy_window_fetch_seconds` | histogram | none | backend fetch duration per split window |
-| `loki_vl_proxy_window_merge_seconds` | histogram | none | merge duration for split-window responses |
-| `loki_vl_proxy_window_count` | histogram | none | split windows per `query_range` request |
-| `loki_vl_proxy_window_prefilter_attempt_total` | counter | none | prefilter runs against `/select/logsql/hits` |
-| `loki_vl_proxy_window_prefilter_error_total` | counter | none | prefilter failures (proxy safely falls back to full window fanout) |
-| `loki_vl_proxy_window_prefilter_kept_total` | counter | none | split windows retained for real log fanout |
-| `loki_vl_proxy_window_prefilter_skipped_total` | counter | none | split windows skipped as empty by prefilter |
-| `loki_vl_proxy_window_prefilter_hit_ratio` | gauge | none | current prefilter kept/total ratio (0-1) |
-| `loki_vl_proxy_window_retry_total` | counter | none | per-window retry attempts after retryable backend failures |
-| `loki_vl_proxy_window_degraded_batch_total` | counter | none | batches that were downgraded to lower parallelism |
-| `loki_vl_proxy_window_partial_response_total` | counter | none | partial query-range responses returned when slow windows exceed budget |
-| `loki_vl_proxy_window_prefilter_duration_seconds` | histogram | none | prefilter latency |
-| `loki_vl_proxy_window_adaptive_parallel_current` | gauge | none | current adaptive split-window parallelism |
-| `loki_vl_proxy_window_adaptive_latency_ewma_seconds` | gauge | none | adaptive EWMA latency |
-| `loki_vl_proxy_window_adaptive_error_ewma` | gauge | none | adaptive EWMA backend error ratio |
+| Metric | Type | Labels | Cardinality | Description |
+|---|---|---|---|---|
+| `loki_vl_proxy_window_cache_hit_total` | counter | none | `Low` | cached split windows served without backend scan |
+| `loki_vl_proxy_window_cache_miss_total` | counter | none | `Low` | split windows requiring backend scan |
+| `loki_vl_proxy_window_fetch_seconds` | histogram | none | `Low` | backend fetch duration per split window |
+| `loki_vl_proxy_window_merge_seconds` | histogram | none | `Low` | merge duration for split-window responses |
+| `loki_vl_proxy_window_count` | histogram | none | `Low` | split windows per `query_range` request |
+| `loki_vl_proxy_window_prefilter_attempt_total` | counter | none | `Low` | prefilter runs against `/select/logsql/hits` |
+| `loki_vl_proxy_window_prefilter_error_total` | counter | none | `Low` | prefilter failures (proxy safely falls back to full window fanout) |
+| `loki_vl_proxy_window_prefilter_kept_total` | counter | none | `Low` | split windows retained for real log fanout |
+| `loki_vl_proxy_window_prefilter_skipped_total` | counter | none | `Low` | split windows skipped as empty by prefilter |
+| `loki_vl_proxy_window_prefilter_hit_ratio` | gauge | none | `Low` | current prefilter kept/total ratio (0-1) |
+| `loki_vl_proxy_window_retry_total` | counter | none | `Low` | per-window retry attempts after retryable backend failures |
+| `loki_vl_proxy_window_degraded_batch_total` | counter | none | `Low` | batches that were downgraded to lower parallelism |
+| `loki_vl_proxy_window_partial_response_total` | counter | none | `Low` | partial query-range responses returned when slow windows exceed budget |
+| `loki_vl_proxy_window_prefilter_duration_seconds` | histogram | none | `Low` | prefilter latency |
+| `loki_vl_proxy_window_adaptive_parallel_current` | gauge | none | `Low` | current adaptive split-window parallelism |
+| `loki_vl_proxy_window_adaptive_latency_ewma_seconds` | gauge | none | `Low` | adaptive EWMA latency |
+| `loki_vl_proxy_window_adaptive_error_ewma` | gauge | none | `Low` | adaptive EWMA backend error ratio |
+
+### Patterns Snapshot Metrics
+
+These metrics track the proxy-side pattern cache and snapshot lifecycle.
+
+| Metric | Type | Labels | Cardinality | Description |
+|---|---|---|---|---|
+| `loki_vl_proxy_patterns_detected_total` | counter | none | `Low` | unique patterns detected from pattern mining |
+| `loki_vl_proxy_patterns_stored_total` | counter | none | `Low` | pattern entries stored in proxy cache or snapshot updates |
+| `loki_vl_proxy_patterns_restored_from_disk_total` | counter | none | `Low` | pattern entries restored from on-disk snapshots |
+| `loki_vl_proxy_patterns_restored_from_peers_total` | counter | none | `Low` | pattern entries restored from peer snapshots |
+| `loki_vl_proxy_patterns_restored_disk_entries_total` | counter | none | `Low` | snapshot cache keys restored from disk |
+| `loki_vl_proxy_patterns_restored_peer_entries_total` | counter | none | `Low` | snapshot cache keys restored from peers |
+| `loki_vl_proxy_patterns_deduplicated_total` | counter | `source` | `Low` | duplicate pattern snapshot entries removed by source (`mem`, `disk`, `peer`) |
+| `loki_vl_proxy_patterns_in_memory` | gauge | none | `Low` | current number of patterns held in in-memory snapshot state |
+| `loki_vl_proxy_patterns_cache_keys` | gauge | none | `Low` | current number of pattern cache keys held in memory |
+| `loki_vl_proxy_patterns_in_memory_bytes` | gauge | none | `Low` | current bytes used by in-memory pattern snapshot payloads |
+| `loki_vl_proxy_patterns_persisted_disk_bytes` | gauge | none | `Low` | last persisted pattern snapshot size on disk |
+
+### Peer Cache Metrics
+
+These families are currently exposed on Prometheus scrape at `/metrics`.
+
+| Metric | Type | Labels | Cardinality | Description |
+|---|---|---|---|---|
+| `loki_vl_proxy_peer_cache_peers` | gauge | none | `Low` | remote peers currently in the fleet-cache ring |
+| `loki_vl_proxy_peer_cache_cluster_members` | gauge | none | `Low` | total fleet-cache ring members including self |
+| `loki_vl_proxy_peer_cache_hits_total` | counter | none | `Low` | successful peer-cache fetches |
+| `loki_vl_proxy_peer_cache_misses_total` | counter | none | `Low` | peer-cache lookups that missed on the owner |
+| `loki_vl_proxy_peer_cache_errors_total` | counter | none | `Low` | peer-cache fetch errors |
+| `loki_vl_proxy_peer_cache_write_through_pushes_total` | counter | none | `Low` | successful owner write-through pushes from non-owner peers |
+| `loki_vl_proxy_peer_cache_write_through_errors_total` | counter | none | `Low` | owner write-through push errors |
+| `loki_vl_proxy_peer_cache_hot_index_requests_total` | counter | none | `Low` | peer hot-index requests |
+| `loki_vl_proxy_peer_cache_hot_index_errors_total` | counter | none | `Low` | peer hot-index request errors |
+| `loki_vl_proxy_peer_cache_read_ahead_prefetches_total` | counter | none | `Low` | successful hot read-ahead prefetches |
+| `loki_vl_proxy_peer_cache_read_ahead_prefetch_bytes_total` | counter | none | `Low` | bytes prefetched by hot read-ahead |
+| `loki_vl_proxy_peer_cache_read_ahead_budget_drops_total` | counter | none | `Low` | hot read-ahead candidates dropped by budget or size filters |
+| `loki_vl_proxy_peer_cache_read_ahead_tenant_skips_total` | counter | none | `Low` | hot read-ahead candidates skipped by tenant fairness |
 
 ### Tenant and Client Metrics
 
 These are the metrics to use when you want to identify the users or tenants actually causing backend load.
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `loki_vl_proxy_tenant_requests_total` | counter | `system`, `direction`, `tenant`, `endpoint`, `route`, `status` | request volume by tenant |
-| `loki_vl_proxy_tenant_request_duration_seconds` | histogram | `system`, `direction`, `tenant`, `endpoint`, `route` | latency by tenant |
-| `loki_vl_proxy_client_requests_total` | counter | `system`, `direction`, `client`, `endpoint`, `route` | request volume by client identity |
-| `loki_vl_proxy_client_response_bytes_total` | counter | `client` | response bytes by client |
-| `loki_vl_proxy_client_status_total` | counter | `system`, `direction`, `client`, `endpoint`, `route`, `status` | final status breakdown by client |
-| `loki_vl_proxy_client_inflight_requests` | gauge | `client` | current parallelism by client |
-| `loki_vl_proxy_client_request_duration_seconds` | histogram | `system`, `direction`, `client`, `endpoint`, `route` | request latency by client |
-| `loki_vl_proxy_client_query_length_chars` | histogram | `system`, `direction`, `client`, `endpoint`, `route` | query size outliers by client |
-| `loki_vl_proxy_client_errors_total` | counter | `system`, `direction`, `endpoint`, `route`, `reason` | categorized downstream client errors |
+| Metric | Type | Labels | Cardinality | Description |
+|---|---|---|---|---|
+| `loki_vl_proxy_tenant_requests_total` | counter | `system`, `direction`, `tenant`, `endpoint`, `route`, `status` | `High (capped)` | request volume by tenant |
+| `loki_vl_proxy_tenant_request_duration_seconds` | histogram | `system`, `direction`, `tenant`, `endpoint`, `route` | `High (capped)` | latency by tenant |
+| `loki_vl_proxy_client_requests_total` | counter | `system`, `direction`, `client`, `endpoint`, `route` | `High (capped)` | request volume by client identity |
+| `loki_vl_proxy_client_response_bytes_total` | counter | `client` | `High (capped)` | response bytes by client |
+| `loki_vl_proxy_client_status_total` | counter | `system`, `direction`, `client`, `endpoint`, `route`, `status` | `High (capped)` | final status breakdown by client |
+| `loki_vl_proxy_client_inflight_requests` | gauge | `client` | `High (capped)` | current parallelism by client |
+| `loki_vl_proxy_client_request_duration_seconds` | histogram | `system`, `direction`, `client`, `endpoint`, `route` | `High (capped)` | request latency by client |
+| `loki_vl_proxy_client_query_length_chars` | histogram | `system`, `direction`, `client`, `endpoint`, `route` | `High (capped)` | query size outliers by client |
+| `loki_vl_proxy_client_errors_total` | counter | `system`, `direction`, `endpoint`, `route`, `reason` | `Low` | categorized downstream client errors |
 
 This is one of the main advantages of putting an explicit proxy between the
 Grafana Loki datasource and VictoriaLogs: the read path becomes attributable.
@@ -299,16 +383,20 @@ traffic while still preserving datasource compatibility at the Grafana edge.
 The proxy also exports a lightweight built-in set of runtime and process/container health metrics.
 App-scoped aliases are emitted with the `loki_vl_proxy_` prefix, while legacy `go_*` and `process_*` families remain for compatibility:
 
-| Metric family | Description |
-|---|---|
-| `loki_vl_proxy_go_*` (`go_*` compatibility aliases) | Go runtime health |
-| `loki_vl_proxy_process_resident_memory_bytes`, `loki_vl_proxy_process_open_fds` (`process_*` compatibility aliases) | process resource usage |
-| `loki_vl_proxy_process_cpu_usage_ratio` (`process_cpu_usage_ratio` alias) | CPU pressure split by `mode` |
-| `loki_vl_proxy_process_memory_*` (`process_memory_*` aliases) | total, free, available, usage ratio |
-| `loki_vl_proxy_process_disk_*_bytes_total` (`process_disk_*_bytes_total` aliases) | disk I/O counters |
-| `loki_vl_proxy_process_disk_*_operations_total` | disk read/write operation counters |
-| `loki_vl_proxy_process_network_*_bytes_total` (`process_network_*_bytes_total` aliases) | network I/O counters |
-| `loki_vl_proxy_process_pressure_*` (`process_pressure_*` aliases) | Linux PSI gauges when available |
+Grouped family rows below mean every concrete metric name in that family shares the same cardinality profile.
+
+| Metric family | Labels | Cardinality | Description |
+|---|---|---|---|
+| `loki_vl_proxy_go_memstats_*`, `loki_vl_proxy_go_goroutines`, `loki_vl_proxy_go_gc_cycles_total`, `loki_vl_proxy_go_gc_duration_seconds` | none | `Low` | Go runtime health |
+| `loki_vl_proxy_process_resident_memory_bytes`, `loki_vl_proxy_process_open_fds` | none | `Low` | process resource usage |
+| `loki_vl_proxy_process_cpu_usage_ratio` | `mode` | `Low` | CPU pressure split by `user`, `system`, `iowait` |
+| `loki_vl_proxy_process_memory_*` | none | `Low` | total, free, available, usage ratio |
+| `loki_vl_proxy_process_disk_*_bytes_total` | none | `Low` | disk I/O byte counters |
+| `loki_vl_proxy_process_disk_*_operations_total` | none | `Low` | disk read/write operation counters |
+| `loki_vl_proxy_process_network_*_bytes_total` | none | `Low` | network I/O counters |
+| `loki_vl_proxy_process_pressure_*_{some,full}_ratio` | `window` | `Low` | Linux PSI gauges when available (`10s`, `60s`, `300s`) |
+
+Legacy unprefixed compatibility aliases (`go_*`, `process_*`) follow the same label sets and cardinality profile as their `loki_vl_proxy_*` counterparts.
 
 Kubernetes notes:
 - These runtime/system metrics are read from `/proc` and do not require Kubernetes RBAC permissions.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -215,6 +215,13 @@ See the dedicated [Observability Guide](observability.md) for the full metrics c
 
 The proxy exposes Prometheus metrics at `/metrics`:
 
+Use the [Observability Guide](observability.md) as the canonical catalog for:
+
+- every documented `loki_vl_proxy_*` metric family
+- cardinality level (`Low`, `Medium`, `High (capped)`) for each family
+- scrape versus OTLP field/label mapping
+- the new fanout and proxy-internal operation metrics/log fields
+
 | Metric | Type | Primary dimensions | Description |
 |--------|------|--------------------|-------------|
 | `loki_vl_proxy_requests_total` | counter | `system`, `direction`, `endpoint`, `route`, `status` | Total requests by downstream Loki route or upstream backend route |

--- a/internal/metrics/metric_name_guard_test.go
+++ b/internal/metrics/metric_name_guard_test.go
@@ -69,6 +69,8 @@ func seededMetricsForMetricNameGuard() *Metrics {
 	m.RecordEndpointCacheHitWithRoute("query_range", "/loki/api/v1/query_range")
 	m.RecordEndpointCacheMissWithRoute("query_range", "/loki/api/v1/query_range")
 	m.RecordBackendDurationWithRoute("query_range", "/loki/api/v1/query_range", 20*time.Millisecond)
+	m.RecordUpstreamCallsPerRequestWithRoute("query_range", "/loki/api/v1/query_range", 3)
+	m.RecordInternalOperation("translate_query", "translated", 5*time.Millisecond)
 	m.RecordTranslation()
 	m.RecordTranslationError()
 	m.RecordCoalesced()

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,13 @@ type Metrics struct {
 	// Backend latency (VL response time, separate from total proxy latency)
 	backendDurations map[string]*histogram // "endpoint<sep>route" → VL duration histogram
 
+	// Upstream fanout per downstream request
+	upstreamCallsPerRequest map[string]*histogram // "endpoint<sep>route" → upstream call count histogram
+
+	// Proxy-side internal operation visibility
+	internalOperationTotal     map[string]*atomic.Int64 // "operation<sep>outcome" → count
+	internalOperationDurations map[string]*histogram    // "operation<sep>outcome" → duration histogram
+
 	// Singleflight coalescing stats
 	coalescedTotal atomic.Int64 // requests served from coalesced results
 	coalescedSaved atomic.Int64 // backend requests saved by coalescing
@@ -119,12 +126,13 @@ type histogram struct {
 	mu    sync.Mutex
 	sum   float64
 	count int64
-	// Buckets: 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
+	// Buckets store cumulative upper bounds.
 	buckets []float64
 	counts  []int64
 }
 
 var defaultBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+var countBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128}
 
 const (
 	defaultMaxTenantLabels = 256
@@ -267,10 +275,18 @@ func normalizeMetricSystem(system string) string {
 }
 
 func newHistogram() *histogram {
+	return newHistogramWithBuckets(defaultBuckets)
+}
+
+func newHistogramWithBuckets(buckets []float64) *histogram {
 	return &histogram{
-		buckets: defaultBuckets,
-		counts:  make([]int64, len(defaultBuckets)),
+		buckets: append([]float64(nil), buckets...),
+		counts:  make([]int64, len(buckets)),
 	}
+}
+
+func newCountHistogram() *histogram {
+	return newHistogramWithBuckets(countBuckets)
 }
 
 func (h *histogram) observe(v float64) {
@@ -301,35 +317,38 @@ func NewMetricsWithOptions(maxTenantLabels, maxClientLabels int, exportSensitive
 		maxClientLabels = defaultMaxClientLabels
 	}
 	m := &Metrics{
-		requestsTotal:           make(map[string]*atomic.Int64),
-		requestDurations:        make(map[string]*histogram),
-		tenantRequests:          make(map[string]*atomic.Int64),
-		tenantDurations:         make(map[string]*histogram),
-		clientErrors:            make(map[string]*atomic.Int64),
-		endpointCacheHits:       make(map[string]*atomic.Int64),
-		endpointCacheMisses:     make(map[string]*atomic.Int64),
-		backendDurations:        make(map[string]*histogram),
-		tupleModes:              make(map[string]*atomic.Int64),
-		clientRequests:          make(map[string]*atomic.Int64),
-		clientDurations:         make(map[string]*histogram),
-		clientBytes:             make(map[string]*atomic.Int64),
-		clientStatuses:          make(map[string]*atomic.Int64),
-		clientInflight:          make(map[string]*atomic.Int64),
-		clientQueryLengths:      make(map[string]*histogram),
-		connectionStates:        make(map[string]*atomic.Int64),
-		connectionTransitions:   make(map[string]*atomic.Int64),
-		connectionRotations:     make(map[string]*atomic.Int64),
-		windowFetch:             newHistogram(),
-		windowMerge:             newHistogram(),
-		windowCount:             newHistogram(),
-		windowPrefilterDuration: newHistogram(),
-		system:                  NewSystemMetrics(),
-		startTime:               time.Now(),
-		maxTenantLabels:         maxTenantLabels,
-		maxClientLabels:         maxClientLabels,
-		exportSensitiveLabels:   exportSensitiveLabels,
-		knownTenants:            make(map[string]struct{}),
-		knownClients:            make(map[string]struct{}),
+		requestsTotal:              make(map[string]*atomic.Int64),
+		requestDurations:           make(map[string]*histogram),
+		tenantRequests:             make(map[string]*atomic.Int64),
+		tenantDurations:            make(map[string]*histogram),
+		clientErrors:               make(map[string]*atomic.Int64),
+		endpointCacheHits:          make(map[string]*atomic.Int64),
+		endpointCacheMisses:        make(map[string]*atomic.Int64),
+		backendDurations:           make(map[string]*histogram),
+		upstreamCallsPerRequest:    make(map[string]*histogram),
+		internalOperationTotal:     make(map[string]*atomic.Int64),
+		internalOperationDurations: make(map[string]*histogram),
+		tupleModes:                 make(map[string]*atomic.Int64),
+		clientRequests:             make(map[string]*atomic.Int64),
+		clientDurations:            make(map[string]*histogram),
+		clientBytes:                make(map[string]*atomic.Int64),
+		clientStatuses:             make(map[string]*atomic.Int64),
+		clientInflight:             make(map[string]*atomic.Int64),
+		clientQueryLengths:         make(map[string]*histogram),
+		connectionStates:           make(map[string]*atomic.Int64),
+		connectionTransitions:      make(map[string]*atomic.Int64),
+		connectionRotations:        make(map[string]*atomic.Int64),
+		windowFetch:                newHistogram(),
+		windowMerge:                newHistogram(),
+		windowCount:                newHistogram(),
+		windowPrefilterDuration:    newHistogram(),
+		system:                     NewSystemMetrics(),
+		startTime:                  time.Now(),
+		maxTenantLabels:            maxTenantLabels,
+		maxClientLabels:            maxClientLabels,
+		exportSensitiveLabels:      exportSensitiveLabels,
+		knownTenants:               make(map[string]struct{}),
+		knownClients:               make(map[string]struct{}),
 	}
 	m.preRegisterZeroSeries()
 	return m
@@ -344,6 +363,9 @@ func (m *Metrics) preRegisterZeroSeries() {
 		routeKey := joinMetricKey(seed.endpoint, seed.route)
 		if _, ok := m.backendDurations[routeKey]; !ok {
 			m.backendDurations[routeKey] = newHistogram()
+		}
+		if _, ok := m.upstreamCallsPerRequest[routeKey]; !ok {
+			m.upstreamCallsPerRequest[routeKey] = newCountHistogram()
 		}
 		if _, ok := m.endpointCacheHits[routeKey]; !ok {
 			m.endpointCacheHits[routeKey] = &atomic.Int64{}
@@ -1096,6 +1118,72 @@ func (m *Metrics) RecordBackendDurationWithRoute(endpoint, route string, d time.
 	h.observe(d.Seconds())
 }
 
+// RecordUpstreamCallsPerRequest records how many upstream calls were triggered by a downstream request.
+func (m *Metrics) RecordUpstreamCallsPerRequest(endpoint string, calls int) {
+	m.RecordUpstreamCallsPerRequestWithRoute(endpoint, "", calls)
+}
+
+func (m *Metrics) RecordUpstreamCallsPerRequestWithRoute(endpoint, route string, calls int) {
+	route = normalizeMetricRoute(route, endpoint)
+	key := joinMetricKey(endpoint, route)
+	m.mu.RLock()
+	h, ok := m.upstreamCallsPerRequest[key]
+	m.mu.RUnlock()
+	if !ok {
+		m.mu.Lock()
+		h, ok = m.upstreamCallsPerRequest[key]
+		if !ok {
+			h = newCountHistogram()
+			m.upstreamCallsPerRequest[key] = h
+		}
+		m.mu.Unlock()
+	}
+	if calls < 0 {
+		calls = 0
+	}
+	h.observe(float64(calls))
+}
+
+// RecordInternalOperation records proxy-side work not performed by VL directly.
+func (m *Metrics) RecordInternalOperation(operation, outcome string, d time.Duration) {
+	operation = strings.TrimSpace(operation)
+	outcome = strings.TrimSpace(outcome)
+	if operation == "" {
+		operation = "unknown"
+	}
+	if outcome == "" {
+		outcome = "unknown"
+	}
+	if d < 0 {
+		d = 0
+	}
+	key := joinMetricKey(operation, outcome)
+	m.mu.RLock()
+	counter, cok := m.internalOperationTotal[key]
+	hist, hok := m.internalOperationDurations[key]
+	m.mu.RUnlock()
+	if !cok || !hok {
+		m.mu.Lock()
+		if !cok {
+			counter, cok = m.internalOperationTotal[key]
+			if !cok {
+				counter = &atomic.Int64{}
+				m.internalOperationTotal[key] = counter
+			}
+		}
+		if !hok {
+			hist, hok = m.internalOperationDurations[key]
+			if !hok {
+				hist = newHistogram()
+				m.internalOperationDurations[key] = hist
+			}
+		}
+		m.mu.Unlock()
+	}
+	counter.Add(1)
+	hist.observe(d.Seconds())
+}
+
 // RecordCoalesced records a request that was served from a coalesced result.
 func (m *Metrics) RecordCoalesced() { m.coalescedTotal.Add(1) }
 
@@ -1536,6 +1624,69 @@ func (m *Metrics) Handler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(&sb, "loki_vl_proxy_backend_duration_seconds_bucket{system=%q,direction=%q,endpoint=%q,route=%q,le=\"+Inf\"} %d\n", vlSystemLabel, upstreamDirection, endpoint, route, h.count)
 		fmt.Fprintf(&sb, "loki_vl_proxy_backend_duration_seconds_sum{system=%q,direction=%q,endpoint=%q,route=%q} %g\n", vlSystemLabel, upstreamDirection, endpoint, route, h.sum)
 		fmt.Fprintf(&sb, "loki_vl_proxy_backend_duration_seconds_count{system=%q,direction=%q,endpoint=%q,route=%q} %d\n", vlSystemLabel, upstreamDirection, endpoint, route, h.count)
+		h.mu.Unlock()
+	}
+
+	sb.WriteString("# HELP loki_vl_proxy_upstream_calls_per_request Upstream call count per downstream request.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_upstream_calls_per_request histogram\n")
+	upstreamCallKeys := make([]string, 0, len(m.upstreamCallsPerRequest))
+	for k := range m.upstreamCallsPerRequest {
+		upstreamCallKeys = append(upstreamCallKeys, k)
+	}
+	sort.Strings(upstreamCallKeys)
+	for _, key := range upstreamCallKeys {
+		parts := splitMetricKey(key, 2)
+		if parts == nil {
+			continue
+		}
+		endpoint := parts[0]
+		route := parts[1]
+		h := m.upstreamCallsPerRequest[key]
+		h.mu.Lock()
+		for i, b := range h.buckets {
+			fmt.Fprintf(&sb, "loki_vl_proxy_upstream_calls_per_request_bucket{system=%q,direction=%q,endpoint=%q,route=%q,le=\"%g\"} %d\n", lokiSystemLabel, downstreamDirection, endpoint, route, b, h.counts[i])
+		}
+		fmt.Fprintf(&sb, "loki_vl_proxy_upstream_calls_per_request_bucket{system=%q,direction=%q,endpoint=%q,route=%q,le=\"+Inf\"} %d\n", lokiSystemLabel, downstreamDirection, endpoint, route, h.count)
+		fmt.Fprintf(&sb, "loki_vl_proxy_upstream_calls_per_request_sum{system=%q,direction=%q,endpoint=%q,route=%q} %g\n", lokiSystemLabel, downstreamDirection, endpoint, route, h.sum)
+		fmt.Fprintf(&sb, "loki_vl_proxy_upstream_calls_per_request_count{system=%q,direction=%q,endpoint=%q,route=%q} %d\n", lokiSystemLabel, downstreamDirection, endpoint, route, h.count)
+		h.mu.Unlock()
+	}
+
+	sb.WriteString("# HELP loki_vl_proxy_internal_operation_total Proxy-side internal operations by operation and outcome.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_internal_operation_total counter\n")
+	internalOpKeys := make([]string, 0, len(m.internalOperationTotal))
+	for k := range m.internalOperationTotal {
+		internalOpKeys = append(internalOpKeys, k)
+	}
+	sort.Strings(internalOpKeys)
+	for _, key := range internalOpKeys {
+		parts := splitMetricKey(key, 2)
+		if parts == nil {
+			continue
+		}
+		fmt.Fprintf(&sb, "loki_vl_proxy_internal_operation_total{operation=%q,outcome=%q} %d\n", parts[0], parts[1], m.internalOperationTotal[key].Load())
+	}
+
+	sb.WriteString("# HELP loki_vl_proxy_internal_operation_duration_seconds Proxy-side internal operation duration.\n")
+	sb.WriteString("# TYPE loki_vl_proxy_internal_operation_duration_seconds histogram\n")
+	internalDurationKeys := make([]string, 0, len(m.internalOperationDurations))
+	for k := range m.internalOperationDurations {
+		internalDurationKeys = append(internalDurationKeys, k)
+	}
+	sort.Strings(internalDurationKeys)
+	for _, key := range internalDurationKeys {
+		parts := splitMetricKey(key, 2)
+		if parts == nil {
+			continue
+		}
+		h := m.internalOperationDurations[key]
+		h.mu.Lock()
+		for i, b := range h.buckets {
+			fmt.Fprintf(&sb, "loki_vl_proxy_internal_operation_duration_seconds_bucket{operation=%q,outcome=%q,le=\"%g\"} %d\n", parts[0], parts[1], b, h.counts[i])
+		}
+		fmt.Fprintf(&sb, "loki_vl_proxy_internal_operation_duration_seconds_bucket{operation=%q,outcome=%q,le=\"+Inf\"} %d\n", parts[0], parts[1], h.count)
+		fmt.Fprintf(&sb, "loki_vl_proxy_internal_operation_duration_seconds_sum{operation=%q,outcome=%q} %g\n", parts[0], parts[1], h.sum)
+		fmt.Fprintf(&sb, "loki_vl_proxy_internal_operation_duration_seconds_count{operation=%q,outcome=%q} %d\n", parts[0], parts[1], h.count)
 		h.mu.Unlock()
 	}
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -14,6 +14,8 @@ func TestMetrics_Handler_Output(t *testing.T) {
 	m := NewMetrics()
 	m.RecordRequest("labels", 200, 5*time.Millisecond)
 	m.RecordRequest("query_range", 500, 100*time.Millisecond)
+	m.RecordUpstreamCallsPerRequest("query_range", 3)
+	m.RecordInternalOperation("translate_query", "cache_hit", 2*time.Millisecond)
 	m.RecordCacheHit()
 	m.RecordCacheMiss()
 	m.RecordTranslation()
@@ -67,6 +69,12 @@ func TestMetrics_Handler_Output(t *testing.T) {
 	if !strings.Contains(body, "loki_vl_proxy_translation_errors_total 1") {
 		t.Error("expected translation_errors_total 1")
 	}
+	if !strings.Contains(body, "loki_vl_proxy_upstream_calls_per_request_bucket") {
+		t.Error("missing upstream_calls_per_request histogram")
+	}
+	if !strings.Contains(body, `loki_vl_proxy_internal_operation_total{operation="translate_query",outcome="cache_hit"} 1`) {
+		t.Error("expected translate_query internal operation counter")
+	}
 
 	// Uptime
 	if !strings.Contains(body, "loki_vl_proxy_uptime_seconds") {
@@ -109,6 +117,7 @@ func TestMetrics_Handler_EmptyState(t *testing.T) {
 		`loki_vl_proxy_requests_total{system="loki",direction="downstream",endpoint="query_range",route="/loki/api/v1/query_range",status="200"} 0`,
 		`loki_vl_proxy_cache_hits_by_endpoint{system="loki",direction="downstream",endpoint="query_range",route="/loki/api/v1/query_range"} 0`,
 		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="query_range",route="/loki/api/v1/query_range"} 0`,
+		`loki_vl_proxy_upstream_calls_per_request_count{system="loki",direction="downstream",endpoint="query_range",route="/loki/api/v1/query_range"} 0`,
 		`loki_vl_proxy_tenant_requests_total{system="loki",direction="downstream",tenant="__none__",endpoint="query_range",route="/loki/api/v1/query_range",status="200"} 0`,
 		`loki_vl_proxy_client_requests_total{system="loki",direction="downstream",client="__none__",endpoint="query_range",route="/loki/api/v1/query_range"} 0`,
 		`loki_vl_proxy_client_status_total{system="loki",direction="downstream",client="__none__",endpoint="query_range",route="/loki/api/v1/query_range",status="200"} 0`,

--- a/internal/metrics/otlp.go
+++ b/internal/metrics/otlp.go
@@ -276,10 +276,12 @@ func (p *OTLPPusher) buildPayload() map[string]interface{} {
 	p.metrics.mu.RLock()
 	metrics = append(metrics, p.connectionMetrics(now)...)
 	metrics = append(metrics, p.requestMetrics(now)...)
+	metrics = append(metrics, p.upstreamFanoutMetrics(now)...)
 	metrics = append(metrics, p.tenantMetrics(now)...)
 	metrics = append(metrics, p.clientErrorMetrics(now)...)
 	metrics = append(metrics, p.endpointCacheMetrics(now)...)
 	metrics = append(metrics, p.backendDurationMetrics(now)...)
+	metrics = append(metrics, p.internalOperationMetrics(now)...)
 	metrics = append(metrics, p.clientMetrics(now)...)
 	p.metrics.mu.RUnlock()
 
@@ -518,6 +520,31 @@ func (p *OTLPPusher) requestMetrics(now int64) []map[string]interface{} {
 	return metrics
 }
 
+func (p *OTLPPusher) upstreamFanoutMetrics(now int64) []map[string]interface{} {
+	keys := sortedKeys(mapsFromHists(p.metrics.upstreamCallsPerRequest))
+	points := make([]map[string]interface{}, 0, len(keys))
+	for _, key := range keys {
+		parts := splitMetricKey(key, 2)
+		if parts == nil {
+			continue
+		}
+		points = append(points, p.histogramDP(
+			p.metrics.upstreamCallsPerRequest[key],
+			now,
+			attr("loki.api.system", lokiSystemLabel),
+			attr("proxy.direction", downstreamDirection),
+			attr("loki.request.type", parts[0]),
+			attr("http.route", parts[1]),
+		))
+	}
+	if len(points) == 0 {
+		return nil
+	}
+	return []map[string]interface{}{
+		p.histogramMetric("loki_vl_proxy_upstream_calls_per_request", "Upstream call count per downstream request.", "{request}", points...),
+	}
+}
+
 func (p *OTLPPusher) tenantMetrics(now int64) []map[string]interface{} {
 	if !p.metrics.ExportSensitiveLabels() {
 		return nil
@@ -609,6 +636,46 @@ func (p *OTLPPusher) backendDurationMetrics(now int64) []map[string]interface{} 
 		return nil
 	}
 	return []map[string]interface{}{p.histogramMetric("loki_vl_proxy_backend_duration_seconds", "VL backend response time.", "s", points...)}
+}
+
+func (p *OTLPPusher) internalOperationMetrics(now int64) []map[string]interface{} {
+	metrics := make([]map[string]interface{}, 0, 2)
+	counterKeys := sortedKeys(mapsFromCounters(p.metrics.internalOperationTotal))
+	counterPoints := make([]map[string]interface{}, 0, len(counterKeys))
+	for _, key := range counterKeys {
+		parts := splitMetricKey(key, 2)
+		if parts == nil {
+			continue
+		}
+		counterPoints = append(counterPoints, p.counterDP(
+			"loki_vl_proxy_internal_operation_total",
+			p.metrics.internalOperationTotal[key].Load(),
+			now,
+			attr("operation", parts[0]),
+			attr("outcome", parts[1]),
+		))
+	}
+	if len(counterPoints) > 0 {
+		metrics = append(metrics, p.sumMetric("loki_vl_proxy_internal_operation_total", "Proxy-side internal operations by operation and outcome.", "", counterPoints...))
+	}
+	durationKeys := sortedKeys(mapsFromHists(p.metrics.internalOperationDurations))
+	durationPoints := make([]map[string]interface{}, 0, len(durationKeys))
+	for _, key := range durationKeys {
+		parts := splitMetricKey(key, 2)
+		if parts == nil {
+			continue
+		}
+		durationPoints = append(durationPoints, p.histogramDP(
+			p.metrics.internalOperationDurations[key],
+			now,
+			attr("operation", parts[0]),
+			attr("outcome", parts[1]),
+		))
+	}
+	if len(durationPoints) > 0 {
+		metrics = append(metrics, p.histogramMetric("loki_vl_proxy_internal_operation_duration_seconds", "Proxy-side internal operation duration.", "s", durationPoints...))
+	}
+	return metrics
 }
 
 func (p *OTLPPusher) queryRangeWindowMetrics(now int64) []map[string]interface{} {

--- a/internal/metrics/otlp_test.go
+++ b/internal/metrics/otlp_test.go
@@ -239,6 +239,8 @@ func TestOTLPPusher_BuildPayload(t *testing.T) {
 	m.RecordCacheMiss()
 	m.RecordTranslation()
 	m.RecordRequest("query_range", 200, 100*time.Millisecond)
+	m.RecordUpstreamCallsPerRequest("query_range", 3)
+	m.RecordInternalOperation("translate_query", "translated", 4*time.Millisecond)
 	m.RecordTenantRequest("team-a", "query_range", 200, 100*time.Millisecond)
 	m.RecordClientIdentity("grafana-user", "query_range", 50*time.Millisecond, 128)
 	m.RecordClientStatus("grafana-user", "query_range", 200)
@@ -268,16 +270,28 @@ func TestOTLPPusher_BuildPayload(t *testing.T) {
 	metricsList := scopeMetrics[0]["metrics"].([]map[string]interface{})
 	foundClientHistogram := false
 	foundTenantCounter := false
+	foundFanoutHistogram := false
+	foundInternalOpCounter := false
 	for _, metric := range metricsList {
 		switch metric["name"] {
 		case "loki_vl_proxy_client_query_length_chars":
 			foundClientHistogram = true
 		case "loki_vl_proxy_tenant_requests_total":
 			foundTenantCounter = true
+		case "loki_vl_proxy_upstream_calls_per_request":
+			foundFanoutHistogram = true
+		case "loki_vl_proxy_internal_operation_total":
+			foundInternalOpCounter = true
 		}
 	}
-	if !foundClientHistogram || !foundTenantCounter {
-		t.Fatalf("expected richer OTLP payload, foundClientHistogram=%v foundTenantCounter=%v", foundClientHistogram, foundTenantCounter)
+	if !foundClientHistogram || !foundTenantCounter || !foundFanoutHistogram || !foundInternalOpCounter {
+		t.Fatalf(
+			"expected richer OTLP payload, foundClientHistogram=%v foundTenantCounter=%v foundFanoutHistogram=%v foundInternalOpCounter=%v",
+			foundClientHistogram,
+			foundTenantCounter,
+			foundFanoutHistogram,
+			foundInternalOpCounter,
+		)
 	}
 }
 
@@ -367,8 +381,8 @@ func TestOTLPPusher_ZstdCompression(t *testing.T) {
 
 func TestNormalizeMetricsEndpoint(t *testing.T) {
 	cases := map[string]string{
-		"":                                "",
-		"://collector%%%":                 "://collector%%%",
+		"":                                  "",
+		"://collector%%%":                   "://collector%%%",
 		"http://collector:4318":             "http://collector:4318/v1/metrics",
 		"http://collector:4318/":            "http://collector:4318/v1/metrics",
 		"http://collector:4318/v1":          "http://collector:4318/v1/metrics",
@@ -446,6 +460,8 @@ func TestOTLPPusher_SpecializedMetricFamilies(t *testing.T) {
 	m.RecordEndpointCacheHit("query_range")
 	m.RecordEndpointCacheMiss("query")
 	m.RecordBackendDuration("query_range", 25*time.Millisecond)
+	m.RecordUpstreamCallsPerRequest("query_range", 7)
+	m.RecordInternalOperation("translate_query", "cache_hit", 2*time.Millisecond)
 	m.RecordQueryRangeWindowFetchDuration(20 * time.Millisecond)
 	m.RecordQueryRangeWindowMergeDuration(5 * time.Millisecond)
 	m.RecordQueryRangeWindowCount(4)
@@ -489,12 +505,17 @@ func TestOTLPPusher_SpecializedMetricFamilies(t *testing.T) {
 	}
 
 	endpointFamilies := append(pusher.endpointCacheMetrics(now), pusher.backendDurationMetrics(now)...)
+	endpointFamilies = append(endpointFamilies, pusher.upstreamFanoutMetrics(now)...)
+	endpointFamilies = append(endpointFamilies, pusher.internalOperationMetrics(now)...)
 	endpointFamilies = append(endpointFamilies, pusher.queryRangeWindowMetrics(now)...)
 	names := metricNamesFromMaps(endpointFamilies)
 	for _, required := range []string{
 		"loki_vl_proxy_cache_hits_by_endpoint",
 		"loki_vl_proxy_cache_misses_by_endpoint",
 		"loki_vl_proxy_backend_duration_seconds",
+		"loki_vl_proxy_upstream_calls_per_request",
+		"loki_vl_proxy_internal_operation_total",
+		"loki_vl_proxy_internal_operation_duration_seconds",
 		"loki_vl_proxy_window_fetch_seconds",
 		"loki_vl_proxy_window_merge_seconds",
 		"loki_vl_proxy_window_count",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -108,19 +108,27 @@ const (
 type requestTelemetry struct {
 	mu sync.Mutex
 
-	cacheResult       string
-	upstreamCalls     int
-	upstreamDuration  time.Duration
-	upstreamLastCode  int
-	upstreamErrorSeen bool
+	cacheResult            string
+	upstreamCalls          int
+	upstreamDuration       time.Duration
+	upstreamLastCode       int
+	upstreamErrorSeen      bool
+	upstreamCallsByType    map[string]int
+	upstreamDurationByType map[string]time.Duration
+	internalOpsByType      map[string]int
+	internalDurationByType map[string]time.Duration
 }
 
 type requestTelemetrySnapshot struct {
-	cacheResult       string
-	upstreamCalls     int
-	upstreamDuration  time.Duration
-	upstreamLastCode  int
-	upstreamErrorSeen bool
+	cacheResult            string
+	upstreamCalls          int
+	upstreamDuration       time.Duration
+	upstreamLastCode       int
+	upstreamErrorSeen      bool
+	upstreamCallsByType    map[string]int
+	upstreamDurationByType map[string]time.Duration
+	internalOpsByType      map[string]int
+	internalDurationByType map[string]time.Duration
 }
 
 type requestRouteMeta struct {
@@ -197,7 +205,31 @@ func forwardedClientAddress(r *http.Request, trustProxyHeaders bool) string {
 	return host
 }
 
-func recordUpstreamCall(ctx context.Context, statusCode int, duration time.Duration, hadError bool) {
+func upstreamBreakdownKey(system, requestType string) string {
+	system = strings.TrimSpace(system)
+	requestType = strings.TrimSpace(requestType)
+	if requestType == "" {
+		requestType = "unknown"
+	}
+	if system == "" {
+		return requestType
+	}
+	return system + ":" + requestType
+}
+
+func internalOperationBreakdownKey(operation, outcome string) string {
+	operation = strings.TrimSpace(operation)
+	outcome = strings.TrimSpace(outcome)
+	if operation == "" {
+		operation = "unknown"
+	}
+	if outcome == "" {
+		outcome = "unknown"
+	}
+	return operation + ":" + outcome
+}
+
+func recordUpstreamCall(ctx context.Context, system, requestType string, statusCode int, duration time.Duration, hadError bool) {
 	rt := getRequestTelemetry(ctx)
 	if rt == nil {
 		return
@@ -207,6 +239,38 @@ func recordUpstreamCall(ctx context.Context, statusCode int, duration time.Durat
 	rt.upstreamDuration += duration
 	rt.upstreamLastCode = statusCode
 	rt.upstreamErrorSeen = rt.upstreamErrorSeen || hadError
+	if requestType != "" {
+		key := upstreamBreakdownKey(system, requestType)
+		if rt.upstreamCallsByType == nil {
+			rt.upstreamCallsByType = make(map[string]int)
+		}
+		if rt.upstreamDurationByType == nil {
+			rt.upstreamDurationByType = make(map[string]time.Duration)
+		}
+		rt.upstreamCallsByType[key]++
+		rt.upstreamDurationByType[key] += duration
+	}
+	rt.mu.Unlock()
+}
+
+func recordInternalOperation(ctx context.Context, operation, outcome string, duration time.Duration) {
+	rt := getRequestTelemetry(ctx)
+	if rt == nil {
+		return
+	}
+	if duration < 0 {
+		duration = 0
+	}
+	rt.mu.Lock()
+	key := internalOperationBreakdownKey(operation, outcome)
+	if rt.internalOpsByType == nil {
+		rt.internalOpsByType = make(map[string]int)
+	}
+	if rt.internalDurationByType == nil {
+		rt.internalDurationByType = make(map[string]time.Duration)
+	}
+	rt.internalOpsByType[key]++
+	rt.internalDurationByType[key] += duration
 	rt.mu.Unlock()
 }
 
@@ -217,12 +281,32 @@ func snapshotTelemetry(ctx context.Context) requestTelemetrySnapshot {
 	}
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	upstreamCallsByType := make(map[string]int, len(rt.upstreamCallsByType))
+	for key, value := range rt.upstreamCallsByType {
+		upstreamCallsByType[key] = value
+	}
+	upstreamDurationByType := make(map[string]time.Duration, len(rt.upstreamDurationByType))
+	for key, value := range rt.upstreamDurationByType {
+		upstreamDurationByType[key] = value
+	}
+	internalOpsByType := make(map[string]int, len(rt.internalOpsByType))
+	for key, value := range rt.internalOpsByType {
+		internalOpsByType[key] = value
+	}
+	internalDurationByType := make(map[string]time.Duration, len(rt.internalDurationByType))
+	for key, value := range rt.internalDurationByType {
+		internalDurationByType[key] = value
+	}
 	return requestTelemetrySnapshot{
-		cacheResult:       rt.cacheResult,
-		upstreamCalls:     rt.upstreamCalls,
-		upstreamDuration:  rt.upstreamDuration,
-		upstreamLastCode:  rt.upstreamLastCode,
-		upstreamErrorSeen: rt.upstreamErrorSeen,
+		cacheResult:            rt.cacheResult,
+		upstreamCalls:          rt.upstreamCalls,
+		upstreamDuration:       rt.upstreamDuration,
+		upstreamLastCode:       rt.upstreamLastCode,
+		upstreamErrorSeen:      rt.upstreamErrorSeen,
+		upstreamCallsByType:    upstreamCallsByType,
+		upstreamDurationByType: upstreamDurationByType,
+		internalOpsByType:      internalOpsByType,
+		internalDurationByType: internalDurationByType,
 	}
 }
 
@@ -1981,7 +2065,7 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 
 	logqlQuery = p.preferWorkingParser(r.Context(), logqlQuery, r.FormValue("start"), r.FormValue("end"))
 
-	logsqlQuery, err := p.translateQuery(logqlQuery)
+	logsqlQuery, err := p.translateQueryWithContext(r.Context(), logqlQuery)
 	if err != nil {
 		p.writeError(w, http.StatusBadRequest, err.Error())
 		p.metrics.RecordRequest("query_range", http.StatusBadRequest, time.Since(start))
@@ -2093,7 +2177,7 @@ func (p *Proxy) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	logqlQuery = p.preferWorkingParser(r.Context(), logqlQuery, r.FormValue("start"), r.FormValue("end"))
 
-	logsqlQuery, err := p.translateQuery(logqlQuery)
+	logsqlQuery, err := p.translateQueryWithContext(r.Context(), logqlQuery)
 	if err != nil {
 		p.writeError(w, http.StatusBadRequest, err.Error())
 		p.metrics.RecordRequest("query", http.StatusBadRequest, time.Since(start))
@@ -2507,7 +2591,7 @@ func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end, s
 
 			params := url.Values{}
 			if strings.TrimSpace(rawQuery) != "" {
-				translated, terr := p.translateQuery(defaultQuery(rawQuery))
+				translated, terr := p.translateQueryWithContext(ctx, defaultQuery(rawQuery))
 				if terr == nil {
 					params.Set("query", translated)
 				} else {
@@ -2570,7 +2654,7 @@ func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuer
 			} else {
 				params := url.Values{}
 				if strings.TrimSpace(rawQuery) != "" {
-					translated, terr := p.translateQuery(defaultQuery(rawQuery))
+					translated, terr := p.translateQueryWithContext(ctx, defaultQuery(rawQuery))
 					if terr == nil {
 						params.Set("query", translated)
 					} else {
@@ -3975,7 +4059,7 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	params := url.Values{}
 	// Forward the query param if provided (Loki uses it to scope label suggestions)
 	if q := r.FormValue("query"); q != "" {
-		translated, terr := p.translateQuery(defaultQuery(q))
+		translated, terr := p.translateQueryWithContext(r.Context(), defaultQuery(q))
 		if terr == nil {
 			params.Set("query", translated)
 		} else {
@@ -4126,7 +4210,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 
 	params := url.Values{}
 	if q := r.FormValue("query"); q != "" {
-		translated, terr := p.translateQuery(defaultQuery(q))
+		translated, terr := p.translateQueryWithContext(r.Context(), defaultQuery(q))
 		if terr == nil {
 			params.Set("query", translated)
 		} else {
@@ -4187,7 +4271,7 @@ func (p *Proxy) handleSeries(w http.ResponseWriter, r *http.Request) {
 	matchQueries := r.Form["match[]"]
 	query := "*"
 	if len(matchQueries) > 0 {
-		translated, err := p.translateQuery(matchQueries[0])
+		translated, err := p.translateQueryWithContext(r.Context(), matchQueries[0])
 		if err == nil {
 			query = translated
 		}
@@ -4262,7 +4346,7 @@ func (p *Proxy) handleIndexStats(w http.ResponseWriter, r *http.Request) {
 	if query == "" {
 		query = "*"
 	}
-	logsqlQuery, _ := p.translateQuery(query)
+	logsqlQuery, _ := p.translateQueryWithContext(r.Context(), query)
 
 	params := url.Values{}
 	params.Set("query", logsqlQuery)
@@ -4418,7 +4502,7 @@ func (p *Proxy) computeVolumeResult(ctx context.Context, query, start, end, targ
 			return result, nil
 		}
 	}
-	logsqlQuery, _ := p.translateQuery(query)
+	logsqlQuery, _ := p.translateQueryWithContext(ctx, query)
 
 	params := url.Values{}
 	params.Set("query", logsqlQuery)
@@ -4523,7 +4607,7 @@ func (p *Proxy) computeVolumeRangeResult(ctx context.Context, query, start, end,
 			return result, nil
 		}
 	}
-	logsqlQuery, _ := p.translateQuery(query)
+	logsqlQuery, _ := p.translateQueryWithContext(ctx, query)
 
 	params := url.Values{}
 	params.Set("query", logsqlQuery+" | sort by (_time desc)")
@@ -5205,6 +5289,11 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 		minWindowSourceLimit = 200
 		maxWindowSourceLimit = 4_000
 		maxPatternWindowSamples = 64
+		// Long selected ranges need enough source lines per window to cover the
+		// full window rather than a single 5m bucket from each 45m sample.
+		if span >= 24*time.Hour {
+			minWindowSourceLimit = maxWindowSourceLimit
+		}
 	}
 	if span < minWindowedSpan {
 		return 0, 0, 0, 0, false
@@ -5911,7 +6000,7 @@ func (p *Proxy) handleDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Translate query
-	logsqlQuery, err := p.translateQuery(query)
+	logsqlQuery, err := p.translateQueryWithContext(r.Context(), query)
 	if err != nil {
 		p.writeError(w, http.StatusBadRequest, "failed to translate query: "+err.Error())
 		p.metrics.RecordRequest("delete", http.StatusBadRequest, time.Since(start))
@@ -5980,7 +6069,7 @@ func (p *Proxy) handleTail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logsqlQuery, err := p.translateQuery(logqlQuery)
+	logsqlQuery, err := p.translateQueryWithContext(r.Context(), logqlQuery)
 	if err != nil {
 		p.writeError(w, http.StatusBadRequest, err.Error())
 		p.metrics.RecordRequest("tail", http.StatusBadRequest, time.Since(start))
@@ -6506,17 +6595,14 @@ func (p *Proxy) alertingBackendGetWithParams(r *http.Request, backend *url.URL, 
 	serverPort, _ := strconv.Atoi(u.Port())
 	if err != nil {
 		mappedStatus := statusFromUpstreamErr(err)
-		recordUpstreamCall(r.Context(), mappedStatus, duration, true)
 		p.recordUpstreamObservation(r.Context(), "loki", http.MethodGet, path, u.Hostname(), serverPort, mappedStatus, duration, err)
 		return nil, err
 	}
 	if err := decodeCompressedHTTPResponse(resp); err != nil {
 		_ = resp.Body.Close()
-		recordUpstreamCall(r.Context(), http.StatusBadGateway, duration, true)
 		p.recordUpstreamObservation(r.Context(), "loki", http.MethodGet, path, u.Hostname(), serverPort, http.StatusBadGateway, duration, err)
 		return nil, fmt.Errorf("decode backend response: %w", err)
 	}
-	recordUpstreamCall(r.Context(), resp.StatusCode, duration, false)
 	p.recordUpstreamObservation(r.Context(), "loki", http.MethodGet, path, u.Hostname(), serverPort, resp.StatusCode, duration, nil)
 	return resp, nil
 }
@@ -6713,6 +6799,10 @@ func deriveRequestType(endpoint, route string) string {
 	return trimmed
 }
 
+func deriveUpstreamRequestType(route string) string {
+	return deriveRequestType("", route)
+}
+
 func normalizeObservedRoute(route string) string {
 	route = strings.TrimSpace(route)
 	if route == "" {
@@ -6723,8 +6813,11 @@ func normalizeObservedRoute(route string) string {
 
 func (p *Proxy) recordUpstreamObservation(ctx context.Context, system, method, route, serverAddress string, serverPort int, statusCode int, duration time.Duration, err error) {
 	meta := requestRouteMetaFromContext(ctx)
-	requestType := deriveRequestType(meta.endpoint, route)
+	requestType := deriveUpstreamRequestType(route)
 	observedRoute := normalizeObservedRoute(route)
+	parentRequestType := deriveRequestType(meta.endpoint, meta.route)
+
+	recordUpstreamCall(ctx, system, requestType, statusCode, duration, err != nil)
 
 	p.metrics.RecordUpstreamRequest(system, requestType, observedRoute, statusCode, duration)
 	if system == "vl" {
@@ -6752,6 +6845,12 @@ func (p *Proxy) recordUpstreamObservation(ctx context.Context, system, method, r
 		"event.duration", duration.Nanoseconds(),
 		"loki.tenant.id", getOrgID(ctx),
 	}
+	if parentRequestType != "" && parentRequestType != "unknown" {
+		logAttrs = append(logAttrs, "loki.parent_request.type", parentRequestType)
+	}
+	if parentRoute := strings.TrimSpace(meta.route); parentRoute != "" {
+		logAttrs = append(logAttrs, "http.parent_route", parentRoute)
+	}
 	if serverAddress != "" {
 		logAttrs = append(logAttrs, "server.address", serverAddress)
 	}
@@ -6765,6 +6864,16 @@ func (p *Proxy) recordUpstreamObservation(ctx context.Context, system, method, r
 		)
 	}
 	p.log.Log(ctx, level, "upstream_request", logAttrs...)
+}
+
+func (p *Proxy) observeInternalOperation(ctx context.Context, operation, outcome string, duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	recordInternalOperation(ctx, operation, outcome, duration)
+	if p != nil && p.metrics != nil {
+		p.metrics.RecordInternalOperation(operation, outcome, duration)
+	}
 }
 
 func (p *Proxy) observeBackendVersionFromHeaders(headers http.Header) {
@@ -7197,7 +7306,6 @@ func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*htt
 	serverPort, _ := strconv.Atoi(u.Port())
 	if err != nil {
 		mappedStatus := statusFromUpstreamErr(err)
-		recordUpstreamCall(ctx, mappedStatus, duration, true)
 		p.recordUpstreamObservation(ctx, "vl", http.MethodGet, path, u.Hostname(), serverPort, mappedStatus, duration, err)
 		if shouldRecordBreakerFailure(err) {
 			p.breaker.RecordFailure()
@@ -7207,11 +7315,9 @@ func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*htt
 	p.observeBackendVersionFromHeaders(resp.Header)
 	if err := decodeCompressedHTTPResponse(resp); err != nil {
 		_ = resp.Body.Close()
-		recordUpstreamCall(ctx, http.StatusBadGateway, duration, true)
 		p.recordUpstreamObservation(ctx, "vl", http.MethodGet, path, u.Hostname(), serverPort, http.StatusBadGateway, duration, err)
 		return nil, fmt.Errorf("decode backend response: %w", err)
 	}
-	recordUpstreamCall(ctx, resp.StatusCode, duration, false)
 	p.recordUpstreamObservation(ctx, "vl", http.MethodGet, path, u.Hostname(), serverPort, resp.StatusCode, duration, nil)
 	// Any completed HTTP response proves backend reachability; keep breaker for transport failures only.
 	p.breaker.RecordSuccess()
@@ -7240,7 +7346,6 @@ func (p *Proxy) vlPost(ctx context.Context, path string, params url.Values) (*ht
 	serverPort, _ := strconv.Atoi(u.Port())
 	if err != nil {
 		mappedStatus := statusFromUpstreamErr(err)
-		recordUpstreamCall(ctx, mappedStatus, duration, true)
 		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, path, u.Hostname(), serverPort, mappedStatus, duration, err)
 		if shouldRecordBreakerFailure(err) {
 			p.breaker.RecordFailure()
@@ -7250,11 +7355,9 @@ func (p *Proxy) vlPost(ctx context.Context, path string, params url.Values) (*ht
 	p.observeBackendVersionFromHeaders(resp.Header)
 	if err := decodeCompressedHTTPResponse(resp); err != nil {
 		_ = resp.Body.Close()
-		recordUpstreamCall(ctx, http.StatusBadGateway, duration, true)
 		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, path, u.Hostname(), serverPort, http.StatusBadGateway, duration, err)
 		return nil, fmt.Errorf("decode backend response: %w", err)
 	}
-	recordUpstreamCall(ctx, resp.StatusCode, duration, false)
 	p.recordUpstreamObservation(ctx, "vl", http.MethodPost, path, u.Hostname(), serverPort, resp.StatusCode, duration, nil)
 	// Any completed HTTP response proves backend reachability; keep breaker for transport failures only.
 	p.breaker.RecordSuccess()
@@ -7332,7 +7435,7 @@ func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, log
 	// VL stats_query_range returns Prometheus-compatible format.
 	// Just wrap it in Loki's envelope.
 	// Translate label names (e.g., dots → underscores) in metric labels.
-	body = p.translateStatsResponseLabels(body, r.FormValue("query"))
+	body = p.translateStatsResponseLabelsWithContext(r.Context(), body, r.FormValue("query"))
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(wrapAsLokiResponse(body, "matrix"))
 }
@@ -7359,7 +7462,7 @@ func (p *Proxy) proxyStatsQuery(w http.ResponseWriter, r *http.Request, logsqlQu
 		return
 	}
 
-	body = p.translateStatsResponseLabels(body, r.FormValue("query"))
+	body = p.translateStatsResponseLabelsWithContext(r.Context(), body, r.FormValue("query"))
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(wrapAsLokiResponse(body, "vector"))
 }
@@ -10397,6 +10500,7 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 		if proxyOverhead < 0 {
 			proxyOverhead = 0
 		}
+		p.metrics.RecordUpstreamCallsPerRequestWithRoute(endpoint, route, telemetry.upstreamCalls)
 
 		// Per-tenant metrics
 		p.metrics.RecordTenantRequestWithRoute(tenant, endpoint, route, sc.code, elapsed)
@@ -10440,6 +10544,14 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 		grafanaSurface := grafanaProfile.surface
 		grafanaSourceTag := grafanaProfile.sourceTag
 		grafanaVersion := grafanaProfile.version
+		upstreamDurationByTypeMs := make(map[string]int64, len(telemetry.upstreamDurationByType))
+		for key, value := range telemetry.upstreamDurationByType {
+			upstreamDurationByTypeMs[key] = value.Milliseconds()
+		}
+		internalDurationByTypeMs := make(map[string]int64, len(telemetry.internalDurationByType))
+		for key, value := range telemetry.internalDurationByType {
+			internalDurationByTypeMs[key] = value.Milliseconds()
+		}
 		logAttrs := []interface{}{
 			"http.route", route,
 			"url.path", r.URL.Path,
@@ -10460,6 +10572,18 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 			"upstream.duration_ms", telemetry.upstreamDuration.Milliseconds(),
 			"upstream.status_code", telemetry.upstreamLastCode,
 			"upstream.error", telemetry.upstreamErrorSeen,
+		}
+		if len(telemetry.upstreamCallsByType) > 0 {
+			logAttrs = append(logAttrs, "upstream.calls_by_type", telemetry.upstreamCallsByType)
+		}
+		if len(upstreamDurationByTypeMs) > 0 {
+			logAttrs = append(logAttrs, "upstream.duration_ms_by_type", upstreamDurationByTypeMs)
+		}
+		if len(telemetry.internalOpsByType) > 0 {
+			logAttrs = append(logAttrs, "proxy.operations_by_type", telemetry.internalOpsByType)
+		}
+		if len(internalDurationByTypeMs) > 0 {
+			logAttrs = append(logAttrs, "proxy.operation_duration_ms_by_type", internalDurationByTypeMs)
 		}
 		if clientAddr != "" {
 			logAttrs = append(logAttrs, "client.address", clientAddr)
@@ -10648,13 +10772,20 @@ func deriveEnduserName(clientID, clientSource string) string {
 
 // translateQuery translates a LogQL query to LogsQL, applying label name translation.
 func (p *Proxy) translateQuery(logql string) (string, error) {
+	return p.translateQueryWithContext(context.Background(), logql)
+}
+
+func (p *Proxy) translateQueryWithContext(ctx context.Context, logql string) (string, error) {
+	start := time.Now()
 	normalized := strings.TrimSpace(logql)
 	switch normalized {
 	case "", "*", `"*"`, "`*`":
+		p.observeInternalOperation(ctx, "translate_query", "passthrough", time.Since(start))
 		return "*", nil
 	}
 	if p.translationCache != nil {
 		if cached, ok := p.translationCache.Get(normalized); ok {
+			p.observeInternalOperation(ctx, "translate_query", "cache_hit", time.Since(start))
 			return string(cached), nil
 		}
 	}
@@ -10673,6 +10804,10 @@ func (p *Proxy) translateQuery(logql string) (string, error) {
 		translated, err = translator.TranslateLogQLWithLabels(logql, labelFn)
 	}
 	if err != nil {
+		if p.metrics != nil {
+			p.metrics.RecordTranslationError()
+		}
+		p.observeInternalOperation(ctx, "translate_query", "error", time.Since(start))
 		return "", err
 	}
 	trimmed := strings.TrimSpace(translated)
@@ -10682,6 +10817,10 @@ func (p *Proxy) translateQuery(logql string) (string, error) {
 	if p.translationCache != nil {
 		p.translationCache.SetWithTTL(normalized, []byte(translated), 5*time.Minute)
 	}
+	if p.metrics != nil {
+		p.metrics.RecordTranslation()
+	}
+	p.observeInternalOperation(ctx, "translate_query", "translated", time.Since(start))
 	return translated, nil
 }
 
@@ -10711,7 +10850,9 @@ func removeParserStage(logql, parser string) string {
 }
 
 func (p *Proxy) preferWorkingParser(ctx context.Context, logql, start, end string) string {
+	opStart := time.Now()
 	if !hasParserStage(logql, "json") || !hasParserStage(logql, "logfmt") {
+		p.observeInternalOperation(ctx, "prefer_working_parser", "bypass", time.Since(opStart))
 		return logql
 	}
 
@@ -10720,8 +10861,9 @@ func (p *Proxy) preferWorkingParser(ctx context.Context, logql, start, end strin
 		baseQuery = logql
 	}
 	baseQuery = defaultFieldDetectionQuery(baseQuery)
-	logsqlQuery, err := p.translateQuery(baseQuery)
+	logsqlQuery, err := p.translateQueryWithContext(ctx, baseQuery)
 	if err != nil {
+		p.observeInternalOperation(ctx, "prefer_working_parser", "probe_translate_error", time.Since(opStart))
 		return logql
 	}
 
@@ -10737,12 +10879,14 @@ func (p *Proxy) preferWorkingParser(ctx context.Context, logql, start, end strin
 
 	resp, err := p.vlPost(ctx, "/select/logsql/query", params)
 	if err != nil {
+		p.observeInternalOperation(ctx, "prefer_working_parser", "probe_upstream_error", time.Since(opStart))
 		return logql
 	}
 	defer resp.Body.Close()
 
 	body, err := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
 	if err != nil || len(body) == 0 {
+		p.observeInternalOperation(ctx, "prefer_working_parser", "probe_empty", time.Since(opStart))
 		return logql
 	}
 
@@ -10779,10 +10923,13 @@ func (p *Proxy) preferWorkingParser(ctx context.Context, logql, start, end strin
 
 	switch {
 	case jsonHits == 0 && logfmtHits == 0:
+		p.observeInternalOperation(ctx, "prefer_working_parser", "no_parser_signal", time.Since(opStart))
 		return logql
 	case jsonHits >= logfmtHits:
+		p.observeInternalOperation(ctx, "prefer_working_parser", "prefer_json", time.Since(opStart))
 		return removeParserStage(logql, "logfmt")
 	default:
+		p.observeInternalOperation(ctx, "prefer_working_parser", "prefer_logfmt", time.Since(opStart))
 		return removeParserStage(logql, "json")
 	}
 }
@@ -10801,8 +10948,14 @@ func extractParserProbeQuery(logql string) string {
 // (both vector and matrix result types) from VL field names (dots) to
 // Loki-compatible label names (underscores).
 func (p *Proxy) translateStatsResponseLabels(body []byte, originalQuery string) []byte {
+	return p.translateStatsResponseLabelsWithContext(context.Background(), body, originalQuery)
+}
+
+func (p *Proxy) translateStatsResponseLabelsWithContext(ctx context.Context, body []byte, originalQuery string) []byte {
+	start := time.Now()
 	var resp map[string]interface{}
 	if err := json.Unmarshal(body, &resp); err != nil {
+		p.observeInternalOperation(ctx, "translate_stats_response_labels", "decode_error", time.Since(start))
 		return body
 	}
 
@@ -10821,9 +10974,11 @@ func (p *Proxy) translateStatsResponseLabels(body []byte, originalQuery string) 
 	}
 
 	if len(results) == 0 {
+		p.observeInternalOperation(ctx, "translate_stats_response_labels", "no_results", time.Since(start))
 		return body
 	}
 
+	translatedMetrics := 0
 	for _, r := range results {
 		entry, ok := r.(map[string]interface{})
 		if !ok {
@@ -10833,13 +10988,18 @@ func (p *Proxy) translateStatsResponseLabels(body []byte, originalQuery string) 
 		if metricRaw, ok := entry["metric"]; ok {
 			if metric, ok := metricRaw.(map[string]interface{}); ok {
 				translated := make(map[string]interface{}, len(metric))
+				changed := false
 				for k, v := range metric {
 					if k == "__name__" {
+						changed = true
 						continue
 					}
 					lokiKey := k
 					if !p.labelTranslator.IsPassthrough() {
 						lokiKey = p.labelTranslator.ToLoki(k)
+					}
+					if lokiKey != k {
+						changed = true
 					}
 					translated[lokiKey] = v
 				}
@@ -10848,8 +11008,12 @@ func (p *Proxy) translateStatsResponseLabels(body []byte, originalQuery string) 
 						if value, ok := translated["level"]; ok {
 							translated["detected_level"] = value
 							delete(translated, "level")
+							changed = true
 						}
 					}
+				}
+				if changed {
+					translatedMetrics++
 				}
 				entry["metric"] = translated
 			}
@@ -10858,7 +11022,13 @@ func (p *Proxy) translateStatsResponseLabels(body []byte, originalQuery string) 
 
 	result, err := json.Marshal(resp)
 	if err != nil {
+		p.observeInternalOperation(ctx, "translate_stats_response_labels", "encode_error", time.Since(start))
 		return body
 	}
+	outcome := "noop"
+	if translatedMetrics > 0 {
+		outcome = "translated"
+	}
+	p.observeInternalOperation(ctx, "translate_stats_response_labels", outcome, time.Since(start))
 	return result
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10944,13 +10944,6 @@ func extractParserProbeQuery(logql string) string {
 	return strings.TrimSpace(logql)
 }
 
-// translateStatsResponseLabels translates label names in VL stats responses
-// (both vector and matrix result types) from VL field names (dots) to
-// Loki-compatible label names (underscores).
-func (p *Proxy) translateStatsResponseLabels(body []byte, originalQuery string) []byte {
-	return p.translateStatsResponseLabelsWithContext(context.Background(), body, originalQuery)
-}
-
 func (p *Proxy) translateStatsResponseLabelsWithContext(ctx context.Context, body []byte, originalQuery string) []byte {
 	start := time.Now()
 	var resp map[string]interface{}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2149,6 +2149,19 @@ func TestPatternWindowedSamplingConfig_DenseIgnoresStepInflationAndCapsFanout(t 
 	}
 }
 
+func TestPatternWindowedSamplingConfig_DenseLongRangeBoostsPerWindowLimit(t *testing.T) {
+	start := strconv.FormatInt(0, 10)
+	end := strconv.FormatInt(int64((48*time.Hour)/time.Second), 10)
+
+	_, _, _, perWindow, ok := patternWindowedSamplingConfig(start, end, "5m", 11540, true)
+	if !ok {
+		t.Fatal("expected dense windowed config to be enabled for long ranges")
+	}
+	if perWindow < 4000 {
+		t.Fatalf("expected dense long-range per-window limit >=4000, got %d", perWindow)
+	}
+}
+
 func TestShouldAcceptWindowedPatternResults(t *testing.T) {
 	if shouldAcceptWindowedPatternResults(1, 4, true) {
 		t.Fatal("expected dense mode to reject highly partial window coverage")

--- a/internal/proxy/request_logger_semconv_test.go
+++ b/internal/proxy/request_logger_semconv_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/metrics"
 )
 
+func decodeLastJSONLogLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected at least one log line")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &payload); err != nil {
+		t.Fatalf("invalid request log json: %v", err)
+	}
+	return payload
+}
+
 func TestRequestLogger_UsesEnduserSemanticFields(t *testing.T) {
 	var buf bytes.Buffer
 	p := &Proxy{
@@ -179,6 +192,71 @@ func TestRequestLogger_DetectsGrafanaDatasourceSurface(t *testing.T) {
 	}
 	if got := payload["grafana.datasource.profile"]; got != "grafana-datasource-v12" {
 		t.Fatalf("expected datasource profile, got %#v", got)
+	}
+}
+
+func TestRequestLogger_EmitsUpstreamAndInternalBreakdowns(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Proxy{
+		log:     slog.New(slog.NewJSONHandler(&buf, nil)),
+		metrics: metrics.NewMetrics(),
+	}
+
+	h := p.requestLogger("query_range", "/loki/api/v1/query_range", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, "/select/logsql/query", "vl.example", 8427, http.StatusOK, 12*time.Millisecond, nil)
+		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, "/select/logsql/query", "vl.example", 8427, http.StatusOK, 18*time.Millisecond, nil)
+		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, "/select/logsql/stats_query_range", "vl.example", 8427, http.StatusOK, 25*time.Millisecond, nil)
+		p.observeInternalOperation(ctx, "translate_query", "cache_hit", 2*time.Millisecond)
+		p.observeInternalOperation(ctx, "translate_stats_response_labels", "translated", 3*time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?query=%7Bapp%3D%22x%22%7D", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	payload := decodeLastJSONLogLine(t, &buf)
+
+	if got := payload["upstream.calls"]; got != float64(3) {
+		t.Fatalf("expected upstream.calls=3, got %#v", got)
+	}
+	upstreamCallsByType, ok := payload["upstream.calls_by_type"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected upstream.calls_by_type map, got %#v", payload["upstream.calls_by_type"])
+	}
+	if got := upstreamCallsByType["vl:select_logsql_query"]; got != float64(2) {
+		t.Fatalf("expected two select_logsql_query calls, got %#v", got)
+	}
+	if got := upstreamCallsByType["vl:select_logsql_stats_query_range"]; got != float64(1) {
+		t.Fatalf("expected one select_logsql_stats_query_range call, got %#v", got)
+	}
+	internalOpsByType, ok := payload["proxy.operations_by_type"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected proxy.operations_by_type map, got %#v", payload["proxy.operations_by_type"])
+	}
+	if got := internalOpsByType["translate_query:cache_hit"]; got != float64(1) {
+		t.Fatalf("expected translate_query:cache_hit once, got %#v", got)
+	}
+	if got := internalOpsByType["translate_stats_response_labels:translated"]; got != float64(1) {
+		t.Fatalf("expected translate_stats_response_labels:translated once, got %#v", got)
+	}
+
+	metricsRR := httptest.NewRecorder()
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	p.metrics.Handler(metricsRR, metricsReq)
+	body := metricsRR.Body.String()
+
+	for _, needle := range []string{
+		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="select_logsql_query",route="/select/logsql/query"} 2`,
+		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="select_logsql_stats_query_range",route="/select/logsql/stats_query_range"} 1`,
+		`loki_vl_proxy_upstream_calls_per_request_count{system="loki",direction="downstream",endpoint="query_range",route="/loki/api/v1/query_range"} 1`,
+		`loki_vl_proxy_internal_operation_total{operation="translate_query",outcome="cache_hit"} 1`,
+		`loki_vl_proxy_internal_operation_total{operation="translate_stats_response_labels",outcome="translated"} 1`,
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("expected metrics output to contain %q", needle)
+		}
 	}
 }
 

--- a/scripts/ci/collect_quality_metrics.sh
+++ b/scripts/ci/collect_quality_metrics.sh
@@ -239,14 +239,35 @@ PY
 
 collect_load() {
   local out="$TMP_DIR/load.txt"
-  go test ./internal/proxy -run '^TestLoad_HighConcurrency_MemoryStability$' -count=1 -v -timeout=180s >"$out"
-  local throughput memory_growth
-  throughput="$(grep -E 'Throughput: ' "$out" | tail -1 | sed -E 's/.*Throughput: ([0-9.]+) req\/s/\1/')"
-  memory_growth="$(grep -E 'Memory growth: ' "$out" | tail -1 | sed -E 's/.*Memory growth: ([0-9.]+) MB.*/\1/')"
-  jq -n \
-    --argjson throughput "${throughput:-0}" \
-    --argjson memory_growth "${memory_growth:-0}" \
-    '{high_concurrency_req_per_s:$throughput,high_concurrency_memory_growth_mb:$memory_growth}'
+  go test ./internal/proxy -run '^TestLoad_HighConcurrency_MemoryStability$' -count=3 -v -timeout=180s >"$out"
+  python3 - "$out" <<'PY'
+import json
+import re
+import statistics
+import sys
+
+throughputs = []
+memory_growth = []
+
+with open(sys.argv[1], "r", encoding="utf-8", errors="ignore") as fh:
+    for line in fh:
+        throughput_match = re.search(r"Throughput: ([0-9.]+) req/s", line)
+        if throughput_match:
+            throughputs.append(float(throughput_match.group(1)))
+            continue
+        memory_match = re.search(r"Memory growth: ([0-9.]+) MB", line)
+        if memory_match:
+            memory_growth.append(float(memory_match.group(1)))
+
+print(
+    json.dumps(
+        {
+            "high_concurrency_req_per_s": statistics.median(throughputs) if throughputs else 0,
+            "high_concurrency_memory_growth_mb": statistics.median(memory_growth) if memory_growth else 0,
+        }
+    )
+)
+PY
 }
 
 tests_file="$TMP_DIR/tests_and_coverage.json"

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -33,7 +33,8 @@ services:
       - "9428:9428"
     command:
       - "-storageDataPath=/vlogs"
-      - "-retentionPeriod=1d"
+      # Keep enough history for long-range Drilldown regressions (>24h).
+      - "-retentionPeriod=7d"
       - "-httpListenAddr=:9428"
     volumes:
       - vl-data:/vlogs

--- a/test/e2e-compat/drilldown_longrange_regression_test.go
+++ b/test/e2e-compat/drilldown_longrange_regression_test.go
@@ -1,0 +1,323 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type longRangeDrilldownSeedConfig struct {
+	rangeWindow             time.Duration
+	step                    time.Duration
+	patternCount            int
+	repeatsPerPatternBucket int
+	batchSize               int
+}
+
+const (
+	longRangePatternsService = "drilldown-longrange-patterns"
+	longRangeVolumeService   = "drilldown-longrange-volume"
+)
+
+func TestDrilldown_LongRangePatterns_MaintainPerPatternCoverage(t *testing.T) {
+	ensureDataIngested(t)
+	waitForReady(t, proxyURL+"/ready", 30*time.Second)
+	waitForReady(t, grafanaURL+"/api/health", 30*time.Second)
+
+	cfg := longRangeDrilldownSeedConfig{
+		rangeWindow:             48 * time.Hour,
+		step:                    5 * time.Minute,
+		patternCount:            12,
+		repeatsPerPatternBucket: 20,
+		batchSize:               4000,
+	}
+	serviceName := longRangeServiceName(longRangePatternsService)
+	start := time.Now().UTC().Add(-cfg.rangeWindow).Truncate(cfg.step)
+	end := start.Add(cfg.rangeWindow)
+	t.Logf("long-range patterns fixture service=%s start=%s end=%s", serviceName, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	seedLongRangeDrilldownServiceData(t, serviceName, start, end, cfg)
+	waitForDrilldownServiceVisible(t, serviceName, start, end)
+
+	dsUID := grafanaDatasourceUID(t, "Loki (via VL proxy patterns autodetect)")
+	query := fmt.Sprintf(`{service_name="%s"}`, serviceName)
+
+	var entries []densePatternEntry
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		fetched, err := fetchPatternsViaGrafanaDatasource(dsUID, query, start, end, cfg.step, cfg.patternCount)
+		if err == nil && len(fetched) > 0 {
+			entries = fetched
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("patterns long-range repro did not stabilize in time; last_err=%v entries=%d", err, len(fetched))
+		}
+		time.Sleep(1500 * time.Millisecond)
+	}
+
+	if len(entries) == 0 {
+		t.Fatalf("expected long-range patterns to be detected, got %d", len(entries))
+	}
+
+	expectedBuckets := int(end.Sub(start)/cfg.step) + 1
+	minCoverageBuckets := (expectedBuckets * 4) / 5
+	checkCount := min(4, len(entries))
+	for i := 0; i < checkCount; i++ {
+		nonzero := countNonZeroPatternBuckets(entries[i].Samples)
+		if nonzero < minCoverageBuckets {
+			t.Fatalf(
+				"expected pattern %q to cover at least %d/%d buckets, got %d samples: %#v",
+				entries[i].Pattern,
+				minCoverageBuckets,
+				expectedBuckets,
+				nonzero,
+				entries[i].Samples,
+			)
+		}
+	}
+}
+
+func TestDrilldown_LongRangeVolume_SplitQueriesStayDense(t *testing.T) {
+	ensureDataIngested(t)
+	waitForReady(t, proxyURL+"/ready", 30*time.Second)
+	waitForReady(t, grafanaURL+"/api/health", 30*time.Second)
+
+	cfg := longRangeDrilldownSeedConfig{
+		rangeWindow:             48 * time.Hour,
+		step:                    5 * time.Minute,
+		patternCount:            6,
+		repeatsPerPatternBucket: 4,
+		batchSize:               4000,
+	}
+	serviceName := longRangeServiceName(longRangeVolumeService)
+	start := time.Now().UTC().Add(-cfg.rangeWindow).Truncate(cfg.step)
+	end := start.Add(cfg.rangeWindow)
+	t.Logf("long-range volume fixture service=%s start=%s end=%s", serviceName, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	seedLongRangeDrilldownServiceData(t, serviceName, start, end, cfg)
+	waitForDrilldownServiceVisible(t, serviceName, start, end)
+
+	expr := fmt.Sprintf(`sum by (detected_level) (count_over_time({service_name="%s"}[%ds]))`, serviceName, int(cfg.step/time.Second))
+	result := queryRangeMatrixResult(t, expr, start, end, cfg.step)
+	if len(result) < 2 {
+		t.Fatalf("expected at least info/error series for long-range volume query, got %d: %v", len(result), result)
+	}
+
+	startBucket, endBucket, expectedBuckets := denseExpectedBuckets(start, end, cfg.step)
+	minPoints := expectedBuckets - 2
+	if minPoints < 1 {
+		minPoints = 1
+	}
+	stepSeconds := int64(cfg.step / time.Second)
+	seenLevels := map[string]bool{}
+
+	for _, item := range result {
+		series, _ := item.(map[string]interface{})
+		metric, _ := series["metric"].(map[string]interface{})
+		level, _ := metric["detected_level"].(string)
+		values, _ := series["values"].([]interface{})
+		if level == "" {
+			t.Fatalf("expected detected_level label on long-range volume series: %v", series)
+		}
+		if len(values) < minPoints {
+			t.Fatalf("expected dense volume series for detected_level=%s, got %d/%d points", level, len(values), expectedBuckets)
+		}
+
+		var prevTS int64
+		for i, raw := range values {
+			pair, _ := raw.([]interface{})
+			if len(pair) != 2 {
+				t.Fatalf("expected [ts,value] pair for detected_level=%s, got %v", level, raw)
+			}
+			ts, ok := denseSampleTs(pair[0])
+			if !ok {
+				t.Fatalf("expected numeric timestamp for detected_level=%s, got %T", level, pair[0])
+			}
+			if i == 0 && ts > startBucket+(2*stepSeconds) {
+				t.Fatalf("expected early coverage for detected_level=%s, first_ts=%d start_bucket=%d", level, ts, startBucket)
+			}
+			if i > 0 && ts-prevTS > (2*stepSeconds) {
+				t.Fatalf("expected contiguous long-range volume buckets for detected_level=%s, prev=%d current=%d", level, prevTS, ts)
+			}
+			prevTS = ts
+		}
+		if prevTS < endBucket-(2*stepSeconds) {
+			t.Fatalf("expected late coverage for detected_level=%s, last_ts=%d end_bucket=%d", level, prevTS, endBucket)
+		}
+		seenLevels[level] = true
+	}
+
+	for _, want := range []string{"info", "error"} {
+		if !seenLevels[want] {
+			t.Fatalf("expected long-range volume result to include detected_level=%s, got %v", want, seenLevels)
+		}
+	}
+}
+
+func seedLongRangeDrilldownServiceData(t *testing.T, serviceName string, start, end time.Time, cfg longRangeDrilldownSeedConfig) {
+	t.Helper()
+
+	if cfg.step <= 0 {
+		cfg.step = 5 * time.Minute
+	}
+	if cfg.patternCount <= 0 {
+		cfg.patternCount = 4
+	}
+	if cfg.repeatsPerPatternBucket <= 0 {
+		cfg.repeatsPerPatternBucket = 1
+	}
+	if cfg.batchSize <= 0 {
+		cfg.batchSize = 2000
+	}
+
+	insertURL := vlURL + "/insert/jsonline?_stream_fields=" + url.QueryEscape("app,service_name,cluster,namespace,level,detected_level")
+	linesInBatch := 0
+	var body strings.Builder
+	body.Grow(cfg.batchSize * 256)
+	flush := func() {
+		if linesInBatch == 0 {
+			return
+		}
+		resp, err := http.Post(insertURL, "application/stream+json", strings.NewReader(body.String()))
+		if err != nil {
+			t.Fatalf("long-range VL push failed: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			t.Fatalf("long-range VL push failed with status=%d", resp.StatusCode)
+		}
+		body.Reset()
+		linesInBatch = 0
+	}
+
+	bucketIndex := 0
+	for bucket := start; !bucket.After(end); bucket = bucket.Add(cfg.step) {
+		for patternID := 0; patternID < cfg.patternCount; patternID++ {
+			level := "info"
+			if patternID%3 == 0 {
+				level = "error"
+			}
+			method := []string{"GET", "POST", "PUT", "DELETE"}[patternID%4]
+			status := []int{200, 201, 204, 400, 404, 500}[patternID%6]
+			path := fmt.Sprintf("/api/v1/route/%02d", patternID)
+			for repeat := 0; repeat < cfg.repeatsPerPatternBucket; repeat++ {
+				ts := bucket.Add(time.Duration((patternID*cfg.repeatsPerPatternBucket)+repeat) * time.Second).UTC().Format(time.RFC3339Nano)
+				msg := fmt.Sprintf(
+					"pattern_%02d method=%s route=%s status=%d latency_ms=%d request_id=req-%03d-%06d-%02d user_id=user-%02d",
+					patternID,
+					method,
+					path,
+					status,
+					((bucketIndex+repeat)%900)+10,
+					patternID,
+					bucketIndex,
+					repeat,
+					patternID%17,
+				)
+				body.WriteString("{\"_time\":\"")
+				body.WriteString(ts)
+				body.WriteString("\",\"_msg\":")
+				body.WriteString(strconv.Quote(msg))
+				body.WriteString(",\"app\":\"")
+				body.WriteString(serviceName)
+				body.WriteString("\",\"service_name\":\"")
+				body.WriteString(serviceName)
+				body.WriteString("\",\"cluster\":\"drilldown-longrange\",\"namespace\":\"drilldown-longrange\",\"level\":\"")
+				body.WriteString(level)
+				body.WriteString("\",\"detected_level\":\"")
+				body.WriteString(level)
+				body.WriteString("\"}\n")
+				linesInBatch++
+				if linesInBatch >= cfg.batchSize {
+					flush()
+				}
+			}
+		}
+		bucketIndex++
+	}
+	flush()
+	time.Sleep(5 * time.Second)
+}
+
+func longRangeServiceName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UTC().UnixNano())
+}
+
+func waitForDrilldownServiceVisible(t *testing.T, serviceName string, start, end time.Time) {
+	t.Helper()
+
+	params := url.Values{}
+	params.Set("query", fmt.Sprintf(`{service_name="%s"}`, serviceName))
+	params.Set("start", start.Format(time.RFC3339Nano))
+	params.Set("end", end.Format(time.RFC3339Nano))
+
+	deadline := time.Now().Add(45 * time.Second)
+	var last map[string]interface{}
+	for {
+		last = getJSON(t, proxyURL+"/loki/api/v1/index/stats?"+params.Encode())
+		if entries, ok := last["entries"].(float64); ok && entries > 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("seeded service %q never became visible in index/stats: %v", serviceName, last)
+		}
+		time.Sleep(1500 * time.Millisecond)
+	}
+}
+
+func countNonZeroPatternBuckets(samples [][]interface{}) int {
+	count := 0
+	for _, sample := range samples {
+		if len(sample) < 2 {
+			continue
+		}
+		v, ok := sample[1].(float64)
+		if ok && v > 0 {
+			count++
+			continue
+		}
+		switch raw := sample[1].(type) {
+		case int:
+			if raw > 0 {
+				count++
+			}
+		case int64:
+			if raw > 0 {
+				count++
+			}
+		case string:
+			if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func queryRangeMatrixResult(t *testing.T, expr string, start, end time.Time, step time.Duration) []interface{} {
+	t.Helper()
+
+	params := url.Values{}
+	params.Set("query", expr)
+	params.Set("start", strconv.FormatInt(start.UnixNano(), 10))
+	params.Set("end", strconv.FormatInt(end.UnixNano(), 10))
+	params.Set("step", strconv.Itoa(int(step/time.Second)))
+
+	resp := getJSON(t, proxyURL+"/loki/api/v1/query_range?"+params.Encode())
+	data := extractMap(resp, "data")
+	if data == nil {
+		t.Fatalf("expected query_range data for %q, got %v", expr, resp)
+	}
+	result := extractArray(data, "result")
+	if result == nil {
+		t.Fatalf("expected query_range matrix result for %q, got %v", expr, resp)
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- fix the long-range Drilldown sparse-sample regression by increasing dense per-window sampling for long ranges
- add fanout and proxy-internal operation telemetry to metrics, OTLP export, structured logs, and the dashboard
- document metric/log cardinality and expose the observability runtime flags as first-class Helm chart values

## Why
Long-range Drilldown requests could collapse into misleading short spikes when dense sampling per split window was too low. At the same time, the proxy only exposed top-level request latency, which made it hard to see how much time was spent in upstream fanout versus proxy-side translation and response shaping.

## What Changed
- increase dense long-range pattern sampling and add a dedicated long-range e2e regression
- record per-parent upstream child-call counts with `loki_vl_proxy_upstream_calls_per_request`
- record proxy-only work with `loki_vl_proxy_internal_operation_total` and `loki_vl_proxy_internal_operation_duration_seconds`
- add per-request log aggregates for upstream child-call breakdowns and proxy internal operations
- update the Grafana dashboard with downstream-only latency panels plus a new fanout/internal-ops row
- expand observability docs with metric/log catalogs and explicit cardinality levels
- expose observability flags in the Helm chart while keeping `extraArgs` precedence

## Validation
- `go test ./internal/metrics ./internal/proxy`
- `helm template loki-vl-proxy ./charts/loki-vl-proxy`
- `git diff --check`
