### PR TITLE
fix: normalize Drilldown pattern and volume queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown: translate Loki pattern-match filters (`|>`, `!>`) into VictoriaLogs regex filters so pattern stats queries compile correctly, and accept both `start/end` and `from/to` on volume endpoints so long-range volume buckets remain dense.
+
 ## [1.4.0] - 2026-04-16
 
 ### Features

--- a/internal/proxy/gaps_test.go
+++ b/internal/proxy/gaps_test.go
@@ -137,6 +137,34 @@ func TestGap_Volume_QueriesVLHits(t *testing.T) {
 	}
 }
 
+func TestGap_Volume_AcceptsFromToParams(t *testing.T) {
+	var receivedStart string
+	var receivedEnd string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedStart = r.URL.Query().Get("start")
+		receivedEnd = r.URL.Query().Get("end")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"app": "nginx"},
+					"timestamps": []int64{1705312200000},
+					"values":     []int{100},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume?query=%7B%7D&from=1705312200000000000&to=1705312800000000000", nil)
+	p.handleVolume(w, r)
+
+	if receivedStart == "" || receivedEnd == "" {
+		t.Fatalf("expected from/to params to be forwarded as start/end, got start=%q end=%q", receivedStart, receivedEnd)
+	}
+}
+
 // =============================================================================
 // Gap #3: /loki/api/v1/index/volume_range — real via VL hits with step
 // Loki response: {"status":"success","data":{"resultType":"matrix","result":[...]}}
@@ -226,6 +254,49 @@ func TestGap_VolumeRange_FillsMissingBucketsAcrossRequestedRange(t *testing.T) {
 	fourth := values[3].([]interface{})
 	if second[1] != "0" || fourth[1] != "0" {
 		t.Fatalf("expected zero-filled missing buckets, got values=%v", values)
+	}
+}
+
+func TestGap_VolumeRange_AcceptsFromToParams(t *testing.T) {
+	var receivedStart string
+	var receivedEnd string
+	var receivedStep string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedStart = r.URL.Query().Get("start")
+		receivedEnd = r.URL.Query().Get("end")
+		receivedStep = r.URL.Query().Get("step")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"app": "nginx"},
+					"timestamps": []string{"2024-01-15T10:30:00Z", "2024-01-15T10:32:00Z"},
+					"values":     []int{100, 80},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume_range?query=%7B%7D&from=2024-01-15T10:30:00Z&to=2024-01-15T10:33:00Z&step=60", nil)
+	p.handleVolumeRange(w, r)
+
+	if receivedStart == "" || receivedEnd == "" {
+		t.Fatalf("expected from/to params to be forwarded as start/end, got start=%q end=%q", receivedStart, receivedEnd)
+	}
+	if receivedStep != "60s" {
+		t.Fatalf("expected step=60s forwarded, got %q", receivedStep)
+	}
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	result := data["result"].([]interface{})
+	entry := result[0].(map[string]interface{})
+	values := entry["values"].([]interface{})
+	if len(values) != 4 {
+		t.Fatalf("expected 4 filled buckets from from/to range, got %d", len(values))
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4462,6 +4462,10 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	r = withOrgID(r)
 	orgID := r.Header.Get("X-Scope-OrgID")
+	query := r.FormValue("query")
+	startParam := strings.TrimSpace(firstNonEmpty(r.FormValue("start"), r.FormValue("from")))
+	endParam := strings.TrimSpace(firstNonEmpty(r.FormValue("end"), r.FormValue("to")))
+	targetLabels := r.FormValue("targetLabels")
 	cacheKey := "volume:" + orgID + ":" + r.URL.RawQuery
 	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
 		if !p.shouldBypassRecentTailCache("volume", remaining, r) {
@@ -4470,14 +4474,14 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 			p.metrics.RecordRequest("volume", http.StatusOK, time.Since(start))
 			p.metrics.RecordCacheHit()
 			if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume"]) {
-				p.refreshVolumeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("targetLabels"))
+				p.refreshVolumeCacheAsync(orgID, cacheKey, query, startParam, endParam, targetLabels)
 			}
 			return
 		}
 	}
 	p.metrics.RecordCacheMiss()
 
-	result, err := p.computeVolumeResult(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("targetLabels"))
+	result, err := p.computeVolumeResult(r.Context(), query, startParam, endParam, targetLabels)
 	if err != nil {
 		result = map[string]interface{}{
 			"status": "success",
@@ -4567,6 +4571,11 @@ func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 	}
 	r = withOrgID(r)
 	orgID := r.Header.Get("X-Scope-OrgID")
+	query := r.FormValue("query")
+	startParam := strings.TrimSpace(firstNonEmpty(r.FormValue("start"), r.FormValue("from")))
+	endParam := strings.TrimSpace(firstNonEmpty(r.FormValue("end"), r.FormValue("to")))
+	stepParam := r.FormValue("step")
+	targetLabels := r.FormValue("targetLabels")
 	cacheKey := "volume_range:" + orgID + ":" + r.URL.RawQuery
 	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
 		if !p.shouldBypassRecentTailCache("volume_range", remaining, r) {
@@ -4575,14 +4584,14 @@ func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 			p.metrics.RecordRequest("volume_range", http.StatusOK, time.Since(start))
 			p.metrics.RecordCacheHit()
 			if p.shouldRefreshLabelsInBackground(remaining, CacheTTLs["volume_range"]) {
-				p.refreshVolumeRangeCacheAsync(orgID, cacheKey, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"), r.FormValue("targetLabels"))
+				p.refreshVolumeRangeCacheAsync(orgID, cacheKey, query, startParam, endParam, stepParam, targetLabels)
 			}
 			return
 		}
 	}
 	p.metrics.RecordCacheMiss()
 
-	result, err := p.computeVolumeRangeResult(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"), r.FormValue("targetLabels"))
+	result, err := p.computeVolumeRangeResult(r.Context(), query, startParam, endParam, stepParam, targetLabels)
 	if err != nil {
 		result = map[string]interface{}{
 			"status": "success",

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2543,6 +2543,24 @@ func TestTranslation_JSONParser(t *testing.T) {
 	}
 }
 
+func TestTranslation_DrilldownPatternQueryForwarded(t *testing.T) {
+	var receivedQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		receivedQuery = r.FormValue("query")
+		w.Write([]byte{})
+	}))
+	defer vlBackend.Close()
+
+	logql := `{app="web"} |> ` + "`" + `GET <_> 500` + "`" + ` | pattern ` + "`" + `GET <field_1> 500` + "`" + ` | keep field_1 | line_format ""`
+	doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query="+url.QueryEscape(logql)+"&start=1&end=2&limit=10")
+
+	want := `app:=web ~"GET .* 500" | extract ` + "`" + `GET <field_1> 500` + "`" + ` | fields _time, _msg, _stream, field_1 | format "" | sort by (_time desc)`
+	if receivedQuery != want {
+		t.Fatalf("expected translated drilldown pattern query,\n got: %q\nwant: %q", receivedQuery, want)
+	}
+}
+
 func TestTranslation_DottedLabelFilterTripletForwarded(t *testing.T) {
 	var receivedQuery string
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -67,6 +67,16 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 			want:  `(service_name:=auth OR "service.name":=auth OR service:=auth OR app:=auth OR application:=auth OR app_name:=auth OR name:=auth OR app_kubernetes_io_name:=auth OR container:=auth OR container_name:=auth OR "k8s.container.name":=auth OR k8s_container_name:=auth OR component:=auth OR workload:=auth OR job:=auth OR "k8s.job.name":=auth OR k8s_job_name:=auth) ~"error"`,
 		},
 		{
+			name:  "pattern include filter expands placeholder span",
+			logql: `{app="api"} |> "GET <_> 500"`,
+			want:  `app:=api ~"GET .* 500"`,
+		},
+		{
+			name:  "pattern exclude filter expands placeholder span",
+			logql: "{app=\"api\"} !> `GET <_> 500`",
+			want:  `app:=api NOT ~"GET .* 500"`,
+		},
+		{
 			name:  "backtick regex matcher",
 			logql: "{service_name=~`auth.*`}",
 			want:  `(service_name:~"auth.*" OR "service.name":~"auth.*" OR service:~"auth.*" OR app:~"auth.*" OR application:~"auth.*" OR app_name:~"auth.*" OR name:~"auth.*" OR app_kubernetes_io_name:~"auth.*" OR container:~"auth.*" OR container_name:~"auth.*" OR "k8s.container.name":~"auth.*" OR k8s_container_name:~"auth.*" OR component:~"auth.*" OR workload:~"auth.*" OR job:~"auth.*" OR "k8s.job.name":~"auth.*" OR k8s_job_name:~"auth.*")`,

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -215,6 +215,22 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 			remaining = rest
 			continue
 		}
+		if strings.HasPrefix(remaining, "|> ") || strings.HasPrefix(remaining, "|>\"") || strings.HasPrefix(remaining, "|>`") {
+			// Pattern match filter: |> "<_> foo" → ~".* foo"
+			remaining = strings.TrimSpace(remaining[2:])
+			val, rest := extractQuotedValue(remaining)
+			parts = append(parts, "~"+translatePatternMatchValue(val))
+			remaining = rest
+			continue
+		}
+		if strings.HasPrefix(remaining, "!> ") || strings.HasPrefix(remaining, "!>\"") || strings.HasPrefix(remaining, "!>`") {
+			// Negative pattern match filter: !> "<_> foo" → NOT ~"..."
+			remaining = strings.TrimSpace(remaining[2:])
+			val, rest := extractQuotedValue(remaining)
+			parts = append(parts, "NOT ~"+translatePatternMatchValue(val))
+			remaining = rest
+			continue
+		}
 
 		if !strings.HasPrefix(remaining, "|") {
 			// Might be bare text — treat as filter
@@ -396,6 +412,34 @@ func translateLabelFilter(stage string, labelFn LabelTranslateFunc) string {
 
 	// Unknown stage — pass through as-is with pipe
 	return "| " + stage
+}
+
+func translatePatternMatchValue(quoted string) string {
+	raw := strings.TrimSpace(quoted)
+	raw = strings.Trim(raw, "\"`")
+	if raw == "" {
+		return strconv.Quote("")
+	}
+
+	placeholderRe := regexp.MustCompile(`<[^>]+>`)
+	matches := placeholderRe.FindAllStringIndex(raw, -1)
+	if len(matches) == 0 {
+		return strconv.Quote(regexp.QuoteMeta(raw))
+	}
+
+	var b strings.Builder
+	last := 0
+	for _, match := range matches {
+		if match[0] > last {
+			b.WriteString(regexp.QuoteMeta(raw[last:match[0]]))
+		}
+		b.WriteString(".*")
+		last = match[1]
+	}
+	if last < len(raw) {
+		b.WriteString(regexp.QuoteMeta(raw[last:]))
+	}
+	return strconv.Quote(b.String())
 }
 
 func translateLogicalLabelFilterChain(stage string, labelFn LabelTranslateFunc) (string, bool) {


### PR DESCRIPTION
## Summary
- translate Loki pattern-match filters (`|>` and `!>`) into VictoriaLogs regex filters so Drilldown pattern stats and pattern-click queries compile correctly
- normalize `volume` and `volume_range` to accept both `start/end` and `from/to`, preserving dense bucket filling across long requested ranges
- add proxy-level regression coverage for pattern-click translation, `from/to` forwarding, and zero-filled volume buckets

## Testing
- go test ./internal/translator -count=1
- go test ./internal/proxy -count=1