### PR TITLE
Recover service_name on Drilldown detected labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/detected-labels: recover `service_name` in broad Drilldown label discovery when native stream labels collapse to `unknown_service` by deriving service identity from structured metadata fields such as `service.name` during scan fallback and replacing incomplete native summaries with scanned service names.
+
 ## [1.8.0] - 2026-04-19
 
 ### Bug Fixes

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -116,6 +116,14 @@ func buildEntryLabels(entry map[string]interface{}) map[string]string {
 
 func buildDetectedLabels(entry map[string]interface{}) map[string]string {
 	labels := parseStreamLabels(asString(entry["_stream"]))
+	for _, key := range serviceNameSourceFields {
+		if _, ok := labels[key]; ok {
+			continue
+		}
+		if value, ok := stringifyEntryValue(entry[key]); ok && strings.TrimSpace(value) != "" {
+			labels[key] = value
+		}
+	}
 	if value, ok := stringifyEntryValue(entry["level"]); ok && strings.TrimSpace(value) != "" {
 		labels["level"] = value
 	}
@@ -1362,19 +1370,44 @@ func needsDetectedLabelScanSupplement(summaries map[string]*detectedLabelSummary
 	if len(summaries) == 0 {
 		return true
 	}
-	_, ok := summaries["level"]
-	return !ok
+	for _, label := range []string{"level", "service_name"} {
+		summary := summaries[label]
+		if summary == nil {
+			return true
+		}
+		if label == "service_name" && detectedServiceNameSummaryNeedsReplacement(summary) {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeDetectedLabelSupplements(dst, scanned map[string]*detectedLabelSummary) {
-	for _, label := range []string{"level"} {
-		if _, ok := dst[label]; ok {
+	for _, label := range []string{"level", "service_name"} {
+		summary := scanned[label]
+		if summary == nil {
 			continue
 		}
-		if summary := scanned[label]; summary != nil {
+		existing := dst[label]
+		if existing == nil {
+			dst[label] = summary
+			continue
+		}
+		if label == "service_name" && detectedServiceNameSummaryNeedsReplacement(existing) {
 			dst[label] = summary
 		}
 	}
+}
+
+func detectedServiceNameSummaryNeedsReplacement(summary *detectedLabelSummary) bool {
+	if summary == nil || len(summary.values) == 0 {
+		return true
+	}
+	if len(summary.values) == 1 {
+		_, onlyUnknown := summary.values[unknownServiceName]
+		return onlyUnknown
+	}
+	return false
 }
 
 func (p *Proxy) detectNativeFields(ctx context.Context, query, start, end string) (map[string]*detectedFieldSummary, error) {

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -232,25 +232,41 @@ func TestDrilldown_DetectedLabelSupplementHelpers(t *testing.T) {
 	}) {
 		t.Fatal("summaries without level should require scan supplement")
 	}
-	if needsDetectedLabelScanSupplement(map[string]*detectedLabelSummary{
+	if !needsDetectedLabelScanSupplement(map[string]*detectedLabelSummary{
 		"level": {label: "level", values: map[string]struct{}{"info": {}}},
 	}) {
-		t.Fatal("summaries with level should not require scan supplement")
+		t.Fatal("summaries without service_name should require scan supplement")
+	}
+	if !needsDetectedLabelScanSupplement(map[string]*detectedLabelSummary{
+		"level":        {label: "level", values: map[string]struct{}{"info": {}}},
+		"service_name": {label: "service_name", values: map[string]struct{}{unknownServiceName: {}}},
+	}) {
+		t.Fatal("summaries with only unknown_service should require scan supplement")
+	}
+	if needsDetectedLabelScanSupplement(map[string]*detectedLabelSummary{
+		"level":        {label: "level", values: map[string]struct{}{"info": {}}},
+		"service_name": {label: "service_name", values: map[string]struct{}{"svc": {}}},
+	}) {
+		t.Fatal("summaries with level and service_name should not require scan supplement")
 	}
 
 	dst := map[string]*detectedLabelSummary{
-		"service_name": {label: "service_name", values: map[string]struct{}{"svc": {}}},
+		"level":        {label: "level", values: map[string]struct{}{"info": {}}},
+		"service_name": {label: "service_name", values: map[string]struct{}{unknownServiceName: {}}},
 	}
 	scanned := map[string]*detectedLabelSummary{
-		"level":        {label: "level", values: map[string]struct{}{"info": {}}},
-		"service_name": {label: "service_name", values: map[string]struct{}{"other": {}}},
+		"level":        {label: "level", values: map[string]struct{}{"warn": {}}},
+		"service_name": {label: "service_name", values: map[string]struct{}{"svc": {}}},
 	}
 	mergeDetectedLabelSupplements(dst, scanned)
-	if dst["level"] == nil {
-		t.Fatalf("expected mergeDetectedLabelSupplements to backfill level, got %v", dst)
+	if dst["service_name"] == nil || len(dst["service_name"].values) != 1 {
+		t.Fatalf("expected mergeDetectedLabelSupplements to backfill service_name, got %v", dst)
 	}
-	if len(dst["service_name"].values) != 1 {
-		t.Fatalf("expected existing non-derived labels to remain unchanged, got %v", dst["service_name"].values)
+	if _, ok := dst["service_name"].values["svc"]; !ok {
+		t.Fatalf("expected mergeDetectedLabelSupplements to replace unknown_service, got %v", dst["service_name"].values)
+	}
+	if len(dst["level"].values) != 1 {
+		t.Fatalf("expected existing non-derived labels to remain unchanged, got %v", dst["level"].values)
 	}
 }
 
@@ -979,6 +995,63 @@ func TestDrilldown_DetectedLabels_ExcludeRawStructuredMetadata(t *testing.T) {
 	}
 	if _, ok := got["service_namespace"]; ok {
 		t.Fatalf("raw structured metadata must not become detected label: %v", got)
+	}
+}
+
+func TestDrilldown_DetectedLabels_BackfillsServiceNameFromScanWhenNativeStreamsMissIt(t *testing.T) {
+	var streamCalls, scanCalls int
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/streams":
+			streamCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"{cluster=\"ops-sand\",k8s.cluster.name=\"ops-sand\",level=\"info\"}","hits":5}]}`))
+		case "/select/logsql/query":
+			scanCalls++
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(`{"_time":"2026-04-19T07:00:00Z","_msg":"request ok","k8s.cluster.name":"ops-sand","service.name":"otel-auth-service","level":"info"}` + "\n"))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL: vlBackend.URL,
+		Cache:      c,
+		LogLevel:   "error",
+		LabelStyle: LabelStyleUnderscores,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_labels?query=%7Bk8s_cluster_name%3D%22ops-sand%22%7D&limit=25", nil)
+	p.handleDetectedLabels(w, r)
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	items, ok := resp["detectedLabels"].([]interface{})
+	if !ok {
+		t.Fatalf("expected detectedLabels array, got %v", resp)
+	}
+
+	got := map[string]float64{}
+	for _, item := range items {
+		obj := item.(map[string]interface{})
+		got[obj["label"].(string)] = obj["cardinality"].(float64)
+	}
+
+	if _, ok := got["service_name"]; !ok {
+		t.Fatalf("expected service_name in detected labels after scan supplement, got %v", got)
+	}
+	if got["service_name"] != 1 {
+		t.Fatalf("expected service_name cardinality 1 after scan supplement, got %v", got)
+	}
+	if streamCalls == 0 || scanCalls == 0 {
+		t.Fatalf("expected both native streams and scan supplement paths, got streamCalls=%d scanCalls=%d", streamCalls, scanCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix the Drilldown detected_labels scan path so it can derive service_name from structured metadata fields such as service.name when native stream labels do not carry service identity
- treat native service_name=unknown_service summaries as incomplete and replace them with scan-derived service names when available
- add regression coverage for the Sand-shaped case where a broad cluster selector returns native streams without service labels but scanned log entries still contain service metadata

## Testing
- go test ./internal/proxy -run 'TestDrilldown_DetectedLabelSupplementHelpers|TestDrilldown_DetectedLabels_BackfillsServiceNameFromScanWhenNativeStreamsMissIt|TestDrilldown_DetectedLabels_ExcludeRawStructuredMetadata'
- go test ./internal/proxy -run 'TestDrilldown_|TestDetectedFields_|TestDefaultFieldDetectionQuery_|TestFieldDetectionQueryCandidates_'
