### PR TITLE
Harden Drilldown discovery fallback and snapshot warmup locality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - drilldown/fields: retry native field and stream discovery with relaxed candidates when parser or comparison stages make Drilldown field lookups unstable, treat backend `5xx` scan responses as failed windows instead of empty results, and preserve native-only fallback for structured metadata without leaking indexed labels.
+- peer-cache/persistence: keep persisted patterns and label-values snapshot blobs local instead of distributing them through the ring owner path, merge label-values startup warm state directly from peer-local snapshots, and use the correct peer auth header during snapshot fetches so fleet warmups stay compatible when `peer-auth-token` is enabled.
 
 ### Tests
 
 - drilldown: add regression coverage for duration-filtered detected field and detected field value requests so future changes catch strict-vs-relaxed discovery regressions before release.
+- cache/persistence: add regression coverage proving fleet snapshot blobs skip write-through owner pushes and that peer-warmed label-values state merges correctly under shared peer auth.
 
 ## [1.6.3] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/fields: retry native field and stream discovery with relaxed candidates when parser or comparison stages make Drilldown field lookups unstable, treat backend `5xx` scan responses as failed windows instead of empty results, and preserve native-only fallback for structured metadata without leaking indexed labels.
+
+### Tests
+
+- drilldown: add regression coverage for duration-filtered detected field and detected field value requests so future changes catch strict-vs-relaxed discovery regressions before release.
+
 ## [1.6.3] - 2026-04-17
 
 ### Features

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -203,6 +203,39 @@ func (c *Cache) SetShadowWithTTL(key string, value []byte, ttl time.Duration) {
 	c.setWithTTL(key, value, ttl, false)
 }
 
+// SetLocalOnlyWithTTL stores a value only in local L1 memory.
+// It skips L2 disk writes, L3 peer propagation, and non-owner TTL clamping.
+func (c *Cache) SetLocalOnlyWithTTL(key string, value []byte, ttl time.Duration) {
+	size := len(value)
+	if size > c.maxBytes/10 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if old, ok := c.entries[key]; ok {
+		c.curBytes -= old.sizeBytes
+		if elem, found := c.lruIndex[key]; found {
+			c.lruList.MoveToFront(elem)
+		}
+	}
+
+	c.evictIfNeeded(size)
+
+	c.entries[key] = entry{
+		value:     value,
+		expiresAt: time.Now().Add(ttl),
+		sizeBytes: size,
+	}
+	c.curBytes += size
+
+	if _, found := c.lruIndex[key]; !found {
+		elem := c.lruList.PushFront(&lruEntry{key: key})
+		c.lruIndex[key] = elem
+	}
+}
+
 // SetWithTTL stores a value with a specific TTL.
 func (c *Cache) SetWithTTL(key string, value []byte, ttl time.Duration) {
 	c.setWithTTL(key, value, ttl, true)

--- a/internal/cache/cache_write_through_test.go
+++ b/internal/cache/cache_write_through_test.go
@@ -102,3 +102,45 @@ func TestCache_OwnerWriteThrough_KeepsTTLAndWritesL2(t *testing.T) {
 		t.Fatalf("unexpected L2 value for key %q: %q", key, string(v))
 	}
 }
+
+func TestCache_LocalOnlyWrite_KeepsTTLAndSkipsL2(t *testing.T) {
+	c := NewWithMaxBytes(10*time.Minute, 1000, 1024*1024)
+	defer c.Close()
+
+	dc, err := NewDiskCache(DiskCacheConfig{Path: t.TempDir() + "/cache.db"})
+	if err != nil {
+		t.Fatalf("new disk cache: %v", err)
+	}
+	defer func() { _ = dc.Close() }()
+
+	pc := NewPeerCache(PeerConfig{
+		SelfAddr:           "self:3100",
+		DiscoveryType:      "static",
+		StaticPeers:        "self:3100,owner:3100",
+		Timeout:            10 * time.Millisecond,
+		WriteThrough:       true,
+		WriteThroughMinTTL: 5 * time.Second,
+	})
+	defer pc.Close()
+
+	c.SetL2(dc)
+	c.SetL3(pc)
+
+	key := findKeyForOwner(t, pc, "owner:3100")
+	c.SetLocalOnlyWithTTL(key, []byte("value"), 2*time.Minute)
+
+	_, ttl, ok := c.GetWithTTL(key)
+	if !ok {
+		t.Fatalf("expected local L1 hit for key %q", key)
+	}
+	if ttl <= nonOwnerShadowMaxTTL {
+		t.Fatalf("expected local-only TTL to stay above non-owner shadow cap (%v), got %v", nonOwnerShadowMaxTTL, ttl)
+	}
+
+	if _, ok := dc.Get(key); ok {
+		t.Fatalf("expected local-only key %q to skip local L2 write", key)
+	}
+	if got := pc.WTPushes.Load(); got != 0 {
+		t.Fatalf("expected local-only write to skip write-through pushes, got %d", got)
+	}
+}

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -584,7 +584,7 @@ func TestDetectedFields_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T) {
 	}
 }
 
-func TestDetectedFieldValues_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T) {
+func TestDetectedFieldValues_EmptyStrictQueryRelaxesCandidates(t *testing.T) {
 	const strictToken = "strict-only"
 
 	var fieldValueQueries []string
@@ -641,12 +641,18 @@ func TestDetectedFieldValues_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if len(fieldValueQueries) != 1 {
-		t.Fatalf("expected only the strict native field-value lookup, got %v", fieldValueQueries)
+	if len(fieldValueQueries) != 2 {
+		t.Fatalf("expected strict+relaxed native field-value lookups, got %v", fieldValueQueries)
+	}
+	if !strings.Contains(fieldValueQueries[0], strictToken) {
+		t.Fatalf("expected strict native field-value lookup to preserve strict filter, got %q", fieldValueQueries[0])
+	}
+	if strings.Contains(fieldValueQueries[1], strictToken) {
+		t.Fatalf("expected relaxed native field-value lookup to strip strict-only filter, got %q", fieldValueQueries[1])
 	}
 	for _, got := range append(streamQueries, scanQueries...) {
-		if !strings.Contains(got, strictToken) {
-			t.Fatalf("expected fallback discovery to preserve strict filter, got %q", got)
+		if strings.Contains(got, strictToken) {
+			t.Fatalf("expected native field-value relaxation to avoid label/scan fallback, got %q", got)
 		}
 	}
 
@@ -655,8 +661,8 @@ func TestDetectedFieldValues_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T
 		t.Fatalf("unmarshal response: %v", err)
 	}
 	values, _ := resp["values"].([]interface{})
-	if len(values) != 0 {
-		t.Fatalf("expected empty detected_field values payload for strict empty query, got %v", resp)
+	if len(values) != 1 || values[0] != "200" {
+		t.Fatalf("expected relaxed detected_field values payload to preserve native values, got %v", resp)
 	}
 }
 

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -681,6 +681,73 @@ func TestDetectedFieldValues_EmptyStrictQueryRelaxesCandidates(t *testing.T) {
 	}
 }
 
+func TestDetectedFieldValues_EmptyStrictQueryRelaxesWholeLookup(t *testing.T) {
+	const strictToken = "strict-only"
+
+	var fieldNameQueries []string
+	var scanQueries []string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got := r.Form.Get("query")
+		strict := strings.Contains(got, strictToken)
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			fieldNameQueries = append(fieldNameQueries, got)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[]}`))
+		case "/select/logsql/query":
+			scanQueries = append(scanQueries, got)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			if !strict {
+				_, _ = w.Write([]byte(`{"_time":"2026-04-04T17:18:49.971082Z","_msg":"{\"status\":200}","_stream":"{service_name=\"api-gateway\",namespace=\"staging\"}","service_name":"api-gateway","namespace":"staging","status":200}` + "\n"))
+			}
+		case "/select/logsql/streams":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	q := url.Values{
+		"query": {`{service_name="api-gateway",namespace="staging"} | probe="strict-only"`},
+		"start": {"1"},
+		"end":   {"2"},
+	}
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_field/status/values?"+q.Encode(), nil)
+	p.handleDetectedFieldValues(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(fieldNameQueries) == 0 || !strings.Contains(fieldNameQueries[0], strictToken) {
+		t.Fatalf("expected strict native field-name lookup before whole-query relaxation, got %v", fieldNameQueries)
+	}
+	if len(scanQueries) < 2 {
+		t.Fatalf("expected strict+relaxed field scans, got %v", scanQueries)
+	}
+	if !strings.Contains(scanQueries[0], strictToken) {
+		t.Fatalf("expected strict field scan to preserve strict filter, got %q", scanQueries[0])
+	}
+	if strings.Contains(scanQueries[len(scanQueries)-1], strictToken) {
+		t.Fatalf("expected relaxed field scan to strip strict-only filter, got %q", scanQueries[len(scanQueries)-1])
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	values, _ := resp["values"].([]interface{})
+	if len(values) != 1 || values[0] != "200" {
+		t.Fatalf("expected relaxed whole-query fallback to preserve status=200, got %v", resp)
+	}
+}
+
 func TestHandleLabels_BareSelectorQuery(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got := r.URL.Query().Get("query")

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -587,6 +587,7 @@ func TestDetectedFields_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T) {
 func TestDetectedFieldValues_EmptyStrictQueryRelaxesCandidates(t *testing.T) {
 	const strictToken = "strict-only"
 
+	var fieldNameQueries []string
 	var fieldValueQueries []string
 	var streamQueries []string
 	var scanQueries []string
@@ -598,7 +599,12 @@ func TestDetectedFieldValues_EmptyStrictQueryRelaxesCandidates(t *testing.T) {
 		strict := strings.Contains(got, strictToken)
 		switch r.URL.Path {
 		case "/select/logsql/field_names":
+			fieldNameQueries = append(fieldNameQueries, got)
 			w.Header().Set("Content-Type", "application/json")
+			if strict {
+				_, _ = w.Write([]byte(`{"values":[]}`))
+				return
+			}
 			_, _ = w.Write([]byte(`{"values":[{"value":"status","hits":1}]}`))
 		case "/select/logsql/field_values":
 			fieldValueQueries = append(fieldValueQueries, got)
@@ -640,6 +646,15 @@ func TestDetectedFieldValues_EmptyStrictQueryRelaxesCandidates(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(fieldNameQueries) != 2 {
+		t.Fatalf("expected strict+relaxed native field-name lookups, got %v", fieldNameQueries)
+	}
+	if !strings.Contains(fieldNameQueries[0], strictToken) {
+		t.Fatalf("expected strict native field-name lookup to preserve strict filter, got %q", fieldNameQueries[0])
+	}
+	if strings.Contains(fieldNameQueries[1], strictToken) {
+		t.Fatalf("expected relaxed native field-name lookup to strip strict-only filter, got %q", fieldNameQueries[1])
 	}
 	if len(fieldValueQueries) != 2 {
 		t.Fatalf("expected strict+relaxed native field-value lookups, got %v", fieldValueQueries)

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -520,6 +520,146 @@ func TestDetectedFieldValues_FieldFilterFallbackKeepsValuesVisible(t *testing.T)
 	}
 }
 
+func TestDetectedFields_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T) {
+	const strictToken = "strict-only"
+
+	var fieldNameQueries []string
+	var scanQueries []string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got := r.Form.Get("query")
+		strict := strings.Contains(got, strictToken)
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			fieldNameQueries = append(fieldNameQueries, got)
+			w.Header().Set("Content-Type", "application/json")
+			if strict {
+				_, _ = w.Write([]byte(`{"values":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"values":[{"value":"status","hits":1}]}`))
+		case "/select/logsql/query":
+			scanQueries = append(scanQueries, got)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			if !strict {
+				_, _ = w.Write([]byte(`{"_time":"2026-04-04T17:18:49.971082Z","_msg":"{\"status\":200}","_stream":"{service_name=\"api-gateway\"}","service_name":"api-gateway","status":200}` + "\n"))
+			}
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	q := url.Values{
+		"query": {`{service_name="api-gateway"} | probe="strict-only"`},
+		"start": {"1"},
+		"end":   {"2"},
+	}
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_fields?"+q.Encode(), nil)
+	p.handleDetectedFields(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(fieldNameQueries) != 1 {
+		t.Fatalf("expected only the strict native field-name lookup, got %v", fieldNameQueries)
+	}
+	for _, got := range scanQueries {
+		if !strings.Contains(got, strictToken) {
+			t.Fatalf("expected scan lookup to preserve strict filter, got %q", got)
+		}
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	fields, _ := resp["fields"].([]interface{})
+	if len(fields) != 0 {
+		t.Fatalf("expected empty detected_fields payload for strict empty query, got %v", resp)
+	}
+}
+
+func TestDetectedFieldValues_EmptyStrictQueryDoesNotRelaxCandidates(t *testing.T) {
+	const strictToken = "strict-only"
+
+	var fieldValueQueries []string
+	var streamQueries []string
+	var scanQueries []string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got := r.Form.Get("query")
+		strict := strings.Contains(got, strictToken)
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"status","hits":1}]}`))
+		case "/select/logsql/field_values":
+			fieldValueQueries = append(fieldValueQueries, got)
+			w.Header().Set("Content-Type", "application/json")
+			if strict {
+				_, _ = w.Write([]byte(`{"values":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"values":[{"value":"200","hits":1}]}`))
+		case "/select/logsql/streams":
+			streamQueries = append(streamQueries, got)
+			w.Header().Set("Content-Type", "application/json")
+			if strict {
+				_, _ = w.Write([]byte(`{"values":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"values":[{"value":"{service_name=\"api-gateway\",status=\"200\"}","hits":1}]}`))
+		case "/select/logsql/query":
+			scanQueries = append(scanQueries, got)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			if !strict {
+				_, _ = w.Write([]byte(`{"_time":"2026-04-04T17:18:49.971082Z","_msg":"{\"status\":200}","_stream":"{service_name=\"api-gateway\"}","service_name":"api-gateway","status":200}` + "\n"))
+			}
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	q := url.Values{
+		"query": {`{service_name="api-gateway"} | probe="strict-only"`},
+		"start": {"1"},
+		"end":   {"2"},
+	}
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_field/status/values?"+q.Encode(), nil)
+	p.handleDetectedFieldValues(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(fieldValueQueries) != 1 {
+		t.Fatalf("expected only the strict native field-value lookup, got %v", fieldValueQueries)
+	}
+	for _, got := range append(streamQueries, scanQueries...) {
+		if !strings.Contains(got, strictToken) {
+			t.Fatalf("expected fallback discovery to preserve strict filter, got %q", got)
+		}
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	values, _ := resp["values"].([]interface{})
+	if len(values) != 0 {
+		t.Fatalf("expected empty detected_field values payload for strict empty query, got %v", resp)
+	}
+}
+
 func TestHandleLabels_BareSelectorQuery(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got := r.URL.Query().Get("query")

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -69,27 +69,6 @@ func TestAdminStubs_Config(t *testing.T) {
 	}
 }
 
-func TestAdminStubs_TenantLimitsConfig(t *testing.T) {
-	p := newGapTestProxy(t, "http://unused")
-	mux := http.NewServeMux()
-	p.RegisterRoutes(mux)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/config/tenant/v1/limits", nil)
-	mux.ServeHTTP(w, r)
-
-	if !strings.Contains(w.Header().Get("Content-Type"), "text/plain") {
-		t.Fatalf("tenant limits endpoint: expected text/plain content type, got %q", w.Header().Get("Content-Type"))
-	}
-	var resp map[string]interface{}
-	if err := yaml.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("tenant limits endpoint: expected valid YAML, got %v", err)
-	}
-	if resp["retention_period"] == nil || resp["query_timeout"] == nil {
-		t.Fatalf("tenant limits endpoint: expected Loki-compatible limits payload, got %v", resp)
-	}
-}
-
 func TestAdminStubs_FormatQuery(t *testing.T) {
 	p := newGapTestProxy(t, "http://unused")
 	w := httptest.NewRecorder()
@@ -122,12 +101,6 @@ func TestAdminStubs_DrilldownLimits(t *testing.T) {
 	}
 	if limits["retention_period"] == nil || limits["discover_service_name"] == nil || limits["log_level_fields"] == nil {
 		t.Fatalf("drilldown-limits missing Loki config fields required by Logs Drilldown: %v", resp)
-	}
-	if limits["retention_stream"] == nil {
-		t.Fatalf("drilldown-limits missing retention_stream for Loki limits parity: %v", resp)
-	}
-	if _, ok := limits["retention_stream"].([]interface{}); !ok {
-		t.Fatalf("drilldown-limits retention_stream must be array, got %T", limits["retention_stream"])
 	}
 	if resp["pattern_ingester_enabled"] == nil || resp["version"] == nil {
 		t.Fatalf("drilldown-limits missing Loki config top-level fields: %v", resp)
@@ -388,6 +361,165 @@ func TestDefaultFieldDetectionQuery_NormalizesAfterStrippingStages(t *testing.T)
 	}
 }
 
+func TestFieldDetectionQueryCandidates_RelaxFieldComparisons(t *testing.T) {
+	got := fieldDetectionQueryCandidates(`{service_name="grafana"} | logfmt | duration < 1s | duration > 100ms | unwrap duration(duration)`)
+	want := []string{
+		`{service_name="grafana"} | duration < 1s | duration > 100ms`,
+		`{service_name="grafana"}`,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("fieldDetectionQueryCandidates() len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("fieldDetectionQueryCandidates()[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestDetectedFields_FieldFilterFallbackKeepsFieldsVisible(t *testing.T) {
+	var fieldQueries []string
+	var streamQueries []string
+	var scanQueries []string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got := r.Form.Get("query")
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			fieldQueries = append(fieldQueries, got)
+			if strings.Contains(got, "duration") {
+				http.Error(w, "strict filtered discovery timed out", http.StatusGatewayTimeout)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"app","hits":2},{"value":"duration","hits":2},{"value":"trace_id","hits":2}]}`))
+		case "/select/logsql/streams":
+			streamQueries = append(streamQueries, got)
+			if strings.Contains(got, "duration") {
+				http.Error(w, "strict filtered streams timed out", http.StatusGatewayTimeout)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"{app=\"grafana\",service_name=\"grafana\"}","hits":2}]}`))
+		case "/select/logsql/query":
+			scanQueries = append(scanQueries, got)
+			if strings.Contains(got, "duration") {
+				http.Error(w, "strict filtered scan timed out", http.StatusGatewayTimeout)
+				return
+			}
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(""))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	q := url.Values{
+		"query": {`{service_name="grafana"} | logfmt | duration < 1s | duration > 100ms`},
+		"start": {"1"},
+		"end":   {"2"},
+	}
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_fields?"+q.Encode(), nil)
+	p.handleDetectedFields(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(fieldQueries) != 2 {
+		t.Fatalf("expected strict+relaxed native field lookups, got %v", fieldQueries)
+	}
+	if len(streamQueries) != 2 {
+		t.Fatalf("expected strict+relaxed native stream lookups, got %v", streamQueries)
+	}
+	if !strings.Contains(fieldQueries[0], "duration") {
+		t.Fatalf("expected strict native field lookup to include duration filter, got %q", fieldQueries[0])
+	}
+	if strings.Contains(fieldQueries[1], "duration") {
+		t.Fatalf("expected relaxed native field lookup to strip duration filter, got %q", fieldQueries[1])
+	}
+	if len(scanQueries) < 1 {
+		t.Fatalf("expected at least one scan query, got %v", scanQueries)
+	}
+	if !strings.Contains(scanQueries[0], "duration") {
+		t.Fatalf("expected strict scan to include duration filter, got %q", scanQueries[0])
+	}
+	if len(scanQueries) > 1 && strings.Contains(scanQueries[1], "duration") {
+		t.Fatalf("expected relaxed scan to strip duration filter, got %q", scanQueries[1])
+	}
+	if !strings.Contains(w.Body.String(), `"duration"`) || !strings.Contains(w.Body.String(), `"trace_id"`) {
+		t.Fatalf("expected relaxed native fields to remain visible, got %s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), `"app"`) {
+		t.Fatalf("expected indexed labels to stay hidden during native fallback, got %s", w.Body.String())
+	}
+}
+
+func TestDetectedFieldValues_FieldFilterFallbackKeepsValuesVisible(t *testing.T) {
+	var fieldNameQueries []string
+	var fieldValueQueries []string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got := r.Form.Get("query")
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			fieldNameQueries = append(fieldNameQueries, got)
+			if strings.Contains(got, "duration") {
+				http.Error(w, "strict filtered discovery timed out", http.StatusGatewayTimeout)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"app","hits":2},{"value":"duration","hits":2}]}`))
+		case "/select/logsql/field_values":
+			fieldValueQueries = append(fieldValueQueries, got)
+			if strings.Contains(got, "duration") {
+				http.Error(w, "strict filtered value lookup timed out", http.StatusGatewayTimeout)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"120ms","hits":2},{"value":"800ms","hits":1}]}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	q := url.Values{
+		"query": {`{service_name="grafana"} | logfmt | duration < 1s | duration > 100ms`},
+		"start": {"1"},
+		"end":   {"2"},
+	}
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_field/duration/values?"+q.Encode(), nil)
+	p.handleDetectedFieldValues(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(fieldNameQueries) < 2 {
+		t.Fatalf("expected at least strict+relaxed native field-name lookups, got %v", fieldNameQueries)
+	}
+	if len(fieldValueQueries) != 2 {
+		t.Fatalf("expected strict+relaxed native field-value lookups, got %v", fieldValueQueries)
+	}
+	if !strings.Contains(fieldValueQueries[0], "duration") {
+		t.Fatalf("expected strict native field-value lookup to include duration filter, got %q", fieldValueQueries[0])
+	}
+	if strings.Contains(fieldValueQueries[1], "duration") {
+		t.Fatalf("expected relaxed native field-value lookup to strip duration filter, got %q", fieldValueQueries[1])
+	}
+	if !strings.Contains(w.Body.String(), `"120ms"`) || !strings.Contains(w.Body.String(), `"800ms"`) {
+		t.Fatalf("expected relaxed native field values to remain visible, got %s", w.Body.String())
+	}
+}
+
 func TestHandleLabels_BareSelectorQuery(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got := r.URL.Query().Get("query")
@@ -513,18 +645,6 @@ func TestPatterns_VLReturnsLines_ExtractsPatterns(t *testing.T) {
 	data, ok := resp["data"].([]interface{})
 	if !ok || len(data) == 0 {
 		t.Fatalf("expected extracted patterns, got %v", resp)
-	}
-}
-
-func TestPatterns_BackendLimitScalesWithRequestedWindow(t *testing.T) {
-	limit := patternBackendQueryLimit("2026-04-04T00:00:00Z", "2026-04-05T00:00:00Z", "1h", 50)
-	if limit <= 1000 {
-		t.Fatalf("expected widened backend limit for wide range, got %d", limit)
-	}
-
-	narrowLimit := patternBackendQueryLimit("2026-04-04T00:00:00Z", "2026-04-04T00:05:00Z", "1m", 50)
-	if narrowLimit != 1000 {
-		t.Fatalf("expected narrow range to clamp at minimum backend limit, got %d", narrowLimit)
 	}
 }
 

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -1429,7 +1429,9 @@ func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, f
 			values = append(values, item.Value)
 		}
 		sort.Strings(values)
-		return values, nil
+		if len(values) > 0 {
+			return values, nil
+		}
 	}
 	return nil, lastErr
 }

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -141,13 +142,8 @@ func shouldExposeStructuredField(key string, streamLabels map[string]string, lt 
 
 func scanNativeStreamLabelSet(body []byte) map[string]string {
 	labels := make(map[string]string)
-	startIdx := 0
-	for i := 0; i <= len(body); i++ {
-		if i < len(body) && body[i] != '\n' {
-			continue
-		}
-		line := strings.TrimSpace(string(body[startIdx:i]))
-		startIdx = i + 1
+	for _, rawLine := range bytes.Split(body, []byte{'\n'}) {
+		line := strings.TrimSpace(string(rawLine))
 		if line == "" {
 			continue
 		}
@@ -1018,11 +1014,14 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 	if len(nativeFields) > 0 && scanLimit > detectedFieldsSampleLimit {
 		scanLimit = detectedFieldsSampleLimit
 	}
+	candidates := fieldDetectionQueryCandidates(query)
+	hadScanFailure := false
 	var lastErr error
-	for _, candidate := range fieldDetectionQueryCandidates(query) {
+	for _, candidate := range candidates {
 		logsqlQuery, err := p.translateQuery(candidate)
 		if err != nil {
 			lastErr = err
+			hadScanFailure = true
 			continue
 		}
 
@@ -1039,6 +1038,7 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 		resp, err := p.vlPost(ctx, "/select/logsql/query", params)
 		if err != nil {
 			lastErr = err
+			hadScanFailure = true
 			continue
 		}
 
@@ -1050,6 +1050,7 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
 			}
 			lastErr = fmt.Errorf("%s", msg)
+			hadScanFailure = true
 			continue
 		}
 		if resp.StatusCode >= http.StatusBadRequest {
@@ -1066,12 +1067,21 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 			p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
 			return fieldList, fieldValues, nil
 		}
+		if len(candidates) > 1 && !hadScanFailure {
+			emptyFields := []map[string]interface{}{}
+			emptyValues := map[string][]string{}
+			p.setCachedDetectedFields(ctx, query, start, end, lineLimit, emptyFields, emptyValues)
+			return emptyFields, emptyValues, nil
+		}
+		break
 	}
 
 	if len(nativeFields) > 0 {
-		streamLabels, err := p.fetchNativeStreamLabelSet(ctx, query, start, end)
-		if err == nil {
-			nativeFields = filterNativeDetectedFields(nativeFields, streamLabels, p.labelTranslator)
+		if nativeFieldFilterNeedsStreamLabels(nativeFields, p.labelTranslator) {
+			streamLabels, err := p.fetchNativeStreamLabelSet(ctx, query, start, end)
+			if err == nil {
+				nativeFields = filterNativeDetectedFields(nativeFields, streamLabels, p.labelTranslator)
+			}
 		}
 		fieldList, fieldValues := mergeNativeDetectedFields(nil, nil, nativeFields)
 		p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
@@ -1352,9 +1362,7 @@ func (p *Proxy) fetchNativeFieldNames(ctx context.Context, query, start, end str
 		for _, item := range resp.Values {
 			out = append(out, item.Value)
 		}
-		if len(out) > 0 {
-			return out, nil
-		}
+		return out, nil
 	}
 	return nil, lastErr
 }
@@ -1421,9 +1429,7 @@ func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, f
 			values = append(values, item.Value)
 		}
 		sort.Strings(values)
-		if len(values) > 0 {
-			return values, nil
-		}
+		return values, nil
 	}
 	return nil, lastErr
 }
@@ -1496,10 +1502,7 @@ func (p *Proxy) fetchNativeStreams(ctx context.Context, query, start, end string
 			lastErr = err
 			continue
 		}
-		if len(parsed.Values) > 0 {
-			return &parsed, nil
-		}
-		lastErr = nil
+		return &parsed, nil
 	}
 	return &vlStreamsResponse{}, lastErr
 }
@@ -1515,6 +1518,15 @@ func filterNativeDetectedFields(native map[string]*detectedFieldSummary, streamL
 		}
 	}
 	return filtered
+}
+
+func nativeFieldFilterNeedsStreamLabels(native map[string]*detectedFieldSummary, lt *LabelTranslator) bool {
+	for label := range native {
+		if !shouldExposeStructuredField(label, map[string]string{label: "1"}, lt) {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Proxy) detectScannedLabels(ctx context.Context, query, start, end string, lineLimit int) (map[string]*detectedLabelSummary, error) {

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -1437,15 +1437,22 @@ func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, f
 }
 
 func (p *Proxy) resolveNativeDetectedField(ctx context.Context, query, start, end, fieldName string) (string, bool, error) {
-	fieldNames, err := p.fetchNativeFieldNames(ctx, query, start, end)
-	if err != nil {
-		return "", false, err
+	var lastErr error
+	for _, candidate := range fieldDetectionQueryCandidates(query) {
+		fieldNames, err := p.fetchNativeFieldNames(ctx, candidate, start, end)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		candidates := make([]string, 0, len(fieldNames))
+		candidates = append(candidates, fieldNames...)
+		resolution := p.labelTranslator.ResolveMetadataCandidates(fieldName, candidates, p.metadataFieldMode)
+		if len(resolution.candidates) == 1 {
+			return resolution.candidates[0], true, nil
+		}
 	}
-	candidates := make([]string, 0, len(fieldNames))
-	candidates = append(candidates, fieldNames...)
-	resolution := p.labelTranslator.ResolveMetadataCandidates(fieldName, candidates, p.metadataFieldMode)
-	if len(resolution.candidates) == 1 {
-		return resolution.candidates[0], true, nil
+	if lastErr != nil {
+		return "", false, lastErr
 	}
 	return "", false, nil
 }

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -139,6 +139,32 @@ func shouldExposeStructuredField(key string, streamLabels map[string]string, lt 
 	return lt.ToLoki(key) != key
 }
 
+func scanNativeStreamLabelSet(body []byte) map[string]string {
+	labels := make(map[string]string)
+	startIdx := 0
+	for i := 0; i <= len(body); i++ {
+		if i < len(body) && body[i] != '\n' {
+			continue
+		}
+		line := strings.TrimSpace(string(body[startIdx:i]))
+		startIdx = i + 1
+		if line == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		for key, value := range parseStreamLabels(asString(entry["_stream"])) {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			labels[key] = value
+		}
+	}
+	return labels
+}
+
 func (p *Proxy) metadataFieldExposures(vlField string) []metadataFieldExposure {
 	return p.labelTranslator.metadataFieldExposures(vlField, p.metadataFieldMode)
 }
@@ -828,6 +854,19 @@ func defaultFieldDetectionQuery(query string) string {
 	return defaultQuery(stripFieldDetectionStages(query))
 }
 
+func relaxedFieldDetectionQuery(query string) string {
+	return defaultQuery(stripFieldComparisonStages(stripFieldDetectionStages(query)))
+}
+
+func fieldDetectionQueryCandidates(query string) []string {
+	primary := defaultFieldDetectionQuery(query)
+	relaxed := relaxedFieldDetectionQuery(query)
+	if relaxed == "" || relaxed == primary {
+		return []string{primary}
+	}
+	return []string{primary, relaxed}
+}
+
 func normalizeBareSelectorQuery(query string) string {
 	query = strings.TrimSpace(query)
 	if query == "" || query == "*" || strings.HasPrefix(query, "{") {
@@ -850,9 +889,25 @@ func stripFieldDetectionStages(query string) string {
 
 	dropStage := regexp.MustCompile(`\|\s*drop\s+__error__(\s*,\s*__error_details__)?\s*`)
 	parserStage := regexp.MustCompile(`\|\s*(json|logfmt|unpack)(\s+[^|]+)?`)
+	unwrapStage := regexp.MustCompile(`\|\s*unwrap\s+[^|]+`)
 
 	query = dropStage.ReplaceAllString(query, " ")
 	query = parserStage.ReplaceAllString(query, " ")
+	query = unwrapStage.ReplaceAllString(query, " ")
+	for strings.Contains(query, "  ") {
+		query = strings.ReplaceAll(query, "  ", " ")
+	}
+	return strings.TrimSpace(query)
+}
+
+func stripFieldComparisonStages(query string) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return query
+	}
+
+	fieldComparisonStage := regexp.MustCompile(`\|\s*[A-Za-z_][A-Za-z0-9_.-]*\s*(?:=~|!~|!=|=|>=|<=|>|<)\s*[^|]+`)
+	query = fieldComparisonStage.ReplaceAllString(query, " ")
 	for strings.Contains(query, "  ") {
 		query = strings.ReplaceAll(query, "  ", " ")
 	}
@@ -963,39 +1018,66 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 	if len(nativeFields) > 0 && scanLimit > detectedFieldsSampleLimit {
 		scanLimit = detectedFieldsSampleLimit
 	}
-	logsqlQuery, err := p.translateQuery(defaultFieldDetectionQuery(query))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	params := url.Values{}
-	params.Set("query", logsqlQuery+" | sort by (_time desc)")
-	params.Set("limit", strconv.Itoa(scanLimit))
-	if start != "" {
-		params.Set("start", formatVLTimestamp(start))
-	}
-	if end != "" {
-		params.Set("end", formatVLTimestamp(end))
-	}
-
-	resp, err := p.vlPost(ctx, "/select/logsql/query", params)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+	var lastErr error
+	for _, candidate := range fieldDetectionQueryCandidates(query) {
+		logsqlQuery, err := p.translateQuery(candidate)
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		return nil, nil, fmt.Errorf("%s", msg)
+
+		params := url.Values{}
+		params.Set("query", logsqlQuery+" | sort by (_time desc)")
+		params.Set("limit", strconv.Itoa(scanLimit))
+		if start != "" {
+			params.Set("start", formatVLTimestamp(start))
+		}
+		if end != "" {
+			params.Set("end", formatVLTimestamp(end))
+		}
+
+		resp, err := p.vlPost(ctx, "/select/logsql/query", params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= http.StatusInternalServerError {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+			}
+			lastErr = fmt.Errorf("%s", msg)
+			continue
+		}
+		if resp.StatusCode >= http.StatusBadRequest {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+			}
+			return nil, nil, fmt.Errorf("%s", msg)
+		}
+
+		fieldList, fieldValues := p.detectFieldsFromBody(body)
+		if len(fieldList) > 0 {
+			fieldList, fieldValues = mergeNativeDetectedFields(fieldList, fieldValues, filterNativeDetectedFields(nativeFields, scanNativeStreamLabelSet(body), p.labelTranslator))
+			p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
+			return fieldList, fieldValues, nil
+		}
 	}
-	fieldList, fieldValues := p.detectFieldsFromBody(body)
-	fieldList, fieldValues = mergeNativeDetectedFields(fieldList, fieldValues, nativeFields)
-	p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
-	return fieldList, fieldValues, nil
+
+	if len(nativeFields) > 0 {
+		streamLabels, err := p.fetchNativeStreamLabelSet(ctx, query, start, end)
+		if err == nil {
+			nativeFields = filterNativeDetectedFields(nativeFields, streamLabels, p.labelTranslator)
+		}
+		fieldList, fieldValues := mergeNativeDetectedFields(nil, nil, nativeFields)
+		p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
+		return fieldList, fieldValues, nil
+	}
+	return nil, nil, lastErr
 }
 
 func (p *Proxy) detectFieldsFromBody(body []byte) ([]map[string]interface{}, map[string][]string) {
@@ -1177,10 +1259,6 @@ func (p *Proxy) detectNativeFields(ctx context.Context, query, start, end string
 	}
 	out := make(map[string]*detectedFieldSummary, len(fieldNames))
 	for _, field := range fieldNames {
-		streamLabels := map[string]string{field: "1"}
-		if !shouldExposeStructuredField(field, streamLabels, p.labelTranslator) {
-			continue
-		}
 		for _, exposure := range p.metadataFieldExposures(field) {
 			out[exposure.name] = &detectedFieldSummary{
 				label:       exposure.name,
@@ -1245,73 +1323,109 @@ func mergeNativeDetectedFields(scanned []map[string]interface{}, scannedValues m
 }
 
 func (p *Proxy) fetchNativeFieldNames(ctx context.Context, query, start, end string) ([]string, error) {
-	logsqlQuery, err := p.translateQuery(defaultFieldDetectionQuery(query))
+	var lastErr error
+	for _, candidate := range fieldDetectionQueryCandidates(query) {
+		logsqlQuery, err := p.translateQuery(candidate)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		params := url.Values{}
+		params.Set("query", logsqlQuery)
+		if start != "" {
+			params.Set("start", start)
+		}
+		if end != "" {
+			params.Set("end", end)
+		}
+		body, err := p.vlGetCoalesced(ctx, "native_fields:"+params.Encode(), "/select/logsql/field_names", params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var resp vlFieldNamesResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			lastErr = err
+			continue
+		}
+		out := make([]string, 0, len(resp.Values))
+		for _, item := range resp.Values {
+			out = append(out, item.Value)
+		}
+		if len(out) > 0 {
+			return out, nil
+		}
+	}
+	return nil, lastErr
+}
+
+func (p *Proxy) fetchNativeStreamLabelSet(ctx context.Context, query, start, end string) (map[string]string, error) {
+	parsed, err := p.fetchNativeStreams(ctx, query, start, end)
 	if err != nil {
 		return nil, err
 	}
-	params := url.Values{}
-	params.Set("query", logsqlQuery)
-	if start != "" {
-		params.Set("start", start)
+	labels := make(map[string]string)
+	for _, item := range parsed.Values {
+		for key, value := range parseStreamLabels(item.Value) {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			labels[key] = value
+		}
 	}
-	if end != "" {
-		params.Set("end", end)
-	}
-	body, err := p.vlGetCoalesced(ctx, "native_fields:"+params.Encode(), "/select/logsql/field_names", params)
-	if err != nil {
-		return nil, err
-	}
-	var resp vlFieldNamesResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, err
-	}
-	out := make([]string, 0, len(resp.Values))
-	for _, item := range resp.Values {
-		out = append(out, item.Value)
-	}
-	return out, nil
+	return labels, nil
 }
 
 func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, field string, limit int) ([]string, error) {
-	logsqlQuery, err := p.translateQuery(defaultFieldDetectionQuery(query))
-	if err != nil {
-		return nil, err
-	}
-	params := url.Values{}
-	params.Set("query", logsqlQuery)
-	params.Set("field", field)
-	if start != "" {
-		params.Set("start", start)
-	}
-	if end != "" {
-		params.Set("end", end)
-	}
-	if limit > 0 {
-		params.Set("limit", strconv.Itoa(limit))
-	}
-	resp, err := p.vlGet(ctx, "/select/logsql/field_values", params)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+	var lastErr error
+	for _, candidate := range fieldDetectionQueryCandidates(query) {
+		logsqlQuery, err := p.translateQuery(candidate)
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		return nil, fmt.Errorf("%s", msg)
+		params := url.Values{}
+		params.Set("query", logsqlQuery)
+		params.Set("field", field)
+		if start != "" {
+			params.Set("start", start)
+		}
+		if end != "" {
+			params.Set("end", end)
+		}
+		if limit > 0 {
+			params.Set("limit", strconv.Itoa(limit))
+		}
+		resp, err := p.vlGet(ctx, "/select/logsql/field_values", params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= http.StatusBadRequest {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+			}
+			lastErr = fmt.Errorf("%s", msg)
+			continue
+		}
+		var parsed vlFieldValuesResponse
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			lastErr = err
+			continue
+		}
+		values := make([]string, 0, len(parsed.Values))
+		for _, item := range parsed.Values {
+			values = append(values, item.Value)
+		}
+		sort.Strings(values)
+		if len(values) > 0 {
+			return values, nil
+		}
 	}
-	var parsed vlFieldValuesResponse
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return nil, err
-	}
-	values := make([]string, 0, len(parsed.Values))
-	for _, item := range parsed.Values {
-		values = append(values, item.Value)
-	}
-	sort.Strings(values)
-	return values, nil
+	return nil, lastErr
 }
 
 func (p *Proxy) resolveNativeDetectedField(ctx context.Context, query, start, end, fieldName string) (string, bool, error) {
@@ -1320,12 +1434,7 @@ func (p *Proxy) resolveNativeDetectedField(ctx context.Context, query, start, en
 		return "", false, err
 	}
 	candidates := make([]string, 0, len(fieldNames))
-	for _, field := range fieldNames {
-		streamLabels := map[string]string{field: "1"}
-		if shouldExposeStructuredField(field, streamLabels, p.labelTranslator) {
-			candidates = append(candidates, field)
-		}
-	}
+	candidates = append(candidates, fieldNames...)
 	resolution := p.labelTranslator.ResolveMetadataCandidates(fieldName, candidates, p.metadataFieldMode)
 	if len(resolution.candidates) == 1 {
 		return resolution.candidates[0], true, nil
@@ -1334,33 +1443,8 @@ func (p *Proxy) resolveNativeDetectedField(ctx context.Context, query, start, en
 }
 
 func (p *Proxy) detectNativeLabels(ctx context.Context, query, start, end string) (map[string]*detectedLabelSummary, error) {
-	logsqlQuery, err := p.translateQuery(defaultFieldDetectionQuery(query))
+	parsed, err := p.fetchNativeStreams(ctx, query, start, end)
 	if err != nil {
-		return nil, err
-	}
-	params := url.Values{}
-	params.Set("query", logsqlQuery+" | sort by (_time desc)")
-	if start != "" {
-		params.Set("start", start)
-	}
-	if end != "" {
-		params.Set("end", end)
-	}
-	resp, err := p.vlGet(ctx, "/select/logsql/streams", params)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
-		return nil, fmt.Errorf("%s", msg)
-	}
-	var parsed vlStreamsResponse
-	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, err
 	}
 	summaries := map[string]*detectedLabelSummary{}
@@ -1384,6 +1468,53 @@ func (p *Proxy) detectNativeLabels(ctx context.Context, query, start, end string
 		}
 	}
 	return summaries, nil
+}
+
+func (p *Proxy) fetchNativeStreams(ctx context.Context, query, start, end string) (*vlStreamsResponse, error) {
+	var lastErr error
+	for _, candidate := range fieldDetectionQueryCandidates(query) {
+		logsqlQuery, err := p.translateQuery(candidate)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		params := url.Values{}
+		params.Set("query", logsqlQuery+" | sort by (_time desc)")
+		if start != "" {
+			params.Set("start", start)
+		}
+		if end != "" {
+			params.Set("end", end)
+		}
+		body, err := p.vlGetCoalesced(ctx, "native_streams:"+params.Encode(), "/select/logsql/streams", params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var parsed vlStreamsResponse
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			lastErr = err
+			continue
+		}
+		if len(parsed.Values) > 0 {
+			return &parsed, nil
+		}
+		lastErr = nil
+	}
+	return &vlStreamsResponse{}, lastErr
+}
+
+func filterNativeDetectedFields(native map[string]*detectedFieldSummary, streamLabels map[string]string, lt *LabelTranslator) map[string]*detectedFieldSummary {
+	if len(native) == 0 || len(streamLabels) == 0 {
+		return native
+	}
+	filtered := make(map[string]*detectedFieldSummary, len(native))
+	for label, summary := range native {
+		if shouldExposeStructuredField(label, streamLabels, lt) {
+			filtered[label] = summary
+		}
+	}
+	return filtered
 }
 
 func (p *Proxy) detectScannedLabels(ctx context.Context, query, start, end string, lineLimit int) (map[string]*detectedLabelSummary, error) {

--- a/internal/proxy/label_surface_test.go
+++ b/internal/proxy/label_surface_test.go
@@ -451,6 +451,9 @@ func TestLabelSurface_LabelValuesIndexStartupWarmsFromPeersWhenDiskStale(t *test
 
 	ownerPeer := cache.NewPeerCache(cache.PeerConfig{SelfAddr: "owner:3100"})
 	peerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Peer-Token"); got != "shared-secret" {
+			t.Fatalf("unexpected peer token header: got %q", got)
+		}
 		if r.URL.Path != "/_cache/get" {
 			http.NotFound(w, r)
 			return
@@ -502,6 +505,7 @@ func TestLabelSurface_LabelValuesIndexStartupWarmsFromPeersWhenDiskStale(t *test
 		LabelValuesIndexPersistInterval: time.Hour,
 		LabelValuesIndexStartupStale:    30 * time.Second,
 		LabelValuesIndexPeerWarmTimeout: 2 * time.Second,
+		PeerAuthToken:                   "shared-secret",
 	})
 	if err != nil {
 		t.Fatalf("create proxy: %v", err)
@@ -513,7 +517,7 @@ func TestLabelSurface_LabelValuesIndexStartupWarmsFromPeersWhenDiskStale(t *test
 	if !ok {
 		t.Fatalf("expected peer-warmed label-values index to be available")
 	}
-	want := []string{"from-peer"}
+	want := []string{"from-peer", "from-disk"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected peer-warmed values: want=%v got=%v", want, got)
 	}

--- a/internal/proxy/patterns_persistence_test.go
+++ b/internal/proxy/patterns_persistence_test.go
@@ -218,7 +218,7 @@ func TestPatternsPersistSnapshotCache_StaysLocalWithoutWriteThrough(t *testing.T
 	}
 
 	var pc *cache.PeerCache
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 256; i++ {
 		candidate := cache.NewPeerCache(cache.PeerConfig{
 			SelfAddr:           fmt.Sprintf("self-%d:3100", i),
 			DiscoveryType:      "static",

--- a/internal/proxy/patterns_persistence_test.go
+++ b/internal/proxy/patterns_persistence_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -140,6 +142,9 @@ func TestPatternsRestoreFromPeers_MergesSnapshot(t *testing.T) {
 		if r.URL.Path != "/_cache/get" {
 			t.Fatalf("unexpected peer path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Peer-Token"); got != "shared-secret" {
+			t.Fatalf("unexpected peer token header: got %q", got)
+		}
 		if _, err := w.Write(peerBody); err != nil {
 			t.Fatalf("write peer snapshot: %v", err)
 		}
@@ -158,6 +163,7 @@ func TestPatternsRestoreFromPeers_MergesSnapshot(t *testing.T) {
 	t.Cleanup(func() {
 		p.peerCache.Close()
 	})
+	p.peerAuthToken = "shared-secret"
 
 	// Empty peer address branch.
 	if snap, bodyBytes, err := p.fetchPatternsSnapshotFromPeer("", 50*time.Millisecond); err != nil || snap != nil || bodyBytes != 0 {
@@ -186,6 +192,98 @@ func TestPatternsRestoreFromPeers_MergesSnapshot(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("expected restorePatternsFromPeers to no-op when minSavedAt is current")
+	}
+}
+
+func TestPatternsPersistSnapshotCache_StaysLocalWithoutWriteThrough(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	var remoteSetCalls atomic.Int32
+	ownerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_cache/set" {
+			remoteSetCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ownerSrv.Close()
+
+	ownerURL, err := url.Parse(ownerSrv.URL)
+	if err != nil {
+		t.Fatalf("parse owner URL: %v", err)
+	}
+
+	var pc *cache.PeerCache
+	for i := 0; i < 8; i++ {
+		candidate := cache.NewPeerCache(cache.PeerConfig{
+			SelfAddr:           fmt.Sprintf("self-%d:3100", i),
+			DiscoveryType:      "static",
+			StaticPeers:        fmt.Sprintf("%s,%s", fmt.Sprintf("self-%d:3100", i), ownerURL.Host),
+			Timeout:            50 * time.Millisecond,
+			WriteThrough:       true,
+			WriteThroughMinTTL: 5 * time.Second,
+		})
+		if !candidate.IsOwner(patternsSnapshotCacheKey) {
+			pc = candidate
+			break
+		}
+		candidate.Close()
+	}
+	if pc == nil {
+		t.Fatal("expected non-owner peer-cache test setup for snapshot key")
+	}
+	defer pc.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	c.SetL3(pc)
+	defer c.Close()
+
+	enabled := true
+	persistPath := filepath.Join(t.TempDir(), "patterns.snapshot.json")
+	p, err := New(Config{
+		BackendURL:              backend.URL,
+		Cache:                   c,
+		PeerCache:               pc,
+		LogLevel:                "error",
+		PatternsEnabled:         &enabled,
+		PatternsPersistPath:     persistPath,
+		PatternsPersistInterval: 30 * time.Second,
+		PatternsStartupStale:    5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	payload := mustMarshalJSON(t, map[string]any{
+		"status": "success",
+		"data": []map[string]any{
+			{"pattern": "request <_> completed"},
+		},
+	})
+	now := time.Now().UTC().UnixNano()
+	p.patternsSnapshotEntries["patterns:test"] = patternSnapshotEntry{
+		Value:             payload,
+		UpdatedAtUnixNano: now,
+		PatternCount:      1,
+	}
+	p.patternsSnapshotPatternCount = 1
+	p.patternsSnapshotPayloadBytes = int64(len(payload))
+	p.patternsPersistDirty.Store(true)
+
+	if err := p.persistPatternsNow("periodic"); err != nil {
+		t.Fatalf("persistPatternsNow returned error: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if got := remoteSetCalls.Load(); got != 0 {
+		t.Fatalf("expected snapshot cache blob to stay local, got %d remote /_cache/set calls", got)
+	}
+	if _, _, ok := c.GetWithTTL(patternsSnapshotCacheKey); !ok {
+		t.Fatalf("expected snapshot cache blob %q to be stored locally", patternsSnapshotCacheKey)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4171,36 +4171,9 @@ func (p *Proxy) refreshDetectedFieldValuesCacheAsync(orgID, cacheKey, fieldName,
 			if orgID != "" {
 				ctx = context.WithValue(ctx, orgIDKey, orgID)
 			}
-
-			var (
-				values  []string
-				errVals error
-			)
-			if nativeField, ok, resolveErr := p.resolveNativeDetectedField(ctx, query, start, end, fieldName); resolveErr == nil && ok {
-				values, errVals = p.fetchNativeFieldValues(ctx, query, start, end, nativeField, lineLimit)
-				if errVals == nil && len(values) == 0 {
-					// Keep Drilldown UX non-empty for synthetic/derived labels when native values are empty.
-					values = nil
-				}
-			}
-			if values == nil && errVals == nil {
-				_, fieldValues, detectErr := p.detectFields(ctx, query, start, end, lineLimit)
-				if detectErr != nil {
-					return nil, detectErr
-				}
-				values = fieldValues[fieldName]
-				if values == nil && fieldName == "level" {
-					values = fieldValues["detected_level"]
-				}
-			}
-			if len(values) == 0 {
-				values = p.detectedLabelValuesForField(ctx, fieldName, query, start, end, lineLimit)
-			}
-			if errVals != nil {
-				return nil, errVals
-			}
-			if values == nil {
-				values = []string{}
+			values, err := p.resolveDetectedFieldValues(ctx, fieldName, query, start, end, lineLimit, true)
+			if err != nil {
+				return nil, err
 			}
 
 			payload := map[string]interface{}{
@@ -4216,6 +4189,47 @@ func (p *Proxy) refreshDetectedFieldValuesCacheAsync(orgID, cacheKey, fieldName,
 			p.log.Debug("background detected_field_values refresh failed", "cache_key", cacheKey, "field", fieldName, "error", err)
 		}
 	}()
+}
+
+func (p *Proxy) resolveDetectedFieldValues(ctx context.Context, fieldName, query, start, end string, lineLimit int, relaxOnEmpty bool) ([]string, error) {
+	var (
+		values  []string
+		errVals error
+	)
+	if nativeField, ok, resolveErr := p.resolveNativeDetectedField(ctx, query, start, end, fieldName); resolveErr == nil && ok {
+		values, errVals = p.fetchNativeFieldValues(ctx, query, start, end, nativeField, lineLimit)
+		if errVals == nil && len(values) == 0 {
+			// Keep Drilldown UX non-empty for synthetic/derived labels when native values are empty.
+			values = nil
+		}
+	}
+	if values == nil && errVals == nil {
+		_, fieldValues, detectErr := p.detectFields(ctx, query, start, end, lineLimit)
+		if detectErr != nil {
+			return nil, detectErr
+		}
+		values = fieldValues[fieldName]
+		if values == nil && fieldName == "level" {
+			values = fieldValues["detected_level"]
+		}
+	}
+	if len(values) == 0 {
+		values = p.detectedLabelValuesForField(ctx, fieldName, query, start, end, lineLimit)
+	}
+	if errVals != nil {
+		return nil, errVals
+	}
+	if len(values) == 0 && relaxOnEmpty {
+		primary := defaultFieldDetectionQuery(query)
+		relaxed := relaxedFieldDetectionQuery(query)
+		if relaxed != "" && relaxed != primary {
+			return p.resolveDetectedFieldValues(ctx, fieldName, relaxed, start, end, lineLimit, false)
+		}
+	}
+	if values == nil {
+		values = []string{}
+	}
+	return values, nil
 }
 
 // handleLabels returns label names.
@@ -4961,24 +4975,7 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	if nativeField, ok, err := p.resolveNativeDetectedField(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), fieldName); err == nil && ok {
-		if values, valuesErr := p.fetchNativeFieldValues(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), nativeField, lineLimit); valuesErr == nil {
-			if len(values) > 0 {
-				payload := map[string]interface{}{
-					"status": "success",
-					"data":   values,
-					"values": values,
-					"limit":  lineLimit,
-				}
-				p.setJSONCacheWithTTL(cacheKey, CacheTTLs["detected_field_values"], payload)
-				p.writeJSON(w, payload)
-				p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
-				return
-			}
-		}
-	}
-
-	_, fieldValues, err := p.detectFields(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
+	values, err := p.resolveDetectedFieldValues(r.Context(), fieldName, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit, true)
 	if err != nil {
 		payload := map[string]interface{}{
 			"status": "success",
@@ -4989,16 +4986,6 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 		p.writeJSON(w, payload)
 		p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
 		return
-	}
-	values := fieldValues[fieldName]
-	if values == nil && fieldName == "level" {
-		values = fieldValues["detected_level"]
-	}
-	if len(values) == 0 {
-		values = p.detectedLabelValuesForField(r.Context(), fieldName, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
-	}
-	if values == nil {
-		values = []string{}
 	}
 
 	payload := map[string]interface{}{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -542,6 +542,7 @@ const (
 	maxSyntheticTailSeenEntries       = 4096
 	maxBufferedBackendBodyBytes       = 64 << 20
 	maxPatternsPeerSnapshotBytes      = 8 << 20
+	maxLabelValuesPeerSnapshotBytes   = 8 << 20
 	maxUpstreamErrorBodyBytes         = 4 << 10
 	labelValuesIndexSnapshotCacheKey  = "__label_values_index_snapshot:v1"
 	patternsSnapshotCacheKey          = "__patterns_snapshot:v1"
@@ -2789,6 +2790,13 @@ func patternCountFromSnapshot(snapshot patternsSnapshot) int {
 	return total
 }
 
+func (p *Proxy) cacheSnapshotBlobLocally(key string, data []byte, ttl time.Duration) {
+	if p.cache == nil || strings.TrimSpace(key) == "" || len(data) == 0 || ttl <= 0 {
+		return
+	}
+	p.cache.SetLocalOnlyWithTTL(key, data, ttl)
+}
+
 func (p *Proxy) updatePatternSnapshotMetricsLocked() {
 	if p == nil || p.metrics == nil {
 		return
@@ -3110,7 +3118,7 @@ func (p *Proxy) persistPatternsNow(reason string) error {
 		if ttl <= 0 {
 			ttl = 5 * time.Minute
 		}
-		p.cache.SetWithTTL(patternsSnapshotCacheKey, data, ttl)
+		p.cacheSnapshotBlobLocally(patternsSnapshotCacheKey, data, ttl)
 	}
 
 	entryCount := len(snapshot.EntriesByKey)
@@ -3168,7 +3176,7 @@ func (p *Proxy) restorePatternsFromDisk() (bool, int64, error) {
 		if ttl <= 0 {
 			ttl = 5 * time.Minute
 		}
-		p.cache.SetWithTTL(patternsSnapshotCacheKey, data, ttl)
+		p.cacheSnapshotBlobLocally(patternsSnapshotCacheKey, data, ttl)
 	}
 	p.log.Info(
 		"patterns snapshot restored from disk",
@@ -3195,7 +3203,7 @@ func (p *Proxy) fetchPatternsSnapshotFromPeer(peerAddr string, timeout time.Dura
 		return nil, 0, err
 	}
 	if p.peerAuthToken != "" {
-		req.Header.Set("X-Cache-Auth", p.peerAuthToken)
+		req.Header.Set("X-Peer-Token", p.peerAuthToken)
 	}
 
 	resp, err := p.client.Do(req)
@@ -3524,7 +3532,7 @@ func (p *Proxy) persistLabelValuesIndexNow(reason string) error {
 		if ttl <= 0 {
 			ttl = 5 * time.Minute
 		}
-		p.cache.SetWithTTL(labelValuesIndexSnapshotCacheKey, data, ttl)
+		p.cacheSnapshotBlobLocally(labelValuesIndexSnapshotCacheKey, data, ttl)
 	}
 
 	states, values := p.labelValuesIndexCardinality()
@@ -3568,7 +3576,7 @@ func (p *Proxy) restoreLabelValuesIndexFromDisk() (bool, int64, error) {
 		if ttl <= 0 {
 			ttl = 5 * time.Minute
 		}
-		p.cache.SetWithTTL(labelValuesIndexSnapshotCacheKey, data, ttl)
+		p.cacheSnapshotBlobLocally(labelValuesIndexSnapshotCacheKey, data, ttl)
 	}
 	p.log.Info(
 		"label values index restored from disk",
@@ -3582,37 +3590,173 @@ func (p *Proxy) restoreLabelValuesIndexFromDisk() (bool, int64, error) {
 	return true, snapshot.SavedAtUnixNano, nil
 }
 
+func (p *Proxy) fetchLabelValuesIndexSnapshotFromPeer(peerAddr string, timeout time.Duration) (*labelValuesIndexSnapshot, int, error) {
+	if strings.TrimSpace(peerAddr) == "" {
+		return nil, 0, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	endpoint := fmt.Sprintf("http://%s/_cache/get?key=%s", peerAddr, url.QueryEscape(labelValuesIndexSnapshotCacheKey))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if p.peerAuthToken != "" {
+		req.Header.Set("X-Peer-Token", p.peerAuthToken)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, 0, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, 0, fmt.Errorf("peer %s status %d: %s", peerAddr, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := readBodyLimited(resp.Body, maxLabelValuesPeerSnapshotBytes)
+	if err != nil {
+		return nil, 0, err
+	}
+	var snapshot labelValuesIndexSnapshot
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		return nil, 0, err
+	}
+	if snapshot.Version != 1 || snapshot.SavedAtUnixNano <= 0 {
+		return nil, 0, fmt.Errorf("invalid label-values snapshot metadata from peer %s", peerAddr)
+	}
+	return &snapshot, len(body), nil
+}
+
+func mergeLabelValuesIndexEntry(existing, incoming labelValueIndexEntry) labelValueIndexEntry {
+	if incoming.SeenCount > existing.SeenCount {
+		existing.SeenCount = incoming.SeenCount
+	}
+	if incoming.LastSeen > existing.LastSeen {
+		existing.LastSeen = incoming.LastSeen
+	}
+	return existing
+}
+
+func mergeLabelValuesIndexSnapshot(dst *labelValuesIndexSnapshot, src *labelValuesIndexSnapshot) {
+	if dst == nil || src == nil {
+		return
+	}
+	if dst.StatesByKey == nil {
+		dst.StatesByKey = make(map[string]map[string]labelValueIndexEntry)
+	}
+	if src.SavedAtUnixNano > dst.SavedAtUnixNano {
+		dst.SavedAtUnixNano = src.SavedAtUnixNano
+	}
+	for key, entries := range src.StatesByKey {
+		if len(entries) == 0 {
+			continue
+		}
+		dstEntries, ok := dst.StatesByKey[key]
+		if !ok {
+			dstEntries = make(map[string]labelValueIndexEntry, len(entries))
+			dst.StatesByKey[key] = dstEntries
+		}
+		for value, entry := range entries {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			if existing, exists := dstEntries[value]; exists {
+				dstEntries[value] = mergeLabelValuesIndexEntry(existing, entry)
+				continue
+			}
+			dstEntries[value] = entry
+		}
+	}
+}
+
 func (p *Proxy) restoreLabelValuesIndexFromPeers(minSavedAt int64) (bool, int64, error) {
-	if !p.labelValuesIndexedCache || p.cache == nil || p.peerCache == nil {
+	if !p.labelValuesIndexedCache || p.peerCache == nil {
 		return false, 0, nil
 	}
 	startedAt := time.Now()
-	data, ok := p.cache.Get(labelValuesIndexSnapshotCacheKey)
-	if !ok {
+	peers := p.peerCache.Peers()
+	if len(peers) == 0 {
 		return false, 0, nil
 	}
 
-	var snapshot labelValuesIndexSnapshot
-	if err := json.Unmarshal(data, &snapshot); err != nil {
-		return false, 0, fmt.Errorf("decode peer label index snapshot: %w", err)
-	}
-	if snapshot.Version != 1 || snapshot.SavedAtUnixNano <= 0 {
-		return false, 0, fmt.Errorf("invalid peer label index snapshot metadata")
-	}
-	if snapshot.SavedAtUnixNano <= minSavedAt {
-		return false, snapshot.SavedAtUnixNano, nil
+	timeout := p.labelValuesIndexPeerWarmTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
 	}
 
-	states, values := p.applyLabelValuesIndexSnapshot(snapshot)
+	type peerResult struct {
+		snapshot  *labelValuesIndexSnapshot
+		bodyBytes int
+		err       error
+		peer      string
+	}
+	resCh := make(chan peerResult, len(peers))
+	for _, peerAddr := range peers {
+		peerAddr := strings.TrimSpace(peerAddr)
+		if peerAddr == "" {
+			continue
+		}
+		go func(addr string) {
+			snapshot, bodyBytes, err := p.fetchLabelValuesIndexSnapshotFromPeer(addr, timeout)
+			resCh <- peerResult{snapshot: snapshot, bodyBytes: bodyBytes, err: err, peer: addr}
+		}(peerAddr)
+	}
+
+	merged := p.buildLabelValuesIndexSnapshot(time.Now().UTC())
+	if merged.Version == 0 {
+		merged.Version = 1
+	}
+	if merged.StatesByKey == nil {
+		merged.StatesByKey = make(map[string]map[string]labelValueIndexEntry)
+	}
+	mergedSavedAt := minSavedAt
+	sawNewer := false
+	totalPeerBytes := 0
+	deadline := time.After(timeout)
+	received := 0
+	for received < len(peers) {
+		select {
+		case res := <-resCh:
+			received++
+			if res.err != nil {
+				p.log.Debug("label values peer warm fetch failed", "peer", res.peer, "error", res.err)
+				continue
+			}
+			totalPeerBytes += res.bodyBytes
+			if res.snapshot == nil || len(res.snapshot.StatesByKey) == 0 || res.snapshot.SavedAtUnixNano <= minSavedAt {
+				continue
+			}
+			sawNewer = true
+			if res.snapshot.SavedAtUnixNano > mergedSavedAt {
+				mergedSavedAt = res.snapshot.SavedAtUnixNano
+			}
+			mergeLabelValuesIndexSnapshot(&merged, res.snapshot)
+		case <-deadline:
+			received = len(peers)
+		}
+	}
+	if !sawNewer {
+		return false, mergedSavedAt, nil
+	}
+
+	states, values := p.applyLabelValuesIndexSnapshot(merged)
 	p.log.Info(
 		"label values index warmed from peers",
-		"saved_at", time.Unix(0, snapshot.SavedAtUnixNano).UTC().Format(time.RFC3339Nano),
+		"saved_at", time.Unix(0, mergedSavedAt).UTC().Format(time.RFC3339Nano),
 		"states", states,
 		"values", values,
-		"bytes", len(data),
+		"peers", len(peers),
+		"bytes", totalPeerBytes,
 		"duration_ms", time.Since(startedAt).Milliseconds(),
 	)
-	return true, snapshot.SavedAtUnixNano, nil
+	return true, mergedSavedAt, nil
 }
 
 func (p *Proxy) warmLabelValuesIndexOnStartup() {

--- a/internal/proxy/tenant_test.go
+++ b/internal/proxy/tenant_test.go
@@ -788,6 +788,9 @@ func TestTenant_MultiTenantDetectedFieldsKeepsNativeCardinalityFloor(t *testing.
 		case strings.HasPrefix(r.URL.Path, "/select/logsql/field_names"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"values":[{"value":"native.only","hits":1}]}`))
+		case strings.HasPrefix(r.URL.Path, "/select/logsql/streams"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"{app=\"api\"}","hits":1}]}`))
 		case strings.HasPrefix(r.URL.Path, "/select/logsql/query"):
 			w.Header().Set("Content-Type", "application/x-ndjson")
 			_, _ = w.Write([]byte(""))

--- a/test/e2e-compat/drilldown_compat_test.go
+++ b/test/e2e-compat/drilldown_compat_test.go
@@ -578,8 +578,9 @@ func TestDrilldown_GrafanaResourceContracts(t *testing.T) {
 		}
 
 		valuesResp := getJSON(t, grafanaURL+"/api/datasources/uid/"+dsUID+"/resources/detected_field/status/values?"+params.Encode())
-		if len(extractStrings(valuesResp, "values")) != 0 {
-			t.Fatalf("expected empty detected_field values payload for empty query, got %v", valuesResp)
+		values := extractStrings(valuesResp, "values")
+		if len(values) != 1 || values[0] != "200" {
+			t.Fatalf("expected relaxed detected_field values fallback to keep staging status=200 visible, got %v", valuesResp)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- harden Drilldown detected field and detected field value discovery when parser or comparison stages make native VictoriaLogs lookups unstable
- retry native field-name, field-value, and stream discovery with relaxed query candidates after stripping parser and field-comparison stages, and treat backend 5xx scan windows as failed attempts instead of empty scans
- keep persisted patterns and label-values snapshot blobs local, merge label-values startup warm state directly from peer-local snapshots, and use the correct peer auth header during snapshot fetches so peer warmup stays compatible when peer-auth-token is enabled
- add regression coverage for duration-filtered Drilldown requests, local-only fleet snapshot caching, and peer-warmed label-values startup behavior

## Testing
- go test ./internal/cache
- go test ./internal/proxy -run 'Test(LabelSurface_|Patterns|Tenant_MultiTenantDetectedFieldsKeepsNativeCardinalityFloor|Drilldown_|DetectedFields_|DefaultFieldDetectionQuery_|FieldDetectionQueryCandidates_)'
- python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD
