### PR TITLE
Normalize float-second step handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/step-parsing: normalize float-second `step` values before forwarding them to backend volume and patterns requests, and reuse the same positive-duration parsing in zero-fill plus patterns bucketing so float-second cadences stay dense and aligned.
+
 ## [1.4.3] - 2026-04-16
 
 ### Bug Fixes

--- a/internal/proxy/gaps_test.go
+++ b/internal/proxy/gaps_test.go
@@ -338,6 +338,50 @@ func TestGap_VolumeRange_FillsSevenDayMinuteRangePastLegacyBucketCap(t *testing.
 	}
 }
 
+func TestGap_VolumeRange_FillsSevenDayFloatSecondRange(t *testing.T) {
+	var receivedStep string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedStep = r.URL.Query().Get("step")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"app": "nginx"},
+					"timestamps": []string{"2026-04-16T00:00:00Z"},
+					"values":     []int{7},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume_range?query=%7B%7D&start=2026-04-09T00:00:00Z&end=2026-04-16T00:00:00Z&step=60.000", nil)
+	p.handleVolumeRange(w, r)
+
+	if receivedStep != "60s" {
+		t.Fatalf("expected float-second step to be normalized to 60s, got %q", receivedStep)
+	}
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	result := data["result"].([]interface{})
+	if len(result) != 1 {
+		t.Fatalf("expected single series, got %d", len(result))
+	}
+	entry := result[0].(map[string]interface{})
+	values := entry["values"].([]interface{})
+	if len(values) != 10081 {
+		t.Fatalf("expected fully filled 7d float-step range with 10081 buckets, got %d", len(values))
+	}
+	first := values[0].([]interface{})
+	last := values[len(values)-1].([]interface{})
+	if first[1] != "0" || last[1] != "7" {
+		t.Fatalf("expected zero-filled leading buckets and retained trailing hit, got first=%v last=%v", first, last)
+	}
+}
+
 // =============================================================================
 // Gap #4: /loki/api/v1/detected_field/{name}/values — missing endpoint
 // Loki response: {"values":["debug","info","warn","error"],"limit":1000}

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -272,11 +271,8 @@ func parsePatternStepSeconds(step string) int64 {
 	if step == "" {
 		return stepSeconds
 	}
-	if d, err := time.ParseDuration(step); err == nil && d > 0 {
+	if d, ok := parsePositiveStepDuration(step); ok && d >= time.Second {
 		return int64(d / time.Second)
-	}
-	if seconds, err := strconv.Atoi(step); err == nil && seconds > 0 {
-		return int64(seconds)
 	}
 	return stepSeconds
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8964,18 +8964,35 @@ func normalizeUnixSeconds(v int64) int64 {
 	}
 }
 
-func parseStepSeconds(step string) (int64, bool) {
+func parsePositiveStepDuration(step string) (time.Duration, bool) {
 	value := strings.TrimSpace(step)
 	if value == "" {
 		return 0, false
 	}
 	if d, err := time.ParseDuration(value); err == nil && d > 0 {
-		return int64(d / time.Second), true
+		return d, true
 	}
-	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
-		return int64(seconds), true
+	seconds, err := strconv.ParseFloat(value, 64)
+	if err != nil || seconds <= 0 {
+		return 0, false
 	}
-	return 0, false
+	nanos := seconds * float64(time.Second)
+	if nanos > float64(math.MaxInt64) {
+		return 0, false
+	}
+	d := time.Duration(nanos)
+	if d <= 0 {
+		return 0, false
+	}
+	return d, true
+}
+
+func parseStepSeconds(step string) (int64, bool) {
+	d, ok := parsePositiveStepDuration(step)
+	if !ok || d < time.Second {
+		return 0, false
+	}
+	return int64(d / time.Second), true
 }
 
 func parseRequestedBucketRange(start, end, step string) (requestedBucketRange, bool) {
@@ -9209,8 +9226,8 @@ func formatVLStep(step string) string {
 		}
 	}
 	// Numeric-only: treat as seconds, append "s"
-	if _, err := strconv.ParseFloat(step, 64); err == nil {
-		return step + "s"
+	if seconds, err := strconv.ParseFloat(step, 64); err == nil && seconds > 0 {
+		return strconv.FormatFloat(seconds, 'f', -1, 64) + "s"
 	}
 	return step
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1860,12 +1860,17 @@ func TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps(t *testi
 }
 
 func TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets(t *testing.T) {
-	var receivedStep string
+	var (
+		mu           sync.Mutex
+		receivedStep string
+	)
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("parse form: %v", err)
 		}
+		mu.Lock()
 		receivedStep = r.FormValue("step")
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		_, _ = w.Write([]byte(`{"_time":"2026-04-04T12:59:59Z","_msg":"GET /api/users 200 15ms","app":"web","level":"info"}` + "\n"))
 	}))
@@ -1883,8 +1888,11 @@ func TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets(t *testing.T)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
 	}
-	if receivedStep != "90s" {
-		t.Fatalf("expected float-second step to be normalized to 90s, got %q", receivedStep)
+	mu.Lock()
+	gotStep := receivedStep
+	mu.Unlock()
+	if gotStep != "90s" {
+		t.Fatalf("expected float-second step to be normalized to 90s, got %q", gotStep)
 	}
 
 	var resp patternsResponse

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1859,6 +1859,52 @@ func TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps(t *testi
 	}
 }
 
+func TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets(t *testing.T) {
+	var receivedStep string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		receivedStep = r.FormValue("step")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"_time":"2026-04-04T12:59:59Z","_msg":"GET /api/users 200 15ms","app":"web","level":"info"}` + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/loki/api/v1/patterns?query=%7Bapp%3D%22web%22%7D&start=2026-04-04T10:00:00Z&end=2026-04-04T13:00:00Z&step=90.000&limit=1",
+		nil,
+	)
+	p.handlePatterns(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for patterns endpoint, got %d body=%s", w.Code, w.Body.String())
+	}
+	if receivedStep != "90s" {
+		t.Fatalf("expected float-second step to be normalized to 90s, got %q", receivedStep)
+	}
+
+	var resp patternsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected one pattern, got %+v", resp.Data)
+	}
+	if got := len(resp.Data[0].Samples); got != 121 {
+		t.Fatalf("expected 121 requested 90s buckets across 3h range, got %d", got)
+	}
+	firstTS, okFirst := numberToInt64(resp.Data[0].Samples[0][0])
+	lastTS, okLast := numberToInt64(resp.Data[0].Samples[len(resp.Data[0].Samples)-1][0])
+	if !okFirst || !okLast {
+		t.Fatalf("expected numeric sample timestamps, got first=%v last=%v", resp.Data[0].Samples[0], resp.Data[0].Samples[len(resp.Data[0].Samples)-1])
+	}
+	if firstTS != 1775296800 || lastTS != 1775307600 {
+		t.Fatalf("expected requested 3h range to stay anchored to 90s buckets, got %d..%d", firstTS, lastTS)
+	}
+}
+
 func TestContract_Patterns_FillCoarsensHugePointRanges(t *testing.T) {
 	entries := []patternResultEntry{
 		{


### PR DESCRIPTION
## What changed
- normalize numeric float-second `step` values before forwarding them to backend volume and patterns requests
- share one positive-duration parser across proxy volume and patterns sampling paths
- add regressions for 7-day float-second `volume_range` filling and short-range patterns bucketing

## Why
Loki accepts `step` as either a duration string or a float number of seconds. The proxy already forwarded numeric steps to VictoriaLogs, but its local zero-fill and patterns bucketing logic only parsed integer seconds or `time.ParseDuration` formats. That left requests like `step=60.000` or `step=90.000` partially handled: backend requests succeeded, but local filling and sample bucketing could drift or be skipped.

## Impact
- keeps long-range volume filling consistent when clients send float-second steps
- keeps patterns sampling anchored to the requested bucket cadence for float-second steps
- narrows one real proxy-side mismatch while deeper Drilldown-specific volume behavior is investigated separately

## Validation
- `go test ./internal/proxy -run 'TestGap_VolumeRange_FillsSevenDayFloatSecondRange|TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets|TestGap_VolumeRange_FillsSevenDayMinuteRangePastLegacyBucketCap|TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps' -count=1`
- `go test ./internal/proxy -count=1`
- `go test ./internal/translator -count=1`
