### PR TITLE
Add custom manifest rendering hook to Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- helm/chart: add a reusable `customManifests` hook so downstream installs can render extra Kubernetes resources with full chart context without forking chart templates.
+
 ## [1.6.2] - 2026-04-17
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -166,6 +166,20 @@ Priority:
 {{- end }}
 
 {{/*
+Render a custom manifest entry from values.customManifests.
+Supports either raw YAML objects/maps or templated string snippets.
+*/}}
+{{- define "loki-vl-proxy.renderCustomManifest" -}}
+{{- $manifest := .manifest -}}
+{{- $context := .context -}}
+{{- if kindIs "string" $manifest -}}
+{{- tpl $manifest $context -}}
+{{- else -}}
+{{- tpl (toYaml $manifest) $context -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve effective GOMEMLIMIT value.
 Priority:
 1) explicit .Values.goMemLimit

--- a/charts/loki-vl-proxy/templates/custom-manifests.yaml
+++ b/charts/loki-vl-proxy/templates/custom-manifests.yaml
@@ -1,0 +1,7 @@
+{{- range $manifest := .Values.customManifests }}
+{{- $rendered := include "loki-vl-proxy.renderCustomManifest" (dict "manifest" $manifest "context" $) | trim }}
+{{- if $rendered }}
+---
+{{ $rendered }}
+{{- end }}
+{{- end }}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -354,6 +354,25 @@ envFrom: []
   # - configMapRef:
   #     name: loki-vl-proxy-config
 
+# Extra manifests rendered with full Helm chart context.
+# Each entry may be either:
+# - a YAML object/map
+# - a templated YAML string using Helm expressions
+# Rendered objects are emitted as standalone resources.
+customManifests: []
+  # - apiVersion: external-secrets.io/v1beta1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: '{{ include "loki-vl-proxy.fullname" . }}-env'
+  #   spec: {}
+  # - |
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: {{ include "loki-vl-proxy.fullname" . }}-extra
+  #   data:
+  #     example: "value"
+
 # --- PrometheusRule (alert rules for Prometheus Operator) ---
 # Base rules source:
 # - canonical repo asset: /alerting/loki-vl-proxy-prometheusrule.yaml


### PR DESCRIPTION
## Summary
Add a reusable `customManifests` hook to the `loki-vl-proxy` Helm chart so downstream environments can attach extra Kubernetes resources without carrying local chart template forks.

## What Changed
- add `customManifests` to chart values
- add a helper that renders either YAML objects or templated YAML strings with full Helm context
- add a `templates/custom-manifests.yaml` renderer that emits each configured object as a standalone manifest

## Why
Downstream consumers sometimes need to attach environment-specific resources next to the chart release. This keeps that escape hatch in the upstream chart so later integrations can reuse it without reintroducing chart-only patches downstream.

## Impact
- no behavior change by default because `customManifests` defaults to an empty list
- supports both static objects and templated snippets
- keeps future downstream additions focused on values rather than template divergence

## Validation
- `helm lint charts/loki-vl-proxy`
- `helm template test charts/loki-vl-proxy -f /tmp/lvp-chart-custom-manifests-values.yaml`