### PR TITLE
Harden proxy peer logging and release metadata

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -309,13 +309,19 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.meta.outputs.version }}"
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "dev" ]; then
+            echo "refusing to build release binaries with VERSION='${VERSION}'" >&2
+            exit 1
+          fi
+          REVISION="${GITHUB_SHA}"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist
           for GOOS_GOARCH in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
             GOOS="${GOOS_GOARCH%/*}"
             GOARCH="${GOOS_GOARCH#*/}"
             OUT="dist/loki-vl-proxy-${GOOS}-${GOARCH}"
             CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-              go build -ldflags="-s -w -X main.version=${VERSION}" \
+              go build -ldflags="-s -w -X main.version=${VERSION} -X main.revision=${REVISION} -X main.buildTime=${BUILD_TIME}" \
               -o "$OUT" ./cmd/proxy
           done
           cd dist && sha256sum loki-vl-proxy-* > checksums.txt
@@ -374,6 +380,10 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            REVISION=${{ github.sha }}
+            BUILD_TIME=${{ github.run_started_at }}
           tags: ${{ steps.image-tags.outputs.tags }}
           labels: |
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,13 +68,19 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "dev" ]; then
+            echo "refusing to build release binaries with VERSION='${VERSION}'" >&2
+            exit 1
+          fi
+          REVISION="${GITHUB_SHA}"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           mkdir -p dist
           for GOOS_GOARCH in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
             GOOS="${GOOS_GOARCH%/*}"
             GOARCH="${GOOS_GOARCH#*/}"
             OUT="dist/loki-vl-proxy-${GOOS}-${GOARCH}"
             CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-              go build -ldflags="-s -w -X main.version=${VERSION}" \
+              go build -ldflags="-s -w -X main.version=${VERSION} -X main.revision=${REVISION} -X main.buildTime=${BUILD_TIME}" \
               -o "$OUT" ./cmd/proxy
           done
           cd dist && sha256sum loki-vl-proxy-* > checksums.txt
@@ -133,6 +139,10 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            REVISION=${{ github.sha }}
+            BUILD_TIME=${{ github.run_started_at }}
           tags: ${{ steps.image-tags.outputs.tags }}
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- proxy/logging: emit build identity on startup and listener bind, carry real version/revision/build-time metadata in release artifacts, add restore/persist duration logging for patterns and label-values snapshots, downgrade `4xx` request errors to warn, and keep verbose per-type request breakdown maps at debug level while warning when peer cache runs without a shared auth token.
+
 ## [1.6.0] - 2026-04-17
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.26.2-alpine3.22 AS builder
 WORKDIR /app
+ARG VERSION=dev
+ARG REVISION=unknown
+ARG BUILD_TIME=unknown
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /loki-vl-proxy ./cmd/proxy
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION} -X main.revision=${REVISION} -X main.buildTime=${BUILD_TIME}" -o /loki-vl-proxy ./cmd/proxy
 
 FROM alpine:3.22.2
 RUN apk --no-cache add ca-certificates

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -221,7 +221,7 @@ extraArgs:
   # ruler-backend: ""                           # optional /rules passthrough backend
   # alerts-backend: ""                          # optional /alerts passthrough backend
   # extra-label-fields: "service.name,host.name"
-  # peer-auth-token: ""                         # token required for /_cache/get and /_cache/set peer calls
+  # peer-auth-token: ""                         # strongly recommended for fleets; avoids transient discovery/IP-only peer auth 403s on /_cache/get and /_cache/set
   # peer-timeout: "2s"                          # timeout for peer-cache fetches to owner peers
   # peer-write-through: "true"                  # push eligible non-owner writes to owner peer
   # peer-write-through-min-ttl: "30s"           # only TTL >= threshold is pushed to owner peer

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -15,6 +15,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -26,7 +27,11 @@ import (
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/proxy"
 )
 
-var version = "dev"
+var (
+	version   = "dev"
+	revision  = "unknown"
+	buildTime = "unknown"
+)
 
 type envConfig struct {
 	listenAddr        string
@@ -1523,14 +1528,32 @@ func buildHTTPServer(opts serverRuntimeOptions) (*http.Server, error) {
 
 func runServerLoop(srv httpServer, opts serverLoopOptions, logger *slog.Logger, fatal func(string, ...any)) {
 	if opts.tlsCertFile != "" && opts.tlsKeyFile != "" {
-		logger.Info("proxy listening", "listen_address", opts.listenAddr, "backend_url", opts.backendURL, "tls", true)
+		logger.Info(
+			"proxy listening",
+			"listen_address", opts.listenAddr,
+			"backend_url", opts.backendURL,
+			"tls", true,
+			"version", version,
+			"revision", revision,
+			"build_time", buildTime,
+			"go_version", runtime.Version(),
+		)
 		if err := srv.ListenAndServeTLS(opts.tlsCertFile, opts.tlsKeyFile); err != nil && err != http.ErrServerClosed {
 			fatal("tls server failed", "error", err)
 		}
 		return
 	}
 
-	logger.Info("proxy listening", "listen_address", opts.listenAddr, "backend_url", opts.backendURL, "tls", false)
+	logger.Info(
+		"proxy listening",
+		"listen_address", opts.listenAddr,
+		"backend_url", opts.backendURL,
+		"tls", false,
+		"version", version,
+		"revision", revision,
+		"build_time", buildTime,
+		"go_version", runtime.Version(),
+	)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		fatal("server failed", "error", err)
 	}
@@ -1558,6 +1581,13 @@ func reloadDynamicConfig(p reloadableProxy, getenv func(string) string, logger *
 }
 
 func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerDiscovery string, c, compat *cache.Cache) {
+	logger.Info(
+		"proxy build info",
+		"version", version,
+		"revision", revision,
+		"build_time", buildTime,
+		"go_version", runtime.Version(),
+	)
 	if proxyCfg.TenantMap != nil {
 		logger.Info("loaded tenant mappings", "count", len(proxyCfg.TenantMap))
 	}
@@ -1617,8 +1647,7 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 		logger.Info("loaded derived fields", "count", len(proxyCfg.DerivedFields))
 	}
 	if proxyCfg.QueryRangeWindowingEnabled {
-		logger.Info(
-			"query_range window cache enabled",
+		fullQueryRangeAttrs := []any{
 			"split_interval", proxyCfg.QueryRangeSplitInterval,
 			"adaptive_parallel", proxyCfg.QueryRangeAdaptiveParallel,
 			"parallel_min", proxyCfg.QueryRangeParallelMin,
@@ -1636,11 +1665,33 @@ func logProxyStartup(logger *slog.Logger, proxyCfg proxy.Config, peerSelf, peerD
 			"partial_responses", proxyCfg.QueryRangePartialResponses,
 			"background_warm", proxyCfg.QueryRangeBackgroundWarm,
 			"background_warm_max_windows", proxyCfg.QueryRangeBackgroundWarmMaxWindows,
+		}
+		logger.Info(
+			"query_range window cache enabled",
+			"split_interval", proxyCfg.QueryRangeSplitInterval,
+			"adaptive_parallel", proxyCfg.QueryRangeAdaptiveParallel,
+			"parallel_min", proxyCfg.QueryRangeParallelMin,
+			"parallel_max", proxyCfg.QueryRangeParallelMax,
+			"history_cache_ttl", proxyCfg.QueryRangeHistoryCacheTTL,
+			"partial_responses", proxyCfg.QueryRangePartialResponses,
+			"background_warm", proxyCfg.QueryRangeBackgroundWarm,
 		)
+		if logger.Enabled(context.Background(), slog.LevelDebug) {
+			logger.Debug("query_range window cache config", fullQueryRangeAttrs...)
+		}
 	}
 	if proxyCfg.PeerCache != nil {
 		c.SetL3(proxyCfg.PeerCache)
 		logger.Info("peer cache enabled", "self", peerSelf, "discovery", peerDiscovery)
+		if strings.TrimSpace(proxyCfg.PeerAuthToken) == "" {
+			logger.Warn(
+				"peer cache shared token not configured",
+				"auth_mode", "peer_membership_only",
+				"hint", "set -peer-auth-token fleet-wide to avoid transient startup/discovery 403s on peer cache endpoints",
+			)
+		} else {
+			logger.Info("peer cache shared token enabled", "auth_mode", "shared_token")
+		}
 	}
 	if compat != nil {
 		logger.Info("compatibility edge cache active", "tier", "tier0")

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1185,6 +1185,47 @@ func TestBuildHTTPServer(t *testing.T) {
 	}
 }
 
+func TestLogProxyStartup_EmitsBuildInfoAndPeerCacheAuthHint(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	oldVersion, oldRevision, oldBuildTime := version, revision, buildTime
+	version, revision, buildTime = "1.6.0", "abc123", "2026-04-17T15:00:00Z"
+	t.Cleanup(func() {
+		version, revision, buildTime = oldVersion, oldRevision, oldBuildTime
+	})
+
+	l1 := cache.New(time.Minute, 10)
+	t.Cleanup(l1.Close)
+
+	logProxyStartup(logger, proxy.Config{
+		QueryRangeWindowingEnabled: true,
+		QueryRangeSplitInterval:    time.Hour,
+		QueryRangeAdaptiveParallel: true,
+		QueryRangeParallelMin:      2,
+		QueryRangeParallelMax:      8,
+		QueryRangeHistoryCacheTTL:  24 * time.Hour,
+		QueryRangePartialResponses: true,
+		QueryRangeBackgroundWarm:   true,
+		PeerCache:                  &cache.PeerCache{},
+	}, "10.0.0.1:3100", "dns", l1, nil)
+
+	out := buf.String()
+	for _, needle := range []string{
+		`"msg":"proxy build info"`,
+		`"version":"1.6.0"`,
+		`"revision":"abc123"`,
+		`"build_time":"2026-04-17T15:00:00Z"`,
+		`"go_version":"` + runtime.Version() + `"`,
+		`"msg":"peer cache shared token not configured"`,
+		`"auth_mode":"peer_membership_only"`,
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("expected startup log to contain %q, got %s", needle, out)
+		}
+	}
+}
+
 func TestValidateAdminExposure(t *testing.T) {
 	if err := validateAdminExposure("127.0.0.1:3100", true, false, ""); err != nil {
 		t.Fatalf("expected loopback admin exposure to be allowed without token, got %v", err)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -575,7 +575,7 @@ Treat these as current implementation defaults, not stable configuration API. If
 | `-peer-dns` | — | — | Headless service DNS name used when `-peer-discovery=dns` |
 | `-peer-static` | — | — | Comma-separated peer list used when `-peer-discovery=static` |
 | `-peer-timeout` | — | `2s` | Timeout applied to peer-cache owner fetches (`/_cache/get`) before falling back locally |
-| `-peer-auth-token` | — | — | Shared token required on `/_cache/get` and `/_cache/set` peer-cache requests when set |
+| `-peer-auth-token` | — | — | Shared token used on `/_cache/get` and `/_cache/set` peer-cache requests. Strongly recommended for fleets so peer auth does not depend only on transient discovery/IP membership during startup. |
 | `-peer-write-through` | — | `true` | Push eligible non-owner cache writes to the owner peer (`/_cache/set`) to keep owner shards warm under skewed traffic |
 | `-peer-write-through-min-ttl` | — | `30s` | Minimum TTL required to push a write-through copy to the owner peer |
 | `-peer-hot-read-ahead-enabled` | — | `false` | Enable bounded periodic hot-read-ahead prefetch from peer hot indexes |
@@ -596,6 +596,7 @@ Peer-cache notes:
 - peer-cache fetches preserve owner TTL and can compress larger `/_cache/get` responses with `zstd` or `gzip`
 - `loki_vl_proxy_peer_cache_error_reason_total{reason=...}` breaks opaque peer fetch failures into low-cardinality reasons like `timeout`, `transport`, `status_502`, `body_read`, and `decode`
 - with `-peer-write-through=true` (default), non-owner writes with TTL above threshold are pushed to owners and stored locally as short-lived shadows to reduce hot-pod disk skew
+- set `-peer-auth-token` fleet-wide whenever peer cache is enabled; it avoids transient startup or discovery-flap `403` responses caused by IP-membership-only peer auth
 - when `-peer-auth-token` is set, all peers must share the same token or peer-cache reuse will fail closed
 
 ### Current Tuning For Higher Fleet Reuse

--- a/docs/fleet-cache.md
+++ b/docs/fleet-cache.md
@@ -238,6 +238,7 @@ Peer fetch behavior details:
 
 - larger `/_cache/get` payloads are compressed when peers request `Accept-Encoding`, preferring `zstd` and falling back to `gzip`
 - when `-peer-write-through=true`, non-owner writes above `-peer-write-through-min-ttl` are pushed to owners via `/_cache/set`
+- set `-peer-auth-token` fleet-wide in Kubernetes deployments so peer fetches authenticate by token instead of only by the currently discovered peer IP set
 - when `-peer-auth-token` is set, both peer fetch and peer write-through calls must carry the shared token or endpoints fail closed
 
 ## Fleet Metrics

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -370,6 +370,12 @@ At log level, the same request can also carry:
 - `loki.tenant.id`
 - `http.route`
 
+Per-request by-type breakdown maps such as `upstream.calls_by_type` and
+`proxy.operations_by_type` are emitted only at debug level. The default info-level
+request logs keep aggregate counts while the detailed per-type visibility stays in
+Prometheus/OTLP metrics. This avoids log-body field explosion in pipelines that
+flatten structured JSON bodies into discoverable `message.*` fields.
+
 That separation matters:
 
 - `enduser.*` answers "which Grafana user or trusted client triggered this?"

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3081,6 +3081,7 @@ func (p *Proxy) persistPatternsNow(reason string) error {
 	if reason == "periodic" && !p.patternsPersistDirty.Load() {
 		return nil
 	}
+	startedAt := time.Now()
 
 	snapshot := p.buildPatternsSnapshot(time.Now().UTC())
 	data, err := json.Marshal(snapshot)
@@ -3121,6 +3122,7 @@ func (p *Proxy) persistPatternsNow(reason string) error {
 		"entries", entryCount,
 		"patterns", patternCount,
 		"bytes", len(data),
+		"duration_ms", time.Since(startedAt).Milliseconds(),
 	)
 	p.metrics.SetPatternsPersistedDiskState(patternCount, entryCount, int64(len(data)))
 	p.metrics.RecordPatternsPersistWrite(int64(len(data)))
@@ -3132,6 +3134,7 @@ func (p *Proxy) restorePatternsFromDisk() (bool, int64, error) {
 	if !p.patternsEnabled || strings.TrimSpace(p.patternsPersistPath) == "" {
 		return false, 0, nil
 	}
+	startedAt := time.Now()
 	data, err := os.ReadFile(p.patternsPersistPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -3174,6 +3177,7 @@ func (p *Proxy) restorePatternsFromDisk() (bool, int64, error) {
 		"entries_applied", appliedEntries,
 		"patterns_applied", appliedPatterns,
 		"bytes", len(data),
+		"duration_ms", time.Since(startedAt).Milliseconds(),
 	)
 	return true, snapshot.SavedAtUnixNano, nil
 }
@@ -3226,6 +3230,7 @@ func (p *Proxy) restorePatternsFromPeers(minSavedAt int64) (bool, int64, error) 
 	if !p.patternsEnabled || p.peerCache == nil {
 		return false, 0, nil
 	}
+	startedAt := time.Now()
 	peers := p.peerCache.Peers()
 	if len(peers) == 0 {
 		return false, 0, nil
@@ -3323,6 +3328,8 @@ func (p *Proxy) restorePatternsFromPeers(minSavedAt int64) (bool, int64, error) 
 		"entries_updated", appliedEntries,
 		"patterns_updated", appliedPatterns,
 		"peers", len(peers),
+		"bytes", totalPeerBytes,
+		"duration_ms", time.Since(startedAt).Milliseconds(),
 	)
 	return true, mergedSavedAt, nil
 }
@@ -3488,6 +3495,7 @@ func (p *Proxy) persistLabelValuesIndexNow(reason string) error {
 	if reason == "periodic" && !p.labelValuesIndexPersistDirty.Load() {
 		return nil
 	}
+	startedAt := time.Now()
 
 	snapshot := p.buildLabelValuesIndexSnapshot(time.Now().UTC())
 	data, err := json.Marshal(snapshot)
@@ -3521,9 +3529,9 @@ func (p *Proxy) persistLabelValuesIndexNow(reason string) error {
 
 	states, values := p.labelValuesIndexCardinality()
 	if reason == "periodic" {
-		p.log.Debug("label values index snapshot persisted", "path", path, "states", states, "values", values, "bytes", len(data))
+		p.log.Debug("label values index snapshot persisted", "path", path, "states", states, "values", values, "bytes", len(data), "duration_ms", time.Since(startedAt).Milliseconds())
 	} else {
-		p.log.Info("label values index snapshot persisted", "reason", reason, "path", path, "states", states, "values", values, "bytes", len(data))
+		p.log.Info("label values index snapshot persisted", "reason", reason, "path", path, "states", states, "values", values, "bytes", len(data), "duration_ms", time.Since(startedAt).Milliseconds())
 	}
 	p.labelValuesIndexPersistDirty.Store(false)
 	return nil
@@ -3533,6 +3541,7 @@ func (p *Proxy) restoreLabelValuesIndexFromDisk() (bool, int64, error) {
 	if !p.labelValuesIndexedCache || strings.TrimSpace(p.labelValuesIndexPersistPath) == "" {
 		return false, 0, nil
 	}
+	startedAt := time.Now()
 
 	data, err := os.ReadFile(p.labelValuesIndexPersistPath)
 	if err != nil {
@@ -3567,6 +3576,8 @@ func (p *Proxy) restoreLabelValuesIndexFromDisk() (bool, int64, error) {
 		"saved_at", time.Unix(0, snapshot.SavedAtUnixNano).UTC().Format(time.RFC3339Nano),
 		"states", states,
 		"values", values,
+		"bytes", len(data),
+		"duration_ms", time.Since(startedAt).Milliseconds(),
 	)
 	return true, snapshot.SavedAtUnixNano, nil
 }
@@ -3575,6 +3586,7 @@ func (p *Proxy) restoreLabelValuesIndexFromPeers(minSavedAt int64) (bool, int64,
 	if !p.labelValuesIndexedCache || p.cache == nil || p.peerCache == nil {
 		return false, 0, nil
 	}
+	startedAt := time.Now()
 	data, ok := p.cache.Get(labelValuesIndexSnapshotCacheKey)
 	if !ok {
 		return false, 0, nil
@@ -3597,6 +3609,8 @@ func (p *Proxy) restoreLabelValuesIndexFromPeers(minSavedAt int64) (bool, int64,
 		"saved_at", time.Unix(0, snapshot.SavedAtUnixNano).UTC().Format(time.RFC3339Nano),
 		"states", states,
 		"values", values,
+		"bytes", len(data),
+		"duration_ms", time.Since(startedAt).Milliseconds(),
 	)
 	return true, snapshot.SavedAtUnixNano, nil
 }
@@ -10822,7 +10836,16 @@ func sanitizeLimit(limitStr string) string {
 }
 
 func (p *Proxy) writeError(w http.ResponseWriter, code int, msg string) {
-	p.log.Error("request error", "code", code, "error", msg)
+	level := slog.LevelInfo
+	switch {
+	case code >= http.StatusInternalServerError:
+		level = slog.LevelError
+	case code >= http.StatusBadRequest:
+		level = slog.LevelWarn
+	}
+	if p.log != nil && p.log.Enabled(context.Background(), level) {
+		p.log.Log(context.Background(), level, "request error", "code", code, "error", msg)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -11233,16 +11256,30 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 			"upstream.error", telemetry.upstreamErrorSeen,
 		}
 		if len(telemetry.upstreamCallsByType) > 0 {
-			logAttrs = append(logAttrs, "upstream.calls_by_type", telemetry.upstreamCallsByType)
+			logAttrs = append(logAttrs, "upstream.call_types", len(telemetry.upstreamCallsByType))
 		}
 		if len(upstreamDurationByTypeMs) > 0 {
-			logAttrs = append(logAttrs, "upstream.duration_ms_by_type", upstreamDurationByTypeMs)
+			logAttrs = append(logAttrs, "upstream.duration_types", len(upstreamDurationByTypeMs))
 		}
 		if len(telemetry.internalOpsByType) > 0 {
-			logAttrs = append(logAttrs, "proxy.operations_by_type", telemetry.internalOpsByType)
+			logAttrs = append(logAttrs, "proxy.operation_types", len(telemetry.internalOpsByType))
 		}
 		if len(internalDurationByTypeMs) > 0 {
-			logAttrs = append(logAttrs, "proxy.operation_duration_ms_by_type", internalDurationByTypeMs)
+			logAttrs = append(logAttrs, "proxy.operation_duration_types", len(internalDurationByTypeMs))
+		}
+		if p.log.Enabled(reqCtx, slog.LevelDebug) {
+			if len(telemetry.upstreamCallsByType) > 0 {
+				logAttrs = append(logAttrs, "upstream.calls_by_type", telemetry.upstreamCallsByType)
+			}
+			if len(upstreamDurationByTypeMs) > 0 {
+				logAttrs = append(logAttrs, "upstream.duration_ms_by_type", upstreamDurationByTypeMs)
+			}
+			if len(telemetry.internalOpsByType) > 0 {
+				logAttrs = append(logAttrs, "proxy.operations_by_type", telemetry.internalOpsByType)
+			}
+			if len(internalDurationByTypeMs) > 0 {
+				logAttrs = append(logAttrs, "proxy.operation_duration_ms_by_type", internalDurationByTypeMs)
+			}
 		}
 		if clientAddr != "" {
 			logAttrs = append(logAttrs, "client.address", clientAddr)

--- a/internal/proxy/request_logger_semconv_test.go
+++ b/internal/proxy/request_logger_semconv_test.go
@@ -195,7 +195,7 @@ func TestRequestLogger_DetectsGrafanaDatasourceSurface(t *testing.T) {
 	}
 }
 
-func TestRequestLogger_EmitsUpstreamAndInternalBreakdowns(t *testing.T) {
+func TestRequestLogger_InfoOmitsPerTypeBreakdowns(t *testing.T) {
 	var buf bytes.Buffer
 	p := &Proxy{
 		log:     slog.New(slog.NewJSONHandler(&buf, nil)),
@@ -221,6 +221,68 @@ func TestRequestLogger_EmitsUpstreamAndInternalBreakdowns(t *testing.T) {
 	if got := payload["upstream.calls"]; got != float64(3) {
 		t.Fatalf("expected upstream.calls=3, got %#v", got)
 	}
+	if got := payload["upstream.call_types"]; got != float64(2) {
+		t.Fatalf("expected upstream.call_types=2, got %#v", got)
+	}
+	if got := payload["proxy.operation_types"]; got != float64(2) {
+		t.Fatalf("expected proxy.operation_types=2, got %#v", got)
+	}
+	if _, ok := payload["upstream.calls_by_type"]; ok {
+		t.Fatalf("did not expect upstream.calls_by_type at info level, got %#v", payload["upstream.calls_by_type"])
+	}
+	if _, ok := payload["upstream.duration_ms_by_type"]; ok {
+		t.Fatalf("did not expect upstream.duration_ms_by_type at info level, got %#v", payload["upstream.duration_ms_by_type"])
+	}
+	if _, ok := payload["proxy.operations_by_type"]; ok {
+		t.Fatalf("did not expect proxy.operations_by_type at info level, got %#v", payload["proxy.operations_by_type"])
+	}
+	if _, ok := payload["proxy.operation_duration_ms_by_type"]; ok {
+		t.Fatalf("did not expect proxy.operation_duration_ms_by_type at info level, got %#v", payload["proxy.operation_duration_ms_by_type"])
+	}
+
+	metricsRR := httptest.NewRecorder()
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	p.metrics.Handler(metricsRR, metricsReq)
+	body := metricsRR.Body.String()
+
+	for _, needle := range []string{
+		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="select_logsql_query",route="/select/logsql/query"} 2`,
+		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="select_logsql_stats_query_range",route="/select/logsql/stats_query_range"} 1`,
+		`loki_vl_proxy_upstream_calls_per_request_count{system="loki",direction="downstream",endpoint="query_range",route="/loki/api/v1/query_range"} 1`,
+		`loki_vl_proxy_internal_operation_total{operation="translate_query",outcome="cache_hit"} 1`,
+		`loki_vl_proxy_internal_operation_total{operation="translate_stats_response_labels",outcome="translated"} 1`,
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("expected metrics output to contain %q", needle)
+		}
+	}
+}
+
+func TestRequestLogger_DebugEmitsPerTypeBreakdowns(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Proxy{
+		log: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		metrics: metrics.NewMetrics(),
+	}
+
+	h := p.requestLogger("query_range", "/loki/api/v1/query_range", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, "/select/logsql/query", "vl.example", 8427, http.StatusOK, 12*time.Millisecond, nil)
+		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, "/select/logsql/query", "vl.example", 8427, http.StatusOK, 18*time.Millisecond, nil)
+		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, "/select/logsql/stats_query_range", "vl.example", 8427, http.StatusOK, 25*time.Millisecond, nil)
+		p.observeInternalOperation(ctx, "translate_query", "cache_hit", 2*time.Millisecond)
+		p.observeInternalOperation(ctx, "translate_stats_response_labels", "translated", 3*time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?query=%7Bapp%3D%22x%22%7D", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	payload := decodeLastJSONLogLine(t, &buf)
+
 	upstreamCallsByType, ok := payload["upstream.calls_by_type"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected upstream.calls_by_type map, got %#v", payload["upstream.calls_by_type"])
@@ -241,22 +303,22 @@ func TestRequestLogger_EmitsUpstreamAndInternalBreakdowns(t *testing.T) {
 	if got := internalOpsByType["translate_stats_response_labels:translated"]; got != float64(1) {
 		t.Fatalf("expected translate_stats_response_labels:translated once, got %#v", got)
 	}
+}
 
-	metricsRR := httptest.NewRecorder()
-	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
-	p.metrics.Handler(metricsRR, metricsReq)
-	body := metricsRR.Body.String()
+func TestWriteError_DowngradesClientErrorsToWarn(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Proxy{log: slog.New(slog.NewJSONHandler(&buf, nil))}
 
-	for _, needle := range []string{
-		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="select_logsql_query",route="/select/logsql/query"} 2`,
-		`loki_vl_proxy_backend_duration_seconds_count{system="vl",direction="upstream",endpoint="select_logsql_stats_query_range",route="/select/logsql/stats_query_range"} 1`,
-		`loki_vl_proxy_upstream_calls_per_request_count{system="loki",direction="downstream",endpoint="query_range",route="/loki/api/v1/query_range"} 1`,
-		`loki_vl_proxy_internal_operation_total{operation="translate_query",outcome="cache_hit"} 1`,
-		`loki_vl_proxy_internal_operation_total{operation="translate_stats_response_labels",outcome="translated"} 1`,
-	} {
-		if !strings.Contains(body, needle) {
-			t.Fatalf("expected metrics output to contain %q", needle)
-		}
+	p.writeError(httptest.NewRecorder(), http.StatusForbidden, "peer cache endpoint is restricted to configured peers")
+	payload := decodeLastJSONLogLine(t, &buf)
+	if got := payload["level"]; got != "WARN" {
+		t.Fatalf("expected WARN for 4xx writeError, got %#v", got)
+	}
+
+	p.writeError(httptest.NewRecorder(), http.StatusBadGateway, "backend unavailable")
+	payload = decodeLastJSONLogLine(t, &buf)
+	if got := payload["level"]; got != "ERROR" {
+		t.Fatalf("expected ERROR for 5xx writeError, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

This hardens proxy startup and request logging around peer cache behavior and release metadata.

- add startup build metadata logs: `version`, `revision`, `build_time`, `go_version`
- include build metadata on `proxy listening`
- make official release workflows embed real version, revision, and build time into binaries and images
- fail release workflows if `VERSION` is empty or still `dev`
- add restore and persist duration logging for patterns snapshot and label-values index paths
- downgrade `4xx` request-error logs from `ERROR` to `WARN`
- warn clearly when peer cache is enabled without `-peer-auth-token`
- trim noisy info-level per-type request breakdown maps and keep full breakdowns at debug only
- document the fleet recommendation to configure `-peer-auth-token` and the observability/logging behavior

## Why

Two operational issues were showing up in production-like logs:

1. Peer-cache `403` bursts during startup and discovery churn looked like backend failures, even though they were really peer endpoint authorization failures caused by relying on transient peer-membership checks.
2. Flattening pipelines were exploding large nested request breakdown maps into many `message.*` fields, which pollutes field discovery and indexing.

This PR makes those behaviors much clearer and less noisy, while preserving detailed breakdowns for debug logging and metrics.

It also fixes another release-quality issue: official releases should not advertise `dev` as their runtime version.

## Operational impact

- startup logs now show the real build identity when built from release workflows
- snapshot and index restore logs now include elapsed `duration_ms`
- request `4xx` errors are less noisy and better reflect severity
- fleets are guided toward `-peer-auth-token` instead of transient IP-membership-only auth
- info-level request logs stop emitting nested by-type maps that downstream log processors flatten into many fields

## Validation

- `go test ./cmd/proxy ./internal/proxy`
- added tests for startup build-info logging
- added tests for info vs debug request-log breakdown behavior
- added tests for `writeError` severity handling
