### PR TITLE
Fix Drilldown query_range compatibility gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/query-range: split long `stats_query_range` metric requests into aligned VL windows before merging them back into one Loki-shaped matrix response, and translate Drilldown pattern hover queries that use Loki pattern line filters (`|>`, `!>`) plus backtick-quoted `pattern`/`extract`/`regexp` stages into VL-compatible syntax.
+
 ## [1.4.2] - 2026-04-16
 
 ### Features

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -7444,6 +7444,10 @@ func (p *Proxy) vlPostCoalesced(ctx context.Context, key, path string, params ur
 // --- Stats query proxying ---
 
 func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	if p.proxyStatsQueryRangeWindowed(w, r, logsqlQuery) {
+		return
+	}
+
 	params := url.Values{}
 	params.Set("query", logsqlQuery)
 	if s := r.FormValue("start"); s != "" {
@@ -7477,6 +7481,239 @@ func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, log
 	body = p.translateStatsResponseLabelsWithContext(r.Context(), body, r.FormValue("query"))
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(wrapAsLokiResponse(body, "matrix"))
+}
+
+func (p *Proxy) proxyStatsQueryRangeWindowed(w http.ResponseWriter, r *http.Request, logsqlQuery string) bool {
+	if !p.queryRangeWindowing {
+		return false
+	}
+
+	startNs, endNs, ok := parseLokiTimeRangeToUnixNano(r.FormValue("start"), r.FormValue("end"))
+	if !ok {
+		return false
+	}
+
+	windows := splitQueryRangeWindowsWithOptions(
+		startNs,
+		endNs,
+		p.queryRangeSplitInterval,
+		"forward",
+		p.queryRangeAlignWindows,
+	)
+	if len(windows) <= 1 {
+		return false
+	}
+
+	p.metrics.RecordQueryRangeWindowCount(len(windows))
+	mergedBody, err := p.fetchAndMergeStatsQueryRangeWindows(r.Context(), r, logsqlQuery, windows)
+	if err != nil {
+		p.writeError(w, statusFromQueryRangeWindowErr(err), err.Error())
+		return true
+	}
+
+	mergedBody = p.translateStatsResponseLabelsWithContext(r.Context(), mergedBody, r.FormValue("query"))
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(wrapAsLokiResponse(mergedBody, "matrix"))
+	return true
+}
+
+func (p *Proxy) fetchAndMergeStatsQueryRangeWindows(ctx context.Context, r *http.Request, logsqlQuery string, windows []queryRangeWindow) ([]byte, error) {
+	bodies := make([][]byte, 0, len(windows))
+	for _, window := range windows {
+		body, err := p.fetchStatsQueryRangeWindow(ctx, r, logsqlQuery, window)
+		if err != nil {
+			return nil, err
+		}
+		bodies = append(bodies, body)
+	}
+	return mergeStatsQueryRangeResponses(bodies)
+}
+
+func (p *Proxy) fetchStatsQueryRangeWindow(ctx context.Context, r *http.Request, logsqlQuery string, window queryRangeWindow) ([]byte, error) {
+	fetchCtx := ctx
+	cancel := func() {}
+	if p.queryRangeWindowTimeout > 0 {
+		fetchCtx, cancel = context.WithTimeout(ctx, p.queryRangeWindowTimeout)
+	}
+	defer cancel()
+
+	params := url.Values{}
+	params.Set("query", logsqlQuery)
+	params.Set("start", strconv.FormatInt(window.startNs, 10))
+	params.Set("end", strconv.FormatInt(window.endNs, 10))
+	if step := r.FormValue("step"); step != "" {
+		params.Set("step", formatVLStep(step))
+	}
+
+	for attempt := 1; attempt <= queryRangeWindowFetchAttempts; attempt++ {
+		fetchStart := time.Now()
+		resp, err := p.vlPost(fetchCtx, "/select/logsql/stats_query_range", params)
+		fetchDuration := time.Since(fetchStart)
+		p.metrics.RecordQueryRangeWindowFetchDuration(fetchDuration)
+
+		if err == nil {
+			body, readErr := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				err = readErr
+			} else if resp.StatusCode < http.StatusBadRequest {
+				p.observeQueryRangeWindowFetch(fetchDuration, false)
+				return body, nil
+			} else {
+				msg := strings.TrimSpace(string(body))
+				if msg == "" {
+					msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+				}
+				err = &queryRangeWindowHTTPError{status: resp.StatusCode, msg: msg}
+			}
+		}
+
+		p.observeQueryRangeWindowFetch(fetchDuration, true)
+		if attempt >= queryRangeWindowFetchAttempts || !shouldRetryQueryRangeWindow(err) {
+			return nil, err
+		}
+
+		p.metrics.RecordQueryRangeWindowRetry()
+		backoff := queryRangeWindowRetryBackoff(attempt)
+		p.log.Warn(
+			"stats_query_range window fetch retrying",
+			"attempt", attempt+1,
+			"max_attempts", queryRangeWindowFetchAttempts,
+			"backoff", backoff.String(),
+			"error", err,
+		)
+		select {
+		case <-fetchCtx.Done():
+			return nil, fetchCtx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return nil, errors.New("stats_query_range window fetch failed")
+}
+
+type statsQueryRangeSeries struct {
+	Metric map[string]interface{} `json:"metric"`
+	Values [][]interface{}        `json:"values"`
+}
+
+type statsQueryRangeResponse struct {
+	Data struct {
+		Result []statsQueryRangeSeries `json:"result"`
+	} `json:"data"`
+	Results []statsQueryRangeSeries `json:"results"`
+}
+
+type mergedStatsQueryRangeSeries struct {
+	metric map[string]interface{}
+	values [][]interface{}
+	seen   map[string]struct{}
+}
+
+func mergeStatsQueryRangeResponses(bodies [][]byte) ([]byte, error) {
+	seriesByKey := make(map[string]*mergedStatsQueryRangeSeries, len(bodies))
+	keys := make([]string, 0, len(bodies))
+
+	for _, body := range bodies {
+		var resp statsQueryRangeResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, err
+		}
+
+		results := resp.Results
+		if len(results) == 0 {
+			results = resp.Data.Result
+		}
+		for _, series := range results {
+			key := metricKey(series.Metric)
+			merged, ok := seriesByKey[key]
+			if !ok {
+				merged = &mergedStatsQueryRangeSeries{
+					metric: cloneStatsQueryRangeMetric(series.Metric),
+					values: make([][]interface{}, 0, len(series.Values)),
+					seen:   make(map[string]struct{}, len(series.Values)),
+				}
+				seriesByKey[key] = merged
+				keys = append(keys, key)
+			}
+			for _, point := range series.Values {
+				pointKey := statsQueryRangePointKey(point)
+				if _, exists := merged.seen[pointKey]; exists {
+					continue
+				}
+				merged.seen[pointKey] = struct{}{}
+				merged.values = append(merged.values, cloneStatsQueryRangePoint(point))
+			}
+		}
+	}
+
+	sort.Strings(keys)
+	results := make([]map[string]interface{}, 0, len(keys))
+	for _, key := range keys {
+		merged := seriesByKey[key]
+		sort.Slice(merged.values, func(i, j int) bool {
+			return statsQueryRangePointTimestamp(merged.values[i]) < statsQueryRangePointTimestamp(merged.values[j])
+		})
+		results = append(results, map[string]interface{}{
+			"metric": merged.metric,
+			"values": merged.values,
+		})
+	}
+
+	return json.Marshal(map[string]interface{}{
+		"resultType": "matrix",
+		"result":     results,
+	})
+}
+
+func cloneStatsQueryRangeMetric(metric map[string]interface{}) map[string]interface{} {
+	if len(metric) == 0 {
+		return map[string]interface{}{}
+	}
+	cloned := make(map[string]interface{}, len(metric))
+	for k, v := range metric {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func cloneStatsQueryRangePoint(point []interface{}) []interface{} {
+	cloned := make([]interface{}, len(point))
+	copy(cloned, point)
+	return cloned
+}
+
+func statsQueryRangePointKey(point []interface{}) string {
+	if len(point) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%v", point[0])
+}
+
+func statsQueryRangePointTimestamp(point []interface{}) float64 {
+	if len(point) == 0 {
+		return 0
+	}
+	switch ts := point[0].(type) {
+	case float64:
+		return ts
+	case float32:
+		return float64(ts)
+	case int:
+		return float64(ts)
+	case int64:
+		return float64(ts)
+	case int32:
+		return float64(ts)
+	case json.Number:
+		value, _ := ts.Float64()
+		return value
+	case string:
+		value, _ := strconv.ParseFloat(ts, 64)
+		return value
+	default:
+		return 0
+	}
 }
 
 func (p *Proxy) proxyStatsQuery(w http.ResponseWriter, r *http.Request, logsqlQuery string) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -456,6 +456,95 @@ func TestContract_QueryRange_MatrixFormat(t *testing.T) {
 	assertLokiSuccess(t, resp)
 }
 
+func TestContract_QueryRange_MatrixFormat_SplitsLongRangeStatsQueries(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		receivedStarts []int64
+	)
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stats_query_range" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		start, err := strconv.ParseInt(r.FormValue("start"), 10, 64)
+		if err != nil {
+			t.Fatalf("parse start: %v", err)
+		}
+		mu.Lock()
+		receivedStarts = append(receivedStarts, start)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"results": []map[string]interface{}{
+				{
+					"metric": map[string]string{"app": "nginx"},
+					"values": [][]interface{}{{start, strconv.FormatInt(start, 10)}},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	p.queryRangeWindowing = true
+	p.queryRangeSplitInterval = 5 * time.Minute
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		http.MethodGet,
+		"/loki/api/v1/query_range?query="+url.QueryEscape(`rate({app="nginx"}[5m])`)+"&start=1705312200&end=1705313100&step=60",
+		nil,
+	)
+	p.handleQueryRange(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 response, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(receivedStarts) < 2 {
+		t.Fatalf("expected split stats_query_range fanout, got %d calls", len(receivedStarts))
+	}
+
+	var resp struct {
+		Data struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]interface{}   `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.ResultType != "matrix" {
+		t.Fatalf("expected matrix result type, got %q", resp.Data.ResultType)
+	}
+	if len(resp.Data.Result) != 1 {
+		t.Fatalf("expected single merged series, got %#v", resp.Data.Result)
+	}
+	if got := len(resp.Data.Result[0].Values); got != len(receivedStarts) {
+		t.Fatalf("expected %d merged points, got %d", len(receivedStarts), got)
+	}
+	prev := -1.0
+	for _, point := range resp.Data.Result[0].Values {
+		if len(point) < 2 {
+			t.Fatalf("expected matrix point pair, got %#v", point)
+		}
+		ts, ok := point[0].(float64)
+		if !ok {
+			t.Fatalf("expected numeric timestamp, got %T (%#v)", point[0], point[0])
+		}
+		if ts <= prev {
+			t.Fatalf("expected strictly increasing merged timestamps, got %#v", resp.Data.Result[0].Values)
+		}
+		prev = ts
+	}
+}
+
 // --- /loki/api/v1/query (instant) ---
 
 func TestContract_Query_ResponseFormat(t *testing.T) {
@@ -2645,9 +2734,27 @@ func TestTranslation_DrilldownPatternQueryForwarded(t *testing.T) {
 	logql := `{app="web"} |> ` + "`" + `GET <_> 500` + "`" + ` | pattern ` + "`" + `GET <field_1> 500` + "`" + ` | keep field_1 | line_format ""`
 	doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query="+url.QueryEscape(logql)+"&start=1&end=2&limit=10")
 
-	want := `app:=web ~"GET .* 500" | extract ` + "`" + `GET <field_1> 500` + "`" + ` | fields _time, _msg, _stream, field_1 | format "" | sort by (_time desc)`
+	want := `app:=web ~"GET .* 500" | extract "GET <field_1> 500" | fields _time, _msg, _stream, field_1 | format "" | sort by (_time desc)`
 	if receivedQuery != want {
 		t.Fatalf("expected translated drilldown pattern query,\n got: %q\nwant: %q", receivedQuery, want)
+	}
+}
+
+func TestTranslation_DrilldownPatternStatsQueryForwarded(t *testing.T) {
+	var receivedQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		receivedQuery = r.FormValue("query")
+		w.Write([]byte{})
+	}))
+	defer vlBackend.Close()
+
+	logql := `{foo="bar"} |> ` + "`" + `test <_> pattern` + "`" + ` | pattern ` + "`" + `test <field_1> pattern` + "`" + ` | keep field_1 | line_format ""`
+	doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query="+url.QueryEscape(logql)+"&start=1&end=2&limit=10")
+
+	want := `foo:=bar ~"test .* pattern" | extract "test <field_1> pattern" | fields _time, _msg, _stream, field_1 | format "" | sort by (_time desc)`
+	if receivedQuery != want {
+		t.Fatalf("expected translated drilldown pattern stats query, got %q", receivedQuery)
 	}
 }
 

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -216,18 +216,22 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 			continue
 		}
 		if strings.HasPrefix(remaining, "|> ") || strings.HasPrefix(remaining, "|>\"") || strings.HasPrefix(remaining, "|>`") {
-			// Pattern match filter: |> "<_> foo" → ~".* foo"
+			// Pattern filter match: |> "foo <_> bar" → ~"foo .* bar"
 			remaining = strings.TrimSpace(remaining[2:])
-			val, rest := extractQuotedValue(remaining)
-			parts = append(parts, "~"+translatePatternMatchValue(val))
+			expr, rest := extractPipelineStage(remaining)
+			if translated := translatePatternLineFilter(expr, false); translated != "" {
+				parts = append(parts, translated)
+			}
 			remaining = rest
 			continue
 		}
 		if strings.HasPrefix(remaining, "!> ") || strings.HasPrefix(remaining, "!>\"") || strings.HasPrefix(remaining, "!>`") {
-			// Negative pattern match filter: !> "<_> foo" → NOT ~"..."
+			// Negative pattern filter: !> "foo <_> bar" → NOT ~"foo .* bar"
 			remaining = strings.TrimSpace(remaining[2:])
-			val, rest := extractQuotedValue(remaining)
-			parts = append(parts, "NOT ~"+translatePatternMatchValue(val))
+			expr, rest := extractPipelineStage(remaining)
+			if translated := translatePatternLineFilter(expr, true); translated != "" {
+				parts = append(parts, translated)
+			}
 			remaining = rest
 			continue
 		}
@@ -311,7 +315,7 @@ func translatePipelineStage(stage string, labelFn LabelTranslateFunc) string {
 	}
 	if strings.HasPrefix(stage, "pattern ") {
 		// | pattern "..." → | extract "..."
-		patternExpr := strings.TrimSpace(stage[8:])
+		patternExpr := normalizeQuotedStageExpr(stage[8:])
 		if isNoopPatternExpression(patternExpr) {
 			// Defensive compatibility: some Drilldown flows emit wildcard-only
 			// patterns like `(.*)`. VL extract requires named placeholders and
@@ -322,11 +326,11 @@ func translatePipelineStage(stage string, labelFn LabelTranslateFunc) string {
 	}
 	if strings.HasPrefix(stage, "regexp ") {
 		// | regexp "..." → | extract_regexp "..."
-		return "| extract_regexp " + stage[7:]
+		return "| extract_regexp " + normalizeQuotedStageExpr(stage[7:])
 	}
 	if strings.HasPrefix(stage, "extract ") {
 		// Defensive pass-through for pre-translated queries.
-		patternExpr := strings.TrimSpace(stage[8:])
+		patternExpr := normalizeQuotedStageExpr(stage[8:])
 		if isNoopPatternExpression(patternExpr) {
 			return ""
 		}
@@ -412,34 +416,6 @@ func translateLabelFilter(stage string, labelFn LabelTranslateFunc) string {
 
 	// Unknown stage — pass through as-is with pipe
 	return "| " + stage
-}
-
-func translatePatternMatchValue(quoted string) string {
-	raw := strings.TrimSpace(quoted)
-	raw = strings.Trim(raw, "\"`")
-	if raw == "" {
-		return strconv.Quote("")
-	}
-
-	placeholderRe := regexp.MustCompile(`<[^>]+>`)
-	matches := placeholderRe.FindAllStringIndex(raw, -1)
-	if len(matches) == 0 {
-		return strconv.Quote(regexp.QuoteMeta(raw))
-	}
-
-	var b strings.Builder
-	last := 0
-	for _, match := range matches {
-		if match[0] > last {
-			b.WriteString(regexp.QuoteMeta(raw[last:match[0]]))
-		}
-		b.WriteString(".*")
-		last = match[1]
-	}
-	if last < len(raw) {
-		b.WriteString(regexp.QuoteMeta(raw[last:]))
-	}
-	return strconv.Quote(b.String())
 }
 
 func translateLogicalLabelFilterChain(stage string, labelFn LabelTranslateFunc) (string, bool) {
@@ -1377,6 +1353,80 @@ func extractQuotedValue(s string) (string, string) {
 		return `"` + s[:end] + `"`, strings.TrimSpace(s[end:])
 	}
 	return `"` + s + `"`, ""
+}
+
+func normalizeQuotedStageExpr(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return expr
+	}
+	quoted, rest := extractQuotedValue(expr)
+	if strings.TrimSpace(rest) == "" && quoted != "" {
+		return quoted
+	}
+	return expr
+}
+
+func translatePatternLineFilter(expr string, negative bool) string {
+	values, ok := extractPatternFilterValues(expr)
+	if !ok || len(values) == 0 {
+		return ""
+	}
+
+	regexes := make([]string, 0, len(values))
+	for _, value := range values {
+		regexes = append(regexes, patternFilterValueToRegex(value))
+	}
+
+	combined := regexes[0]
+	if len(regexes) > 1 {
+		combined = "(?:" + strings.Join(regexes, ")|(?:") + ")"
+	}
+
+	if negative {
+		return "NOT ~" + strconv.Quote(combined)
+	}
+	return "~" + strconv.Quote(combined)
+}
+
+func extractPatternFilterValues(expr string) ([]string, bool) {
+	remaining := strings.TrimSpace(expr)
+	if remaining == "" {
+		return nil, false
+	}
+
+	values := make([]string, 0, 1)
+	for remaining != "" {
+		quoted, rest := extractQuotedValue(remaining)
+		value, err := strconv.Unquote(quoted)
+		if err != nil {
+			return nil, false
+		}
+		values = append(values, value)
+
+		remaining = strings.TrimSpace(rest)
+		if remaining == "" {
+			break
+		}
+		if !strings.HasPrefix(remaining, "or ") {
+			return nil, false
+		}
+		remaining = strings.TrimSpace(remaining[2:])
+	}
+
+	return values, len(values) > 0
+}
+
+func patternFilterValueToRegex(value string) string {
+	if value == "" {
+		return ".*"
+	}
+
+	parts := strings.Split(value, "<_>")
+	for i, part := range parts {
+		parts[i] = regexp.QuoteMeta(part)
+	}
+	return strings.Join(parts, ".*")
 }
 
 // splitStreamMatchers splits stream selector content like `app="x",level="error"`

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -62,6 +62,21 @@ func TestTranslateLogQL(t *testing.T) {
 			want:  `app:=nginx NOT ~"debug.*"`,
 		},
 		{
+			name:  "pattern line filter",
+			logql: `{app="nginx"} |> "test <_> pattern"`,
+			want:  `app:=nginx ~"test .* pattern"`,
+		},
+		{
+			name:  "negative pattern line filter",
+			logql: `{app="nginx"} !> "test <_> pattern"`,
+			want:  `app:=nginx NOT ~"test .* pattern"`,
+		},
+		{
+			name:  "pattern line filter with alternation",
+			logql: `{app="nginx"} |> "test <_> pattern" or "other <_> value"`,
+			want:  `app:=nginx ~"(?:test .* pattern)|(?:other .* value)"`,
+		},
+		{
 			name:  "json parser",
 			logql: `{app="nginx"} | json`,
 			want:  `app:=nginx | unpack_json`,
@@ -178,6 +193,11 @@ func TestTranslateLogQL(t *testing.T) {
 			name:  "json then keep",
 			logql: `{app="api"} | json | keep level, status`,
 			want:  `app:=api | unpack_json | fields _time, _msg, _stream, level, status`,
+		},
+		{
+			name:  "drilldown pattern stats query shape",
+			logql: `{foo="bar"} |> ` + "`" + `test <_> pattern` + "`" + ` | pattern ` + "`" + `test <field_1> pattern` + "`" + ` | keep field_1 | line_format ""`,
+			want:  `foo:=bar ~"test .* pattern" | extract "test <field_1> pattern" | fields _time, _msg, _stream, field_1 | format ""`,
 		},
 		{
 			name:  "json then drop",


### PR DESCRIPTION
## What changed
- split long metric `query_range` requests backed by `stats_query_range` into aligned VL windows and merge the matrix response back into one Loki-shaped result
- add translator support for Loki pattern line filters (`|>` / `!>`) including alternation
- normalize backtick-quoted `pattern` / `regexp` / `extract` stages so Drilldown queries are forwarded in a VL-compatible form
- add focused proxy and translator coverage for the long-range split path and Drilldown pattern query shapes

## Why
Two Drilldown compatibility gaps remained on long ranges:
- long-range metric `query_range` requests still went to VL as one large `stats_query_range` call instead of being split like other long-range fanout paths
- Drilldown pattern-hover queries rely on Loki pattern line filters and backtick-quoted stages that were not translated into a VL-compatible form

## Impact
- improves long-range volume and metric query behavior for Drilldown and Explore paths that use `stats_query_range`
- fixes forwarding of Drilldown per-pattern stats queries so they no longer depend on unsupported Loki-only syntax reaching VL unchanged

## Validation
- `rtk go test ./internal/translator ./internal/proxy`
- `rtk git diff --check`
