### PR TITLE
Fallback query_range windowing to direct query on window fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- query-range/windowing: fall back from the windowed log `query_range` path to the direct full-range Loki-compatible query when per-window fetches exhaust retries, instead of surfacing the windowed-path failure immediately.
+
 ## [1.4.4] - 2026-04-16
 
 ### Bug Fixes

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -193,8 +193,7 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 				"batch_size", batchSize,
 				"status", status,
 			)
-			p.writeError(w, status, err.Error())
-			return true
+			return false
 		}
 
 		for _, result := range results {

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -848,7 +848,8 @@ func TestQueryRangeWindow_SevenDayRegressionSLO(t *testing.T) {
 		t.Fatalf("expected prefilter to inspect all 168 windows, got %d", got)
 	}
 }
-func TestQueryRangeWindow_DoesNotFallbackToDirectQueryOnWindowFetchError(t *testing.T) {
+
+func TestQueryRangeWindow_FallsBackToDirectQueryOnWindowFetchError(t *testing.T) {
 	start := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Hour).UnixNano()
 	end := start + int64(2*time.Hour) - 1
 
@@ -863,10 +864,18 @@ func TestQueryRangeWindow_DoesNotFallbackToDirectQueryOnWindowFetchError(t *test
 		reqStart, _ := strconv.ParseInt(startParam, 10, 64)
 		reqEnd, _ := strconv.ParseInt(endParam, 10, 64)
 
-		if reqStart == start && reqEnd == end {
-			fullRangeCalls.Add(1)
+		// Windowed calls should fail to force fallback.
+		if reqStart != start || reqEnd != end {
+			http.Error(w, "all backends unavailable", http.StatusBadGateway)
+			return
 		}
-		http.Error(w, "all backends unavailable", http.StatusBadGateway)
+
+		fullRangeCalls.Add(1)
+		_, _ = fmt.Fprintf(
+			w,
+			"{\"_time\":%q,\"_msg\":\"fallback-ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
+			time.Unix(0, reqStart).UTC().Format(time.RFC3339Nano),
+		)
 	}))
 	defer vlBackend.Close()
 
@@ -884,22 +893,21 @@ func TestQueryRangeWindow_DoesNotFallbackToDirectQueryOnWindowFetchError(t *test
 	resp := httptest.NewRecorder()
 	p.handleQueryRange(resp, req)
 
-	if resp.Code != http.StatusBadGateway {
-		t.Fatalf("expected windowed query failure status=502, got=%d body=%s", resp.Code, resp.Body.String())
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected fallback query_range status=200, got=%d body=%s", resp.Code, resp.Body.String())
 	}
-	if got := fullRangeCalls.Load(); got != 0 {
-		t.Fatalf("expected no direct full-range fallback call, got %d", got)
+	if got := fullRangeCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly one direct full-range fallback call, got %d", got)
 	}
 
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(resp.Body.Bytes(), &parsed); err != nil {
-		t.Fatalf("failed to decode error response: %v body=%s", err, resp.Body.String())
+		t.Fatalf("failed to decode fallback response: %v body=%s", err, resp.Body.String())
 	}
-	if parsed["status"] != "error" {
-		t.Fatalf("expected Loki error response status=error, body=%s", resp.Body.String())
-	}
-	if parsed["errorType"] != "unavailable" {
-		t.Fatalf("expected Loki errorType=unavailable, body=%s", resp.Body.String())
+	data, _ := parsed["data"].(map[string]interface{})
+	result, _ := data["result"].([]interface{})
+	if len(result) == 0 {
+		t.Fatalf("expected non-empty result from direct fallback, body=%s", resp.Body.String())
 	}
 }
 
@@ -1043,6 +1051,7 @@ func TestQueryRangeWindow_DegradesBatchParallelismOnBackendUnavailable(t *testin
 		t.Fatalf("expected additional backend attempts after degradation, got calls=%d", calls.Load())
 	}
 }
+
 func TestQueryRangeWindow_ParseLokiTimeAndNormalization(t *testing.T) {
 	t.Run("rfc3339", func(t *testing.T) {
 		raw := "2026-04-10T12:00:00Z"


### PR DESCRIPTION
## What changed
This PR rebases the pending `query_range` window-fallback work onto current `main`, which already includes the last merged tests PR `#175` (`1dee274`).

It keeps one behavioral delta:
- when windowed log `query_range` fanout exhausts retries and would otherwise fail, the proxy now falls back to the normal direct full-range `query_range` path instead of surfacing the windowed-path error immediately

It also updates the focused regression test to assert the direct fallback behavior.

## Why
Current `main` already contains newer long-range windowing, retry, degradation, and partial-response logic than the historical branch. The real missing compatibility behavior was only the fallback to the direct full-range query path.

Keeping that isolated on top of current `main` avoids reintroducing stale metrics and windowing changes while preserving the intended compatibility fix.

## User impact
- long-range windowed log queries can recover by using the direct path when the windowed path fails
- the change is narrow and does not replace the current retry/backoff/partial-response logic on `main`

## Validation
- `go test ./internal/proxy`
- `git diff --check origin/main...HEAD`
