### PR TITLE
proxy: improve drilldown density and peer cache visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- peer-cache/metrics: add configurable peer fetch timeout wiring (`peer-timeout`) and per-reason peer fetch error counters so peer cache failures are no longer a single opaque `errors_total` bucket.
+
+### Bug Fixes
+
+- drilldown: keep 7-day minute `volume_range` requests zero-filled beyond the old 10k-bucket ceiling, and make dense short-range patterns fan out enough to avoid the “one visible burst every ~40 minutes” sampling shape.
+
 ## [1.4.1] - 2026-04-16
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -107,6 +107,7 @@ extraArgs:
   # - route-aware policy in the proxy raises thresholds for metadata/control paths
   response-compression: "gzip"
   response-compression-min-bytes: "1024"
+  peer-timeout: "2s"
   peer-write-through: "true"
   peer-write-through-min-ttl: "30s"
   log-level: "info"
@@ -221,6 +222,7 @@ extraArgs:
   # alerts-backend: ""                          # optional /alerts passthrough backend
   # extra-label-fields: "service.name,host.name"
   # peer-auth-token: ""                         # token required for /_cache/get and /_cache/set peer calls
+  # peer-timeout: "2s"                          # timeout for peer-cache fetches to owner peers
   # peer-write-through: "true"                  # push eligible non-owner writes to owner peer
   # peer-write-through-min-ttl: "30s"           # only TTL >= threshold is pushed to owner peer
   # peer-hot-read-ahead-enabled: "false"        # bounded periodic prefetch from peer hot indexes

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -144,6 +144,7 @@ type proxyRuntimeConfig struct {
 	peerDiscovery                       string
 	peerDNS                             string
 	peerStatic                          string
+	peerTimeout                         time.Duration
 	peerAuthToken                       string
 	peerWriteThrough                    bool
 	peerWriteThroughMinTTL              time.Duration
@@ -462,6 +463,7 @@ func run(
 	peerDiscovery := fs.String("peer-discovery", "", `Peer discovery: "dns" (headless service) or "static" (comma-separated)`)
 	peerDNS := fs.String("peer-dns", "", `Headless service DNS name for peer discovery (e.g., "proxy-headless.ns.svc.cluster.local")`)
 	peerStatic := fs.String("peer-static", "", `Static peer list (e.g., "10.0.0.1:3100,10.0.0.2:3100")`)
+	peerTimeout := fs.Duration("peer-timeout", 2*time.Second, "Timeout for peer-cache fetch requests to owner peers")
 	peerAuthToken := fs.String("peer-auth-token", "", "Shared token required on /_cache/get and /_cache/set peer-cache requests when set")
 	peerWriteThrough := fs.Bool("peer-write-through", true, "Push cache writes from non-owner peers to owner peers for warmer distributed cache under skewed traffic")
 	peerWriteThroughMinTTL := fs.Duration("peer-write-through-min-ttl", 30*time.Second, "Minimum TTL eligible for peer owner write-through pushes")
@@ -641,6 +643,7 @@ func run(
 			peerDiscovery:                       *peerDiscovery,
 			peerDNS:                             *peerDNS,
 			peerStatic:                          *peerStatic,
+			peerTimeout:                         *peerTimeout,
 			peerAuthToken:                       *peerAuthToken,
 			peerWriteThrough:                    *peerWriteThrough,
 			peerWriteThroughMinTTL:              *peerWriteThroughMinTTL,
@@ -1357,6 +1360,7 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 			DNSName:                  cfg.peerDNS,
 			StaticPeers:              cfg.peerStatic,
 			Port:                     3100,
+			Timeout:                  cfg.peerTimeout,
 			AuthToken:                cfg.peerAuthToken,
 			WriteThrough:             cfg.peerWriteThrough,
 			WriteThroughMinTTL:       cfg.peerWriteThroughMinTTL,

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -946,6 +946,7 @@ func TestBuildProxyConfig(t *testing.T) {
 		peerSelf:                        "10.0.0.1:3100",
 		peerDiscovery:                   "static",
 		peerStatic:                      "10.0.0.2:3100,10.0.0.3:3100",
+		peerTimeout:                     7 * time.Second,
 		peerAuthToken:                   "peer-secret",
 	}
 
@@ -1079,6 +1080,9 @@ func TestBuildProxyConfig(t *testing.T) {
 	}
 	if got.PeerAuthToken != "peer-secret" {
 		t.Fatalf("unexpected peer auth token: %q", got.PeerAuthToken)
+	}
+	if got.PeerCache.RequestTimeout() != 7*time.Second {
+		t.Fatalf("unexpected peer cache timeout: %s", got.PeerCache.RequestTimeout())
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -574,6 +574,7 @@ Treat these as current implementation defaults, not stable configuration API. If
 | `-peer-discovery` | — | — | Peer discovery mode: `dns` or `static` |
 | `-peer-dns` | — | — | Headless service DNS name used when `-peer-discovery=dns` |
 | `-peer-static` | — | — | Comma-separated peer list used when `-peer-discovery=static` |
+| `-peer-timeout` | — | `2s` | Timeout applied to peer-cache owner fetches (`/_cache/get`) before falling back locally |
 | `-peer-auth-token` | — | — | Shared token required on `/_cache/get` and `/_cache/set` peer-cache requests when set |
 | `-peer-write-through` | — | `true` | Push eligible non-owner cache writes to the owner peer (`/_cache/set`) to keep owner shards warm under skewed traffic |
 | `-peer-write-through-min-ttl` | — | `30s` | Minimum TTL required to push a write-through copy to the owner peer |
@@ -593,6 +594,7 @@ Peer-cache notes:
 
 - the Helm chart manages `-peer-self`, `-peer-discovery`, and `-peer-dns` automatically when `peerCache.enabled=true`
 - peer-cache fetches preserve owner TTL and can compress larger `/_cache/get` responses with `zstd` or `gzip`
+- `loki_vl_proxy_peer_cache_error_reason_total{reason=...}` breaks opaque peer fetch failures into low-cardinality reasons like `timeout`, `transport`, `status_502`, `body_read`, and `decode`
 - with `-peer-write-through=true` (default), non-owner writes with TTL above threshold are pushed to owners and stored locally as short-lived shadows to reduce hot-pod disk skew
 - when `-peer-auth-token` is set, all peers must share the same token or peer-cache reuse will fail closed
 

--- a/internal/cache/peer.go
+++ b/internal/cache/peer.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -81,6 +82,9 @@ type PeerCache struct {
 
 	// Singleflight to prevent cache stampede
 	inflight sync.Map // key → *inflightEntry
+
+	// Low-cardinality fetch error reasons for observability.
+	peerErrorReasons sync.Map // string → *atomic.Int64
 
 	// Stats
 	PeerHits   atomic.Int64
@@ -295,6 +299,7 @@ func (pc *PeerCache) Get(key string) ([]byte, time.Duration, bool) {
 	}
 
 	if !pc.peerAllowed(owner) {
+		pc.RecordPeerErrorReason("breaker_open")
 		pc.PeerErrors.Add(1)
 		return nil, 0, false
 	}
@@ -325,6 +330,7 @@ func (pc *PeerCache) Get(key string) ([]byte, time.Duration, bool) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		pc.recordPeerFailure(owner)
+		pc.RecordPeerErrorReason("request_build")
 		pc.PeerErrors.Add(1)
 		return nil, 0, false
 	}
@@ -336,6 +342,7 @@ func (pc *PeerCache) Get(key string) ([]byte, time.Duration, bool) {
 	resp, err := pc.client.Do(req)
 	if err != nil {
 		pc.recordPeerFailure(owner)
+		pc.RecordPeerErrorReason(classifyPeerFetchError(err))
 		pc.PeerErrors.Add(1)
 		return nil, 0, false
 	}
@@ -349,6 +356,7 @@ func (pc *PeerCache) Get(key string) ([]byte, time.Duration, bool) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		pc.recordPeerFailure(owner)
+		pc.RecordPeerErrorReason(peerStatusReason(resp.StatusCode))
 		pc.PeerErrors.Add(1)
 		return nil, 0, false
 	}
@@ -356,12 +364,14 @@ func (pc *PeerCache) Get(key string) ([]byte, time.Duration, bool) {
 	body, err := readPeerBodyLimited(resp.Body, maxPeerResponseBytes)
 	if err != nil {
 		pc.recordPeerFailure(owner)
+		pc.RecordPeerErrorReason("body_read")
 		pc.PeerErrors.Add(1)
 		return nil, 0, false
 	}
 	body, err = decodePeerResponseBody(resp.Header.Get("Content-Encoding"), body, maxPeerDecodedBodyBytes)
 	if err != nil {
 		pc.recordPeerFailure(owner)
+		pc.RecordPeerErrorReason("decode")
 		pc.PeerErrors.Add(1)
 		return nil, 0, false
 	}
@@ -946,6 +956,14 @@ func (pc *PeerCache) WriteThroughEnabled() bool {
 	return pc != nil && pc.writeThrough
 }
 
+// RequestTimeout reports the timeout used for peer-cache HTTP fetches.
+func (pc *PeerCache) RequestTimeout() time.Duration {
+	if pc == nil || pc.client == nil {
+		return 0
+	}
+	return pc.client.Timeout
+}
+
 // Close stops the discovery loop.
 func (pc *PeerCache) Close() {
 	select {
@@ -958,19 +976,51 @@ func (pc *PeerCache) Close() {
 // Stats returns peer cache statistics.
 func (pc *PeerCache) Stats() map[string]interface{} {
 	return map[string]interface{}{
-		"peers":             pc.PeerCount(),
-		"peer_hits":         pc.PeerHits.Load(),
-		"peer_misses":       pc.PeerMisses.Load(),
-		"peer_errors":       pc.PeerErrors.Load(),
-		"wt_pushes":         pc.WTPushes.Load(),
-		"wt_errors":         pc.WTErrors.Load(),
-		"ra_hot_requests":   pc.RAHotReq.Load(),
-		"ra_hot_errors":     pc.RAHotErr.Load(),
-		"ra_prefetches":     pc.RAPrefetch.Load(),
-		"ra_prefetch_bytes": pc.RABytes.Load(),
-		"ra_budget_drops":   pc.RABudget.Load(),
-		"ra_tenant_skips":   pc.RATenant.Load(),
+		"peers":              pc.PeerCount(),
+		"peer_hits":          pc.PeerHits.Load(),
+		"peer_misses":        pc.PeerMisses.Load(),
+		"peer_errors":        pc.PeerErrors.Load(),
+		"peer_error_reasons": pc.PeerErrorReasons(),
+		"wt_pushes":          pc.WTPushes.Load(),
+		"wt_errors":          pc.WTErrors.Load(),
+		"ra_hot_requests":    pc.RAHotReq.Load(),
+		"ra_hot_errors":      pc.RAHotErr.Load(),
+		"ra_prefetches":      pc.RAPrefetch.Load(),
+		"ra_prefetch_bytes":  pc.RABytes.Load(),
+		"ra_budget_drops":    pc.RABudget.Load(),
+		"ra_tenant_skips":    pc.RATenant.Load(),
 	}
+}
+
+// RecordPeerErrorReason increments a low-cardinality peer fetch failure reason.
+func (pc *PeerCache) RecordPeerErrorReason(reason string) {
+	reason = strings.TrimSpace(reason)
+	if pc == nil || reason == "" {
+		return
+	}
+	counter, _ := pc.peerErrorReasons.LoadOrStore(reason, &atomic.Int64{})
+	counter.(*atomic.Int64).Add(1)
+}
+
+// PeerErrorReasons returns a stable snapshot of peer fetch failure reasons.
+func (pc *PeerCache) PeerErrorReasons() map[string]int64 {
+	if pc == nil {
+		return nil
+	}
+	out := map[string]int64{}
+	pc.peerErrorReasons.Range(func(key, value any) bool {
+		reason, ok := key.(string)
+		if !ok || reason == "" {
+			return true
+		}
+		counter, ok := value.(*atomic.Int64)
+		if !ok {
+			return true
+		}
+		out[reason] = counter.Load()
+		return true
+	})
+	return out
 }
 
 // MetricsJSON returns stats as JSON bytes.
@@ -990,6 +1040,24 @@ func (pc *PeerCache) updatePeers(peers []string) {
 		pc.ring.add(p)
 	}
 	pc.log.Info("peer cache updated", "peers", len(peers), "self", pc.selfAddr)
+}
+
+func classifyPeerFetchError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	return "transport"
+}
+
+func peerStatusReason(statusCode int) string {
+	return "status_" + strconv.Itoa(statusCode)
 }
 
 func (pc *PeerCache) discoveryLoop() {

--- a/internal/cache/peer_test.go
+++ b/internal/cache/peer_test.go
@@ -424,6 +424,80 @@ func TestPeerCache_Get_DecodesCompressedPeerPayload(t *testing.T) {
 	t.Fatal("no key mapped to peer")
 }
 
+func TestPeerCache_Get_RecordsTimeoutReason(t *testing.T) {
+	peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(40 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer peerServer.Close()
+
+	pc := NewPeerCache(PeerConfig{
+		SelfAddr:      "self:3100",
+		DiscoveryType: "static",
+		StaticPeers:   peerServer.Listener.Addr().String(),
+		Timeout:       10 * time.Millisecond,
+	})
+	defer pc.Close()
+
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("timeout-key-%d", i)
+		pc.mu.RLock()
+		owner := pc.ring.get(key)
+		pc.mu.RUnlock()
+		if owner != peerServer.Listener.Addr().String() {
+			continue
+		}
+		if value, _, ok := pc.Get(key); ok || value != nil {
+			t.Fatalf("expected timeout miss for key %q", key)
+		}
+		if got := pc.PeerErrorReasons()["timeout"]; got != 1 {
+			t.Fatalf("expected timeout reason count 1, got %d", got)
+		}
+		if got := pc.PeerErrors.Load(); got != 1 {
+			t.Fatalf("expected peer error count 1, got %d", got)
+		}
+		return
+	}
+	t.Fatal("no key mapped to peer")
+}
+
+func TestPeerCache_Get_RecordsStatusReason(t *testing.T) {
+	peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream boom", http.StatusBadGateway)
+	}))
+	defer peerServer.Close()
+
+	pc := NewPeerCache(PeerConfig{
+		SelfAddr:      "self:3100",
+		DiscoveryType: "static",
+		StaticPeers:   peerServer.Listener.Addr().String(),
+		Timeout:       2 * time.Second,
+	})
+	defer pc.Close()
+
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("status-key-%d", i)
+		pc.mu.RLock()
+		owner := pc.ring.get(key)
+		pc.mu.RUnlock()
+		if owner != peerServer.Listener.Addr().String() {
+			continue
+		}
+		if value, _, ok := pc.Get(key); ok || value != nil {
+			t.Fatalf("expected status miss for key %q", key)
+		}
+		reasons := pc.PeerErrorReasons()
+		if got := reasons["status_502"]; got != 1 {
+			t.Fatalf("expected status_502 reason count 1, got %d (%v)", got, reasons)
+		}
+		if got := pc.PeerErrors.Load(); got != 1 {
+			t.Fatalf("expected peer error count 1, got %d", got)
+		}
+		return
+	}
+	t.Fatal("no key mapped to peer")
+}
+
 func TestPeerCache_ShadowCopy_ShortTTL(t *testing.T) {
 	// Verify that L3 hits get stored in L1 with shadow TTL (≤30s)
 	peerCache := New(60*time.Second, 1000)

--- a/internal/proxy/gaps_test.go
+++ b/internal/proxy/gaps_test.go
@@ -300,6 +300,44 @@ func TestGap_VolumeRange_AcceptsFromToParams(t *testing.T) {
 	}
 }
 
+func TestGap_VolumeRange_FillsSevenDayMinuteRangePastLegacyBucketCap(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"app": "nginx"},
+					"timestamps": []string{"2026-04-16T00:00:00Z"},
+					"values":     []int{7},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume_range?query=%7B%7D&start=2026-04-09T00:00:00Z&end=2026-04-16T00:00:00Z&step=60", nil)
+	p.handleVolumeRange(w, r)
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	result := data["result"].([]interface{})
+	if len(result) != 1 {
+		t.Fatalf("expected single series, got %d", len(result))
+	}
+	entry := result[0].(map[string]interface{})
+	values := entry["values"].([]interface{})
+	if len(values) != 10081 {
+		t.Fatalf("expected fully filled 7d minute range with 10081 buckets, got %d", len(values))
+	}
+	first := values[0].([]interface{})
+	last := values[len(values)-1].([]interface{})
+	if first[1] != "0" || last[1] != "7" {
+		t.Fatalf("expected zero-filled leading buckets and retained trailing hit, got first=%v last=%v", first, last)
+	}
+}
+
 // =============================================================================
 // Gap #4: /loki/api/v1/detected_field/{name}/values — missing endpoint
 // Loki response: {"values":["debug","info","warn","error"],"limit":1000}

--- a/internal/proxy/metrics_route_test.go
+++ b/internal/proxy/metrics_route_test.go
@@ -21,6 +21,7 @@ func TestMetricsRoute_ExportsPeerCacheMetrics(t *testing.T) {
 	pc.PeerHits.Add(3)
 	pc.PeerMisses.Add(2)
 	pc.PeerErrors.Add(1)
+	pc.RecordPeerErrorReason("timeout")
 
 	p, err := New(Config{
 		BackendURL: "http://unused",
@@ -49,6 +50,7 @@ func TestMetricsRoute_ExportsPeerCacheMetrics(t *testing.T) {
 		"loki_vl_proxy_peer_cache_hits_total 3",
 		"loki_vl_proxy_peer_cache_misses_total 2",
 		"loki_vl_proxy_peer_cache_errors_total 1",
+		"loki_vl_proxy_peer_cache_error_reason_total{reason=\"timeout\"} 1",
 	} {
 		if !strings.Contains(body, metric) {
 			t.Fatalf("expected %q in metrics output\nbody:\n%s", metric, body)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -530,7 +530,7 @@ const (
 	maxQueryLength = 65536 // 64KB
 	// maxLimitValue caps the number of results per query.
 	maxLimitValue                     = 10000
-	maxZeroFillBuckets                = 10000
+	maxZeroFillBuckets                = 32768
 	maxPatternBackendQueryLimit       = 20000
 	maxUserDrivenSlicePrealloc        = 512
 	tailWriteTimeout                  = 2 * time.Second
@@ -1973,6 +1973,7 @@ func (p *Proxy) peerCacheMetrics() string {
 	hits, _ := stats["peer_hits"].(int64)
 	misses, _ := stats["peer_misses"].(int64)
 	errors, _ := stats["peer_errors"].(int64)
+	errorReasons, _ := stats["peer_error_reasons"].(map[string]int64)
 	wtPushes, _ := stats["wt_pushes"].(int64)
 	wtErrors, _ := stats["wt_errors"].(int64)
 	raHotRequests, _ := stats["ra_hot_requests"].(int64)
@@ -1982,6 +1983,19 @@ func (p *Proxy) peerCacheMetrics() string {
 	raBudgetDrops, _ := stats["ra_budget_drops"].(int64)
 	raTenantSkips, _ := stats["ra_tenant_skips"].(int64)
 	clusterMembers := len(p.peerCache.Peers())
+	var reasonLines strings.Builder
+	if len(errorReasons) > 0 {
+		reasons := make([]string, 0, len(errorReasons))
+		for reason := range errorReasons {
+			reasons = append(reasons, reason)
+		}
+		sort.Strings(reasons)
+		reasonLines.WriteString("# HELP loki_vl_proxy_peer_cache_error_reason_total Peer-cache fetch errors by reason.\n")
+		reasonLines.WriteString("# TYPE loki_vl_proxy_peer_cache_error_reason_total counter\n")
+		for _, reason := range reasons {
+			fmt.Fprintf(&reasonLines, "loki_vl_proxy_peer_cache_error_reason_total{reason=%q} %d\n", reason, errorReasons[reason])
+		}
+	}
 
 	return fmt.Sprintf(
 		"# HELP loki_vl_proxy_peer_cache_peers Number of remote peers currently in the fleet cache ring.\n"+
@@ -1999,6 +2013,7 @@ func (p *Proxy) peerCacheMetrics() string {
 			"# HELP loki_vl_proxy_peer_cache_errors_total Peer-cache fetch errors.\n"+
 			"# TYPE loki_vl_proxy_peer_cache_errors_total counter\n"+
 			"loki_vl_proxy_peer_cache_errors_total %d\n"+
+			"%s"+
 			"# HELP loki_vl_proxy_peer_cache_write_through_pushes_total Successful owner write-through pushes from non-owner peers.\n"+
 			"# TYPE loki_vl_proxy_peer_cache_write_through_pushes_total counter\n"+
 			"loki_vl_proxy_peer_cache_write_through_pushes_total %d\n"+
@@ -2023,7 +2038,7 @@ func (p *Proxy) peerCacheMetrics() string {
 			"# HELP loki_vl_proxy_peer_cache_read_ahead_tenant_skips_total Hot read-ahead candidates skipped by tenant fairness pass.\n"+
 			"# TYPE loki_vl_proxy_peer_cache_read_ahead_tenant_skips_total counter\n"+
 			"loki_vl_proxy_peer_cache_read_ahead_tenant_skips_total %d\n",
-		remotePeers, clusterMembers, hits, misses, errors, wtPushes, wtErrors, raHotRequests, raHotErrors, raPrefetches, raPrefetchBytes, raBudgetDrops, raTenantSkips,
+		remotePeers, clusterMembers, hits, misses, errors, reasonLines.String(), wtPushes, wtErrors, raHotRequests, raHotErrors, raPrefetches, raPrefetchBytes, raBudgetDrops, raTenantSkips,
 	)
 }
 
@@ -5291,6 +5306,8 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 	minWindowSourceLimit := 200
 	maxWindowSourceLimit := 1_000
 	maxPatternWindowSamples := 96
+	shortDenseSpanThreshold := 6 * time.Hour
+	shortDenseWindowCap := 96
 	if denseWindowing {
 		// Dense ranges can otherwise explode into hundreds of windows and produce
 		// short/unstable tails under backend pressure. Keep fanout bounded.
@@ -5309,8 +5326,21 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 	}
 
 	windowCount := int(span/targetWindowSpan) + 1
+	stepSeconds := parsePatternStepSeconds(stepParam)
+	if denseWindowing && stepSeconds > 0 && span <= shortDenseSpanThreshold {
+		stepNs := stepSeconds * int64(time.Second)
+		if stepNs > 0 {
+			stepBasedCount := int(((endNs - startNs) / stepNs) + 1)
+			if stepBasedCount > windowCount {
+				windowCount = stepBasedCount
+			}
+		}
+		if windowCount > shortDenseWindowCap {
+			windowCount = shortDenseWindowCap
+		}
+	}
 	if !denseWindowing {
-		if stepSeconds := parsePatternStepSeconds(stepParam); stepSeconds > 0 {
+		if stepSeconds > 0 {
 			stepNs := stepSeconds * int64(time.Second)
 			if stepNs > 0 {
 				stepBasedCount := int(((endNs - startNs) / stepNs) + 1)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1701,6 +1701,75 @@ func TestContract_Patterns_FillsSamplesAcrossRelativeNowRange(t *testing.T) {
 	}
 }
 
+func TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("expected dense patterns to query /select/logsql/query, got %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		endNs, err := strconv.ParseInt(r.FormValue("end"), 10, 64)
+		if err != nil {
+			t.Fatalf("parse window end: %v", err)
+		}
+		ts := time.Unix(0, endNs).Add(-time.Second).UTC().Format(time.RFC3339)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintf(w, `{"_time":"%s","_msg":"GET /api/users 200 15ms","app":"web","level":"info"}`+"\n", ts)
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	p.backendSupportsDensePatternWindowing = true
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=2026-04-04T10:00:00Z&end=2026-04-04T13:00:00Z&step=90s&limit=1",
+		nil,
+	)
+	req = req.WithContext(context.WithValue(req.Context(), requestGrafanaClientKey, grafanaClientProfile{
+		surface:      "grafana_drilldown",
+		runtimeMajor: 12,
+	}))
+	p.handlePatterns(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp patternsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected one pattern, got %+v", resp.Data)
+	}
+
+	nonZeroBuckets := 0
+	lastNonZeroTS := int64(-1)
+	maxGap := int64(0)
+	for _, sample := range resp.Data[0].Samples {
+		if len(sample) < 2 {
+			continue
+		}
+		ts, okTS := numberToInt64(sample[0])
+		count, okCount := numberToInt(sample[1])
+		if !okTS || !okCount || count <= 0 {
+			continue
+		}
+		nonZeroBuckets++
+		if lastNonZeroTS >= 0 && ts-lastNonZeroTS > maxGap {
+			maxGap = ts - lastNonZeroTS
+		}
+		lastNonZeroTS = ts
+	}
+	if nonZeroBuckets < 20 {
+		t.Fatalf("expected dense short-range sampling to populate many non-zero buckets, got %d from %+v", nonZeroBuckets, resp.Data[0].Samples)
+	}
+	if maxGap > int64((10*time.Minute)/time.Second) {
+		t.Fatalf("expected dense short-range sampling gaps <=10m, got max gap %ds", maxGap)
+	}
+}
+
 func TestContract_Patterns_FillCoarsensHugePointRanges(t *testing.T) {
 	entries := []patternResultEntry{
 		{
@@ -2146,6 +2215,27 @@ func TestPatternWindowedSamplingConfig_DenseIgnoresStepInflationAndCapsFanout(t 
 	}
 	if perWindowA < 200 {
 		t.Fatalf("expected dense mode per-window lower bound >=200, got %d", perWindowA)
+	}
+}
+
+func TestPatternWindowedSamplingConfig_DenseShortRangeUsesStepToIncreaseFanout(t *testing.T) {
+	start := strconv.FormatInt(0, 10)
+	end := strconv.FormatInt(int64((3*time.Hour)/time.Second), 10)
+
+	_, _, interval, perWindow, ok := patternWindowedSamplingConfig(start, end, "90s", 2420, true)
+	if !ok {
+		t.Fatal("expected dense windowed config for short 3h range")
+	}
+	span := 3 * time.Hour
+	windowCount := int(span/interval) + 1
+	if windowCount < 20 {
+		t.Fatalf("expected short dense range to fan out beyond coarse 45m windows, got %d windows", windowCount)
+	}
+	if windowCount > 96 {
+		t.Fatalf("expected short dense range fanout capped at 96 windows, got %d", windowCount)
+	}
+	if perWindow < 200 {
+		t.Fatalf("expected short dense per-window lower bound >=200, got %d", perWindow)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add configurable peer cache fetch timeout wiring and per-reason peer fetch error metrics
- keep seven-day minute volume_range requests zero-filled past the old bucket ceiling
- increase dense short-range pattern fanout so drilldown patterns do not collapse into coarse periodic bursts

## Testing
- go test ./internal/cache ./internal/proxy ./cmd/proxy -count=1
- go test -race ./internal/cache ./internal/proxy ./cmd/proxy -count=1