### PR TITLE
fix: restore synthetic service_name non-empty drilldown metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/metrics: treat synthetic `service_name!=""` filters as "any service source field is populated" instead of requiring every possible backing field to be non-empty, restoring Grafana Drilldown label-card metric queries such as `sum(count_over_time({service_name="argocd",service_name != ""}[5s])) by (service_name)`.
+
+### Tests
+
+- drilldown/translator: add regression coverage for synthetic `service_name` empty and non-empty matcher translation, including the exact Drilldown grouped `query_range` label-card shape used by Grafana.
+
 ## [1.9.0] - 2026-04-19
 
 ### Features

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -1332,6 +1332,84 @@ func TestDrilldown_InstantMetricQueriesPreferSingleWorkingParser(t *testing.T) {
 	}
 }
 
+func TestDrilldown_LabelCardMetricQuery_ServiceNameNonEmptyFilterUsesSyntheticAnyMatch(t *testing.T) {
+	var statsQuery string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		switch r.URL.Path {
+		case "/select/logsql/stats_query_range":
+			statsQuery = r.Form.Get("query")
+			if strings.Contains(statsQuery, `service_name:!"" "service.name":!""`) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "success",
+					"data": map[string]interface{}{
+						"resultType": "matrix",
+						"result":     []map[string]interface{}{},
+					},
+				})
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "success",
+				"data": map[string]interface{}{
+					"resultType": "matrix",
+					"result": []map[string]interface{}{
+						{
+							"metric": map[string]string{"service.name": "argocd"},
+							"values": [][]interface{}{{float64(1712538000), "42"}},
+						},
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p, err := New(Config{
+		BackendURL: vlBackend.URL,
+		Cache:      cache.New(60*time.Second, 1000),
+		LogLevel:   "error",
+		LabelStyle: LabelStyleUnderscores,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	q := url.Values{}
+	q.Set("query", `sum(count_over_time({service_name="argocd",service_name != ""}[5s])) by (service_name)`)
+	q.Set("start", "2026-04-04T17:00:00Z")
+	q.Set("end", "2026-04-04T17:30:00Z")
+	q.Set("step", "300")
+	r := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
+	p.handleQueryRange(w, r)
+
+	if statsQuery == "" {
+		t.Fatal("expected stats query_range request to be issued")
+	}
+	if !strings.Contains(statsQuery, `(service_name:!"" OR "service.name":!""`) {
+		t.Fatalf("expected synthetic service_name non-empty matcher to use OR across source fields, got %q", statsQuery)
+	}
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := assertDataIsObject(t, resp)
+	result := assertResultIsArray(t, data)
+	if len(result) != 1 {
+		t.Fatalf("expected one matrix series, got %v", result)
+	}
+	metric := result[0].(map[string]interface{})["metric"].(map[string]interface{})
+	if metric["service_name"] != "argocd" {
+		t.Fatalf("expected translated service_name label in metric response, got %v", metric)
+	}
+}
+
 func contains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -84,7 +84,17 @@ func TestTranslateLogQLWithLabels(t *testing.T) {
 		{
 			name:  "non empty app matcher",
 			logql: `{app!="",service_name!=""}`,
-			want:  `app:!"" service_name:!"" "service.name":!"" service:!"" app:!"" application:!"" app_name:!"" name:!"" app_kubernetes_io_name:!"" container:!"" container_name:!"" "k8s.container.name":!"" k8s_container_name:!"" component:!"" workload:!"" job:!"" "k8s.job.name":!"" k8s_job_name:!""`,
+			want:  `app:!"" (service_name:!"" OR "service.name":!"" OR service:!"" OR app:!"" OR application:!"" OR app_name:!"" OR name:!"" OR app_kubernetes_io_name:!"" OR container:!"" OR container_name:!"" OR "k8s.container.name":!"" OR k8s_container_name:!"" OR component:!"" OR workload:!"" OR job:!"" OR "k8s.job.name":!"" OR k8s_job_name:!"")`,
+		},
+		{
+			name:  "synthetic empty service_name requires all source fields empty",
+			logql: `{service_name=""}`,
+			want:  `service_name:="" "service.name":="" service:="" app:="" application:="" app_name:="" name:="" app_kubernetes_io_name:="" container:="" container_name:="" "k8s.container.name":="" k8s_container_name:="" component:="" workload:="" job:="" "k8s.job.name":="" k8s_job_name:=""`,
+		},
+		{
+			name:  "synthetic non empty service_name uses any non empty source field",
+			logql: `{service_name!=""}`,
+			want:  `(service_name:!"" OR "service.name":!"" OR service:!"" OR app:!"" OR application:!"" OR app_name:!"" OR name:!"" OR app_kubernetes_io_name:!"" OR container:!"" OR container_name:!"" OR "k8s.container.name":!"" OR k8s_container_name:!"" OR component:!"" OR workload:!"" OR job:!"" OR "k8s.job.name":!"" OR k8s_job_name:!"")`,
 		},
 		{
 			name:  "parsed field non empty filter",

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -1616,6 +1616,12 @@ func serviceNameMatcherFilter(op, value string, neg, isRegex bool) string {
 			parts = append(parts, fmt.Sprintf(`%s%s%s`, name, op, formattedValue))
 		}
 	}
+	if value == "" && !isRegex {
+		if neg {
+			return "(" + strings.Join(parts, " OR ") + ")"
+		}
+		return strings.Join(parts, " ")
+	}
 	if neg {
 		return strings.Join(parts, " ")
 	}


### PR DESCRIPTION
Summary
- fix synthetic service_name!="" translation so it means any backing service field is populated instead of requiring every possible source field to be non-empty
- restore Grafana Drilldown label-card metric queries such as sum(count_over_time({service_name="argocd",service_name != ""}[5s])) by (service_name)
- add translator and proxy regressions for synthetic empty/non-empty service_name matcher semantics

Validation
- go test ./internal/translator
- go test ./internal/proxy -run TestDrilldown_|TestDetectedFields_|TestDefaultFieldDetectionQuery_|TestFieldDetectionQueryCandidates_
- python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD

Live repro
On Sand, raw queries with {service_name="argocd"} returned logs, and sum(count_over_time({service_name="argocd"}[5s])) by (service_name) returned data, but the Grafana Drilldown label-card query with the extra non-empty matcher returned an empty result: sum(count_over_time({service_name="argocd",service_name != ""}[5s])) by (service_name). This change fixes that exact path.