### PR TITLE
Keep query_range window caches local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- patterns/read-path: tighten dense short-range `/patterns` fanout and second-pass widening so Drilldown refreshes stop turning a single request into dozens of raw-log backend fetches under fine step sizes.
+- query-range/cache: keep window fragment results and prefilter hit estimates local to the serving pod instead of distributing those short-lived scratch entries through peer-cache write-through, reducing avoidable owner hot spots, network churn, and disk activity during Drilldown or Explore fanout.
 
 ## [1.8.1] - 2026-04-19
 

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -382,7 +382,10 @@ func (p *Proxy) fetchQueryRangeWindow(
 			entry := queryRangeWindowCacheEntry{Entries: entries}
 			if ttl := p.queryRangeWindowTTL(window.endNs); ttl > 0 {
 				if encoded, err := json.Marshal(entry); err == nil {
-					p.cache.SetWithTTL(cacheKey, encoded, ttl)
+					// Window fragments are short-lived and high churn. Keeping them
+					// local avoids concentrating peer-cache write-through on a single
+					// ring owner when Drilldown or Explore fans a read into many windows.
+					p.cache.SetLocalOnlyWithTTL(cacheKey, encoded, ttl)
 				}
 			}
 			return entry, nil
@@ -512,7 +515,9 @@ func (p *Proxy) queryRangeWindowHitEstimate(
 				hitEstimate = 0
 			}
 			if ttl := p.queryRangeWindowPrefilterTTL(window.endNs); ttl > 0 {
-				p.cache.SetWithTTL(cacheKey, []byte(strconv.FormatInt(hitEstimate, 10)), ttl)
+				// Prefilter hit estimates are window-scoped scratch state. They are
+				// cheap to recompute and do not justify peer write-through churn.
+				p.cache.SetLocalOnlyWithTTL(cacheKey, []byte(strconv.FormatInt(hitEstimate, 10)), ttl)
 			}
 			return hitEstimate, nil
 		}

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -321,6 +321,158 @@ func TestQueryRangeWindow_MultiTenantCompatibility(t *testing.T) {
 	}
 }
 
+func TestQueryRangeWindow_FetchStoresCacheLocallyWhenPeerWriteThroughEnabled(t *testing.T) {
+	var remoteSetCalls atomic.Int64
+	ownerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_cache/set" {
+			remoteSetCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ownerSrv.Close()
+
+	ownerURL, err := url.Parse(ownerSrv.URL)
+	if err != nil {
+		t.Fatalf("parse owner URL: %v", err)
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		startNs, _ := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+		_, _ = fmt.Fprintf(w, "{\"_time\":%q,\"_msg\":\"window-cache\",\"_stream\":\"{app=\\\"api\\\"}\"}\n", time.Unix(0, startNs).UTC().Format(time.RFC3339Nano))
+	}))
+	defer backend.Close()
+
+	window := queryRangeWindow{
+		startNs: time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Hour).UnixNano(),
+	}
+	window.endNs = window.startNs + int64(time.Hour) - 1
+	req := httptest.NewRequest("GET", fmt.Sprintf("/loki/api/v1/query_range?query=%s&limit=100", url.QueryEscape(`{app="api"}`)), nil)
+	if err := req.ParseForm(); err != nil {
+		t.Fatalf("parse form: %v", err)
+	}
+	cacheKey := (&Proxy{}).queryRangeWindowCacheKey(req, `{app="api"}`, "100", window, false, false)
+
+	pc := newNonOwnerPeerCacheForKey(t, ownerURL.Host, cacheKey)
+	defer pc.Close()
+	c := cache.New(60*time.Second, 1000)
+	c.SetL3(pc)
+	defer c.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      c,
+		PeerCache:                  pc,
+		LogLevel:                   "error",
+		QueryRangeWindowingEnabled: true,
+		QueryRangeFreshness:        10 * time.Minute,
+		QueryRangeRecentCacheTTL:   0,
+		QueryRangeHistoryCacheTTL:  time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	if _, err := p.fetchQueryRangeWindow(context.Background(), req, `{app="api"}`, "100", 100, window, false, false); err != nil {
+		t.Fatalf("fetchQueryRangeWindow returned error: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if got := remoteSetCalls.Load(); got != 0 {
+		t.Fatalf("expected window cache entry to stay local, got %d remote /_cache/set calls", got)
+	}
+	if got := pc.WTPushes.Load(); got != 0 {
+		t.Fatalf("expected local-only window cache write to skip write-through pushes, got %d", got)
+	}
+	if got := pc.WTErrors.Load(); got != 0 {
+		t.Fatalf("expected local-only window cache write to skip write-through errors, got %d", got)
+	}
+	if _, ok := p.cache.Get(cacheKey); !ok {
+		t.Fatalf("expected local cache key %q to be stored", cacheKey)
+	}
+}
+
+func TestQueryRangeWindowHitEstimate_CachesLocallyWhenPeerWriteThroughEnabled(t *testing.T) {
+	var remoteSetCalls atomic.Int64
+	ownerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_cache/set" {
+			remoteSetCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ownerSrv.Close()
+
+	ownerURL, err := url.Parse(ownerSrv.URL)
+	if err != nil {
+		t.Fatalf("parse owner URL: %v", err)
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hits":[{"timestamps":["1710000000"],"values":[7]}]}`))
+	}))
+	defer backend.Close()
+
+	window := queryRangeWindow{
+		startNs: time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Hour).UnixNano(),
+	}
+	window.endNs = window.startNs + int64(time.Hour) - 1
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range", nil)
+	cacheKey := (&Proxy{}).queryRangeWindowHasHitsCacheKey(req, `{app="api"}`, window)
+
+	pc := newNonOwnerPeerCacheForKey(t, ownerURL.Host, cacheKey)
+	defer pc.Close()
+	c := cache.New(60*time.Second, 1000)
+	c.SetL3(pc)
+	defer c.Close()
+
+	p, err := New(Config{
+		BackendURL:                 backend.URL,
+		Cache:                      c,
+		PeerCache:                  pc,
+		LogLevel:                   "error",
+		QueryRangeWindowingEnabled: true,
+		QueryRangeFreshness:        10 * time.Minute,
+		QueryRangeRecentCacheTTL:   0,
+		QueryRangeHistoryCacheTTL:  time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	got, err := p.queryRangeWindowHitEstimate(context.Background(), req, `{app="api"}`, window)
+	if err != nil {
+		t.Fatalf("queryRangeWindowHitEstimate returned error: %v", err)
+	}
+	if got != 7 {
+		t.Fatalf("expected hit estimate 7, got %d", got)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if got := remoteSetCalls.Load(); got != 0 {
+		t.Fatalf("expected hit-estimate cache entry to stay local, got %d remote /_cache/set calls", got)
+	}
+	if got := pc.WTPushes.Load(); got != 0 {
+		t.Fatalf("expected local-only hit-estimate cache write to skip write-through pushes, got %d", got)
+	}
+	if got := pc.WTErrors.Load(); got != 0 {
+		t.Fatalf("expected local-only hit-estimate cache write to skip write-through errors, got %d", got)
+	}
+	if _, ok := p.cache.Get(cacheKey); !ok {
+		t.Fatalf("expected local prefilter cache key %q to be stored", cacheKey)
+	}
+}
+
 func TestQueryRangeWindow_SevenDayRangeUsesParallelWindowFetch(t *testing.T) {
 	var calls atomic.Int64
 	var inFlight atomic.Int64
@@ -1438,6 +1590,26 @@ func newWindowingTestProxy(t *testing.T, backendURL string) *Proxy {
 		t.Fatalf("failed to create proxy: %v", err)
 	}
 	return p
+}
+
+func newNonOwnerPeerCacheForKey(t *testing.T, ownerHost, key string) *cache.PeerCache {
+	t.Helper()
+	for i := 0; i < 1024; i++ {
+		candidate := cache.NewPeerCache(cache.PeerConfig{
+			SelfAddr:           fmt.Sprintf("self-%d:3100", i),
+			DiscoveryType:      "static",
+			StaticPeers:        fmt.Sprintf("%s,remote-a:3100,remote-b:3100,%s", fmt.Sprintf("self-%d:3100", i), ownerHost),
+			Timeout:            50 * time.Millisecond,
+			WriteThrough:       true,
+			WriteThroughMinTTL: 5 * time.Second,
+		})
+		if !candidate.IsOwner(key) {
+			return candidate
+		}
+		candidate.Close()
+	}
+	t.Fatalf("expected non-owner peer cache setup for key %q", key)
+	return nil
 }
 
 func assertQueryRangeFirstTimestamp(t *testing.T, rec *httptest.ResponseRecorder, expectedTs int64) {


### PR DESCRIPTION
## Summary
- keep query_range window fragment results local instead of pushing them through peer-cache write-through
- keep query_range prefilter hit estimates local for the same reason
- add regressions proving these short-lived window cache entries do not trigger peer write-through when a non-owner pod serves the request

## Why
Live Sand metrics after the recent releases still show unnecessary network and disk churn on read spikes even when request distribution is improved. The remaining hot-path signal is that window-scoped cache entries are volatile, high-churn scratch state and are not producing useful cross-pod reuse, while peer-cache write-through can still concentrate that churn on a ring owner.

## Validation
- go test ./internal/proxy -run 'Test(QueryRangeWindow_|PatternWindowedSamplingConfig_)'
