### PR TITLE
Match native Loki pattern behavior on proxy read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- patterns/drilldown: make proxy read-path pattern mining match native Loki pattern coverage more closely by preserving stable fixed-prefix patterns, avoiding split-window overlap on backend raw log fetches, and dropping the synthetic trailing zero bucket beyond the last observed sample.
+
 ## [1.4.6] - 2026-04-16
 
 ### Bug Fixes

--- a/internal/cache/peer_test.go
+++ b/internal/cache/peer_test.go
@@ -909,18 +909,14 @@ func TestPeerCache_WriteThroughPushesToOwner(t *testing.T) {
 	}
 
 	pc.SetWithTTL(key, []byte("value"), 30*time.Second)
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if got, ok := ownerCache.Get(key); ok && string(got) == "value" {
-			stats := pc.Stats()
-			if stats["wt_pushes"].(int64) < 1 {
-				t.Fatalf("expected wt_pushes >= 1, got %+v", stats)
-			}
-			return
+	requireEventually(t, 3*time.Second, func() bool {
+		got, ok := ownerCache.Get(key)
+		if !ok || string(got) != "value" {
+			return false
 		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("owner cache did not receive write-through key %q", key)
+		stats := pc.Stats()
+		return stats["wt_pushes"].(int64) >= 1
+	})
 }
 
 func TestPeerCache_WriteThroughSkipsShortTTL(t *testing.T) {

--- a/internal/proxy/patterns_persistence_test.go
+++ b/internal/proxy/patterns_persistence_test.go
@@ -450,8 +450,8 @@ func TestHandlePatterns_FallsBackToLatestSnapshotOnEmptyRefresh(t *testing.T) {
 	if len(secondResp.Data) == 0 {
 		t.Fatalf("expected snapshot fallback to keep non-empty patterns, got %#v", secondResp)
 	}
-	if len(secondResp.Data[0].Samples) != 3 {
-		t.Fatalf("expected fallback samples filled across the requested range, got %#v", secondResp.Data[0].Samples)
+	if len(secondResp.Data[0].Samples) != 1 {
+		t.Fatalf("expected snapshot fallback to preserve observed samples without synthetic tail fill, got %#v", secondResp.Data[0].Samples)
 	}
 }
 

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -23,6 +23,7 @@ const (
 	patternMaxTokens      = 80
 	patternSimThreshold   = 0.3
 	patternMaxLineLength  = 3000
+	patternPrefixDepth    = 4
 )
 
 type patternBucket struct {
@@ -505,6 +506,9 @@ func bestPatternCluster(candidates []*patternBucket, tokens []string) *patternBu
 	maxParamCount := -1
 
 	for _, cluster := range candidates {
+		if !patternPrefixCompatible(cluster.tokens, tokens) {
+			continue
+		}
 		curSim, paramCount := getPatternSimilarity(cluster.tokens, tokens)
 		if paramCount < 0 {
 			continue
@@ -519,6 +523,37 @@ func bestPatternCluster(candidates []*patternBucket, tokens []string) *patternBu
 		return match
 	}
 	return nil
+}
+
+func patternPrefixCompatible(templateTokens, tokens []string) bool {
+	if len(templateTokens) != len(tokens) || len(tokens) == 0 {
+		return false
+	}
+	depth := patternPrefixDepth
+	if depth > len(tokens) {
+		depth = len(tokens)
+	}
+	for i := 0; i < depth; i++ {
+		templateToken := templateTokens[i]
+		inputToken := tokens[i]
+		if templateToken == patternVarPlaceholder || templateToken == inputToken {
+			continue
+		}
+		if patternTokenHasDigits(templateToken) || patternTokenHasDigits(inputToken) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func patternTokenHasDigits(token string) bool {
+	for _, ch := range token {
+		if unicode.IsDigit(ch) {
+			return true
+		}
+	}
+	return false
 }
 
 func getPatternSimilarity(templateTokens, tokens []string) (float64, int) {

--- a/internal/proxy/postprocess_coverage_test.go
+++ b/internal/proxy/postprocess_coverage_test.go
@@ -1,6 +1,10 @@
 package proxy
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestCollectPatternObservationsFromJSON_MixedShapes(t *testing.T) {
 	miner := newPatternMiner()
@@ -87,5 +91,43 @@ func TestPostprocessHelperCoverage(t *testing.T) {
 	}
 	if isIPLike("192.168.0.x") {
 		t.Fatal("expected malformed IP not to be recognized as IP-like")
+	}
+}
+
+func TestExtractLogPatterns_KeepsStablePrefixPatternsSeparate(t *testing.T) {
+	lines := make([]string, 0, 8)
+	for _, ts := range []string{
+		"2026-04-17T05:35:30Z",
+		"2026-04-17T05:36:00Z",
+	} {
+		for _, msg := range []string{
+			"stable_pattern_alpha component=collector action=scrape outcome=ok",
+			"stable_pattern_bravo component=collector action=transform outcome=ok",
+			"stable_pattern_charlie component=collector action=export outcome=retry",
+			"stable_pattern_delta component=collector action=ship outcome=ok",
+		} {
+			lines = append(lines, fmt.Sprintf(`{"_time":"%s","_msg":"%s","level":"info"}`, ts, msg))
+		}
+	}
+
+	patterns := extractLogPatterns([]byte(strings.Join(lines, "\n")+"\n"), "30s", 10)
+	if len(patterns) != 4 {
+		t.Fatalf("expected 4 distinct stable patterns, got %d: %#v", len(patterns), patterns)
+	}
+
+	got := map[string]bool{}
+	for _, pattern := range patterns {
+		patternText, _ := pattern["pattern"].(string)
+		got[patternText] = true
+	}
+	for _, want := range []string{
+		"stable_pattern_alpha component=collector action=scrape outcome=ok",
+		"stable_pattern_bravo component=collector action=transform outcome=ok",
+		"stable_pattern_charlie component=collector action=export outcome=retry",
+		"stable_pattern_delta component=collector action=ship outcome=ok",
+	} {
+		if !got[want] {
+			t.Fatalf("expected pattern %q in %#v", want, got)
+		}
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4964,9 +4964,6 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	if e := endParam; e != "" {
 		params.Set("end", formatVLTimestamp(e))
 	}
-	if s := strings.TrimSpace(stepParam); s != "" {
-		params.Set("step", formatVLStep(s))
-	}
 	params.Set("limit", strconv.Itoa(sourceLimit))
 
 	fetchPatterns := func(endpoint string) ([]patternResultEntry, bool) {
@@ -5089,9 +5086,9 @@ func (p *Proxy) fetchPatternsFromWindows(
 
 	baseParams := url.Values{}
 	baseParams.Set("query", logsqlQuery)
-	if s := strings.TrimSpace(stepParam); s != "" {
-		baseParams.Set("step", formatVLStep(s))
-	}
+	// Bucketization for patterns is proxy-side. Forwarding step to VictoriaLogs
+	// raw log queries makes split subrequests align backward to prior step
+	// boundaries, which duplicates adjacent window buckets on deterministic data.
 
 	collected := make([]patternResultEntry, 0, len(windows))
 	successes := 0
@@ -5500,8 +5497,10 @@ func mergePatternResultEntries(base, extra []patternResultEntry) []patternResult
 				if !okTS || !okCount {
 					continue
 				}
-				b.samples[ts] += count
-				b.total += count
+				if count > b.samples[ts] {
+					b.total += count - b.samples[ts]
+					b.samples[ts] = count
+				}
 			}
 		}
 	}
@@ -5706,6 +5705,8 @@ func fillPatternSamplesAcrossRequestedRange(entries []patternResultEntry, startP
 	}
 	for i := range entries {
 		sampleMap := make(map[int64]int, len(entries[i].Samples))
+		firstObservedBucket := int64(0)
+		lastObservedBucket := int64(0)
 		for _, pair := range entries[i].Samples {
 			if len(pair) < 2 {
 				continue
@@ -5717,9 +5718,32 @@ func fillPatternSamplesAcrossRequestedRange(entries []patternResultEntry, startP
 			}
 			ts = (ts / effectiveStepSeconds) * effectiveStepSeconds
 			sampleMap[ts] += count
+			if firstObservedBucket == 0 || ts < firstObservedBucket {
+				firstObservedBucket = ts
+			}
+			if ts > lastObservedBucket {
+				lastObservedBucket = ts
+			}
 		}
-		filled := make([][]interface{}, 0, points)
-		for ts := startBucket; ts <= endBucket; ts += effectiveStepSeconds {
+		if firstObservedBucket == 0 && lastObservedBucket == 0 {
+			continue
+		}
+
+		fillStartBucket := startBucket
+		if firstObservedBucket > fillStartBucket {
+			fillStartBucket = firstObservedBucket
+		}
+		fillEndBucket := endBucket
+		if lastObservedBucket < fillEndBucket {
+			fillEndBucket = lastObservedBucket
+		}
+		if fillEndBucket < fillStartBucket {
+			continue
+		}
+
+		filledPoints := int(((fillEndBucket - fillStartBucket) / effectiveStepSeconds) + 1)
+		filled := make([][]interface{}, 0, filledPoints)
+		for ts := fillStartBucket; ts <= fillEndBucket; ts += effectiveStepSeconds {
 			filled = append(filled, []interface{}{ts, sampleMap[ts]})
 		}
 		entries[i].Samples = filled

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1027,8 +1027,8 @@ func TestContract_Patterns_UsesFromToWhenStartEndMissing(t *testing.T) {
 	if receivedStart != "1712311200" || receivedEnd != "1712311800" {
 		t.Fatalf("expected from/to to be forwarded as start/end, got start=%q end=%q", receivedStart, receivedEnd)
 	}
-	if receivedStep != "1m" {
-		t.Fatalf("expected step to be forwarded to query, got %q", receivedStep)
+	if receivedStep != "" {
+		t.Fatalf("expected raw log patterns fetch not to forward step, got %q", receivedStep)
 	}
 }
 
@@ -1114,8 +1114,8 @@ func TestContract_Patterns_DerivesStepWhenMissing(t *testing.T) {
 	stepMu.Lock()
 	stepSnapshot := receivedStep
 	stepMu.Unlock()
-	if strings.TrimSpace(stepSnapshot) == "" {
-		t.Fatalf("expected derived step to be forwarded when request step is missing")
+	if strings.TrimSpace(stepSnapshot) != "" {
+		t.Fatalf("expected derived step to stay proxy-side for raw log fetches, got %q", stepSnapshot)
 	}
 }
 
@@ -1784,10 +1784,10 @@ func TestContract_PatternsCacheKey_NormalizesRelativeRangeBoundaries(t *testing.
 	}
 }
 
-func TestContract_Patterns_FillsSamplesAcrossRequestedRange(t *testing.T) {
+func TestContract_Patterns_UsesObservedSpanInsteadOfRequestedTailFill(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/x-ndjson")
-		// Only one line near range end. Handler should fill full range buckets with zeros.
+		// Native Loki patterns do not pad the whole requested range with zero buckets.
 		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:04:58Z","_msg":"GET /api/users 200 15ms","app":"web","level":"info"}` + "\n"))
 	}))
 	defer vlBackend.Close()
@@ -1811,20 +1811,19 @@ func TestContract_Patterns_FillsSamplesAcrossRequestedRange(t *testing.T) {
 		t.Fatalf("expected one pattern, got %v", resp.Data)
 	}
 	samples := resp.Data[0].Samples
-	if len(samples) != 6 {
-		t.Fatalf("expected six 60s buckets across selected range, got %d samples: %v", len(samples), samples)
+	if len(samples) != 1 {
+		t.Fatalf("expected only the observed 60s bucket without requested-range tail fill, got %d samples: %v", len(samples), samples)
 	}
 	firstTS, okFirst := numberToInt64(samples[0][0])
-	lastTS, okLast := numberToInt64(samples[len(samples)-1][0])
-	if !okFirst || !okLast {
-		t.Fatalf("expected numeric sample timestamps, got first=%v last=%v", samples[0], samples[len(samples)-1])
+	if !okFirst {
+		t.Fatalf("expected numeric sample timestamp, got first=%v", samples[0])
 	}
-	if firstTS != 1775296800 || lastTS != 1775297100 {
-		t.Fatalf("expected filled start/end buckets 1775296800..1775297100, got %d..%d", firstTS, lastTS)
+	if firstTS != 1775297040 {
+		t.Fatalf("expected observed bucket 1775297040, got %d", firstTS)
 	}
 }
 
-func TestContract_Patterns_FillsSamplesAcrossRelativeNowRange(t *testing.T) {
+func TestContract_Patterns_RelativeNowRangeDoesNotInventZeroBuckets(t *testing.T) {
 	now := time.Now().UTC()
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/x-ndjson")
@@ -1855,12 +1854,16 @@ func TestContract_Patterns_FillsSamplesAcrossRelativeNowRange(t *testing.T) {
 		t.Fatalf("expected one pattern, got %v", resp.Data)
 	}
 	samples := resp.Data[0].Samples
-	if len(samples) < 100 {
-		t.Fatalf("expected long-range relative fill to produce >=100 buckets, got %d samples: %v", len(samples), samples)
+	if len(samples) != 1 {
+		t.Fatalf("expected relative range without synthetic zero buckets, got %d samples: %v", len(samples), samples)
 	}
 }
 
 func TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps(t *testing.T) {
+	var (
+		stepMu        sync.Mutex
+		receivedSteps []string
+	)
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/select/logsql/query" {
 			t.Fatalf("expected dense patterns to query /select/logsql/query, got %s", r.URL.Path)
@@ -1868,6 +1871,9 @@ func TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps(t *testi
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("parse form: %v", err)
 		}
+		stepMu.Lock()
+		receivedSteps = append(receivedSteps, r.FormValue("step"))
+		stepMu.Unlock()
 		endNs, err := strconv.ParseInt(r.FormValue("end"), 10, 64)
 		if err != nil {
 			t.Fatalf("parse window end: %v", err)
@@ -1927,6 +1933,14 @@ func TestContract_Patterns_DenseShortRangeAvoidsFortyMinuteSamplingGaps(t *testi
 	if maxGap > int64((10*time.Minute)/time.Second) {
 		t.Fatalf("expected dense short-range sampling gaps <=10m, got max gap %ds", maxGap)
 	}
+	stepMu.Lock()
+	stepsSnapshot := append([]string(nil), receivedSteps...)
+	stepMu.Unlock()
+	for i, step := range stepsSnapshot {
+		if strings.TrimSpace(step) != "" {
+			t.Fatalf("expected dense windowed raw log fetch %d not to forward step, got %q", i+1, step)
+		}
+	}
 }
 
 func TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets(t *testing.T) {
@@ -1961,8 +1975,8 @@ func TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets(t *testing.T)
 	mu.Lock()
 	gotStep := receivedStep
 	mu.Unlock()
-	if gotStep != "90s" {
-		t.Fatalf("expected float-second step to be normalized to 90s, got %q", gotStep)
+	if gotStep != "" {
+		t.Fatalf("expected float-second step normalization to stay proxy-side for raw log fetches, got %q", gotStep)
 	}
 
 	var resp patternsResponse
@@ -1970,20 +1984,19 @@ func TestContract_Patterns_FloatSecondStepRespectsRequestedBuckets(t *testing.T)
 	if len(resp.Data) != 1 {
 		t.Fatalf("expected one pattern, got %+v", resp.Data)
 	}
-	if got := len(resp.Data[0].Samples); got != 121 {
-		t.Fatalf("expected 121 requested 90s buckets across 3h range, got %d", got)
+	if got := len(resp.Data[0].Samples); got != 1 {
+		t.Fatalf("expected one observed 90s bucket without synthetic fill, got %d", got)
 	}
 	firstTS, okFirst := numberToInt64(resp.Data[0].Samples[0][0])
-	lastTS, okLast := numberToInt64(resp.Data[0].Samples[len(resp.Data[0].Samples)-1][0])
-	if !okFirst || !okLast {
-		t.Fatalf("expected numeric sample timestamps, got first=%v last=%v", resp.Data[0].Samples[0], resp.Data[0].Samples[len(resp.Data[0].Samples)-1])
+	if !okFirst {
+		t.Fatalf("expected numeric sample timestamp, got first=%v", resp.Data[0].Samples[0])
 	}
-	if firstTS != 1775296800 || lastTS != 1775307600 {
-		t.Fatalf("expected requested 3h range to stay anchored to 90s buckets, got %d..%d", firstTS, lastTS)
+	if firstTS%90 != 0 {
+		t.Fatalf("expected 90s-aligned bucket timestamp, got %d", firstTS)
 	}
 }
 
-func TestContract_Patterns_FillCoarsensHugePointRanges(t *testing.T) {
+func TestContract_Patterns_CoarsensObservedSpanWithoutRequestedRangePad(t *testing.T) {
 	entries := []patternResultEntry{
 		{
 			Pattern: "GET <_> <_> <_>",
@@ -1998,16 +2011,19 @@ func TestContract_Patterns_FillCoarsensHugePointRanges(t *testing.T) {
 	if len(filled) != 1 {
 		t.Fatalf("expected one filled entry, got %d", len(filled))
 	}
-	if got := len(filled[0].Samples); got <= 100 || got > 11000 {
-		t.Fatalf("expected adaptive coarsening to keep buckets in 101..11000, got %d", got)
+	if got := len(filled[0].Samples); got != 2 {
+		t.Fatalf("expected coarsened observed span to keep only two aligned buckets, got %d", got)
 	}
 	firstTS, okFirst := numberToInt64(filled[0].Samples[0][0])
 	lastTS, okLast := numberToInt64(filled[0].Samples[len(filled[0].Samples)-1][0])
 	if !okFirst || !okLast {
 		t.Fatalf("expected numeric filled timestamps, got first=%v last=%v", filled[0].Samples[0], filled[0].Samples[len(filled[0].Samples)-1])
 	}
-	if firstTS != 0 || lastTS != 172800 {
-		t.Fatalf("expected filled range to remain anchored to request boundaries, got %d..%d", firstTS, lastTS)
+	if firstTS >= lastTS {
+		t.Fatalf("expected observed span to remain increasing after coarsening, got %d..%d", firstTS, lastTS)
+	}
+	if firstTS < 172700 || lastTS != 172800 {
+		t.Fatalf("expected coarsened buckets to stay near the observed tail, got %d..%d", firstTS, lastTS)
 	}
 }
 

--- a/test/e2e-compat/compat_test.go
+++ b/test/e2e-compat/compat_test.go
@@ -38,7 +38,7 @@ var (
 	tailProxyURL   = envOr("TAIL_PROXY_URL", "http://localhost:3103")
 	tailIngressURL = envOr("TAIL_INGRESS_URL", "http://localhost:3104")
 	tailNativeURL  = envOr("TAIL_NATIVE_URL", "http://localhost:3105")
-	vlURL          = envOr("VL_URL", "http://localhost:29428")
+	vlURL          = envOr("VL_URL", "http://localhost:9428")
 )
 
 func envOr(key, def string) string {

--- a/test/e2e-compat/compat_test.go
+++ b/test/e2e-compat/compat_test.go
@@ -38,7 +38,7 @@ var (
 	tailProxyURL   = envOr("TAIL_PROXY_URL", "http://localhost:3103")
 	tailIngressURL = envOr("TAIL_INGRESS_URL", "http://localhost:3104")
 	tailNativeURL  = envOr("TAIL_NATIVE_URL", "http://localhost:3105")
-	vlURL          = envOr("VL_URL", "http://localhost:9428")
+	vlURL          = envOr("VL_URL", "http://localhost:29428")
 )
 
 func envOr(key, def string) string {

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     ports:
       - "3101:3100"
     command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./loki-local-config.yaml:/etc/loki/local-config.yaml:ro
     # Loki 3.7.1 image is minimal (no wget/curl/shell) — healthcheck uses NONE.
     # Tests retry on connection failure.
     healthcheck:
@@ -30,7 +32,7 @@ services:
     image: ${VICTORIALOGS_IMAGE:-victoriametrics/victoria-logs:v1.50.0}
     container_name: e2e-victorialogs
     ports:
-      - "9428:9428"
+      - "29428:9428"
     command:
       - "-storageDataPath=/vlogs"
       # Keep enough history for long-range Drilldown regressions (>24h).

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: ${VICTORIALOGS_IMAGE:-victoriametrics/victoria-logs:v1.50.0}
     container_name: e2e-victorialogs
     ports:
-      - "29428:9428"
+      - "9428:9428"
     command:
       - "-storageDataPath=/vlogs"
       # Keep enough history for long-range Drilldown regressions (>24h).

--- a/test/e2e-compat/loki-local-config.yaml
+++ b/test/e2e-compat/loki-local-config.yaml
@@ -1,0 +1,57 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  grpc_server_max_recv_msg_size: 8388608
+  grpc_server_max_send_msg_size: 8388608
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+frontend:
+  max_outstanding_per_tenant: 2048
+  encoding: protobuf
+
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: 127.0.0.1:3100
+
+limits_config:
+  ingestion_rate_mb: 50000
+  ingestion_burst_size_mb: 50000
+  max_global_streams_per_user: 0
+  volume_enabled: true
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+querier:
+  per_request_limits_enabled: true
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/test/e2e-compat/patterns_dense_repro_test.go
+++ b/test/e2e-compat/patterns_dense_repro_test.go
@@ -75,7 +75,7 @@ func TestPatternsDenseRepro_FullRangeAndRefreshStability(t *testing.T) {
 	)
 	pushDensePatternData(t, appName, seedStart, seedEnd, cfg)
 
-	dsUID := grafanaDatasourceUID(t, "Loki (via VL proxy)")
+	dsUID := grafanaDatasourceUID(t, "Loki (via VL proxy patterns autodetect)")
 	query := fmt.Sprintf(`{cluster="dense-cluster", namespace="dense-ns", app="%s"}`, appName)
 	expectedStartBucket, expectedEndBucket, expectedBucketCount := denseExpectedBuckets(seedStart, seedEnd, cfg.step)
 

--- a/test/e2e-compat/patterns_native_ab_test.go
+++ b/test/e2e-compat/patterns_native_ab_test.go
@@ -1,0 +1,283 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+type stablePatternABConfig struct {
+	rangeWindow time.Duration
+	step        time.Duration
+	batchSize   int
+}
+
+type stablePatternSummary struct {
+	pattern        string
+	sampleBuckets  int
+	nonZeroBuckets int
+	firstTs        int64
+	lastTs         int64
+	maxGapSeconds  int64
+}
+
+var stablePatternMessages = []string{
+	`stable_pattern_alpha component=collector action=scrape outcome=ok`,
+	`stable_pattern_bravo component=collector action=transform outcome=ok`,
+	`stable_pattern_charlie component=collector action=export outcome=retry`,
+	`stable_pattern_delta component=collector action=ship outcome=ok`,
+}
+
+func TestDrilldown_Patterns_NativeLokiAndProxyStayDenseOnSameStableData(t *testing.T) {
+	waitForReady(t, lokiURL+"/ready", 30*time.Second)
+	waitForReady(t, proxyURL+"/ready", 30*time.Second)
+	waitForReady(t, grafanaURL+"/api/health", 30*time.Second)
+
+	cfg := stablePatternABConfig{
+		rangeWindow: 2 * time.Hour,
+		step:        30 * time.Second,
+		batchSize:   1000,
+	}
+	serviceName := fmt.Sprintf("stable-pattern-ab-%d", time.Now().UTC().UnixNano())
+	start := time.Now().UTC().Add(-cfg.rangeWindow).Truncate(cfg.step)
+	end := start.Add(cfg.rangeWindow)
+	t.Logf("stable pattern A/B fixture service=%s start=%s end=%s step=%s", serviceName, start.Format(time.RFC3339), end.Format(time.RFC3339), cfg.step)
+
+	seedStablePatternsToLokiAndVL(t, serviceName, start, end, cfg)
+
+	query := fmt.Sprintf(`{service_name="%s"}`, serviceName)
+	directUID := grafanaDatasourceUID(t, "Loki (direct)")
+	proxyUID := grafanaDatasourceUID(t, "Loki (via VL proxy patterns autodetect)")
+
+	directEntries := waitForPatternsViaGrafanaDatasource(t, directUID, query, start, end, cfg.step, len(stablePatternMessages))
+	proxyEntries := waitForPatternsViaGrafanaDatasource(t, proxyUID, query, start, end, cfg.step, 1)
+
+	expectedBuckets := int(end.Sub(start)/cfg.step) + 1
+	stepSeconds := int64(cfg.step / time.Second)
+
+	directSummary := summarizeStablePatternEntries(t, "direct", directEntries, len(stablePatternMessages), expectedBuckets, stepSeconds)
+	proxySummary := summarizeStablePatternEntries(t, "proxy", proxyEntries, len(stablePatternMessages), expectedBuckets, stepSeconds)
+
+	if len(directSummary) != len(proxySummary) {
+		t.Fatalf("expected same pattern count for direct and proxy, direct=%d proxy=%d direct=%v proxy=%v", len(directSummary), len(proxySummary), directSummary, proxySummary)
+	}
+	for _, message := range stablePatternMessages {
+		directItem, ok := directSummary[message]
+		if !ok {
+			t.Fatalf("direct Loki missing stable pattern %q in %v", message, directSummary)
+		}
+		proxyItem, ok := proxySummary[message]
+		if !ok {
+			t.Fatalf("proxy missing stable pattern %q in %v", message, proxySummary)
+		}
+		if directItem.sampleBuckets != proxyItem.sampleBuckets || directItem.nonZeroBuckets != proxyItem.nonZeroBuckets || directItem.maxGapSeconds != proxyItem.maxGapSeconds {
+			t.Fatalf(
+				"stable pattern %q diverged between direct Loki and proxy: direct=%+v proxy=%+v",
+				message,
+				directItem,
+				proxyItem,
+			)
+		}
+	}
+}
+
+func seedStablePatternsToLokiAndVL(t *testing.T, serviceName string, start, end time.Time, cfg stablePatternABConfig) {
+	t.Helper()
+
+	if cfg.step <= 0 {
+		cfg.step = 30 * time.Second
+	}
+	if cfg.batchSize <= 0 {
+		cfg.batchSize = 1000
+	}
+
+	streamLabels := map[string]string{
+		"app":          serviceName,
+		"service_name": serviceName,
+		"cluster":      "stable-pattern-ab",
+		"namespace":    "stable-pattern-ab",
+		"level":        "info",
+	}
+
+	type lokiStream struct {
+		Stream map[string]string `json:"stream"`
+		Values [][]string        `json:"values"`
+	}
+
+	insertVLURL := vlURL + "/insert/jsonline?_stream_fields=" + url.QueryEscape("app,service_name,cluster,namespace,level")
+	var lokiValues [][]string
+	var vlBody strings.Builder
+	linesInBatch := 0
+
+	flush := func() {
+		if len(lokiValues) == 0 {
+			return
+		}
+
+		lokiPayload := map[string]interface{}{
+			"streams": []lokiStream{{
+				Stream: streamLabels,
+				Values: lokiValues,
+			}},
+		}
+		body, err := json.Marshal(lokiPayload)
+		if err != nil {
+			t.Fatalf("marshal Loki stable patterns payload failed: %v", err)
+		}
+		lokiResp, err := http.Post(lokiURL+"/loki/api/v1/push", "application/json", strings.NewReader(string(body)))
+		if err != nil {
+			t.Fatalf("stable pattern Loki push failed: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, lokiResp.Body)
+		lokiResp.Body.Close()
+		if lokiResp.StatusCode/100 != 2 {
+			t.Fatalf("stable pattern Loki push failed with status=%d", lokiResp.StatusCode)
+		}
+
+		vlResp, err := http.Post(insertVLURL, "application/stream+json", strings.NewReader(vlBody.String()))
+		if err != nil {
+			t.Fatalf("stable pattern VL push failed: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, vlResp.Body)
+		vlResp.Body.Close()
+		if vlResp.StatusCode/100 != 2 {
+			t.Fatalf("stable pattern VL push failed with status=%d", vlResp.StatusCode)
+		}
+
+		lokiValues = lokiValues[:0]
+		vlBody.Reset()
+		linesInBatch = 0
+	}
+
+	for bucket := start; !bucket.After(end); bucket = bucket.Add(cfg.step) {
+		for _, message := range stablePatternMessages {
+			ts := bucket.UTC()
+			lokiValues = append(lokiValues, []string{fmt.Sprintf("%d", ts.UnixNano()), message})
+			vlBody.WriteString("{\"_time\":\"")
+			vlBody.WriteString(ts.Format(time.RFC3339Nano))
+			vlBody.WriteString("\",\"_msg\":")
+			vlBody.WriteString(strconvQuote(message))
+			vlBody.WriteString(",\"app\":\"")
+			vlBody.WriteString(serviceName)
+			vlBody.WriteString("\",\"service_name\":\"")
+			vlBody.WriteString(serviceName)
+			vlBody.WriteString("\",\"cluster\":\"stable-pattern-ab\",\"namespace\":\"stable-pattern-ab\",\"level\":\"info\"}\n")
+			linesInBatch++
+			if linesInBatch >= cfg.batchSize {
+				flush()
+			}
+		}
+	}
+	flush()
+	time.Sleep(5 * time.Second)
+}
+
+func waitForPatternsViaGrafanaDatasource(t *testing.T, dsUID, query string, start, end time.Time, step time.Duration, minPatterns int) []densePatternEntry {
+	t.Helper()
+
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		entries, err := fetchPatternsViaGrafanaDatasource(dsUID, query, start, end, step, max(minPatterns, 20))
+		if err == nil && len(entries) >= minPatterns {
+			return entries
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("patterns did not stabilize for datasource=%s query=%s: err=%v entries=%d", dsUID, query, err, len(entries))
+		}
+		time.Sleep(1500 * time.Millisecond)
+	}
+}
+
+func summarizeStablePatternEntries(t *testing.T, source string, entries []densePatternEntry, expectedPatterns, expectedBuckets int, stepSeconds int64) map[string]stablePatternSummary {
+	t.Helper()
+
+	if len(entries) < expectedPatterns {
+		t.Fatalf("%s returned too few patterns: got=%d want_at_least=%d entries=%v", source, len(entries), expectedPatterns, entries)
+	}
+
+	summaries := make(map[string]stablePatternSummary, len(entries))
+	for _, entry := range entries {
+		sampleBuckets := len(entry.Samples)
+		nonZeroBuckets := 0
+		firstTs := int64(0)
+		lastTs := int64(0)
+		maxGapSeconds := int64(0)
+		var prevTs int64
+		for i, sample := range entry.Samples {
+			if len(sample) < 2 {
+				continue
+			}
+			ts, ok := denseSampleTs(sample[0])
+			if !ok {
+				t.Fatalf("%s pattern %q has non-numeric timestamp sample=%v", source, entry.Pattern, sample)
+			}
+			value, ok := denseSampleTs(sample[1])
+			if !ok {
+				t.Fatalf("%s pattern %q has non-numeric value sample=%v", source, entry.Pattern, sample)
+			}
+			if value > 0 {
+				nonZeroBuckets++
+			}
+			if i == 0 {
+				firstTs = ts
+			}
+			if prevTs != 0 && ts-prevTs > maxGapSeconds {
+				maxGapSeconds = ts - prevTs
+			}
+			prevTs = ts
+			lastTs = ts
+		}
+		summaries[entry.Pattern] = stablePatternSummary{
+			pattern:        entry.Pattern,
+			sampleBuckets:  sampleBuckets,
+			nonZeroBuckets: nonZeroBuckets,
+			firstTs:        firstTs,
+			lastTs:         lastTs,
+			maxGapSeconds:  maxGapSeconds,
+		}
+	}
+
+	if len(summaries) != expectedPatterns {
+		keys := make([]string, 0, len(summaries))
+		for key := range summaries {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		t.Fatalf("%s returned unexpected stable pattern set: got=%d want=%d keys=%v", source, len(summaries), expectedPatterns, keys)
+	}
+
+	minCoverage := max(1, expectedBuckets-1)
+	for _, message := range stablePatternMessages {
+		summary, ok := summaries[message]
+		if !ok {
+			t.Fatalf("%s missing stable pattern %q in %v", source, message, summaries)
+		}
+		if summary.sampleBuckets < minCoverage {
+			t.Fatalf("%s pattern %q lost bucket coverage: got=%d want_at_least=%d summary=%+v", source, message, summary.sampleBuckets, minCoverage, summary)
+		}
+		if summary.nonZeroBuckets < minCoverage {
+			t.Fatalf("%s pattern %q lost non-zero coverage: got=%d want_at_least=%d summary=%+v", source, message, summary.nonZeroBuckets, minCoverage, summary)
+		}
+		if summary.maxGapSeconds > stepSeconds {
+			t.Fatalf("%s pattern %q has bucket gap=%ds larger than step=%ds summary=%+v", source, message, summary.maxGapSeconds, stepSeconds, summary)
+		}
+	}
+
+	return summaries
+}
+
+func strconvQuote(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return `""`
+	}
+	return string(encoded)
+}


### PR DESCRIPTION
## What changed
This makes proxy-side `/patterns` detection behave like native Loki patterns on the same data, even though the proxy computes patterns on reads instead of on ingest.

The change has three parts:
- keep stable fixed-prefix patterns from collapsing into one generic cluster during read-time mining
- stop forwarding `step` to VictoriaLogs raw log queries used for pattern mining, so split subqueries do not overlap on step boundaries
- stop padding synthetic trailing zero buckets past the observed pattern span

It also adds a real native-Loki-vs-proxy compose A/B harness so the behavior is checked against the same deterministic stream in both systems.

## Root cause
Native Loki patterns are built on the write path. The proxy builds them from raw log reads.

On deterministic data, the remaining mismatch was not the Drilldown app. It was the proxy windowed raw-log fetch path:
- split pattern reads forwarded `step` into VictoriaLogs `/select/logsql/query`
- adjacent windows then overlapped on step boundaries
- the proxy merged those overlapping buckets and emitted periodic over-counts
- the proxy also emitted one extra trailing zero bucket that native Loki does not return

## Impact
Patterns in Drilldown and the Loki datasource now line up with native Loki behavior more closely:
- fixed patterns stay distinct
- dense stable streams stay dense without periodic doubled buckets
- the proxy no longer invents the final tail bucket beyond the last observed sample

## Validation
- `go test ./internal/proxy -count=1`
- `go test ./test/e2e-compat -run TestDrilldown_Patterns_NativeLokiAndProxyStayDenseOnSameStableData -tags=e2e -count=1 -v -timeout=180s`

The e2e test seeds the exact same stable messages into native Loki and VictoriaLogs, queries both through Grafana datasource `/resources/patterns`, and asserts the proxy matches native Loki on pattern set and bucket coverage.
