### PR TITLE
test: raise Linux coverage to 90 percent

### DIFF
--- a/cmd/proxy/http_conn_rotation_coverage_test.go
+++ b/cmd/proxy/http_conn_rotation_coverage_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPConnRotator_HelperCoverage(t *testing.T) {
+	if rotator := newHTTPConnRotator(httpConnRotationConfig{}, nil, nil); rotator != nil {
+		t.Fatal("expected zero-value rotation config not to create a rotator")
+	}
+
+	rotator := newHTTPConnRotator(httpConnRotationConfig{
+		maxAge:         -time.Second,
+		maxAgeJitter:   -time.Second,
+		maxRequests:    3,
+		overloadMaxAge: -time.Second,
+	}, nil, nil)
+	if rotator == nil {
+		t.Fatal("expected non-zero config to create a rotator")
+	}
+	if rotator.cfg.maxAge != 0 || rotator.cfg.maxAgeJitter != 0 || rotator.cfg.overloadMaxAge != 0 {
+		t.Fatalf("expected negative durations to clamp to zero, got %+v", rotator.cfg)
+	}
+
+	if got := rotator.Wrap(nil); got != nil {
+		t.Fatalf("expected Wrap(nil) to return nil, got %#v", got)
+	}
+
+	var nilRotator *httpConnRotator
+	if got := nilRotator.ConnContextHook(); got != nil {
+		t.Fatal("expected nil rotator conn-context hook to be nil")
+	}
+
+	ageRotator := newHTTPConnRotator(httpConnRotationConfig{
+		maxAge:       time.Minute,
+		maxAgeJitter: time.Second,
+		maxRequests:  10,
+	}, nil, func() bool { return false })
+	if ageRotator == nil {
+		t.Fatal("expected age rotator")
+	}
+
+	connA, connB := net.Pipe()
+	defer func() { _ = connA.Close() }()
+	defer func() { _ = connB.Close() }()
+
+	ctx := ageRotator.ConnContextHook()(context.Background(), connA)
+	state, _ := ctx.Value(httpConnStateContextKey{}).(*httpConnState)
+	if state == nil {
+		t.Fatal("expected connection state in context")
+	}
+	if state.maxAge < 59*time.Second || state.maxAge > 61*time.Second {
+		t.Fatalf("unexpected jittered maxAge %s", state.maxAge)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.test/loki/api/v1/query_range", nil).WithContext(ctx)
+	req.ProtoMajor = 1
+	state.acceptedAt = time.Now().Add(-2 * time.Minute)
+	if reason := ageRotator.recordAndDecide(req, state, time.Now()); reason != "age" {
+		t.Fatalf("expected age-based rotation, got %q", reason)
+	}
+
+	req.Header.Set("Upgrade", "websocket")
+	if reason := ageRotator.recordAndDecide(req, state, time.Now()); reason != "" {
+		t.Fatalf("expected websocket upgrade to bypass rotation, got %q", reason)
+	}
+
+	if got := jitterDuration(5*time.Second, 0, connA, 1); got != 5*time.Second {
+		t.Fatalf("expected no-jitter duration to equal base, got %s", got)
+	}
+}

--- a/cmd/proxy/main_coverage_test.go
+++ b/cmd/proxy/main_coverage_test.go
@@ -1,0 +1,121 @@
+package main
+
+import "testing"
+
+func TestResponseCompressionHelpers(t *testing.T) {
+	t.Run("resolve response compression", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			explicit      string
+			legacyEnabled bool
+			want          string
+			wantErr       bool
+		}{
+			{name: "legacy auto", explicit: "", legacyEnabled: true, want: "auto"},
+			{name: "legacy disabled none", explicit: "", legacyEnabled: false, want: "none"},
+			{name: "explicit gzip", explicit: " gzip ", want: "gzip"},
+			{name: "explicit none", explicit: "none", want: "none"},
+			{name: "explicit zstd aliases to gzip", explicit: "zstd", want: "gzip"},
+			{name: "invalid explicit", explicit: "brotli", wantErr: true},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := resolveResponseCompression(tc.explicit, tc.legacyEnabled)
+				if tc.wantErr {
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.want {
+					t.Fatalf("resolveResponseCompression(%q, %v) = %q, want %q", tc.explicit, tc.legacyEnabled, got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("normalize frontend compression setting", func(t *testing.T) {
+		tests := []struct {
+			input   string
+			want    string
+			wantErr bool
+		}{
+			{input: "", want: "auto"},
+			{input: "AUTO", want: "auto"},
+			{input: "none", want: "none"},
+			{input: "gzip", want: "gzip"},
+			{input: "zstd", want: "gzip"},
+			{input: "brotli", wantErr: true},
+		}
+		for _, tc := range tests {
+			got, err := normalizeFrontendCompressionSetting(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				continue
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeFrontendCompressionSetting(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("normalize backend compression setting", func(t *testing.T) {
+		tests := []struct {
+			input   string
+			want    string
+			wantErr bool
+		}{
+			{input: "", want: "auto"},
+			{input: "auto", want: "auto"},
+			{input: "none", want: "none"},
+			{input: "gzip", want: "gzip"},
+			{input: "zstd", want: "zstd"},
+			{input: "brotli", wantErr: true},
+		}
+		for _, tc := range tests {
+			got, err := normalizeCompressionSetting(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				continue
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeCompressionSetting(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		}
+	})
+}
+
+func TestIsLoopbackListenAddr_AdditionalCoverage(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{addr: "localhost:3100", want: true},
+		{addr: "127.0.0.1:3100", want: true},
+		{addr: "[::1]:3100", want: true},
+		{addr: "0.0.0.0:3100", want: false},
+		{addr: "[2001:db8::1]:3100", want: false},
+		{addr: "example.com:3100", want: false},
+		{addr: "", want: false},
+		{addr: " :3100 ", want: false},
+	}
+
+	for _, tc := range tests {
+		if got := isLoopbackListenAddr(tc.addr); got != tc.want {
+			t.Fatalf("isLoopbackListenAddr(%q) = %v, want %v", tc.addr, got, tc.want)
+		}
+	}
+}

--- a/internal/cache/cache_hot_coverage_test.go
+++ b/internal/cache/cache_hot_coverage_test.go
@@ -1,0 +1,109 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheHotHelpers_PruneAndTopHotKeys(t *testing.T) {
+	c := &Cache{
+		entries: map[string]entry{
+			"query_range:tenant-a:key-hot": {
+				value:     []byte("abcd"),
+				expiresAt: time.Now().Add(3 * time.Minute),
+				sizeBytes: 4,
+			},
+			"query_range:tenant-b:key-other": {
+				value:     []byte("abcdefgh"),
+				expiresAt: time.Now().Add(2 * time.Minute),
+				sizeBytes: 8,
+			},
+			"query_range:tenant-c:key-short": {
+				value:     []byte("abc"),
+				expiresAt: time.Now().Add(15 * time.Second),
+				sizeBytes: 3,
+			},
+		},
+		hot: map[string]hotStat{
+			"query_range:tenant-a:key-hot":   {score: 5, lastAccess: 30, tenant: "tenant-a"},
+			"query_range:tenant-b:key-other": {score: 2, lastAccess: 10, tenant: "tenant-b"},
+			"query_range:tenant-c:key-short": {score: 2, lastAccess: 5, tenant: "tenant-c"},
+			"query_range:tenant-missing:key": {score: 9, lastAccess: 100, tenant: "tenant-missing"},
+		},
+		hotOn: true,
+	}
+
+	hot := c.TopHotKeys(10, 30*time.Second, 6)
+	if len(hot) != 1 {
+		t.Fatalf("expected only one hot key after TTL and size filters, got %#v", hot)
+	}
+	if hot[0].Key != "query_range:tenant-a:key-hot" || hot[0].Tenant != "tenant-a" || hot[0].Score != 5 {
+		t.Fatalf("unexpected hot key snapshot: %#v", hot[0])
+	}
+
+	c.pruneHotLocked(2)
+	if _, ok := c.hot["query_range:tenant-c:key-short"]; ok {
+		t.Fatalf("expected oldest lowest-score key to be pruned")
+	}
+	if _, ok := c.hot["query_range:tenant-b:key-other"]; ok {
+		t.Fatalf("expected second-lowest-score key to be pruned")
+	}
+	if _, ok := c.hot["query_range:tenant-a:key-hot"]; !ok {
+		t.Fatalf("expected hottest key to remain after prune")
+	}
+}
+
+func TestCacheHotHelpers_RecordHotLockedAssignsTenant(t *testing.T) {
+	c := &Cache{
+		hot:    map[string]hotStat{},
+		hotMax: 2,
+	}
+
+	c.recordHotLocked("query_range:tenant-a:key-1")
+	c.recordHotLocked("query_range:tenant-b:key-2")
+	c.recordHotLocked("query_range:tenant-a:key-1")
+
+	stat := c.hot["query_range:tenant-a:key-1"]
+	if stat.score != 2 {
+		t.Fatalf("expected score to increment, got %#v", stat)
+	}
+	if stat.tenant != "tenant-a" {
+		t.Fatalf("expected tenant derived from cache key, got %#v", stat)
+	}
+	if stat.lastAccess == 0 {
+		t.Fatalf("expected lastAccess to be recorded")
+	}
+}
+
+func TestTenantFromCacheKey_Variants(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "internal key", key: "__meta:ignored", want: ""},
+		{name: "malformed key", key: "query_range:tenant-only", want: ""},
+		{name: "supported prefix", key: "patterns:tenant-a:selector", want: "tenant-a"},
+		{name: "unsupported prefix", key: "custom:tenant-a:value", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tenantFromCacheKey(tt.key); got != tt.want {
+				t.Fatalf("tenantFromCacheKey(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCache_MaxEntrySizeBytesNilAndZero(t *testing.T) {
+	var nilCache *Cache
+	if got := nilCache.MaxEntrySizeBytes(); got != 0 {
+		t.Fatalf("expected nil cache max entry size to be 0, got %d", got)
+	}
+
+	zero := &Cache{}
+	if got := zero.MaxEntrySizeBytes(); got != 0 {
+		t.Fatalf("expected zero-byte cache max entry size to be 0, got %d", got)
+	}
+}

--- a/internal/cache/peer_coverage_test.go
+++ b/internal/cache/peer_coverage_test.go
@@ -1,0 +1,361 @@
+package cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return true }
+
+func decodeGzipPeerBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	gr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create gzip reader: %v", err)
+	}
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("read gzip body: %v", err)
+	}
+	return decoded
+}
+
+func TestPeerHelperFunctions(t *testing.T) {
+	t.Run("request timeout", func(t *testing.T) {
+		var pc *PeerCache
+		if got := pc.RequestTimeout(); got != 0 {
+			t.Fatalf("expected nil peer cache timeout 0, got %s", got)
+		}
+
+		pc = &PeerCache{}
+		if got := pc.RequestTimeout(); got != 0 {
+			t.Fatalf("expected nil client timeout 0, got %s", got)
+		}
+
+		pc = NewPeerCache(PeerConfig{SelfAddr: "self", Timeout: 3 * time.Second})
+		defer pc.Close()
+		if got := pc.RequestTimeout(); got != 3*time.Second {
+			t.Fatalf("expected request timeout 3s, got %s", got)
+		}
+	})
+
+	t.Run("classify peer fetch error", func(t *testing.T) {
+		if got := classifyPeerFetchError(nil); got != "" {
+			t.Fatalf("expected empty reason for nil error, got %q", got)
+		}
+		if got := classifyPeerFetchError(context.DeadlineExceeded); got != "timeout" {
+			t.Fatalf("expected deadline to map to timeout, got %q", got)
+		}
+		if got := classifyPeerFetchError(timeoutNetError{}); got != "timeout" {
+			t.Fatalf("expected timeout net error to map to timeout, got %q", got)
+		}
+		if got := classifyPeerFetchError(errors.New("boom")); got != "transport" {
+			t.Fatalf("expected generic error to map to transport, got %q", got)
+		}
+	})
+
+	t.Run("read peer body limited", func(t *testing.T) {
+		body, err := readPeerBodyLimited(strings.NewReader("hello"), 0)
+		if err != nil {
+			t.Fatalf("unexpected unlimited read error: %v", err)
+		}
+		if string(body) != "hello" {
+			t.Fatalf("unexpected unlimited body %q", string(body))
+		}
+
+		if _, err := readPeerBodyLimited(strings.NewReader("toolong"), 3); err == nil {
+			t.Fatal("expected limit error")
+		}
+	})
+
+	t.Run("decode peer response body", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		if _, err := zw.Write([]byte("hello")); err != nil {
+			t.Fatalf("write gzip payload: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("close gzip payload: %v", err)
+		}
+
+		decoded, err := decodePeerResponseBody("gzip", buf.Bytes(), 1024)
+		if err != nil {
+			t.Fatalf("decode gzip payload: %v", err)
+		}
+		if string(decoded) != "hello" {
+			t.Fatalf("unexpected decoded gzip payload %q", string(decoded))
+		}
+
+		identity, err := decodePeerResponseBody("br", []byte("raw"), 1024)
+		if err != nil {
+			t.Fatalf("unexpected unknown-encoding error: %v", err)
+		}
+		if string(identity) != "raw" {
+			t.Fatalf("unexpected unknown-encoding fallback %q", string(identity))
+		}
+
+		if _, err := decodePeerResponseBody("gzip", []byte("bad-gzip"), 1024); err == nil {
+			t.Fatal("expected invalid gzip to fail")
+		}
+	})
+}
+
+func TestWritePeerEncodedResponse_AdditionalCoverage(t *testing.T) {
+	t.Run("gzip branch", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/_cache/get?key=test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		payload := []byte(strings.Repeat("x", 2048))
+		writePeerEncodedResponse(recorder, req, payload)
+
+		if got := recorder.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Fatalf("expected gzip content encoding, got %q", got)
+		}
+		if got := decodeGzipPeerBody(t, recorder.Body.Bytes()); !bytes.Equal(got, payload) {
+			t.Fatalf("unexpected decoded payload len=%d want=%d", len(got), len(payload))
+		}
+	})
+
+	t.Run("identity fallback for small body", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/_cache/get?key=test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		writePeerEncodedResponse(recorder, req, []byte("tiny"))
+
+		if got := recorder.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("expected identity response, got %q", got)
+		}
+		if got := recorder.Body.String(); got != "tiny" {
+			t.Fatalf("unexpected identity body %q", got)
+		}
+	})
+}
+
+func TestPeerReadAheadHelpers(t *testing.T) {
+	pc := NewPeerCache(PeerConfig{
+		SelfAddr:              "self",
+		ReadAheadEnabled:      true,
+		ReadAheadInterval:     20 * time.Millisecond,
+		ReadAheadJitter:       10 * time.Millisecond,
+		ReadAheadErrorBackoff: 15 * time.Millisecond,
+	})
+	defer pc.Close()
+
+	noJitter := NewPeerCache(PeerConfig{
+		SelfAddr:          "self",
+		ReadAheadEnabled:  true,
+		ReadAheadInterval: 25 * time.Millisecond,
+	})
+	defer noJitter.Close()
+
+	if got := noJitter.nextReadAheadDelay(); got != 25*time.Millisecond {
+		t.Fatalf("expected exact interval without jitter, got %s", got)
+	}
+
+	if got := pc.nextReadAheadDelay(); got < 20*time.Millisecond || got > 30*time.Millisecond {
+		t.Fatalf("expected jittered delay in [20ms,30ms], got %s", got)
+	}
+
+	pc.readAheadErrorStreak.Store(7)
+	pc.readAheadBackoffUntilUnix.Store(time.Now().Add(time.Second).UnixNano())
+	pc.applyReadAheadBackoff(0)
+	if got := pc.readAheadErrorStreak.Load(); got != 0 {
+		t.Fatalf("expected streak reset, got %d", got)
+	}
+	if got := pc.readAheadBackoffUntilUnix.Load(); got != 0 {
+		t.Fatalf("expected backoff reset, got %d", got)
+	}
+
+	pc.applyReadAheadBackoff(1)
+	firstUntil := time.Unix(0, pc.readAheadBackoffUntilUnix.Load())
+	if time.Until(firstUntil) <= 0 {
+		t.Fatal("expected positive backoff window")
+	}
+	for range 5 {
+		pc.applyReadAheadBackoff(1)
+	}
+	if got := pc.readAheadErrorStreak.Load(); got < 2 {
+		t.Fatalf("expected error streak to increase, got %d", got)
+	}
+}
+
+func TestPeerCache_WriteThroughAndReadAheadBranches(t *testing.T) {
+	t.Run("set with ttl pushes to remote owner", func(t *testing.T) {
+		localCache := New(60*time.Second, 1000)
+		defer localCache.Close()
+
+		var pushedKey string
+		var pushedTTL string
+		var pushedBody []byte
+		peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pushedKey = r.URL.Query().Get("key")
+			pushedTTL = r.URL.Query().Get("ttl_ms")
+			pushedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer peerServer.Close()
+
+		pc := NewPeerCache(PeerConfig{
+			SelfAddr:           "self:3100",
+			DiscoveryType:      "static",
+			StaticPeers:        peerServer.Listener.Addr().String(),
+			Timeout:            time.Second,
+			WriteThrough:       true,
+			WriteThroughMinTTL: 10 * time.Second,
+		})
+		defer pc.Close()
+		localCache.SetL3(pc)
+
+		var targetKey string
+		for i := 0; i < 100; i++ {
+			key := "write-through-key-" + strconv.Itoa(i)
+			pc.mu.RLock()
+			owner := pc.ring.get(key)
+			pc.mu.RUnlock()
+			if owner == peerServer.Listener.Addr().String() {
+				targetKey = key
+				break
+			}
+		}
+		if targetKey == "" {
+			t.Fatal("no key mapped to peer")
+		}
+
+		localCache.SetWithTTL(targetKey, []byte("payload"), 30*time.Second)
+		requireEventually(t, time.Second, func() bool { return pushedKey == targetKey })
+
+		if string(pushedBody) != "payload" {
+			t.Fatalf("unexpected pushed body %q", string(pushedBody))
+		}
+		if pushedTTL != "30000" {
+			t.Fatalf("unexpected pushed ttl %q", pushedTTL)
+		}
+		if got := pc.WTPushes.Load(); got != 1 {
+			t.Fatalf("expected write-through push count 1, got %d", got)
+		}
+	})
+
+	t.Run("prefetch hot key additional branches", func(t *testing.T) {
+		pc := NewPeerCache(PeerConfig{
+			SelfAddr:                "self",
+			ReadAheadEnabled:        true,
+			ReadAheadMinTTL:         10 * time.Second,
+			ReadAheadMaxObjectBytes: 4,
+		})
+		defer pc.Close()
+
+		if pc.prefetchHotKey(nil, hotIndexEntry{Key: "k"}) {
+			t.Fatal("expected nil local cache to fail")
+		}
+		local := New(60*time.Second, 1000)
+		defer local.Close()
+		local.SetWithTTL("warm", []byte("ok"), 30*time.Second)
+		if !pc.prefetchHotKey(local, hotIndexEntry{Key: "warm"}) {
+			t.Fatal("expected already-warm local key to succeed")
+		}
+	})
+
+	t.Run("select read ahead candidates enforces tenant fairness and size budget", func(t *testing.T) {
+		pc := NewPeerCache(PeerConfig{
+			SelfAddr:                 "self",
+			ReadAheadEnabled:         true,
+			ReadAheadMaxKeys:         2,
+			ReadAheadMaxBytes:        10,
+			ReadAheadTenantFairShare: 50,
+			ReadAheadMinTTL:          time.Second,
+		})
+		defer pc.Close()
+
+		selected := pc.selectReadAheadCandidates([]hotIndexEntry{
+			{Key: "a", Tenant: "tenant-a", Score: 9, SizeBytes: 3, RemainingTTLMS: 20_000},
+			{Key: "b", Tenant: "tenant-a", Score: 8, SizeBytes: 3, RemainingTTLMS: 20_000},
+			{Key: "c", Tenant: "tenant-b", Score: 7, SizeBytes: 20, RemainingTTLMS: 20_000},
+			{Key: "d", Tenant: "tenant-b", Score: 6, SizeBytes: 3, RemainingTTLMS: 20_000},
+		})
+
+		if len(selected) != 2 {
+			t.Fatalf("expected 2 selected keys, got %d", len(selected))
+		}
+		if selected[0].Key != "a" || selected[1].Key != "d" {
+			t.Fatalf("unexpected selected keys %+v", selected)
+		}
+		if got := pc.RATenant.Load(); got == 0 {
+			t.Fatal("expected tenant fairness counter to increase")
+		}
+		if got := pc.RABudget.Load(); got == 0 {
+			t.Fatal("expected budget counter to increase")
+		}
+	})
+}
+
+func TestFetchPeerHotIndex_FailurePaths(t *testing.T) {
+	t.Run("status error", func(t *testing.T) {
+		peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusBadGateway)
+		}))
+		defer peerServer.Close()
+
+		pc := NewPeerCache(PeerConfig{SelfAddr: "self", Timeout: time.Second})
+		defer pc.Close()
+
+		if _, err := pc.fetchPeerHotIndex(peerServer.Listener.Addr().String(), 10); err == nil {
+			t.Fatal("expected fetchPeerHotIndex to fail on 502")
+		}
+		breaker, ok := pc.breakers.Load(peerServer.Listener.Addr().String())
+		if !ok {
+			t.Fatal("expected peer breaker to be created")
+		}
+		if got := breaker.(*peerBreaker).failures.Load(); got == 0 {
+			t.Fatal("expected breaker failures to increase")
+		}
+	})
+
+	t.Run("decode error", func(t *testing.T) {
+		peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Encoding", "gzip")
+			_, _ = w.Write([]byte("not-gzip"))
+		}))
+		defer peerServer.Close()
+
+		pc := NewPeerCache(PeerConfig{SelfAddr: "self", Timeout: time.Second})
+		defer pc.Close()
+
+		if _, err := pc.fetchPeerHotIndex(peerServer.Listener.Addr().String(), 10); err == nil {
+			t.Fatal("expected fetchPeerHotIndex to fail on decode error")
+		}
+	})
+}
+
+func TestPeerServeHTTP_AdditionalBranches(t *testing.T) {
+	localCache := New(60*time.Second, 1000)
+	defer localCache.Close()
+	pc := NewPeerCache(PeerConfig{SelfAddr: "self"})
+	defer pc.Close()
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/_cache/get?key=test", nil)
+	pc.ServeHTTP(recorder, req, localCache)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for unsupported method, got %d", recorder.Code)
+	}
+	if got := recorder.Header().Get("Allow"); got != "GET, POST" {
+		t.Fatalf("unexpected Allow header %q", got)
+	}
+}

--- a/internal/cache/peer_coverage_test.go
+++ b/internal/cache/peer_coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -201,13 +202,24 @@ func TestPeerCache_WriteThroughAndReadAheadBranches(t *testing.T) {
 		localCache := New(60*time.Second, 1000)
 		defer localCache.Close()
 
-		var pushedKey string
-		var pushedTTL string
-		var pushedBody []byte
+		type pushResult struct {
+			key  string
+			ttl  string
+			body []byte
+		}
+		var (
+			mu     sync.Mutex
+			pushed pushResult
+		)
 		peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			pushedKey = r.URL.Query().Get("key")
-			pushedTTL = r.URL.Query().Get("ttl_ms")
-			pushedBody, _ = io.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			pushed = pushResult{
+				key:  r.URL.Query().Get("key"),
+				ttl:  r.URL.Query().Get("ttl_ms"),
+				body: append([]byte(nil), body...),
+			}
+			mu.Unlock()
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer peerServer.Close()
@@ -239,13 +251,20 @@ func TestPeerCache_WriteThroughAndReadAheadBranches(t *testing.T) {
 		}
 
 		localCache.SetWithTTL(targetKey, []byte("payload"), 30*time.Second)
-		requireEventually(t, time.Second, func() bool { return pushedKey == targetKey })
+		requireEventually(t, time.Second, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return pushed.key == targetKey
+		})
 
-		if string(pushedBody) != "payload" {
-			t.Fatalf("unexpected pushed body %q", string(pushedBody))
+		mu.Lock()
+		got := pushed
+		mu.Unlock()
+		if string(got.body) != "payload" {
+			t.Fatalf("unexpected pushed body %q", string(got.body))
 		}
-		if pushedTTL != "30000" {
-			t.Fatalf("unexpected pushed ttl %q", pushedTTL)
+		if got.ttl != "30000" {
+			t.Fatalf("unexpected pushed ttl %q", got.ttl)
 		}
 		if got := pc.WTPushes.Load(); got != 1 {
 			t.Fatalf("expected write-through push count 1, got %d", got)

--- a/internal/metrics/metrics_coverage_test.go
+++ b/internal/metrics/metrics_coverage_test.go
@@ -1,0 +1,133 @@
+package metrics
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type comparableHandler struct {
+	called *bool
+}
+
+func (h comparableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.called != nil {
+		*h.called = true
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func TestMetricsWrapHandler_TracksInflightRequests(t *testing.T) {
+	m := NewMetrics()
+	handler := m.WrapHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := m.activeRequests.Load(); got != 1 {
+			t.Fatalf("expected active request gauge 1 during handler execution, got %d", got)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("unexpected status %d", recorder.Code)
+	}
+	if got := m.activeRequests.Load(); got != 0 {
+		t.Fatalf("expected active request gauge reset to 0, got %d", got)
+	}
+	if got := m.WrapHandler(nil); got != nil {
+		t.Fatalf("expected nil handler to remain nil, got %#v", got)
+	}
+
+	var nilMetrics *Metrics
+	called := false
+	next := comparableHandler{called: &called}
+	got := nilMetrics.WrapHandler(next)
+	recorder = httptest.NewRecorder()
+	got.ServeHTTP(recorder, req)
+	if !called || recorder.Code != http.StatusNoContent {
+		t.Fatal("expected nil metrics wrapper to pass through to original handler")
+	}
+}
+
+func TestMetricsConnectionHelpers_AdditionalCoverage(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordActiveRequest(-2)
+	if got := m.activeRequests.Load(); got != 0 {
+		t.Fatalf("expected active requests to clamp at 0, got %d", got)
+	}
+
+	connA, connB := net.Pipe()
+	defer func() { _ = connA.Close() }()
+	defer func() { _ = connB.Close() }()
+
+	hook := m.ConnStateHook()
+	if hook == nil {
+		t.Fatal("expected non-nil conn state hook")
+	}
+	hook(connA, http.StateNew)
+	hook(connA, http.StateNew)
+	hook(connA, http.StateHijacked)
+
+	if got := m.connectionTransitionCounter("custom").Add(1); got != 1 {
+		t.Fatalf("expected dynamic transition counter to initialize, got %d", got)
+	}
+	if got := m.connectionStateGauge("custom").Add(2); got != 2 {
+		t.Fatalf("expected dynamic connection gauge to initialize, got %d", got)
+	}
+	m.RecordHTTPConnectionRotation("")
+	m.RecordHTTPConnectionRotation("manual")
+
+	if got := connStateLabel(http.ConnState(99)); got != "unknown" {
+		t.Fatalf("expected unknown conn state label, got %q", got)
+	}
+	if isLiveConnState("custom") {
+		t.Fatal("expected custom state not to be treated as live")
+	}
+}
+
+func TestMetricsAdditionalRecorders(t *testing.T) {
+	m := NewMetricsWithLimits(1, 1)
+
+	if got := m.canonicalTenantLabel("tenant-a"); got != "tenant-a" {
+		t.Fatalf("expected first tenant to be retained, got %q", got)
+	}
+	if got := m.canonicalTenantLabel("tenant-b"); got != overflowMetricLabel {
+		t.Fatalf("expected second tenant to overflow, got %q", got)
+	}
+
+	m.RecordClientInflight("client-a", 1)
+	m.RecordClientInflight("client-a", -3)
+	if got := m.clientInflight["client-a"].Load(); got != 0 {
+		t.Fatalf("expected inflight to clamp at 0, got %d", got)
+	}
+
+	m.RecordUpstreamCallsPerRequestWithRoute("custom", "/custom/route", -5)
+	m.RecordQueryRangeWindowFetchDuration(2 * time.Millisecond)
+	m.RecordQueryRangeWindowMergeDuration(3 * time.Millisecond)
+	m.RecordQueryRangeWindowCount(0)
+	m.RecordQueryRangeWindowCount(4)
+	m.RecordQueryRangeWindowPrefilterDuration(5 * time.Millisecond)
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	m.Handler(recorder, req)
+	body := recorder.Body.String()
+
+	for _, needle := range []string{
+		`loki_vl_proxy_upstream_calls_per_request_count{system="loki",direction="downstream",endpoint="custom",route="/custom/route"} 1`,
+		`loki_vl_proxy_window_fetch_seconds_count 1`,
+		`loki_vl_proxy_window_merge_seconds_count 1`,
+		`loki_vl_proxy_window_count_count 1`,
+		`loki_vl_proxy_window_prefilter_duration_seconds_count 1`,
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("expected metrics output to contain %q", needle)
+		}
+	}
+}

--- a/internal/middleware/compress_coverage_test.go
+++ b/internal/middleware/compress_coverage_test.go
@@ -1,0 +1,245 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type unwrapResponseWriter struct {
+	http.ResponseWriter
+	next http.ResponseWriter
+}
+
+func (u *unwrapResponseWriter) Unwrap() http.ResponseWriter {
+	return u.next
+}
+
+type selfUnwrappingResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (s *selfUnwrappingResponseWriter) Unwrap() http.ResponseWriter {
+	return s
+}
+
+func decodeGzipBody(t *testing.T, body []byte) string {
+	t.Helper()
+
+	gr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create gzip reader: %v", err)
+	}
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("read gzip body: %v", err)
+	}
+	return string(decoded)
+}
+
+func TestCompressedResponseWriter_DirectBranches(t *testing.T) {
+	t.Run("started bypass write uses safe headers", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		writer := &compressedResponseWriter{
+			ResponseWriter: recorder,
+			started:        true,
+			bypass:         true,
+		}
+
+		if _, err := writer.Write([]byte("plain")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if got := recorder.Body.String(); got != "plain" {
+			t.Fatalf("unexpected body %q", got)
+		}
+		if got := recorder.Header().Get("Content-Type"); got != "text/plain; charset=utf-8" {
+			t.Fatalf("unexpected content-type %q", got)
+		}
+		if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("unexpected nosniff header %q", got)
+		}
+	})
+
+	t.Run("started compression write sends gzip payload", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		writer := &compressedResponseWriter{
+			ResponseWriter: recorder,
+			encoding:       "gzip",
+			minBytes:       1,
+		}
+
+		if err := writer.startCompression(); err != nil {
+			t.Fatalf("startCompression: %v", err)
+		}
+		if _, err := writer.Write([]byte("hello")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := writer.finish(); err != nil {
+			t.Fatalf("finish: %v", err)
+		}
+
+		if got := recorder.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Fatalf("unexpected content-encoding %q", got)
+		}
+		if got := decodeGzipBody(t, recorder.Body.Bytes()); got != "hello" {
+			t.Fatalf("unexpected decoded body %q", got)
+		}
+	})
+
+	t.Run("flush bypasses when status forbids body compression", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		writer := &compressedResponseWriter{
+			ResponseWriter: recorder,
+			encoding:       "gzip",
+			statusCode:     http.StatusNoContent,
+		}
+
+		writer.Flush()
+
+		if !writer.started || !writer.bypass {
+			t.Fatalf("expected flush to start bypass path, got started=%v bypass=%v", writer.started, writer.bypass)
+		}
+		if got := recorder.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("expected no compression for 204, got %q", got)
+		}
+	})
+}
+
+func TestCompressionHelpers_AdditionalCoverage(t *testing.T) {
+	t.Run("register encoded capture direct branches", func(t *testing.T) {
+		writer := &compressedResponseWriter{encoding: "gzip"}
+		if ok := writer.registerEncodedResponseCapture("gzip", nil); ok {
+			t.Fatal("expected nil callback registration to fail")
+		}
+
+		writer.started = true
+		if ok := writer.registerEncodedResponseCapture("gzip", func(string, []byte) {}); ok {
+			t.Fatal("expected started writer registration to fail")
+		}
+
+		writer.started = false
+		if ok := writer.registerEncodedResponseCapture("identity", func(string, []byte) {}); ok {
+			t.Fatal("expected encoding mismatch registration to fail")
+		}
+
+		var capturedEncoding string
+		var capturedBody []byte
+		if ok := writer.registerEncodedResponseCapture("gzip", func(encoding string, body []byte) {
+			capturedEncoding = encoding
+			capturedBody = append([]byte(nil), body...)
+		}); !ok {
+			t.Fatal("expected matching registration to succeed")
+		}
+
+		writer.capture.buf.WriteString("payload")
+		writer.finalizeEncodedCapture()
+		if capturedEncoding != "gzip" || string(capturedBody) != "payload" {
+			t.Fatalf("unexpected capture %q %q", capturedEncoding, string(capturedBody))
+		}
+		writer.finalizeEncodedCapture()
+	})
+
+	t.Run("register encoded capture unwraps and rejects loops", func(t *testing.T) {
+		target := &compressedResponseWriter{ResponseWriter: httptest.NewRecorder(), encoding: "gzip"}
+		wrapped := &unwrapResponseWriter{ResponseWriter: httptest.NewRecorder(), next: target}
+
+		if ok := RegisterEncodedResponseCapture(wrapped, "gzip", func(string, []byte) {}); !ok {
+			t.Fatal("expected unwrap chain to reach registrar")
+		}
+
+		loop := &selfUnwrappingResponseWriter{ResponseWriter: httptest.NewRecorder()}
+		if ok := RegisterEncodedResponseCapture(loop, "gzip", func(string, []byte) {}); ok {
+			t.Fatal("expected self-unwrapping writer to be rejected")
+		}
+	})
+
+	t.Run("ensure safe headers handles nil and existing headers", func(t *testing.T) {
+		ensureSafeResponseHeaders(nil, "text/plain; charset=utf-8")
+
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "application/json")
+		ensureSafeResponseHeaders(recorder, "")
+		if got := recorder.Header().Get("Content-Type"); got != "application/json" {
+			t.Fatalf("unexpected content-type overwrite %q", got)
+		}
+		if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("expected nosniff, got %q", got)
+		}
+	})
+
+	t.Run("normalize and plan response compression", func(t *testing.T) {
+		if got := normalizeCompressionMode("zstd"); got != ResponseCompressionGzip {
+			t.Fatalf("expected zstd alias to gzip, got %q", got)
+		}
+		if got := normalizeCompressionMode("weird"); got != ResponseCompressionAuto {
+			t.Fatalf("expected invalid mode to fall back to auto, got %q", got)
+		}
+
+		if encoding, minBytes := PlanResponseCompression(nil, CompressionOptions{Mode: "gzip", MinBytes: 16}); encoding != "" || minBytes != 32 {
+			t.Fatalf("unexpected nil-request plan: encoding=%q minBytes=%d", encoding, minBytes)
+		}
+
+		headReq := httptest.NewRequest(http.MethodHead, "/loki/api/v1/query_range", nil)
+		headReq.Header.Set("Accept-Encoding", "gzip")
+		if encoding, minBytes := PlanResponseCompression(headReq, CompressionOptions{Mode: "gzip", MinBytes: 16}); encoding != "" || minBytes != 16 {
+			t.Fatalf("unexpected HEAD plan: encoding=%q minBytes=%d", encoding, minBytes)
+		}
+
+		wsReq := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range", nil)
+		wsReq.Header.Set("Connection", "Upgrade")
+		wsReq.Header.Set("Upgrade", "websocket")
+		wsReq.Header.Set("Accept-Encoding", "gzip")
+		if encoding, _ := PlanResponseCompression(wsReq, CompressionOptions{Mode: "gzip", MinBytes: 16}); encoding != "" {
+			t.Fatalf("expected websocket upgrade to bypass compression, got %q", encoding)
+		}
+
+		controlReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		controlReq.Header.Set("Accept-Encoding", "gzip")
+		if encoding, minBytes := PlanResponseCompression(controlReq, CompressionOptions{Mode: "gzip", MinBytes: 16}); encoding != "" || minBytes != 0 {
+			t.Fatalf("unexpected control-plane plan: encoding=%q minBytes=%d", encoding, minBytes)
+		}
+
+		metaReq := httptest.NewRequest(http.MethodGet, "/loki/api/v1/labels", nil)
+		metaReq.Header.Set("Accept-Encoding", "gzip")
+		if encoding, minBytes := PlanResponseCompression(metaReq, CompressionOptions{Mode: "gzip", MinBytes: 16}); encoding != "gzip" || minBytes != 64 {
+			t.Fatalf("unexpected metadata plan: encoding=%q minBytes=%d", encoding, minBytes)
+		}
+	})
+
+	t.Run("encode response body and helpers", func(t *testing.T) {
+		identity, err := EncodeResponseBody("", []byte("hello"))
+		if err != nil {
+			t.Fatalf("identity encode: %v", err)
+		}
+		if string(identity) != "hello" {
+			t.Fatalf("unexpected identity body %q", string(identity))
+		}
+
+		encoded, err := EncodeResponseBody("gzip", []byte("hello"))
+		if err != nil {
+			t.Fatalf("gzip encode: %v", err)
+		}
+		if got := decodeGzipBody(t, encoded); got != "hello" {
+			t.Fatalf("unexpected gzip-decoded body %q", got)
+		}
+
+		if _, err := EncodeResponseBody("brotli", []byte("hello")); err == nil {
+			t.Fatal("expected unsupported encoding error")
+		}
+
+		if !responseStatusAllowsBody(0) || responseStatusAllowsBody(101) || responseStatusAllowsBody(http.StatusNoContent) || responseStatusAllowsBody(http.StatusNotModified) == true || !responseStatusAllowsBody(http.StatusOK) {
+			t.Fatal("unexpected responseStatusAllowsBody results")
+		}
+
+		header := http.Header{}
+		addVaryHeader(header, "Accept-Encoding")
+		addVaryHeader(header, "accept-encoding")
+		if values := header.Values("Vary"); len(values) != 1 || values[0] != "Accept-Encoding" {
+			t.Fatalf("unexpected vary header values %#v", values)
+		}
+	})
+}

--- a/internal/proxy/config_helpers_coverage_test.go
+++ b/internal/proxy/config_helpers_coverage_test.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestProxyConfigHelpersCoverage(t *testing.T) {
+	src := map[string]any{"limit": 10, "mode": "strict"}
+	cloned := cloneStringAnyMap(src)
+	if !reflect.DeepEqual(cloned, src) {
+		t.Fatalf("unexpected cloned map %#v", cloned)
+	}
+	cloned["limit"] = 20
+	if src["limit"] != 10 {
+		t.Fatalf("expected cloneStringAnyMap to deep-copy top-level map")
+	}
+	if cloneStringAnyMap(nil) != nil {
+		t.Fatalf("expected nil map clone to stay nil")
+	}
+
+	tenantLimits := map[string]map[string]any{"tenant-a": {"limit": 10}}
+	clonedTenantLimits := cloneTenantLimitsMap(tenantLimits)
+	clonedTenantLimits["tenant-a"]["limit"] = 99
+	if tenantLimits["tenant-a"]["limit"] != 10 {
+		t.Fatalf("expected nested tenant limits map to be cloned")
+	}
+	if cloneTenantLimitsMap(nil) != nil {
+		t.Fatalf("expected nil tenant limits clone to stay nil")
+	}
+
+	dst := map[string]any{"existing": "keep"}
+	mergeStringAnyMap(dst, map[string]any{"existing": "override", "new": true})
+	if dst["existing"] != "override" || dst["new"] != true {
+		t.Fatalf("unexpected merged map %#v", dst)
+	}
+
+	if got := filterPublishedLimits(src, nil); !reflect.DeepEqual(got, src) {
+		t.Fatalf("expected empty allowlist to preserve full limits map, got %#v", got)
+	}
+	filtered := filterPublishedLimits(map[string]any{"limit": 10, "burst": 20}, []string{" limit ", "", "missing"})
+	if !reflect.DeepEqual(filtered, map[string]any{"limit": 10}) {
+		t.Fatalf("unexpected filtered limits %#v", filtered)
+	}
+
+	if got := buildStreamFieldsMap([]string{"", "   "}); got != nil {
+		t.Fatalf("expected blank stream fields to normalize to nil, got %#v", got)
+	}
+	fields := buildStreamFieldsMap([]string{" app ", "team", "app"})
+	if len(fields) != 2 || !fields["app"] || !fields["team"] {
+		t.Fatalf("unexpected stream fields map %#v", fields)
+	}
+
+	if err := ensureWritableSnapshotPath(""); err != nil {
+		t.Fatalf("expected empty snapshot path to be accepted, got %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "snapshots", "state.json")
+	if err := ensureWritableSnapshotPath(target); err != nil {
+		t.Fatalf("expected writable snapshot path, got %v", err)
+	}
+
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	declared := buildDeclaredLabelFields(
+		[]string{"service_name", " app "},
+		[]string{"service.name", "team", "team"},
+		lt,
+	)
+	if !reflect.DeepEqual(declared, []string{"app", "service.name", "team"}) {
+		t.Fatalf("unexpected declared label fields %#v", declared)
+	}
+	if buildDeclaredLabelFields(nil, nil, lt) != nil {
+		t.Fatalf("expected empty declared label fields to normalize to nil")
+	}
+
+	custom := normalizeCustomPatterns([]string{" error * ", "", "error *", "warn *"})
+	if !reflect.DeepEqual(custom, []string{"error *", "warn *"}) {
+		t.Fatalf("unexpected normalized custom patterns %#v", custom)
+	}
+	if normalizeCustomPatterns(nil) != nil {
+		t.Fatalf("expected nil custom patterns to stay nil")
+	}
+}

--- a/internal/proxy/drilldown_coverage_test.go
+++ b/internal/proxy/drilldown_coverage_test.go
@@ -1,0 +1,148 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+)
+
+func TestDrilldownHelpers_AdditionalCoverage(t *testing.T) {
+	t.Run("synthetic service name and detected level", func(t *testing.T) {
+		ensureSyntheticServiceName(nil)
+
+		labels := map[string]string{"app": "api"}
+		ensureSyntheticServiceName(labels)
+		if got := labels["service_name"]; got != "api" {
+			t.Fatalf("expected synthetic service_name from app, got %q", got)
+		}
+
+		labels["service_name"] = "frontend"
+		ensureSyntheticServiceName(labels)
+		if got := labels["service_name"]; got != "frontend" {
+			t.Fatalf("expected existing service_name to win, got %q", got)
+		}
+
+		levelLabels := map[string]string{"level": "warn"}
+		ensureDetectedLevel(levelLabels)
+		if got := levelLabels["detected_level"]; got != "warn" {
+			t.Fatalf("expected detected_level from level, got %q", got)
+		}
+	})
+
+	t.Run("structured field exposure and detected field accumulation", func(t *testing.T) {
+		lt := NewLabelTranslator(LabelStyleUnderscores, []FieldMapping{{VLField: "service.name", LokiLabel: "service_name"}})
+
+		if shouldExposeStructuredField("_time", nil, lt) {
+			t.Fatal("expected internal field to be hidden")
+		}
+		if !shouldExposeStructuredField("service.name", map[string]string{"service.name": "api"}, lt) {
+			t.Fatal("expected dotted field to remain exposed")
+		}
+		if shouldExposeStructuredField("service_name", map[string]string{"service_name": "api"}, nil) {
+			t.Fatal("expected passthrough structured field to stay hidden without translator")
+		}
+		if !shouldExposeStructuredField("custom", map[string]string{}, lt) {
+			t.Fatal("expected unknown structured field to be exposed")
+		}
+
+		fields := map[string]*detectedFieldSummary{}
+		addDetectedField(fields, "", "", "string", nil, "ignored")
+		addDetectedField(fields, "duration", "json", "int", []string{"duration"}, "10")
+		addDetectedField(fields, "duration", "logfmt", "string", nil, "ten")
+
+		summary := fields["duration"]
+		if summary == nil {
+			t.Fatal("expected detected field summary")
+		}
+		if summary.typ != "string" {
+			t.Fatalf("expected detected type to widen to string, got %q", summary.typ)
+		}
+		if len(summary.parsers) != 2 {
+			t.Fatalf("expected two parser sources, got %d", len(summary.parsers))
+		}
+		if len(summary.jsonPath) != 1 || summary.jsonPath[0] != "duration" {
+			t.Fatalf("expected original json path to be preserved, got %#v", summary.jsonPath)
+		}
+		if got := asString(map[string]any{"line": "hello\nworld"}); !strings.Contains(got, "hello") || strings.Contains(got, "\n") {
+			t.Fatalf("expected asString to flatten JSON, got %q", got)
+		}
+	})
+
+	t.Run("selector and query helpers", func(t *testing.T) {
+		if got := appendSyntheticLabels([]string{"app", "app"}); len(got) != 2 || got[1] != "service_name" {
+			t.Fatalf("unexpected synthetic labels %#v", got)
+		}
+		if got := streamSelectorPrefix(`{app="api|web"} |= "error"`); got != `{app="api|web"}` {
+			t.Fatalf("unexpected selector prefix %q", got)
+		}
+		if got := inferPrimaryTargetLabel(`{namespace="prod",pod=~"api-.*"} |= "error"`); got != "namespace" {
+			t.Fatalf("unexpected primary target label %q", got)
+		}
+		if got := normalizeBareSelectorQuery(`app="api"`); got != `{app="api"}` {
+			t.Fatalf("expected bare selector to be wrapped, got %q", got)
+		}
+		if got := normalizeBareSelectorQuery(`{app="api"} |= "error"`); got != `{app="api"} |= "error"` {
+			t.Fatalf("expected LogQL pipeline query to remain unchanged, got %q", got)
+		}
+
+		dst := map[string]*detectedLabelSummary{
+			"service_name": {label: "service_name", values: map[string]struct{}{"api": {}}},
+		}
+		scanned := map[string]*detectedLabelSummary{
+			"level": {label: "level", values: map[string]struct{}{"error": {}}},
+		}
+		mergeDetectedLabelSupplements(dst, scanned)
+		if dst["level"] == nil {
+			t.Fatal("expected level supplement to be merged")
+		}
+	})
+}
+
+func TestDrilldownBackendHelpers_AdditionalCoverage(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"{service_name=\"api\"}","hits":2},{"value":"{app=\"worker\"}","hits":1},{"value":"{service_name=\"api\"}","hits":1}]}`))
+		case "/select/logsql/field_values":
+			if r.URL.Query().Get("field") == "broken" {
+				http.Error(w, "backend boom", http.StatusBadGateway)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"zulu","hits":1},{"value":"alpha","hits":2}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	t.Cleanup(func() { p.cache.Close() })
+	p.translationCache = cache.New(5, 10)
+	t.Cleanup(func() { p.translationCache.Close() })
+
+	values, err := p.serviceNameValues(context.Background(), `{app="api"}`, "", "")
+	if err != nil {
+		t.Fatalf("serviceNameValues returned error: %v", err)
+	}
+	if strings.Join(values, ",") != "api,worker" {
+		t.Fatalf("unexpected service names %v", values)
+	}
+
+	fieldValues, err := p.fetchNativeFieldValues(context.Background(), `{app="api"}`, "", "", "service.name", 2)
+	if err != nil {
+		t.Fatalf("fetchNativeFieldValues returned error: %v", err)
+	}
+	if strings.Join(fieldValues, ",") != "alpha,zulu" {
+		t.Fatalf("unexpected field values %v", fieldValues)
+	}
+
+	if _, err := p.fetchNativeFieldValues(context.Background(), `{app="api"}`, "", "", "broken", 0); err == nil || !strings.Contains(err.Error(), "backend boom") {
+		t.Fatalf("expected backend error to surface, got %v", err)
+	}
+}

--- a/internal/proxy/persistence_path_test.go
+++ b/internal/proxy/persistence_path_test.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -22,15 +21,10 @@ func TestEnsureWritableSnapshotPath_CreatesTargetFile(t *testing.T) {
 }
 
 func TestNew_FailsFastOnUnwritablePatternsPersistPath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission semantics differ on Windows")
+	parent := filepath.Join(t.TempDir(), "occupied-parent")
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create occupied parent file: %v", err)
 	}
-
-	parent := t.TempDir()
-	if err := os.Chmod(parent, 0o500); err != nil {
-		t.Fatalf("chmod parent dir: %v", err)
-	}
-	defer func() { _ = os.Chmod(parent, 0o700) }()
 
 	_, err := New(Config{
 		BackendURL:          "http://unused",
@@ -47,15 +41,10 @@ func TestNew_FailsFastOnUnwritablePatternsPersistPath(t *testing.T) {
 }
 
 func TestNew_FailsFastOnUnwritableLabelValuesPersistPath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission semantics differ on Windows")
+	parent := filepath.Join(t.TempDir(), "occupied-parent")
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create occupied parent file: %v", err)
 	}
-
-	parent := t.TempDir()
-	if err := os.Chmod(parent, 0o500); err != nil {
-		t.Fatalf("chmod parent dir: %v", err)
-	}
-	defer func() { _ = os.Chmod(parent, 0o700) }()
 
 	_, err := New(Config{
 		BackendURL:                  "http://unused",

--- a/internal/proxy/postprocess_coverage_test.go
+++ b/internal/proxy/postprocess_coverage_test.go
@@ -1,0 +1,91 @@
+package proxy
+
+import "testing"
+
+func TestCollectPatternObservationsFromJSON_MixedShapes(t *testing.T) {
+	miner := newPatternMiner()
+	observed := 0
+	decoded := map[string]interface{}{
+		"_msg":  "root request completed successfully",
+		"_time": "1712434830",
+		"level": "debug",
+		"results": []interface{}{
+			map[string]interface{}{
+				"_msg":  "database timeout threshold exceeded",
+				"_time": "1712434800",
+				"level": "error",
+			},
+		},
+		"values": []interface{}{
+			map[string]interface{}{
+				"_msg":  "cache miss detected again",
+				"_time": "1712434810",
+				"level": "warn",
+			},
+		},
+		"data": map[string]interface{}{
+			"result": []interface{}{
+				map[string]interface{}{
+					"stream": map[string]interface{}{
+						"level": "info",
+					},
+					"values": []interface{}{
+						[]interface{}{"1712434820", "http request completed normally"},
+						[]interface{}{"bad", "skip me"},
+					},
+				},
+			},
+		},
+	}
+
+	collectPatternObservationsFromJSON(miner, decoded, 60, "", &observed)
+
+	if observed != 4 {
+		t.Fatalf("expected 4 observed patterns, got %d", observed)
+	}
+
+	patterns := buildPatternResponse(miner, 10)
+	if len(patterns) != 4 {
+		t.Fatalf("expected 4 pattern buckets, got %d", len(patterns))
+	}
+	for _, pattern := range patterns {
+		samples, ok := pattern["samples"].([][]interface{})
+		if !ok || len(samples) != 1 {
+			t.Fatalf("expected exactly one sample per collected pattern, got %#v", pattern["samples"])
+		}
+	}
+}
+
+func TestPostprocessHelperCoverage(t *testing.T) {
+	if got := deduplicatePlaceholders("<_><_> constant <_><_><_>", patternVarPlaceholder); got != "<_> constant <_>" {
+		t.Fatalf("unexpected deduplicated placeholders %q", got)
+	}
+	if got := deduplicatePlaceholders("constant only", patternVarPlaceholder); got != "constant only" {
+		t.Fatalf("unexpected unchanged placeholders %q", got)
+	}
+
+	if got := tokenizeToPattern(`{"foo":1,"bar":"x"}`); got != "{bar=<_> foo=<_>}" {
+		t.Fatalf("unexpected JSON pattern %q", got)
+	}
+	if got := tokenizeToPattern("{broken-json"); got != "<_>" {
+		t.Fatalf("expected invalid JSON to collapse to placeholder, got %q", got)
+	}
+
+	for _, token := range []string{"1234", "10.0.0.1", "2026-04-06T20:21:22Z", "/a/b/c/d"} {
+		if !isVariableToken(token) {
+			t.Fatalf("expected %q to be treated as variable", token)
+		}
+	}
+	for _, token := range []string{"INFO", "service=api"} {
+		if isVariableToken(token) {
+			t.Fatalf("expected %q to remain structural", token)
+		}
+	}
+
+	if !isIPLike("192.168.0.1") {
+		t.Fatal("expected dotted quad to be recognized as IP-like")
+	}
+	if isIPLike("192.168.0.x") {
+		t.Fatal("expected malformed IP not to be recognized as IP-like")
+	}
+}

--- a/internal/proxy/postprocess_helpers_coverage_test.go
+++ b/internal/proxy/postprocess_helpers_coverage_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPostprocessHelperBranchesCoverage(t *testing.T) {
+	streams := []map[string]interface{}{
+		{"stream": map[string]string{"app": "web"}, "values": "bad-values"},
+		{"values": [][]string{{"1000"}, {"1001", "\x1b[31m  error  \x1b[0m"}}},
+	}
+	decolorizeStreams(streams)
+	values := streams[1]["values"].([][]string)
+	if values[1][1] != "  error  " {
+		t.Fatalf("expected ansi sequences to be stripped, got %q", values[1][1])
+	}
+
+	formatted := cloneStreams([]map[string]interface{}{
+		{"values": [][]string{{"1000"}, {"1001", "  padded line  "}}},
+		{"stream": map[string]string{"app": "web-api"}, "values": [][]string{{"1002", "unchanged"}}},
+	})
+	applyLineFormatTemplate(formatted, `{{TrimSpace ._line}}|{{default "n/a" .app}}`)
+	if got := formatted[0]["values"].([][]string)[1][1]; got != "padded line|n/a" {
+		t.Fatalf("unexpected formatted line %q", got)
+	}
+
+	entries := []queryRangeWindowEntry{
+		{Value: []interface{}{"only-timestamp"}},
+		{Value: []interface{}{"bad-time", "GET /health 200 1ms"}},
+		{Value: []interface{}{"1712311200000000000", ""}},
+		{Stream: map[string]string{"level": "error"}, Value: []interface{}{"1712311200000000000", "POST /api/orders 500 10ms"}},
+	}
+	patterns := extractLogPatternsFromWindowEntries(entries, "10s", 10)
+	if len(patterns) != 1 {
+		t.Fatalf("expected one pattern from valid window entry, got %#v", patterns)
+	}
+	if patterns[0]["level"] != "error" {
+		t.Fatalf("expected fallback level label, got %#v", patterns[0])
+	}
+
+	if got := parsePatternStepSeconds(""); got != 60 {
+		t.Fatalf("expected default pattern step, got %d", got)
+	}
+	if got := parsePatternStepSeconds("15"); got != 15 {
+		t.Fatalf("expected numeric pattern step 15, got %d", got)
+	}
+	if got := parsePatternStepSeconds("-5"); got != 60 {
+		t.Fatalf("expected invalid pattern step to fall back to default, got %d", got)
+	}
+
+	if ts, ok := patternUnixSecondsFromEntry(map[string]interface{}{"timestamp": "2026-04-04T10:00:00Z"}); !ok || ts == 0 {
+		t.Fatalf("expected timestamp field to be parsed, got %d %v", ts, ok)
+	}
+	if _, ok := patternUnixSecondsFromEntry(map[string]interface{}{"msg": "no time"}); ok {
+		t.Fatalf("expected missing time fields to fail parsing")
+	}
+
+	if sim, params := getPatternSimilarity([]string{"GET", patternVarPlaceholder}, []string{"GET", "42"}); sim != 0.5 || params != 1 {
+		t.Fatalf("unexpected similarity result sim=%v params=%d", sim, params)
+	}
+	if sim, params := getPatternSimilarity([]string{"GET"}, []string{"GET", "42"}); sim != 0 || params != -1 {
+		t.Fatalf("expected mismatched token lengths to fail similarity, got sim=%v params=%d", sim, params)
+	}
+
+	template := []string{"GET", "200"}
+	if merged := mergePatternTemplate(template, []string{"POST", "200"}); merged[0] != patternVarPlaceholder || merged[1] != "200" {
+		t.Fatalf("unexpected merged template %#v", merged)
+	}
+	if merged := mergePatternTemplate([]string{"GET"}, []string{"GET", "200"}); len(merged) != 1 || merged[0] != "GET" {
+		t.Fatalf("expected mismatched merge to keep original template, got %#v", merged)
+	}
+
+	tokenizer := newPatternLineTokenizer()
+	if _, _, ok := tokenizer.Tokenize(""); ok {
+		t.Fatalf("expected empty line tokenization to fail")
+	}
+	if _, _, ok := tokenizer.Tokenize(strings.Repeat("x", patternMaxLineLength+1)); ok {
+		t.Fatalf("expected oversized line tokenization to fail")
+	}
+	tokens, spaces, ok := tokenizer.Tokenize("level=info path=/ready status=200")
+	if !ok || len(tokens) == 0 {
+		t.Fatalf("expected valid tokenization, got tokens=%#v spaces=%#v ok=%v", tokens, spaces, ok)
+	}
+	if got := tokenizer.Join([]string{patternVarPlaceholder, patternVarPlaceholder}, nil); got != patternVarPlaceholder {
+		t.Fatalf("expected adjacent placeholders to deduplicate, got %q", got)
+	}
+
+	if isHexLike("token-xyz") {
+		t.Fatalf("expected non-hex token to be rejected")
+	}
+}

--- a/internal/proxy/proxy_helpers_coverage_test.go
+++ b/internal/proxy/proxy_helpers_coverage_test.go
@@ -1,0 +1,187 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flushRecorder) Flush() {
+	f.flushed = true
+	f.ResponseRecorder.Flush()
+}
+
+func TestCompatCacheCaptureWriter_HelperBranches(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	w := newCompatCacheCaptureWriter(rec, 4)
+
+	w.WriteHeader(http.StatusCreated)
+	w.capture([]byte("ab"))
+	w.Flush()
+	if !w.flushed || !rec.flushed {
+		t.Fatalf("expected flush to be recorded on wrapper and inner recorder")
+	}
+
+	w.capture([]byte("cde"))
+	if body := w.CapturedBody(); body != nil {
+		t.Fatalf("expected overflowed capture body to be nil, got %q", string(body))
+	}
+	if !w.overflowed {
+		t.Fatalf("expected capture writer to mark overflow")
+	}
+
+	w.Release()
+	if w.body != nil || w.bufHolder != nil {
+		t.Fatalf("expected capture buffers to be released")
+	}
+
+	buf, holder := acquireCompatCaptureBuf(defaultCompatCaptureBufSize * 2)
+	if cap(buf) < defaultCompatCaptureBufSize {
+		t.Fatalf("expected pooled buffer capacity to be initialized, got %d", cap(buf))
+	}
+	releaseCompatCaptureBuf(make([]byte, 0, maxPooledCompatCaptureBufSize+1), holder)
+	releaseCompatCaptureBuf(nil, nil)
+}
+
+func TestCompatCacheCaptureAllowedAndPatternsPayloadEmpty(t *testing.T) {
+	cookieHeader := http.Header{}
+	cookieHeader.Add("Set-Cookie", "sid=abc")
+
+	tests := []struct {
+		name    string
+		code    int
+		flushed bool
+		header  http.Header
+		want    bool
+	}{
+		{name: "default ok json", code: 0, header: http.Header{}, want: true},
+		{name: "non-200", code: http.StatusBadGateway, header: http.Header{}, want: false},
+		{name: "flushed", code: http.StatusOK, flushed: true, header: http.Header{}, want: false},
+		{name: "cookie", code: http.StatusOK, header: cookieHeader, want: false},
+		{name: "plain text", code: http.StatusOK, header: http.Header{"Content-Type": []string{"text/plain"}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compatCacheCaptureAllowed(tt.code, tt.flushed, tt.header); got != tt.want {
+				t.Fatalf("compatCacheCaptureAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	if !patternsPayloadEmpty(nil) {
+		t.Fatalf("expected empty body to be treated as empty payload")
+	}
+	if !patternsPayloadEmpty([]byte(`{"data":[]}`)) {
+		t.Fatalf("expected empty data array to be treated as empty payload")
+	}
+	if patternsPayloadEmpty([]byte(`{"data":[{}]}`)) {
+		t.Fatalf("expected non-empty data array to be treated as non-empty payload")
+	}
+	if patternsPayloadEmpty([]byte(`{not-json`)) {
+		t.Fatalf("expected invalid json payload to be treated as non-empty/unknown")
+	}
+}
+
+func TestNormalizeBackendCompressionAndLimiter(t *testing.T) {
+	if got := normalizeBackendCompression(" GZIP "); got != "gzip" {
+		t.Fatalf("expected gzip normalization, got %q", got)
+	}
+	if got := normalizeBackendCompression("bogus"); got != "auto" {
+		t.Fatalf("expected unknown backend compression to fall back to auto, got %q", got)
+	}
+	if limiter := buildConcurrencyLimiter(0); limiter != nil {
+		t.Fatalf("expected zero limit to disable limiter")
+	}
+	if limiter := buildConcurrencyLimiter(3); cap(limiter) != 3 {
+		t.Fatalf("expected limiter capacity 3, got %d", cap(limiter))
+	}
+}
+
+func TestDecodeCompressedHTTPResponse_Variants(t *testing.T) {
+	original := []byte(`{"status":"ok"}`)
+
+	t.Run("identity", func(t *testing.T) {
+		resp := &http.Response{
+			Header: http.Header{"Content-Encoding": []string{"identity"}},
+			Body:   io.NopCloser(bytes.NewReader(original)),
+		}
+		if err := decodeCompressedHTTPResponse(resp); err != nil {
+			t.Fatalf("identity decode failed: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != string(original) {
+			t.Fatalf("unexpected identity body %q", string(body))
+		}
+	})
+
+	t.Run("gzip", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		if _, err := zw.Write(original); err != nil {
+			t.Fatalf("gzip write: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("gzip close: %v", err)
+		}
+
+		resp := &http.Response{
+			Header:        http.Header{"Content-Encoding": []string{"x-gzip"}, "Content-Length": []string{"123"}},
+			Body:          io.NopCloser(bytes.NewReader(buf.Bytes())),
+			ContentLength: 123,
+		}
+		if err := decodeCompressedHTTPResponse(resp); err != nil {
+			t.Fatalf("gzip decode failed: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != string(original) {
+			t.Fatalf("unexpected gzip body %q", string(body))
+		}
+		if got := resp.Header.Get("Content-Encoding"); got != "" || resp.ContentLength != -1 || !resp.Uncompressed {
+			t.Fatalf("expected decoded response metadata to be cleared, got encoding=%q len=%d uncompressed=%v", got, resp.ContentLength, resp.Uncompressed)
+		}
+	})
+
+	t.Run("zstd", func(t *testing.T) {
+		var buf bytes.Buffer
+		zw, err := zstd.NewWriter(&buf)
+		if err != nil {
+			t.Fatalf("zstd writer: %v", err)
+		}
+		if _, err := zw.Write(original); err != nil {
+			t.Fatalf("zstd write: %v", err)
+		}
+		zw.Close()
+
+		resp := &http.Response{
+			Header: http.Header{"Content-Encoding": []string{"zstd"}},
+			Body:   io.NopCloser(bytes.NewReader(buf.Bytes())),
+		}
+		if err := decodeCompressedHTTPResponse(resp); err != nil {
+			t.Fatalf("zstd decode failed: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != string(original) {
+			t.Fatalf("unexpected zstd body %q", string(body))
+		}
+	})
+
+	t.Run("invalid gzip", func(t *testing.T) {
+		resp := &http.Response{
+			Header: http.Header{"Content-Encoding": []string{"gzip"}},
+			Body:   io.NopCloser(bytes.NewReader([]byte("not-gzip"))),
+		}
+		if err := decodeCompressedHTTPResponse(resp); err == nil {
+			t.Fatalf("expected invalid gzip stream to fail")
+		}
+	})
+}

--- a/internal/proxy/query_range_windowing_coverage_test.go
+++ b/internal/proxy/query_range_windowing_coverage_test.go
@@ -1,0 +1,126 @@
+package proxy
+
+import (
+	"context"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestQueryRangeWindowHitEstimate_CachedVariants(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	req.Header.Set("X-Scope-OrgID", "tenant-a")
+	window := queryRangeWindow{startNs: 10, endNs: 20}
+	cacheKey := p.queryRangeWindowHasHitsCacheKey(req, "{app=\"api\"}", window)
+
+	p.cache.Set(cacheKey, []byte("42"))
+	if got, err := p.queryRangeWindowHitEstimate(context.Background(), req, "{app=\"api\"}", window); err != nil || got != 42 {
+		t.Fatalf("expected parsed cached hit estimate, got %d err=%v", got, err)
+	}
+
+	p.cache.Set(cacheKey, []byte("1x"))
+	if got, err := p.queryRangeWindowHitEstimate(context.Background(), req, "{app=\"api\"}", window); err != nil || got != 1 {
+		t.Fatalf("expected legacy truthy cached hit estimate, got %d err=%v", got, err)
+	}
+
+	p.cache.Set(cacheKey, []byte("garbage"))
+	if got, err := p.queryRangeWindowHitEstimate(context.Background(), req, "{app=\"api\"}", window); err != nil || got != 0 {
+		t.Fatalf("expected invalid cached hit estimate to fall back to zero, got %d err=%v", got, err)
+	}
+}
+
+func TestQueryRangeWindowBatchParallelLimitAndTTL(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	p.queryRangeAdaptiveParallel = false
+	p.queryRangeMaxParallel = 8
+	p.queryRangeStreamAwareBatching = true
+	p.queryRangeExpensiveWindowHitThreshold = 100
+	p.queryRangeExpensiveWindowMaxParallel = 2
+
+	window := queryRangeWindow{startNs: 1, endNs: 2}
+	estimates := map[string]int64{queryRangeWindowKey(window): 150}
+	if got := p.queryRangeWindowBatchParallelLimit(window, estimates); got != 2 {
+		t.Fatalf("expected expensive window to degrade batch parallelism, got %d", got)
+	}
+
+	p.queryRangeExpensiveWindowMaxParallel = 0
+	if got := p.queryRangeWindowBatchParallelLimit(window, estimates); got != 1 {
+		t.Fatalf("expected non-positive expensive max parallel to clamp to 1, got %d", got)
+	}
+
+	p.queryRangeStreamAwareBatching = false
+	if got := p.queryRangeWindowBatchParallelLimit(window, estimates); got != 8 {
+		t.Fatalf("expected disabled stream-aware batching to keep default parallelism, got %d", got)
+	}
+
+	p.queryRangeHistoryCacheTTL = 0
+	p.queryRangeRecentCacheTTL = 0
+	if got := p.queryRangeWindowPrefilterTTL(time.Now().UnixNano()); got != queryRangePrefilterFallbackTTL {
+		t.Fatalf("expected zero window ttl to fall back to prefilter ttl, got %v", got)
+	}
+}
+
+func TestSplitQueryRangeWindowsWithOptions_AlignmentAndReverse(t *testing.T) {
+	if windows := splitQueryRangeWindowsWithOptions(0, 10, 0, "forward", false); windows != nil {
+		t.Fatalf("expected zero interval to produce no windows")
+	}
+	if windows := splitQueryRangeWindowsWithOptions(10, 0, time.Second, "forward", false); windows != nil {
+		t.Fatalf("expected inverted range to produce no windows")
+	}
+
+	windows := splitQueryRangeWindowsWithOptions(2, 12, 5*time.Nanosecond, "backward", true)
+	if len(windows) != 3 {
+		t.Fatalf("expected three aligned windows, got %#v", windows)
+	}
+	if windows[0] != (queryRangeWindow{startNs: 10, endNs: 12}) ||
+		windows[1] != (queryRangeWindow{startNs: 5, endNs: 9}) ||
+		windows[2] != (queryRangeWindow{startNs: 2, endNs: 4}) {
+		t.Fatalf("unexpected aligned reverse windows: %#v", windows)
+	}
+}
+
+func TestNormalizeLokiNumericTimeToUnixNano_Thresholds(t *testing.T) {
+	tests := []struct {
+		name  string
+		value float64
+		want  int64
+	}{
+		{name: "seconds", value: 12.5, want: int64(12.5 * float64(time.Second))},
+		{name: "milliseconds", value: 1700000000000.5, want: int64(1700000000000.5 * float64(time.Millisecond))},
+		{name: "microseconds", value: 1700000000000000.5, want: int64(1700000000000000.5 * float64(time.Microsecond))},
+		{name: "nanoseconds", value: 1700000000000000000.0, want: 1700000000000000000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeLokiNumericTimeToUnixNano(tt.value); got != tt.want {
+				t.Fatalf("normalizeLokiNumericTimeToUnixNano(%v) = %d, want %d", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVLLogsToLokiWindowEntries_SkipsInvalidAndDerivesFields(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	body := []byte(
+		"not-json\n" +
+			`{"_msg":"missing-time","_stream":"{app=\"api\"}"}` + "\n" +
+			`{"_time":"2026-04-01T00:00:00Z","_msg":"ok","_stream":"{app=\"api\",level=\"warn\"}","trace_id":"abc"}` + "\n",
+	)
+
+	entries := p.vlLogsToLokiWindowEntries(body, `{app="api"}`, true, true)
+	if len(entries) != 1 {
+		t.Fatalf("expected one valid translated window entry, got %#v", entries)
+	}
+	if entries[0].Stream["service_name"] != "api" {
+		t.Fatalf("expected synthetic service name to be derived, got %#v", entries[0].Stream)
+	}
+	if entries[0].Stream["detected_level"] != "warn" {
+		t.Fatalf("expected detected level to be preserved, got %#v", entries[0].Stream)
+	}
+	if got := entries[0].Value[0]; got != strconv.FormatInt(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).UnixNano(), 10) {
+		t.Fatalf("unexpected translated timestamp %v", got)
+	}
+}

--- a/internal/proxy/request_helpers_coverage_test.go
+++ b/internal/proxy/request_helpers_coverage_test.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestHelpersAndGrafanaProfileCoverage(t *testing.T) {
+	rt := newRequestTelemetry()
+	ctx := context.WithValue(context.Background(), requestTelemetryKey, rt)
+	setCacheResult(ctx, "hit")
+	if got := snapshotTelemetry(ctx).cacheResult; got != "hit" {
+		t.Fatalf("expected cache result to be recorded, got %q", got)
+	}
+	setCacheResult(context.Background(), "miss")
+
+	if host, port := splitHostPortValue("127.0.0.1:3100"); host != "127.0.0.1" || port != 3100 {
+		t.Fatalf("unexpected host/port split: %q %d", host, port)
+	}
+	if host, port := splitHostPortValue("example.invalid"); host != "example.invalid" || port != 0 {
+		t.Fatalf("unexpected fallback host/port split: %q %d", host, port)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range", nil)
+	req.RemoteAddr = "10.0.0.10:9090"
+	req.Header.Set("X-Forwarded-For", "198.51.100.10, 10.0.0.10")
+	if got := forwardedClientAddress(req, true); got != "198.51.100.10" {
+		t.Fatalf("unexpected forwarded client address %q", got)
+	}
+	if got := forwardedClientAddress(req, false); got != "10.0.0.10" {
+		t.Fatalf("unexpected direct client address %q", got)
+	}
+
+	if got := upstreamBreakdownKey("", ""); got != "unknown" {
+		t.Fatalf("unexpected empty upstream breakdown key %q", got)
+	}
+	if got := upstreamBreakdownKey("vl", "select_logsql_query"); got != "vl:select_logsql_query" {
+		t.Fatalf("unexpected upstream breakdown key %q", got)
+	}
+	if got := internalOperationBreakdownKey("", ""); got != "unknown:unknown" {
+		t.Fatalf("unexpected empty internal operation key %q", got)
+	}
+	if got := internalOperationBreakdownKey("translate_query", "cache_hit"); got != "translate_query:cache_hit" {
+		t.Fatalf("unexpected internal operation key %q", got)
+	}
+
+	drilldownReq := httptest.NewRequest(http.MethodGet, "/patterns", nil)
+	drilldownReq.Header.Set("User-Agent", "Grafana/12.4.0")
+	profile := detectGrafanaClientProfile(drilldownReq, "patterns", "/patterns")
+	if profile.surface != "grafana_drilldown" || profile.drilldownProfile != "drilldown-v2" || profile.runtimeFamily != "12.x+" {
+		t.Fatalf("unexpected drilldown profile %#v", profile)
+	}
+
+	dsReq := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range", nil)
+	dsReq.Header["X-Query-Tags"] = []string{`source="grafana-loki"`}
+	dsReq.Header.Set("User-Agent", "Grafana/11.6.1")
+	profile = detectGrafanaClientProfile(dsReq, "query_range", "/loki/api/v1/query_range")
+	if profile.surface != "grafana_loki_datasource" || profile.datasourceProfile != "grafana-datasource-v11" {
+		t.Fatalf("unexpected datasource profile %#v", profile)
+	}
+
+	if got := parseGrafanaVersionFromUserAgent("Mozilla/5.0 Grafana/12.2.1-beta1 extra"); got != "12.2.1-beta1" {
+		t.Fatalf("unexpected grafana version parse %q", got)
+	}
+	if got := parseGrafanaVersionFromUserAgent("curl/8.0.0"); got != "" {
+		t.Fatalf("expected empty grafana version for non-grafana agent, got %q", got)
+	}
+}
+
+func TestTranslateStatsResponseLabelsWithContext_Coverage(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+	p.labelTranslator = NewLabelTranslator(LabelStyleUnderscores, nil)
+
+	invalid := []byte(`{not-json`)
+	if got := p.translateStatsResponseLabelsWithContext(context.Background(), invalid, `{app="api"}`); string(got) != string(invalid) {
+		t.Fatalf("expected invalid body to pass through unchanged")
+	}
+
+	noResults := []byte(`{"status":"success","data":{}}`)
+	if got := p.translateStatsResponseLabelsWithContext(context.Background(), noResults, `{app="api"}`); string(got) != string(noResults) {
+		t.Fatalf("expected empty results body to pass through unchanged")
+	}
+
+	body := []byte(`{"result":[{"metric":{"__name__":"hits","service.name":"api","level":"warn"}}]}`)
+	got := p.translateStatsResponseLabelsWithContext(context.Background(), body, `{app="api"} |= "x" | stats count() by (detected_level)`)
+
+	var resp struct {
+		Result []struct {
+			Metric map[string]interface{} `json:"metric"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(got, &resp); err != nil {
+		t.Fatalf("decode translated stats response: %v", err)
+	}
+	metric := resp.Result[0].Metric
+	if _, ok := metric["__name__"]; ok {
+		t.Fatalf("expected __name__ to be removed, got %#v", metric)
+	}
+	if _, ok := metric["level"]; ok {
+		t.Fatalf("expected level to be rewritten when detected_level requested, got %#v", metric)
+	}
+	if metric["service_name"] != "api" || metric["detected_level"] != "warn" {
+		t.Fatalf("unexpected translated metric labels %#v", metric)
+	}
+}

--- a/internal/rulesmigrate/helper_coverage_test.go
+++ b/internal/rulesmigrate/helper_coverage_test.go
@@ -1,0 +1,39 @@
+package rulesmigrate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHelperCoverage_ReportRuleNameAndSubquery(t *testing.T) {
+	if got := (Report{}).String(); got != "No migration warnings.\n" {
+		t.Fatalf("unexpected empty report string %q", got)
+	}
+
+	report := Report{
+		Warnings: []Warning{{Group: "api", Rule: "HighErrorRate", Reason: "needs manual review"}},
+	}
+	if got := report.String(); !strings.Contains(got, `group "api" rule "HighErrorRate"`) {
+		t.Fatalf("unexpected warning report string %q", got)
+	}
+
+	if got := ruleName(Rule{Alert: "AlertName"}); got != "AlertName" {
+		t.Fatalf("unexpected alert rule name %q", got)
+	}
+	if got := ruleName(Rule{Record: "record_name"}); got != "record_name" {
+		t.Fatalf("unexpected recording rule name %q", got)
+	}
+	if got := ruleName(Rule{}); got != "<unnamed>" {
+		t.Fatalf("unexpected unnamed rule fallback %q", got)
+	}
+
+	if !hasSubquery(`sum(rate({app="api"}[5m:30s]))`) {
+		t.Fatal("expected subquery syntax with range:step to be detected")
+	}
+	if hasSubquery(`sum(rate({app="api"}[5m]))`) {
+		t.Fatal("expected plain range selector not to be treated as subquery")
+	}
+	if hasSubquery(`sum(rate({app="api"}[5m))`) {
+		t.Fatal("expected malformed selector without closing bracket not to be treated as subquery")
+	}
+}

--- a/internal/translator/helper_coverage_test.go
+++ b/internal/translator/helper_coverage_test.go
@@ -1,0 +1,71 @@
+package translator
+
+import "testing"
+
+func TestCoverage_SplitLogicalStageAndSanitizeHelpers(t *testing.T) {
+	parts, ops, ok := splitLogicalStage(`level="info and ready" and (status="200" or status="201")`)
+	if !ok {
+		t.Fatal("expected logical stage to split")
+	}
+	if len(parts) != 2 || len(ops) != 1 || ops[0] != "and" {
+		t.Fatalf("unexpected logical split parts=%#v ops=%#v", parts, ops)
+	}
+	if _, _, ok := splitLogicalStage(`and level="info"`); ok {
+		t.Fatal("expected malformed logical stage to fail splitting")
+	}
+
+	if got := sanitizeFieldIdentifier(" `k8s . pod..name` "); got != "k8s.pod.name" {
+		t.Fatalf("unexpected sanitized field identifier %q", got)
+	}
+	if got := sanitizeFieldIdentifier("..."); got != "" {
+		t.Fatalf("expected empty identifier after trimming dots, got %q", got)
+	}
+
+	if got := quoteLogsQLFieldNameIfNeeded("service.name"); got != `"service.name"` {
+		t.Fatalf("expected dotted field name to be quoted, got %q", got)
+	}
+	if got := quoteLogsQLFieldNameIfNeeded("service_name"); got != "service_name" {
+		t.Fatalf("expected underscore field name to stay bare, got %q", got)
+	}
+
+	if !logsQLEqualityValueNeedsQuoting("hello world") {
+		t.Fatal("expected spaced equality value to require quoting")
+	}
+	if logsQLEqualityValueNeedsQuoting("api-1/ready") {
+		t.Fatal("expected simple path token not to require quoting")
+	}
+}
+
+func TestCoverage_CanUseStreamSelectorAndTranslateLabelFormat(t *testing.T) {
+	streamFields := map[string]bool{"app": true, "k8s.pod.name": true}
+	labelFn := func(label string) string {
+		if label == "pod" {
+			return "k8s.pod.name"
+		}
+		if label == "drop" {
+			return ""
+		}
+		return label
+	}
+
+	if !canUseStreamSelector(`app="api"`, streamFields, nil) {
+		t.Fatal("expected exact app matcher to qualify for native stream selector")
+	}
+	if !canUseStreamSelector(`pod="api-0"`, streamFields, labelFn) {
+		t.Fatal("expected translated exact matcher to qualify for native stream selector")
+	}
+	for _, matcher := range []string{`service_name="api"`, `app=~"api.*"`, `app!="api"`, `drop="x"`} {
+		if canUseStreamSelector(matcher, streamFields, labelFn) {
+			t.Fatalf("expected matcher %q not to qualify for native stream selector", matcher)
+		}
+	}
+
+	got := translateLabelFormat(`app="{{.service.name}}", team="{{.k8s.team}}"`)
+	want := `| format "<service.name>" as app | format "<k8s.team>" as team`
+	if got != want {
+		t.Fatalf("unexpected translated label format %q", got)
+	}
+	if got := translateLabelFormat(`not-an-assignment`); got != `| not-an-assignment` {
+		t.Fatalf("expected malformed label_format to fall back to passthrough, got %q", got)
+	}
+}

--- a/internal/translator/more_helper_coverage_test.go
+++ b/internal/translator/more_helper_coverage_test.go
@@ -1,0 +1,60 @@
+package translator
+
+import "testing"
+
+func TestCoverage_MoreTranslatorHelpers(t *testing.T) {
+	if !isNoopPatternExpression(`"^.*$"`) {
+		t.Fatal("expected quoted catch-all regex to be treated as noop pattern")
+	}
+	if isNoopPatternExpression(`"error"`) {
+		t.Fatal("expected concrete pattern not to be treated as noop")
+	}
+
+	if got := translatePatternMatchValue(`"foo<bar>baz"`); got != `"foo.*baz"` {
+		t.Fatalf("unexpected placeholder translation %q", got)
+	}
+	if got := translatePatternMatchValue(`"literal.*value"`); got != `"literal\\.\\*value"` {
+		t.Fatalf("unexpected literal pattern translation %q", got)
+	}
+	if got := translatePatternMatchValue(`""`); got != `""` {
+		t.Fatalf("unexpected empty pattern translation %q", got)
+	}
+
+	if field, op, ok := translatedFilterFieldOp(`-"service.name":~"api.*"`); !ok || field != `"service.name"` || op != ":~" {
+		t.Fatalf("unexpected translated filter field/op: %q %q %v", field, op, ok)
+	}
+	if _, _, ok := translatedFilterFieldOp(`bogus`); ok {
+		t.Fatal("expected malformed translated filter to fail parsing")
+	}
+
+	if query, duration := extractQueryAndDuration(`{app="api"} | unwrap latency [5m]`); query != `{app="api"} | unwrap latency` || duration != "5m" {
+		t.Fatalf("unexpected query/duration split query=%q duration=%q", query, duration)
+	}
+	if query, duration := extractQueryAndDuration(`{app="api"}`); query != `{app="api"}` || duration != "" {
+		t.Fatalf("unexpected query/duration split without window query=%q duration=%q", query, duration)
+	}
+
+	labelFn := func(label string) string {
+		if label == "detected_level" {
+			return "level"
+		}
+		if label == "drop" {
+			return ""
+		}
+		return label
+	}
+	if got := normalizeByLabels(`detected_level, cluster, detected_level, drop`, labelFn); got != "level, cluster" {
+		t.Fatalf("unexpected normalized by-labels %q", got)
+	}
+
+	if got, ok := tryTranslateQuantileOverTime(`quantile_over_time(0.95, {app="api"} | unwrap duration(latency) [5m])`, "", "detected_level", labelFn); !ok || got != `app:=api | stats by (level) quantile(0.95, latency)` {
+		t.Fatalf("unexpected quantile translation %q ok=%v", got, ok)
+	}
+	if _, ok := tryTranslateQuantileOverTime(`quantile_over_time(0.95 {app="api"})`, "", "", nil); ok {
+		t.Fatal("expected malformed quantile_over_time expression to fail translation")
+	}
+
+	if got := findLastMatchingParen(`inner(")") ) tail`); got < 0 {
+		t.Fatalf("expected last matching paren finder to locate closing paren")
+	}
+}

--- a/internal/translator/more_helper_coverage_test.go
+++ b/internal/translator/more_helper_coverage_test.go
@@ -10,14 +10,29 @@ func TestCoverage_MoreTranslatorHelpers(t *testing.T) {
 		t.Fatal("expected concrete pattern not to be treated as noop")
 	}
 
-	if got := translatePatternMatchValue(`"foo<bar>baz"`); got != `"foo.*baz"` {
+	if got := patternFilterValueToRegex(`foo<_>baz`); got != `foo.*baz` {
 		t.Fatalf("unexpected placeholder translation %q", got)
 	}
-	if got := translatePatternMatchValue(`"literal.*value"`); got != `"literal\\.\\*value"` {
+	if got := patternFilterValueToRegex(`literal.*value`); got != `literal\.\*value` {
 		t.Fatalf("unexpected literal pattern translation %q", got)
 	}
-	if got := translatePatternMatchValue(`""`); got != `""` {
+	if got := patternFilterValueToRegex(``); got != `.*` {
 		t.Fatalf("unexpected empty pattern translation %q", got)
+	}
+	if got := translatePatternLineFilter(`"foo<_>bar" or "baz"`, false); got != `~"(?:foo.*bar)|(?:baz)"` {
+		t.Fatalf("unexpected translated pattern line filter %q", got)
+	}
+	if got := translatePatternLineFilter(`"foo<_>bar"`, true); got != `NOT ~"foo.*bar"` {
+		t.Fatalf("unexpected translated negative pattern line filter %q", got)
+	}
+	if values, ok := extractPatternFilterValues(`"foo<_>bar" or "baz"`); !ok || len(values) != 2 || values[0] != "foo<_>bar" || values[1] != "baz" {
+		t.Fatalf("unexpected extracted pattern filter values %#v ok=%v", values, ok)
+	}
+	if _, ok := extractPatternFilterValues(`"foo<_>bar" and "baz"`); ok {
+		t.Fatal("expected malformed pattern alternation to fail parsing")
+	}
+	if got := normalizeQuotedStageExpr("`(?P<field>.*)`"); got != `"(?P<field>.*)"` {
+		t.Fatalf("unexpected normalized raw stage expression %q", got)
 	}
 
 	if field, op, ok := translatedFilterFieldOp(`-"service.name":~"api.*"`); !ok || field != `"service.name"` || op != ":~" {


### PR DESCRIPTION
## Summary
- add focused coverage tests across proxy, cache, middleware, translator, metrics, and rules migration helpers
- harden the persistence path tests so they fail consistently on Linux runners that execute as root
- verify total statement coverage reaches 90.0 percent on Linux while keeping the full suite green

## Verification
- go test ./... -count=1
- go test ./... -coverprofile=/tmp/lvp-coverage-90-main.cover.out -count=1
- docker run --rm -v /tmp/lvp-coverage-90-main:/workspace -w /workspace golang:1.26.2 /bin/sh -lc '/usr/local/go/bin/go test ./... -coverprofile=/tmp/linux.cover.out -count=1 >/tmp/linux.test.out && /usr/local/go/bin/go tool cover -func=/tmp/linux.cover.out | tail -1'

## Linux Coverage
- total statements 90.0 percent