### PR TITLE
Reduce short-range dense pattern fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- patterns/read-path: reduce dense short-range sampling fanout so 30-minute pattern refreshes stay bounded instead of exploding into excessive backend raw-log window fetches.
+
 ## [1.6.1] - 2026-04-17
 
 ### Bug Fixes

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5504,10 +5504,12 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 	maxWindowSourceLimit := 1_000
 	maxPatternWindowSamples := 96
 	shortDenseSpanThreshold := 6 * time.Hour
-	shortDenseWindowCap := 96
+	shortDenseWindowCap := 24
 	if denseWindowing {
 		// Dense ranges can otherwise explode into hundreds of windows and produce
-		// short/unstable tails under backend pressure. Keep fanout bounded.
+		// short/unstable tails under backend pressure. Keep fanout bounded so
+		// short Drilldown ranges don't turn a single /patterns refresh into
+		// dozens of raw-log backend fetches.
 		targetWindowSpan = 45 * time.Minute
 		minWindowSourceLimit = 200
 		maxWindowSourceLimit = 4_000

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5508,8 +5508,8 @@ func patternWindowedSamplingConfig(startParam, endParam, stepParam string, sourc
 	if denseWindowing {
 		// Dense ranges can otherwise explode into hundreds of windows and produce
 		// short/unstable tails under backend pressure. Keep fanout bounded so
-		// short Drilldown ranges don't turn a single /patterns refresh into
-		// dozens of raw-log backend fetches.
+		// short dense ranges don't turn a single /patterns refresh into dozens
+		// of raw-log backend fetches.
 		targetWindowSpan = 45 * time.Minute
 		minWindowSourceLimit = 200
 		maxWindowSourceLimit = 4_000

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2556,6 +2556,26 @@ func TestPatternWindowedSamplingConfig_DenseShortRangeUsesStepToIncreaseFanout(t
 	}
 }
 
+func TestPatternWindowedSamplingConfig_DenseThirtyMinuteRangeCapsDrilldownFanout(t *testing.T) {
+	start := strconv.FormatInt(0, 10)
+	end := strconv.FormatInt(int64((30*time.Minute)/time.Second), 10)
+
+	startNs, endNs, interval, perWindow, ok := patternWindowedSamplingConfig(start, end, "5s", 7220, true)
+	if !ok {
+		t.Fatal("expected dense windowed config for 30m range")
+	}
+	windows := splitQueryRangeWindowsWithOptions(startNs, endNs, interval, "backward", true)
+	if got := len(windows); got > 25 {
+		t.Fatalf("expected short dense drilldown fanout capped at 25 aligned windows, got %d", got)
+	}
+	if got := len(windows); got < 20 {
+		t.Fatalf("expected short dense drilldown fanout to stay granular, got %d", got)
+	}
+	if perWindow < 200 {
+		t.Fatalf("expected dense per-window lower bound >=200, got %d", perWindow)
+	}
+}
+
 func TestPatternWindowedSamplingConfig_DenseLongRangeBoostsPerWindowLimit(t *testing.T) {
 	start := strconv.FormatInt(0, 10)
 	end := strconv.FormatInt(int64((48*time.Hour)/time.Second), 10)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2556,7 +2556,7 @@ func TestPatternWindowedSamplingConfig_DenseShortRangeUsesStepToIncreaseFanout(t
 	}
 }
 
-func TestPatternWindowedSamplingConfig_DenseThirtyMinuteRangeCapsDrilldownFanout(t *testing.T) {
+func TestPatternWindowedSamplingConfig_DenseThirtyMinuteRangeCapsShortRangeFanout(t *testing.T) {
 	start := strconv.FormatInt(0, 10)
 	end := strconv.FormatInt(int64((30*time.Minute)/time.Second), 10)
 
@@ -2566,10 +2566,10 @@ func TestPatternWindowedSamplingConfig_DenseThirtyMinuteRangeCapsDrilldownFanout
 	}
 	windows := splitQueryRangeWindowsWithOptions(startNs, endNs, interval, "backward", true)
 	if got := len(windows); got > 25 {
-		t.Fatalf("expected short dense drilldown fanout capped at 25 aligned windows, got %d", got)
+		t.Fatalf("expected short dense fanout capped at 25 aligned windows, got %d", got)
 	}
 	if got := len(windows); got < 20 {
-		t.Fatalf("expected short dense drilldown fanout to stay granular, got %d", got)
+		t.Fatalf("expected short dense fanout to stay granular, got %d", got)
 	}
 	if perWindow < 200 {
 		t.Fatalf("expected dense per-window lower bound >=200, got %d", perWindow)


### PR DESCRIPTION
## What changed

- cap dense short-range `/patterns` window fanout so short dense ranges no longer explode into dozens of raw-log backend fetches
- add a regression test for the `30m` + `5s` request shape that exercises the capped fanout behavior

## Why it changed

A recent performance regression showed `/loki/api/v1/patterns` could fan out into dozens of upstream raw-log queries on short dense ranges. That request burst was a major source of latency and backend pressure.

## User impact

This reduces proxy-side load for short dense-range pattern refreshes and removes a major source of avoidable backend work.

## Root cause

Dense short-range pattern sampling let the requested step inflate the number of sampling windows too aggressively. On a `30m` range with a `5s` step, the proxy could hit the dense window cap and then add second-pass re-fetches, turning one `/patterns` refresh into dozens of backend raw-log queries.

## Validation

- `go test ./internal/proxy -run 'TestContract_Patterns_|TestPatternWindowedSamplingConfig_'`
