### PR TITLE
Restore drilldown metadata discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/metadata: restore `service_name` label discovery by preferring native field metadata over stream scans, and retry relaxed query candidates for labels, label values, and detected-label fallbacks when parser-heavy Drilldown queries return empty metadata.
+
 ## [1.7.0] - 2026-04-18
 
 ### Bug Fixes

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -38,6 +38,26 @@ var serviceNameSourceFields = []string{
 	"k8s_job_name",
 }
 
+var serviceNameNativeValueFields = []string{
+	"service.name",
+	"service",
+	"app",
+	"application",
+	"app_name",
+	"name",
+	"app_kubernetes_io_name",
+	"container",
+	"container_name",
+	"k8s.container.name",
+	"k8s_container_name",
+	"component",
+	"workload",
+	"job",
+	"k8s.job.name",
+	"k8s_job_name",
+	"service_name",
+}
+
 type detectedFieldSummary struct {
 	label       string
 	typ         string
@@ -392,7 +412,7 @@ func (p *Proxy) serviceNameValuesFromNativeFields(ctx context.Context, query, st
 	}
 
 	var lastErr error
-	for _, field := range serviceNameSourceFields {
+	for _, field := range serviceNameNativeValueFields {
 		if _, ok := available[field]; !ok {
 			continue
 		}
@@ -404,25 +424,31 @@ func (p *Proxy) serviceNameValuesFromNativeFields(ctx context.Context, query, st
 		if len(fieldValues) == 0 {
 			continue
 		}
-		values := make([]string, 0, len(fieldValues))
-		seen := make(map[string]struct{}, len(fieldValues))
-		for _, value := range fieldValues {
-			value = strings.TrimSpace(value)
-			if value == "" {
-				continue
-			}
-			if _, ok := seen[value]; ok {
-				continue
-			}
-			seen[value] = struct{}{}
-			values = append(values, value)
-		}
+		values := uniqueSortedNonEmptyStrings(fieldValues)
 		sort.Strings(values)
 		if len(values) > 0 {
 			return values, nil
 		}
 	}
 	return nil, lastErr
+}
+
+func uniqueSortedNonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func streamSelectorPrefix(query string) string {

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -38,26 +38,6 @@ var serviceNameSourceFields = []string{
 	"k8s_job_name",
 }
 
-var serviceNameNativeValueFields = []string{
-	"service.name",
-	"service",
-	"app",
-	"application",
-	"app_name",
-	"name",
-	"app_kubernetes_io_name",
-	"container",
-	"container_name",
-	"k8s.container.name",
-	"k8s_container_name",
-	"component",
-	"workload",
-	"job",
-	"k8s.job.name",
-	"k8s_job_name",
-	"service_name",
-}
-
 type detectedFieldSummary struct {
 	label       string
 	typ         string
@@ -401,34 +381,85 @@ func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string)
 }
 
 func (p *Proxy) serviceNameValuesFromNativeFields(ctx context.Context, query, start, end string) ([]string, error) {
-	fieldNames, err := p.fetchNativeFieldNames(ctx, query, start, end)
-	if err != nil {
-		return nil, err
-	}
-
-	available := make(map[string]struct{}, len(fieldNames))
-	for _, field := range fieldNames {
-		available[field] = struct{}{}
-	}
-
+	values := make([]string, 0, 16)
+	seen := make(map[string]struct{}, 16)
 	var lastErr error
-	for _, field := range serviceNameNativeValueFields {
-		if _, ok := available[field]; !ok {
-			continue
+	appendFieldValues := func(fieldValues []string) {
+		for _, value := range fieldValues {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			values = append(values, value)
 		}
-		fieldValues, err := p.fetchNativeFieldValues(ctx, query, start, end, field, 0)
-		if err != nil {
+	}
+
+	params := url.Values{}
+	params.Set("query", defaultFieldDetectionQuery(query))
+	if start != "" {
+		params.Set("start", start)
+	}
+	if end != "" {
+		params.Set("end", end)
+	}
+
+	if p.supportsStreamMetadataEndpoints() {
+		streamFields, err := p.fetchVLFieldNames(ctx, "/select/logsql/stream_field_names", params)
+		if err == nil {
+			streamFields = appendUniqueStrings(streamFields, p.snapshotDeclaredLabelFields()...)
+			available := make(map[string]struct{}, len(streamFields))
+			for _, field := range streamFields {
+				available[field] = struct{}{}
+			}
+			for _, field := range serviceNameSourceFields {
+				if _, ok := available[field]; !ok {
+					continue
+				}
+				queryParams := cloneURLValues(params)
+				queryParams.Set("field", field)
+				fieldValues, fieldErr := p.fetchVLFieldValues(ctx, "/select/logsql/stream_field_values", queryParams)
+				if fieldErr != nil && shouldFallbackToGenericMetadata(fieldErr) {
+					fieldValues, fieldErr = p.fetchNativeFieldValues(ctx, query, start, end, field, 0)
+				}
+				if fieldErr != nil {
+					lastErr = fieldErr
+					continue
+				}
+				appendFieldValues(fieldValues)
+			}
+		} else if !shouldFallbackToGenericMetadata(err) {
 			lastErr = err
-			continue
 		}
-		if len(fieldValues) == 0 {
-			continue
+	}
+
+	fieldNames, err := p.fetchNativeFieldNames(ctx, query, start, end)
+	if err == nil {
+		available := make(map[string]struct{}, len(fieldNames))
+		for _, field := range fieldNames {
+			available[field] = struct{}{}
 		}
-		values := uniqueSortedNonEmptyStrings(fieldValues)
-		sort.Strings(values)
-		if len(values) > 0 {
-			return values, nil
+		for _, field := range serviceNameSourceFields {
+			if _, ok := available[field]; !ok {
+				continue
+			}
+			fieldValues, fieldErr := p.fetchNativeFieldValues(ctx, query, start, end, field, 0)
+			if fieldErr != nil {
+				lastErr = fieldErr
+				continue
+			}
+			appendFieldValues(fieldValues)
 		}
+	} else if lastErr == nil {
+		lastErr = err
+	}
+
+	values = uniqueSortedNonEmptyStrings(values)
+	if len(values) > 0 {
+		return values, nil
 	}
 	return nil, lastErr
 }

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -318,6 +318,11 @@ func formatDetectedLabelSummaries(summaries map[string]*detectedLabelSummary) []
 }
 
 func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string) ([]string, error) {
+	values, err := p.serviceNameValuesFromNativeFields(ctx, query, start, end)
+	if err == nil && len(values) > 0 {
+		return values, nil
+	}
+
 	selectorQuery := streamSelectorPrefix(query)
 	if selectorQuery == "" {
 		selectorQuery = defaultFieldDetectionQuery(query)
@@ -358,7 +363,7 @@ func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string)
 	}
 
 	seen := make(map[string]struct{}, len(vlResp.Values))
-	values := make([]string, 0, len(vlResp.Values))
+	fallbackValues := make([]string, 0, len(vlResp.Values))
 	for _, item := range vlResp.Values {
 		labels := parseStreamLabels(item.Value)
 		serviceName := deriveServiceName(labels)
@@ -366,13 +371,58 @@ func (p *Proxy) serviceNameValues(ctx context.Context, query, start, end string)
 			continue
 		}
 		seen[serviceName] = struct{}{}
-		values = append(values, serviceName)
+		fallbackValues = append(fallbackValues, serviceName)
 	}
-	sort.Strings(values)
-	if len(values) == 0 {
+	sort.Strings(fallbackValues)
+	if len(fallbackValues) == 0 {
 		return p.serviceNameValuesFromDetectedLabels(ctx, detectionQuery, start, end)
 	}
-	return values, nil
+	return fallbackValues, nil
+}
+
+func (p *Proxy) serviceNameValuesFromNativeFields(ctx context.Context, query, start, end string) ([]string, error) {
+	fieldNames, err := p.fetchNativeFieldNames(ctx, query, start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	available := make(map[string]struct{}, len(fieldNames))
+	for _, field := range fieldNames {
+		available[field] = struct{}{}
+	}
+
+	var lastErr error
+	for _, field := range serviceNameSourceFields {
+		if _, ok := available[field]; !ok {
+			continue
+		}
+		fieldValues, err := p.fetchNativeFieldValues(ctx, query, start, end, field, 0)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(fieldValues) == 0 {
+			continue
+		}
+		values := make([]string, 0, len(fieldValues))
+		seen := make(map[string]struct{}, len(fieldValues))
+		for _, value := range fieldValues {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			values = append(values, value)
+		}
+		sort.Strings(values)
+		if len(values) > 0 {
+			return values, nil
+		}
+	}
+	return nil, lastErr
 }
 
 func streamSelectorPrefix(query string) string {
@@ -861,6 +911,14 @@ func fieldDetectionQueryCandidates(query string) []string {
 		return []string{primary}
 	}
 	return []string{primary, relaxed}
+}
+
+func metadataQueryCandidates(query string) []string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []string{"*"}
+	}
+	return fieldDetectionQueryCandidates(query)
 }
 
 func normalizeBareSelectorQuery(query string) string {
@@ -1539,36 +1597,48 @@ func nativeFieldFilterNeedsStreamLabels(native map[string]*detectedFieldSummary,
 }
 
 func (p *Proxy) detectScannedLabels(ctx context.Context, query, start, end string, lineLimit int) (map[string]*detectedLabelSummary, error) {
-	logsqlQuery, err := p.translateQuery(defaultQuery(query))
-	if err != nil {
-		return nil, err
-	}
-
-	params := url.Values{}
-	params.Set("query", logsqlQuery+" | sort by (_time desc)")
-	params.Set("limit", strconv.Itoa(lineLimit))
-	if start != "" {
-		params.Set("start", formatVLTimestamp(start))
-	}
-	if end != "" {
-		params.Set("end", formatVLTimestamp(end))
-	}
-
-	resp, err := p.vlPost(ctx, "/select/logsql/query", params)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+	candidates := fieldDetectionQueryCandidates(query)
+	var lastErr error
+	for i, candidate := range candidates {
+		logsqlQuery, err := p.translateQuery(candidate)
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		return nil, fmt.Errorf("%s", msg)
+
+		params := url.Values{}
+		params.Set("query", logsqlQuery+" | sort by (_time desc)")
+		params.Set("limit", strconv.Itoa(lineLimit))
+		if start != "" {
+			params.Set("start", formatVLTimestamp(start))
+		}
+		if end != "" {
+			params.Set("end", formatVLTimestamp(end))
+		}
+
+		resp, err := p.vlPost(ctx, "/select/logsql/query", params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= http.StatusBadRequest {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+			}
+			lastErr = fmt.Errorf("%s", msg)
+			continue
+		}
+
+		summaries := scanDetectedLabelSummaries(body, p.labelTranslator)
+		if len(summaries) > 0 || i == len(candidates)-1 {
+			return summaries, nil
+		}
 	}
-	return scanDetectedLabelSummaries(body, p.labelTranslator), nil
+	return nil, lastErr
 }
 
 type detectedFieldsCachePayload struct {

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -595,10 +595,11 @@ func TestDrilldown_IndexVolumeRange_TargetLabelsServiceName_FillsFullRangeBucket
 func TestDrilldown_LabelValues_ServiceNameUsesNativeFieldValues(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.NotFound(w, r)
 		case "/select/logsql/field_names":
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"values": []map[string]interface{}{
-					{"value": "app", "hits": 12},
 					{"value": "service.name", "hits": 12},
 				},
 			})
@@ -627,6 +628,8 @@ func TestDrilldown_LabelValues_ServiceNameUsesNativeFieldValues(t *testing.T) {
 func TestDrilldown_LabelValues_ServiceNamePrefersConcreteNativeFieldInventory(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.NotFound(w, r)
 		case "/select/logsql/field_names":
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"values": []map[string]interface{}{
@@ -635,15 +638,23 @@ func TestDrilldown_LabelValues_ServiceNamePrefersConcreteNativeFieldInventory(t 
 				},
 			})
 		case "/select/logsql/field_values":
-			if got := r.URL.Query().Get("field"); got != "app" {
-				t.Fatalf("expected service_name values to prefer concrete app inventory over sparse service_name inventory, got %q", got)
+			switch got := r.URL.Query().Get("field"); got {
+			case "app":
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"values": []map[string]interface{}{
+						{"value": "api-gateway", "hits": 12},
+						{"value": "worker", "hits": 5},
+					},
+				})
+			case "service_name":
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"values": []map[string]interface{}{
+						{"value": "otel-auth-service", "hits": 2},
+					},
+				})
+			default:
+				t.Fatalf("expected service_name values to use concrete app inventory and merge any sparse service_name values, got %q", got)
 			}
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"values": []map[string]interface{}{
-					{"value": "api-gateway", "hits": 12},
-					{"value": "worker", "hits": 5},
-				},
-			})
 		case "/select/logsql/streams", "/select/logsql/query":
 			t.Fatalf("service_name native inventory must not fall back to stream scans when app inventory is available, got %s", r.URL.Path)
 		default:
@@ -654,11 +665,60 @@ func TestDrilldown_LabelValues_ServiceNamePrefersConcreteNativeFieldInventory(t 
 
 	resp := doGet(t, vlBackend.URL, "/loki/api/v1/label/service_name/values")
 	data := assertDataIsStringArray(t, resp)
-	if len(data) != 2 {
-		t.Fatalf("expected 2 service_name values from concrete inventory, got %v", data)
+	assertContains(t, data, "api-gateway")
+	assertContains(t, data, "worker")
+}
+
+func TestDrilldown_LabelValues_ServiceNameMergesStreamAndStructuredMetadataInventory(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "app", "hits": 12},
+				},
+			})
+		case "/select/logsql/stream_field_values":
+			if got := r.URL.Query().Get("field"); got != "app" {
+				t.Fatalf("expected stream service inventory lookup to use app field, got %q", got)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "api-gateway", "hits": 12},
+					{"value": "worker", "hits": 5},
+				},
+			})
+		case "/select/logsql/field_names":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "service.name", "hits": 4},
+				},
+			})
+		case "/select/logsql/field_values":
+			if got := r.URL.Query().Get("field"); got != "service.name" {
+				t.Fatalf("expected structured metadata lookup to use service.name field, got %q", got)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "otel-auth-service", "hits": 4},
+				},
+			})
+		case "/select/logsql/streams", "/select/logsql/query":
+			t.Fatalf("service_name label values must be resolved from metadata inventory before stream scans, got %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	resp := doGet(t, vlBackend.URL, "/loki/api/v1/label/service_name/values?query=*")
+	data := assertDataIsStringArray(t, resp)
+	if len(data) != 3 {
+		t.Fatalf("expected merged service inventory from stream and structured metadata fields, got %v", data)
 	}
 	assertContains(t, data, "api-gateway")
 	assertContains(t, data, "worker")
+	assertContains(t, data, "otel-auth-service")
 }
 
 func TestDrilldown_DetectedFields_ParseStructuredLogsInsteadOfIndexedLabels(t *testing.T) {
@@ -1059,10 +1119,12 @@ func TestDrilldown_DetectedFieldValues_ServiceNameUsesFastPath(t *testing.T) {
 	)
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.NotFound(w, r)
 		case "/select/logsql/field_names":
 			sawFieldNames = true
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"values":[{"value":"service.name","hits":2},{"value":"app","hits":1}]}`))
+			w.Write([]byte(`{"values":[{"value":"service.name","hits":2}]}`))
 		case "/select/logsql/field_values":
 			sawFieldValues = true
 			if r.URL.Query().Get("field") != "service.name" {

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -624,6 +624,43 @@ func TestDrilldown_LabelValues_ServiceNameUsesNativeFieldValues(t *testing.T) {
 	assertContains(t, data, "worker")
 }
 
+func TestDrilldown_LabelValues_ServiceNamePrefersConcreteNativeFieldInventory(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "service_name", "hits": 3},
+					{"value": "app", "hits": 12},
+				},
+			})
+		case "/select/logsql/field_values":
+			if got := r.URL.Query().Get("field"); got != "app" {
+				t.Fatalf("expected service_name values to prefer concrete app inventory over sparse service_name inventory, got %q", got)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "api-gateway", "hits": 12},
+					{"value": "worker", "hits": 5},
+				},
+			})
+		case "/select/logsql/streams", "/select/logsql/query":
+			t.Fatalf("service_name native inventory must not fall back to stream scans when app inventory is available, got %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	resp := doGet(t, vlBackend.URL, "/loki/api/v1/label/service_name/values")
+	data := assertDataIsStringArray(t, resp)
+	if len(data) != 2 {
+		t.Fatalf("expected 2 service_name values from concrete inventory, got %v", data)
+	}
+	assertContains(t, data, "api-gateway")
+	assertContains(t, data, "worker")
+}
+
 func TestDrilldown_DetectedFields_ParseStructuredLogsInsteadOfIndexedLabels(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -592,17 +592,29 @@ func TestDrilldown_IndexVolumeRange_TargetLabelsServiceName_FillsFullRangeBucket
 	}
 }
 
-func TestDrilldown_LabelValues_ServiceNameDerivedFromStreams(t *testing.T) {
+func TestDrilldown_LabelValues_ServiceNameUsesNativeFieldValues(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/select/logsql/streams" {
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "app", "hits": 12},
+					{"value": "service.name", "hits": 12},
+				},
+			})
+		case "/select/logsql/field_values":
+			if got := r.URL.Query().Get("field"); got != "service.name" {
+				t.Fatalf("expected service_name fast path to use service.name field first, got %q", got)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"value": "api-gateway", "hits": 12},
+					{"value": "worker", "hits": 5},
+				},
+			})
+		default:
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"values": []map[string]interface{}{
-				{"value": `{app="api-gateway",cluster="us-east-1"}`, "hits": 12},
-				{"value": `{container="worker"}`, "hits": 5},
-			},
-		})
 	}))
 	defer vlBackend.Close()
 
@@ -1004,15 +1016,25 @@ func TestDrilldown_DetectedFieldValues_ReturnStructuredMetadataValues(t *testing
 }
 
 func TestDrilldown_DetectedFieldValues_ServiceNameUsesFastPath(t *testing.T) {
-	var sawStreams bool
+	var (
+		sawFieldNames  bool
+		sawFieldValues bool
+	)
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/select/logsql/streams":
-			sawStreams = true
+		case "/select/logsql/field_names":
+			sawFieldNames = true
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"values":[{"value":"{service.name=\"grafana\",cluster=\"test-cluster\"}","hits":2}]}`))
-		case "/select/logsql/field_names", "/select/logsql/query", "/select/logsql/field_values":
-			t.Fatalf("service_name detected field values must use dedicated fast path, got %s", r.URL.Path)
+			w.Write([]byte(`{"values":[{"value":"service.name","hits":2},{"value":"app","hits":1}]}`))
+		case "/select/logsql/field_values":
+			sawFieldValues = true
+			if r.URL.Query().Get("field") != "service.name" {
+				t.Fatalf("expected service_name fast path to use service.name field first, got %q", r.URL.Query().Get("field"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"grafana","hits":2}]}`))
+		case "/select/logsql/streams", "/select/logsql/query":
+			t.Fatalf("service_name detected field values must avoid stream scans, got %s", r.URL.Path)
 		default:
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
 		}
@@ -1047,8 +1069,8 @@ func TestDrilldown_DetectedFieldValues_ServiceNameUsesFastPath(t *testing.T) {
 	if len(values) != 1 || values[0].(string) != "grafana" {
 		t.Fatalf("expected service_name values from fast path, got %v", values)
 	}
-	if !sawStreams {
-		t.Fatalf("expected streams endpoint to be used")
+	if !sawFieldNames || !sawFieldValues {
+		t.Fatalf("expected field_names + field_values fast path, got fieldNames=%v fieldValues=%v", sawFieldNames, sawFieldValues)
 	}
 }
 

--- a/internal/proxy/perf_hardening_test.go
+++ b/internal/proxy/perf_hardening_test.go
@@ -238,6 +238,8 @@ func TestLabelValuesServiceName_StripsFieldStagesForDrilldownQueries(t *testing.
 	var receivedQuery string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.NotFound(w, r)
 		case "/select/logsql/field_names":
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprintln(w, `{"values":[{"value":"service.name","hits":1}]}`)

--- a/internal/proxy/perf_hardening_test.go
+++ b/internal/proxy/perf_hardening_test.go
@@ -238,17 +238,17 @@ func TestLabelValuesServiceName_StripsFieldStagesForDrilldownQueries(t *testing.
 	var receivedQuery string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/select/logsql/streams":
+		case "/select/logsql/field_names":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"values":[{"value":"service.name","hits":1}]}`)
+		case "/select/logsql/field_values":
 			receivedQuery = r.URL.Query().Get("query")
 			w.Header().Set("Content-Type", "application/json")
 			if strings.Contains(receivedQuery, "source_message_bytes") || strings.Contains(receivedQuery, "unpack_json") || strings.Contains(receivedQuery, "logfmt") {
 				fmt.Fprintln(w, `{"values":[]}`)
 				return
 			}
-			fmt.Fprintln(w, `{"values":[{"value":"{service=\"grafana\"}","hits":1}]}`)
-		case "/select/logsql/query":
-			w.Header().Set("Content-Type", "application/x-ndjson")
-			fmt.Fprintln(w, `{"_time":"2024-01-15T10:30:00Z","_msg":"ok","_stream":"{service=\"grafana\"}"}`)
+			fmt.Fprintln(w, `{"values":[{"value":"grafana","hits":1}]}`)
 		default:
 			t.Fatalf("unexpected backend path %s", r.URL.Path)
 		}
@@ -278,6 +278,156 @@ func TestLabelValuesServiceName_StripsFieldStagesForDrilldownQueries(t *testing.
 	}
 	if len(resp.Data) == 0 || resp.Data[0] != "grafana" {
 		t.Fatalf("expected derived service_name value, got %#v (query=%q)", resp.Data, receivedQuery)
+	}
+}
+
+func TestLabels_StripsFieldStagesForDrilldownQueries(t *testing.T) {
+	var receivedQueries []string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stream_field_names" && r.URL.Path != "/select/logsql/field_names" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		query := r.URL.Query().Get("query")
+		receivedQueries = append(receivedQueries, query)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(query, "source_message_bytes") || strings.Contains(query, "unpack_json") || strings.Contains(query, "logfmt") {
+			fmt.Fprintln(w, `{"values":[]}`)
+			return
+		}
+		fmt.Fprintln(w, `{"values":[{"value":"app","hits":1},{"value":"level","hits":1}]}`)
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		http.MethodGet,
+		`/loki/api/v1/labels?query=%7Bdeployment_environment%3D%22dev%22%7D+%7C+json+%7C+source_message_bytes%3D%2289%22&start=1&end=2`,
+		nil,
+	)
+	p.handleLabels(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if len(receivedQueries) == 0 {
+		t.Fatal("expected metadata labels lookup to hit backend")
+	}
+	lastQuery := receivedQueries[len(receivedQueries)-1]
+	if strings.Contains(lastQuery, "source_message_bytes") || strings.Contains(lastQuery, "unpack_json") || strings.Contains(lastQuery, "logfmt") {
+		t.Fatalf("labels lookup should strip field-detection stages, got query %q (all=%v)", lastQuery, receivedQueries)
+	}
+
+	var resp struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data) == 0 || resp.Data[0] != "app" {
+		t.Fatalf("expected scoped labels after relaxed fallback, got %#v (queries=%v)", resp.Data, receivedQueries)
+	}
+}
+
+func TestLabelValues_StripsFieldStagesForDrilldownQueries(t *testing.T) {
+	var receivedValueQueries []string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"values":[{"value":"app","hits":1}]}`)
+		case "/select/logsql/stream_field_values", "/select/logsql/field_values":
+			query := r.URL.Query().Get("query")
+			receivedValueQueries = append(receivedValueQueries, query)
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(query, "source_message_bytes") || strings.Contains(query, "unpack_json") || strings.Contains(query, "logfmt") {
+				fmt.Fprintln(w, `{"values":[]}`)
+				return
+			}
+			fmt.Fprintln(w, `{"values":[{"value":"grafana","hits":1}]}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		http.MethodGet,
+		`/loki/api/v1/label/app/values?query=%7Bdeployment_environment%3D%22dev%22%7D+%7C+json+%7C+source_message_bytes%3D%2289%22&start=1&end=2`,
+		nil,
+	)
+	p.handleLabelValues(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if len(receivedValueQueries) == 0 {
+		t.Fatal("expected label values lookup to hit backend")
+	}
+	lastQuery := receivedValueQueries[len(receivedValueQueries)-1]
+	if strings.Contains(lastQuery, "source_message_bytes") || strings.Contains(lastQuery, "unpack_json") || strings.Contains(lastQuery, "logfmt") {
+		t.Fatalf("label values lookup should strip field-detection stages, got query %q (all=%v)", lastQuery, receivedValueQueries)
+	}
+
+	var resp struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0] != "grafana" {
+		t.Fatalf("expected scoped label values after relaxed fallback, got %#v (queries=%v)", resp.Data, receivedValueQueries)
+	}
+}
+
+func TestDetectedLabels_ScannedFallback_StripsFieldStagesForDrilldownQueries(t *testing.T) {
+	var scanQueries []string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			http.Error(w, "backend unavailable", http.StatusBadGateway)
+		case "/select/logsql/query":
+			query := r.FormValue("query")
+			scanQueries = append(scanQueries, query)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			if strings.Contains(query, "source_message_bytes") || strings.Contains(query, "unpack_json") || strings.Contains(query, "logfmt") {
+				http.Error(w, "unsupported parser stage", http.StatusBadRequest)
+				return
+			}
+			fmt.Fprintln(w, `{"_time":"2024-01-15T10:30:00Z","_msg":"ok","_stream":"{app=\"grafana\",level=\"info\"}"}`)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	p := newTestProxy(t, backend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		http.MethodGet,
+		`/loki/api/v1/detected_labels?query=%7Bdeployment_environment%3D%22dev%22%7D+%7C+json+%7C+source_message_bytes%3D%2289%22&start=1&end=2`,
+		nil,
+	)
+	p.handleDetectedLabels(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if len(scanQueries) < 2 {
+		t.Fatalf("expected detected_labels scan fallback to retry with relaxed query, got %v", scanQueries)
+	}
+	lastQuery := scanQueries[len(scanQueries)-1]
+	if strings.Contains(lastQuery, "source_message_bytes") || strings.Contains(lastQuery, "unpack_json") || strings.Contains(lastQuery, "logfmt") {
+		t.Fatalf("detected_labels scan fallback should strip field-detection stages, got query %q (all=%v)", lastQuery, scanQueries)
+	}
+
+	var resp struct {
+		DetectedLabels []map[string]interface{} `json:"detectedLabels"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.DetectedLabels) == 0 {
+		t.Fatalf("expected detected_labels after relaxed fallback, got empty response (queries=%v body=%s)", scanQueries, w.Body.String())
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2392,6 +2392,90 @@ func appendUniqueStrings(dst []string, values ...string) []string {
 	return dst
 }
 
+func (p *Proxy) metadataQueryParams(ctx context.Context, candidate, start, end, limit, search string) (url.Values, error) {
+	params := url.Values{}
+	translated, err := p.translateQueryWithContext(ctx, candidate)
+	if err != nil {
+		return nil, err
+	}
+	params.Set("query", translated)
+	if strings.TrimSpace(start) != "" {
+		params.Set("start", start)
+	}
+	if strings.TrimSpace(end) != "" {
+		params.Set("end", end)
+	}
+	if strings.TrimSpace(limit) != "" {
+		params.Set("limit", limit)
+	}
+	if search = strings.TrimSpace(search); search != "" && p.supportsMetadataSubstringFilter() {
+		params.Set("q", search)
+		params.Set("filter", "substring")
+	}
+	return params, nil
+}
+
+func (p *Proxy) fetchScopedLabelNames(ctx context.Context, rawQuery, start, end, search string, useInventoryCache bool) ([]string, error) {
+	candidates := metadataQueryCandidates(rawQuery)
+	var (
+		lastErr   error
+		lastEmpty []string
+	)
+	for i, candidate := range candidates {
+		params, err := p.metadataQueryParams(ctx, candidate, start, end, "", search)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var labels []string
+		if useInventoryCache {
+			labels, err = p.fetchPreferredLabelNamesCached(ctx, params)
+		} else {
+			labels, err = p.fetchPreferredLabelNames(ctx, params)
+		}
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(labels) > 0 || i == len(candidates)-1 {
+			return labels, nil
+		}
+		lastEmpty = labels
+	}
+	if lastEmpty != nil {
+		return lastEmpty, nil
+	}
+	return nil, lastErr
+}
+
+func (p *Proxy) fetchScopedLabelValues(ctx context.Context, labelName, rawQuery, start, end, limit, search string) ([]string, error) {
+	candidates := metadataQueryCandidates(rawQuery)
+	var (
+		lastErr   error
+		lastEmpty []string
+	)
+	for i, candidate := range candidates {
+		params, err := p.metadataQueryParams(ctx, candidate, start, end, limit, search)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		values, err := p.fetchPreferredLabelValues(ctx, labelName, params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(values) > 0 || i == len(candidates)-1 {
+			return values, nil
+		}
+		lastEmpty = values
+	}
+	if lastEmpty != nil {
+		return lastEmpty, nil
+	}
+	return nil, lastErr
+}
+
 func (p *Proxy) snapshotDeclaredLabelFields() []string {
 	if p == nil || len(p.declaredLabelFields) == 0 {
 		return nil
@@ -2607,29 +2691,7 @@ func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end, s
 				ctx = context.WithValue(ctx, orgIDKey, orgID)
 			}
 
-			params := url.Values{}
-			if strings.TrimSpace(rawQuery) != "" {
-				translated, terr := p.translateQueryWithContext(ctx, defaultQuery(rawQuery))
-				if terr == nil {
-					params.Set("query", translated)
-				} else {
-					params.Set("query", "*")
-				}
-			} else {
-				params.Set("query", "*")
-			}
-			if strings.TrimSpace(start) != "" {
-				params.Set("start", start)
-			}
-			if strings.TrimSpace(end) != "" {
-				params.Set("end", end)
-			}
-			if search = strings.TrimSpace(search); search != "" && p.supportsMetadataSubstringFilter() {
-				params.Set("q", search)
-				params.Set("filter", "substring")
-			}
-
-			labels, fetchErr := p.fetchPreferredLabelNames(ctx, params)
+			labels, fetchErr := p.fetchScopedLabelNames(ctx, rawQuery, start, end, search, false)
 			if fetchErr != nil {
 				return nil, fetchErr
 			}
@@ -2670,31 +2732,7 @@ func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuer
 			if labelName == "service_name" {
 				values, fetchErr = p.serviceNameValues(ctx, rawQuery, start, end)
 			} else {
-				params := url.Values{}
-				if strings.TrimSpace(rawQuery) != "" {
-					translated, terr := p.translateQueryWithContext(ctx, defaultQuery(rawQuery))
-					if terr == nil {
-						params.Set("query", translated)
-					} else {
-						params.Set("query", "*")
-					}
-				} else {
-					params.Set("query", "*")
-				}
-				if strings.TrimSpace(start) != "" {
-					params.Set("start", start)
-				}
-				if strings.TrimSpace(end) != "" {
-					params.Set("end", end)
-				}
-				if strings.TrimSpace(limit) != "" {
-					params.Set("limit", limit)
-				}
-				if search = strings.TrimSpace(search); search != "" && p.supportsMetadataSubstringFilter() {
-					params.Set("q", search)
-					params.Set("filter", "substring")
-				}
-				values, fetchErr = p.fetchPreferredLabelValues(ctx, labelName, params)
+				values, fetchErr = p.fetchScopedLabelValues(ctx, labelName, rawQuery, start, end, limit, search)
 			}
 			if fetchErr != nil {
 				return nil, fetchErr
@@ -4262,34 +4300,12 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	p.metrics.RecordCacheMiss()
 	r = withOrgID(r)
 
-	params := url.Values{}
-	// Forward the query param if provided (Loki uses it to scope label suggestions)
-	if q := r.FormValue("query"); q != "" {
-		translated, terr := p.translateQueryWithContext(r.Context(), defaultQuery(q))
-		if terr == nil {
-			params.Set("query", translated)
-		} else {
-			params.Set("query", "*")
-		}
-	} else {
-		params.Set("query", "*")
-	}
-	if s := r.FormValue("start"); s != "" {
-		params.Set("start", s)
-	}
-	if e := r.FormValue("end"); e != "" {
-		params.Set("end", e)
-	}
 	search := strings.TrimSpace(r.FormValue("search"))
 	if search == "" {
 		search = strings.TrimSpace(r.FormValue("q"))
 	}
-	if search != "" && p.supportsMetadataSubstringFilter() {
-		params.Set("q", search)
-		params.Set("filter", "substring")
-	}
 
-	labels, err := p.fetchPreferredLabelNamesCached(r.Context(), params)
+	labels, err := p.fetchScopedLabelNames(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), search, true)
 	if err != nil {
 		status := statusFromUpstreamErr(err)
 		p.writeError(w, status, err.Error())
@@ -4414,32 +4430,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := url.Values{}
-	if q := r.FormValue("query"); q != "" {
-		translated, terr := p.translateQueryWithContext(r.Context(), defaultQuery(q))
-		if terr == nil {
-			params.Set("query", translated)
-		} else {
-			params.Set("query", "*")
-		}
-	} else {
-		params.Set("query", "*")
-	}
-	if s := r.FormValue("start"); s != "" {
-		params.Set("start", s)
-	}
-	if e := r.FormValue("end"); e != "" {
-		params.Set("end", e)
-	}
-	if l := r.FormValue("limit"); l != "" {
-		params.Set("limit", l)
-	}
-	if search != "" && p.supportsMetadataSubstringFilter() {
-		params.Set("q", search)
-		params.Set("filter", "substring")
-	}
-
-	values, err := p.fetchPreferredLabelValues(r.Context(), labelName, params)
+	values, err := p.fetchScopedLabelValues(r.Context(), labelName, rawQuery, r.FormValue("start"), r.FormValue("end"), r.FormValue("limit"), search)
 	if err != nil {
 		status := statusFromUpstreamErr(err)
 		p.writeError(w, status, err.Error())

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -3212,6 +3212,8 @@ func TestCache_DetectedFieldServiceNameHitOnRepeat(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			http.NotFound(w, r)
 		case "/select/logsql/field_names":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"values":[{"value":"service.name","hits":1}]}`))
@@ -3232,13 +3234,13 @@ func TestCache_DetectedFieldServiceNameHitOnRepeat(t *testing.T) {
 
 	w1 := httptest.NewRecorder()
 	p.handleDetectedFieldValues(w1, httptest.NewRequest(http.MethodGet, path, nil))
-	if callCount != 2 {
-		t.Fatalf("expected 2 backend calls on cache miss (field_names + field_values), got %d", callCount)
+	if callCount != 3 {
+		t.Fatalf("expected 3 backend calls on cache miss (stream_field_names probe + field_names + field_values), got %d", callCount)
 	}
 
 	w2 := httptest.NewRecorder()
 	p.handleDetectedFieldValues(w2, httptest.NewRequest(http.MethodGet, path, nil))
-	if callCount != 2 {
+	if callCount != 3 {
 		t.Fatalf("expected cache hit before backend call, got %d", callCount)
 	}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -3212,9 +3212,15 @@ func TestCache_DetectedFieldServiceNameHitOnRepeat(t *testing.T) {
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		switch r.URL.Path {
-		case "/select/logsql/streams":
+		case "/select/logsql/field_names":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"values":[{"value":"{service.name=\"grafana\"}","hits":1}]}`))
+			_, _ = w.Write([]byte(`{"values":[{"value":"service.name","hits":1}]}`))
+		case "/select/logsql/field_values":
+			if got := r.URL.Query().Get("field"); got != "service.name" {
+				t.Fatalf("expected service_name cache warmup to use service.name field, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"grafana","hits":1}]}`))
 		default:
 			t.Fatalf("unexpected backend path: %s", r.URL.Path)
 		}
@@ -3226,13 +3232,13 @@ func TestCache_DetectedFieldServiceNameHitOnRepeat(t *testing.T) {
 
 	w1 := httptest.NewRecorder()
 	p.handleDetectedFieldValues(w1, httptest.NewRequest(http.MethodGet, path, nil))
-	if callCount != 1 {
-		t.Fatalf("expected 1 backend call on cache miss, got %d", callCount)
+	if callCount != 2 {
+		t.Fatalf("expected 2 backend calls on cache miss (field_names + field_values), got %d", callCount)
 	}
 
 	w2 := httptest.NewRecorder()
 	p.handleDetectedFieldValues(w2, httptest.NewRequest(http.MethodGet, path, nil))
-	if callCount != 1 {
+	if callCount != 2 {
 		t.Fatalf("expected cache hit before backend call, got %d", callCount)
 	}
 


### PR DESCRIPTION
## What changed
This updates Drilldown metadata discovery to prefer native VictoriaLogs field inventory and to retry relaxed query candidates when parser-heavy Drilldown queries return empty metadata.

## Why
`service_name` was effectively on a different path than other labels. It still depended on stream scans, while the rest of metadata discovery was closer to indexed field APIs. In practice that made `service_name` regularly show `No data` in the labels view, and it also left some Drilldown label and field loading paths empty when the query contained parser/comparison stages.

## Root cause
The proxy treated metadata lookups inconsistently:
- `service_name` values were derived primarily from `/select/logsql/streams`
- label inventory and label values did not consistently retry stripped/relaxed Drilldown queries
- scanned detected-label fallback did not retry those relaxed candidates either

That meant queries that were valid for result fetching could still be poor candidates for metadata inventory, especially once parser stages were added.

## Impact
- restores `service_name` loading in label views by using native field metadata first
- makes labels, label values, and detected-label fallback more resilient for Drilldown queries with parser stages
- keeps stream scanning only as a fallback path instead of the primary path

## Validation
- `rtk go test ./internal/proxy`
