### PR TITLE
Fix split query_range volume gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/volume: compensate split `stats_query_range` metric windows by extending backend end timestamps by one step and trimming the extra point back to the requested range, so 2-day Explore and Drilldown volume queries stay dense across 24h boundaries.
+
 ## [1.4.5] - 2026-04-16
 
 ### Bug Fixes

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -7448,17 +7448,7 @@ func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, log
 		return
 	}
 
-	params := url.Values{}
-	params.Set("query", logsqlQuery)
-	if s := r.FormValue("start"); s != "" {
-		params.Set("start", formatVLTimestamp(s))
-	}
-	if e := r.FormValue("end"); e != "" {
-		params.Set("end", formatVLTimestamp(e))
-	}
-	if step := r.FormValue("step"); step != "" {
-		params.Set("step", formatVLStep(step))
-	}
+	params := buildStatsQueryRangeParams(logsqlQuery, r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
 
 	resp, err := p.vlPost(r.Context(), "/select/logsql/stats_query_range", params)
 	if err != nil {
@@ -7474,6 +7464,8 @@ func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, log
 		p.writeError(w, resp.StatusCode, string(body))
 		return
 	}
+
+	body = trimStatsQueryRangeResponseToEnd(body, r.FormValue("end"))
 
 	// VL stats_query_range returns Prometheus-compatible format.
 	// Just wrap it in Loki's envelope.
@@ -7538,12 +7530,12 @@ func (p *Proxy) fetchStatsQueryRangeWindow(ctx context.Context, r *http.Request,
 	defer cancel()
 
 	params := url.Values{}
-	params.Set("query", logsqlQuery)
-	params.Set("start", strconv.FormatInt(window.startNs, 10))
-	params.Set("end", strconv.FormatInt(window.endNs, 10))
-	if step := r.FormValue("step"); step != "" {
-		params.Set("step", formatVLStep(step))
-	}
+	params = buildStatsQueryRangeParams(
+		logsqlQuery,
+		strconv.FormatInt(window.startNs, 10),
+		strconv.FormatInt(window.endNs, 10),
+		r.FormValue("step"),
+	)
 
 	for attempt := 1; attempt <= queryRangeWindowFetchAttempts; attempt++ {
 		fetchStart := time.Now()
@@ -7557,6 +7549,7 @@ func (p *Proxy) fetchStatsQueryRangeWindow(ctx context.Context, r *http.Request,
 			if readErr != nil {
 				err = readErr
 			} else if resp.StatusCode < http.StatusBadRequest {
+				body = trimStatsQueryRangeResponseToEnd(body, strconv.FormatInt(window.endNs, 10))
 				p.observeQueryRangeWindowFetch(fetchDuration, false)
 				return body, nil
 			} else {
@@ -7683,6 +7676,83 @@ func cloneStatsQueryRangePoint(point []interface{}) []interface{} {
 	return cloned
 }
 
+func buildStatsQueryRangeParams(logsqlQuery, startRaw, endRaw, stepRaw string) url.Values {
+	params := url.Values{}
+	params.Set("query", logsqlQuery)
+	if s := strings.TrimSpace(startRaw); s != "" {
+		params.Set("start", formatVLTimestamp(s))
+	}
+	if e := strings.TrimSpace(endRaw); e != "" {
+		if extendedEnd, ok := extendStatsQueryRangeEnd(e, stepRaw); ok {
+			params.Set("end", extendedEnd)
+		} else {
+			params.Set("end", formatVLTimestamp(e))
+		}
+	}
+	if step := strings.TrimSpace(stepRaw); step != "" {
+		params.Set("step", formatVLStep(step))
+	}
+	return params
+}
+
+func extendStatsQueryRangeEnd(endRaw, stepRaw string) (string, bool) {
+	endNs, ok := parseLokiTimeToUnixNano(endRaw)
+	if !ok {
+		return "", false
+	}
+	stepDur, ok := parsePositiveStepDuration(stepRaw)
+	if !ok || stepDur <= 0 {
+		return "", false
+	}
+	return strconv.FormatInt(endNs+stepDur.Nanoseconds(), 10), true
+}
+
+func trimStatsQueryRangeResponseToEnd(body []byte, endRaw string) []byte {
+	endNs, ok := parseLokiTimeToUnixNano(endRaw)
+	if !ok {
+		return body
+	}
+
+	var resp statsQueryRangeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return body
+	}
+
+	results := resp.Results
+	target := &resp.Results
+	if len(results) == 0 {
+		results = resp.Data.Result
+		target = &resp.Data.Result
+	}
+	if len(results) == 0 {
+		return body
+	}
+
+	changed := false
+	trimmed := make([]statsQueryRangeSeries, 0, len(results))
+	for _, series := range results {
+		filtered := make([][]interface{}, 0, len(series.Values))
+		for _, point := range series.Values {
+			if statsQueryRangePointUnixNano(point) <= endNs {
+				filtered = append(filtered, point)
+				continue
+			}
+			changed = true
+		}
+		series.Values = filtered
+		trimmed = append(trimmed, series)
+	}
+	if !changed {
+		return body
+	}
+	*target = trimmed
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		return body
+	}
+	return encoded
+}
+
 func statsQueryRangePointKey(point []interface{}) string {
 	if len(point) == 0 {
 		return ""
@@ -7714,6 +7784,33 @@ func statsQueryRangePointTimestamp(point []interface{}) float64 {
 	default:
 		return 0
 	}
+}
+
+func statsQueryRangePointUnixNano(point []interface{}) int64 {
+	if len(point) == 0 {
+		return 0
+	}
+	switch ts := point[0].(type) {
+	case float64:
+		return normalizeLokiNumericTimeToUnixNano(ts)
+	case float32:
+		return normalizeLokiNumericTimeToUnixNano(float64(ts))
+	case int:
+		return normalizeLokiIntTimeToUnixNano(int64(ts))
+	case int64:
+		return normalizeLokiIntTimeToUnixNano(ts)
+	case int32:
+		return normalizeLokiIntTimeToUnixNano(int64(ts))
+	case json.Number:
+		if value, err := ts.Float64(); err == nil {
+			return normalizeLokiNumericTimeToUnixNano(value)
+		}
+	case string:
+		if value, ok := parseLokiTimeToUnixNano(ts); ok {
+			return value
+		}
+	}
+	return 0
 }
 
 func (p *Proxy) proxyStatsQuery(w http.ResponseWriter, r *http.Request, logsqlQuery string) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -7529,8 +7529,7 @@ func (p *Proxy) fetchStatsQueryRangeWindow(ctx context.Context, r *http.Request,
 	}
 	defer cancel()
 
-	params := url.Values{}
-	params = buildStatsQueryRangeParams(
+	params := buildStatsQueryRangeParams(
 		logsqlQuery,
 		strconv.FormatInt(window.startNs, 10),
 		strconv.FormatInt(window.endNs, 10),

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -545,6 +545,76 @@ func TestContract_QueryRange_MatrixFormat_SplitsLongRangeStatsQueries(t *testing
 	}
 }
 
+func TestContract_QueryRange_MatrixFormat_ExtendsBackendEndByStepAndTrimsExtraPoint(t *testing.T) {
+	var receivedEnd string
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stats_query_range" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		receivedEnd = r.FormValue("end")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"resultType": "matrix",
+				"result": []map[string]interface{}{
+					{
+						"metric": map[string]string{"app": "nginx"},
+						"values": [][]interface{}{
+							{1705312200, "1"},
+							{1705312260, "2"},
+							{1705312320, "3"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	resp := doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query=rate(%7Bapp%3D%22nginx%22%7D%5B5m%5D)&start=1705312200&end=1705312260&step=60")
+	assertLokiSuccess(t, resp)
+
+	expectedEnd := strconv.FormatInt((1705312260+60)*int64(time.Second), 10)
+	if receivedEnd != expectedEnd {
+		t.Fatalf("expected compensated backend end %q, got %q", expectedEnd, receivedEnd)
+	}
+
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Loki data object, got %#v", resp["data"])
+	}
+	result, ok := data["result"].([]interface{})
+	if !ok || len(result) != 1 {
+		t.Fatalf("expected single series, got %#v", data["result"])
+	}
+	series, ok := result[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected series object, got %#v", result[0])
+	}
+	values, ok := series["values"].([]interface{})
+	if !ok {
+		t.Fatalf("expected values array, got %#v", series["values"])
+	}
+	if len(values) != 2 {
+		t.Fatalf("expected proxy to trim extra backend point, got %#v", values)
+	}
+	lastPair, ok := values[len(values)-1].([]interface{})
+	if !ok {
+		t.Fatalf("expected [ts,value] pair, got %#v", values[len(values)-1])
+	}
+	lastTS, ok := lastPair[0].(float64)
+	if !ok {
+		t.Fatalf("expected numeric timestamp, got %T", lastPair[0])
+	}
+	if int64(lastTS) != 1705312260 {
+		t.Fatalf("expected last timestamp to stay at requested end, got %v", lastPair)
+	}
+}
+
 // --- /loki/api/v1/query (instant) ---
 
 func TestContract_Query_ResponseFormat(t *testing.T) {

--- a/test/e2e-compat/drilldown_longrange_regression_test.go
+++ b/test/e2e-compat/drilldown_longrange_regression_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -156,6 +157,94 @@ func TestDrilldown_LongRangeVolume_SplitQueriesStayDense(t *testing.T) {
 	for _, want := range []string{"info", "error"} {
 		if !seenLevels[want] {
 			t.Fatalf("expected long-range volume result to include detected_level=%s, got %v", want, seenLevels)
+		}
+	}
+}
+
+func TestDrilldown_LongRangeVolume_GrafanaStyleSplitQueriesStayDense(t *testing.T) {
+	ensureDataIngested(t)
+	waitForReady(t, proxyURL+"/ready", 30*time.Second)
+
+	cfg := longRangeDrilldownSeedConfig{
+		rangeWindow:             48 * time.Hour,
+		step:                    5 * time.Minute,
+		patternCount:            6,
+		repeatsPerPatternBucket: 4,
+		batchSize:               4000,
+	}
+	serviceName := longRangeServiceName(longRangeVolumeService)
+	start := time.Now().UTC().Add(-cfg.rangeWindow).Truncate(cfg.step)
+	end := start.Add(cfg.rangeWindow)
+	seedLongRangeDrilldownServiceData(t, serviceName, start, end, cfg)
+	waitForDrilldownServiceVisible(t, serviceName, start, end)
+
+	queryStep := time.Hour
+	expr := fmt.Sprintf(`sum by (detected_level) (count_over_time({service_name="%s"}[1h]))`, serviceName)
+
+	type splitWindow struct {
+		start time.Time
+		end   time.Time
+	}
+
+	windows := make([]splitWindow, 0, 3)
+	for chunkStart := start; !chunkStart.After(end); {
+		chunkEnd := chunkStart.Add(23 * queryStep)
+		if chunkEnd.After(end) {
+			chunkEnd = end
+		}
+		windows = append(windows, splitWindow{start: chunkStart, end: chunkEnd})
+		if !chunkEnd.Before(end) {
+			break
+		}
+		chunkStart = chunkEnd.Add(queryStep)
+	}
+	if len(windows) < 2 {
+		t.Fatalf("expected multi-window long-range split, got %#v", windows)
+	}
+
+	merged := map[string][]int64{}
+	for _, window := range windows {
+		windowResult := queryRangeMatrixResult(t, expr, window.start, window.end, queryStep)
+		for _, item := range windowResult {
+			series, _ := item.(map[string]interface{})
+			metric, _ := series["metric"].(map[string]interface{})
+			level, _ := metric["detected_level"].(string)
+			values, _ := series["values"].([]interface{})
+			for _, raw := range values {
+				pair, _ := raw.([]interface{})
+				if len(pair) != 2 {
+					t.Fatalf("expected [ts,value] pair for split volume series, got %v", raw)
+				}
+				ts, ok := denseSampleTs(pair[0])
+				if !ok {
+					t.Fatalf("expected numeric timestamp for detected_level=%s, got %T", level, pair[0])
+				}
+				merged[level] = append(merged[level], ts)
+			}
+		}
+	}
+
+	startBucket, endBucket, expectedBuckets := denseExpectedBuckets(start, end, queryStep)
+	minPoints := expectedBuckets - 1
+	for _, level := range []string{"info", "error"} {
+		series := merged[level]
+		if len(series) < minPoints {
+			t.Fatalf("expected dense merged split coverage for detected_level=%s, got %d/%d points", level, len(series), expectedBuckets)
+		}
+		series = uniqueSortedInt64s(series)
+		if len(series) < minPoints {
+			t.Fatalf("expected dense unique split coverage for detected_level=%s, got %d/%d points", level, len(series), expectedBuckets)
+		}
+		if series[0] > startBucket+(2*int64(queryStep/time.Second)) {
+			t.Fatalf("expected early split coverage for detected_level=%s, first_ts=%d start_bucket=%d", level, series[0], startBucket)
+		}
+		for i := 1; i < len(series); i++ {
+			if gap := series[i] - series[i-1]; gap > int64(queryStep/time.Second) {
+				t.Fatalf("expected contiguous merged split buckets for detected_level=%s, prev=%d current=%d gap=%d", level, series[i-1], series[i], gap)
+			}
+		}
+		if series[len(series)-1] < endBucket-(2*int64(queryStep/time.Second)) {
+			t.Fatalf("expected late split coverage for detected_level=%s, last_ts=%d end_bucket=%d", level, series[len(series)-1], endBucket)
 		}
 	}
 }
@@ -320,4 +409,19 @@ func queryRangeMatrixResult(t *testing.T, expr string, start, end time.Time, ste
 		t.Fatalf("expected query_range matrix result for %q, got %v", expr, resp)
 	}
 	return result
+}
+
+func uniqueSortedInt64s(values []int64) []int64 {
+	if len(values) == 0 {
+		return nil
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	out := sorted[:1]
+	for _, value := range sorted[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## What changed

This fixes dense long-range volume gaps on translated metric `query_range` requests.

- extend backend `stats_query_range` window ends by one `step`
- trim any extra returned point back to the caller's original requested end
- add a proxy unit regression for the compensated backend end + trim behavior
- add an e2e regression that reproduces Grafana-style split 2-day volume queries and asserts the merged series stays dense

## Why

The remaining 24h boundary gaps were reproduced locally in compose on the proxy path, not on the direct Loki path.

For long-range volume queries, Grafana issues multiple split metric requests. The translated proxy path goes through `stats_query_range`, and VictoriaLogs drops the trailing bucket for those split windows unless the backend `end` is pushed forward by one step. When those windows are merged back together, the missing trailing bucket from each split produces the visible gap between day-sized windows.

The proxy now compensates for that backend behavior while preserving the original Loki-compatible caller range by trimming the extra backend point after the response comes back.

## Impact

- 2-day Explore / Drilldown volume queries stay dense across 24h boundaries
- the fix is limited to translated metric `query_range` requests
- caller-visible range semantics stay unchanged

## Validation

- `go test ./internal/proxy -run 'TestContract_QueryRange_MatrixFormat_(SplitsLongRangeStatsQueries|ExtendsBackendEndByStepAndTrimsExtraPoint)' -count=1`
- `PROXY_URL=http://localhost:3102 GRAFANA_URL=http://localhost:3002 LOKI_URL=http://localhost:3101 VL_URL=http://localhost:29428 go test -tags=e2e -run 'TestDrilldown_LongRangeVolume_(SplitQueriesStayDense|GrafanaStyleSplitQueriesStayDense)' -v ./test/e2e-compat`
