### PR TITLE
Keep L1-only Drilldown caches local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Bug Fixes
+
+- cache/read-path: keep full `query_range`, label, volume, and detected-* response caches local to the serving pod when those handlers only read cache through L1 `GetWithTTL`, avoiding redundant disk writes and peer write-through churn that do not provide any fallback benefit.
 
 ## [1.9.1] - 2026-04-19
 

--- a/internal/proxy/cache_locality_test.go
+++ b/internal/proxy/cache_locality_test.go
@@ -1,0 +1,171 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/cache"
+)
+
+func newLocalOnlyCacheFixture(t *testing.T, cacheKey string) (*cache.Cache, *cache.DiskCache, *cache.PeerCache, *atomic.Int64) {
+	t.Helper()
+
+	remoteSetCalls := &atomic.Int64{}
+	ownerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_cache/set" {
+			remoteSetCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(ownerSrv.Close)
+
+	ownerURL, err := url.Parse(ownerSrv.URL)
+	if err != nil {
+		t.Fatalf("parse owner URL: %v", err)
+	}
+
+	dc, err := cache.NewDiskCache(cache.DiskCacheConfig{Path: t.TempDir() + "/cache.db"})
+	if err != nil {
+		t.Fatalf("new disk cache: %v", err)
+	}
+	t.Cleanup(func() { _ = dc.Close() })
+
+	pc := newNonOwnerPeerCacheForKey(t, ownerURL.Host, cacheKey)
+	t.Cleanup(pc.Close)
+
+	c := cache.New(60*time.Second, 1000)
+	c.SetL2(dc)
+	c.SetL3(pc)
+	t.Cleanup(c.Close)
+
+	return c, dc, pc, remoteSetCalls
+}
+
+func TestQueryRangeCache_StoresFullResponsesLocallyWhenPeerWriteThroughEnabled(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte("{\"_time\":\"2026-04-19T10:00:00Z\",\"_msg\":\"ok\",\"_stream\":\"{app=\\\"api\\\"}\"}\n"))
+	}))
+	defer backend.Close()
+
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?query=%7Bapp%3D%22api%22%7D&limit=100", nil)
+	cacheKey := (&Proxy{}).queryRangeCacheKey(req, `{app="api"}`)
+	c, dc, pc, remoteSetCalls := newLocalOnlyCacheFixture(t, cacheKey)
+
+	p, err := New(Config{
+		BackendURL: backend.URL,
+		Cache:      c,
+		PeerCache:  pc,
+		LogLevel:   "error",
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	p.handleQueryRange(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	if _, _, ok := p.cache.GetWithTTL(cacheKey); !ok {
+		t.Fatalf("expected local cache entry for %q", cacheKey)
+	}
+	if _, ok := dc.Get(cacheKey); ok {
+		t.Fatalf("expected query_range cache entry %q to skip L2 disk cache", cacheKey)
+	}
+	if got := remoteSetCalls.Load(); got != 0 {
+		t.Fatalf("expected query_range cache entry to skip remote /_cache/set, got %d", got)
+	}
+	if got := pc.WTPushes.Load(); got != 0 {
+		t.Fatalf("expected query_range cache entry to skip write-through pushes, got %d", got)
+	}
+}
+
+func TestLabelsCache_StoresResponsesLocallyWhenPeerWriteThroughEnabled(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stream_field_names":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"service.name","hits":10},{"value":"k8s.namespace.name","hits":5}]}`))
+		default:
+			t.Fatalf("unexpected backend path: %s", r.URL.Path)
+		}
+	}))
+	defer backend.Close()
+
+	req := httptest.NewRequest("GET", "/loki/api/v1/labels?query=%7Bservice_name%3D%22api%22%7D", nil)
+	cacheKey := "labels::" + req.URL.RawQuery
+	c, dc, pc, remoteSetCalls := newLocalOnlyCacheFixture(t, cacheKey)
+
+	p, err := New(Config{
+		BackendURL: backend.URL,
+		Cache:      c,
+		PeerCache:  pc,
+		LogLevel:   "error",
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	p.handleLabels(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	if _, _, ok := p.cache.GetWithTTL(cacheKey); !ok {
+		t.Fatalf("expected local labels cache entry for %q", cacheKey)
+	}
+	if _, ok := dc.Get(cacheKey); ok {
+		t.Fatalf("expected labels cache entry %q to skip L2 disk cache", cacheKey)
+	}
+	if got := remoteSetCalls.Load(); got != 0 {
+		t.Fatalf("expected labels cache entry to skip remote /_cache/set, got %d", got)
+	}
+	if got := pc.WTPushes.Load(); got != 0 {
+		t.Fatalf("expected labels cache entry to skip write-through pushes, got %d", got)
+	}
+}
+
+func TestSetJSONCacheWithTTL_StoresResponsesLocally(t *testing.T) {
+	cacheKey := "detected_labels:tenant-a:test"
+	c, dc, pc, remoteSetCalls := newLocalOnlyCacheFixture(t, cacheKey)
+	p := &Proxy{cache: c}
+
+	p.setJSONCacheWithTTL(cacheKey, time.Minute, map[string]interface{}{
+		"status": "success",
+		"data":   []string{"service_name"},
+	})
+
+	body, _, ok := p.cache.GetWithTTL(cacheKey)
+	if !ok {
+		t.Fatalf("expected local JSON cache entry for %q", cacheKey)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode cached JSON: %v", err)
+	}
+	if decoded["status"] != "success" {
+		t.Fatalf("unexpected cached JSON payload: %v", decoded)
+	}
+	if _, ok := dc.Get(cacheKey); ok {
+		t.Fatalf("expected JSON cache entry %q to skip L2 disk cache", cacheKey)
+	}
+	if got := remoteSetCalls.Load(); got != 0 {
+		t.Fatalf("expected JSON cache entry to skip remote /_cache/set, got %d", got)
+	}
+	if got := pc.WTPushes.Load(); got != 0 {
+		t.Fatalf("expected JSON cache entry to skip write-through pushes, got %d", got)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2155,12 +2155,12 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		}
 		_, _ = w.Write(cacheOut)
 		if cacheable && sc.code == http.StatusOK {
-			p.cache.SetWithTTL(cacheKey, append([]byte(nil), cacheOut...), CacheTTLs["query_range"])
+			p.setLocalReadCacheWithTTL(cacheKey, append([]byte(nil), cacheOut...), CacheTTLs["query_range"])
 		}
 	} else if cacheTap != nil {
 		if cacheable && sc.code == http.StatusOK {
 			if body := cacheTap.CapturedBody(); len(body) > 0 {
-				p.cache.SetWithTTL(cacheKey, append([]byte(nil), body...), CacheTTLs["query_range"])
+				p.setLocalReadCacheWithTTL(cacheKey, append([]byte(nil), body...), CacheTTLs["query_range"])
 			}
 		}
 		cacheTap.Release()
@@ -2724,7 +2724,7 @@ func (p *Proxy) refreshLabelsCacheAsync(orgID, cacheKey, rawQuery, start, end, s
 			}
 			labels = p.labelTranslator.TranslateLabelsList(filtered)
 			labels = appendSyntheticLabels(labels)
-			p.cache.SetWithTTL(cacheKey, lokiLabelsResponse(labels), CacheTTLs["labels"])
+			p.setLocalReadCacheWithTTL(cacheKey, lokiLabelsResponse(labels), CacheTTLs["labels"])
 			return nil, nil
 		})
 		if err != nil {
@@ -2763,7 +2763,7 @@ func (p *Proxy) refreshLabelValuesCacheAsync(orgID, cacheKey, labelName, rawQuer
 					values = indexedValues
 				}
 			}
-			p.cache.SetWithTTL(cacheKey, lokiLabelsResponse(values), CacheTTLs["label_values"])
+			p.setLocalReadCacheWithTTL(cacheKey, lokiLabelsResponse(values), CacheTTLs["label_values"])
 			return nil, nil
 		})
 		if err != nil {
@@ -4160,7 +4160,18 @@ func (p *Proxy) setJSONCacheWithTTL(cacheKey string, ttl time.Duration, value in
 	if err != nil {
 		return
 	}
-	p.cache.SetWithTTL(cacheKey, encoded, ttl)
+	p.setLocalReadCacheWithTTL(cacheKey, encoded, ttl)
+}
+
+// setLocalReadCacheWithTTL stores response bodies for handlers that only read
+// cache entries via GetWithTTL, which is intentionally L1-only. Writing those
+// entries to disk or peer write-through adds churn without creating a fallback
+// path the handlers actually use.
+func (p *Proxy) setLocalReadCacheWithTTL(cacheKey string, value []byte, ttl time.Duration) {
+	if p == nil || p.cache == nil {
+		return
+	}
+	p.cache.SetLocalOnlyWithTTL(cacheKey, value, ttl)
 }
 
 func (p *Proxy) refreshDetectedFieldsCacheAsync(orgID, cacheKey, query, start, end string, lineLimit int) {
@@ -4346,7 +4357,7 @@ func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	labels = appendSyntheticLabels(labels)
 
 	result := lokiLabelsResponse(labels)
-	p.cache.SetWithTTL(cacheKey, result, CacheTTLs["labels"])
+	p.setLocalReadCacheWithTTL(cacheKey, result, CacheTTLs["labels"])
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(result)
 	p.metrics.RecordRequest("labels", http.StatusOK, time.Since(start))
@@ -4417,7 +4428,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	if p.labelValuesBrowseMode(rawQuery) {
 		if indexedValues, ok := p.selectLabelValuesFromIndex(orgID, labelName, search, offset, limit); ok {
 			result := lokiLabelsResponse(indexedValues)
-			p.cache.SetWithTTL(cacheKey, result, CacheTTLs["label_values"])
+			p.setLocalReadCacheWithTTL(cacheKey, result, CacheTTLs["label_values"])
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(result)
 			p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
@@ -4442,7 +4453,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		result := lokiLabelsResponse(values)
-		p.cache.SetWithTTL(cacheKey, result, CacheTTLs["label_values"])
+		p.setLocalReadCacheWithTTL(cacheKey, result, CacheTTLs["label_values"])
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(result)
 		p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
@@ -4469,7 +4480,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result := lokiLabelsResponse(values)
-	p.cache.SetWithTTL(cacheKey, result, CacheTTLs["label_values"])
+	p.setLocalReadCacheWithTTL(cacheKey, result, CacheTTLs["label_values"])
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(result)
 	p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))


### PR DESCRIPTION
## What changed
- keep full `query_range` response cache entries local to the serving pod
- keep label, label values, volume, and detected-* JSON response caches local as well
- add regressions proving these response caches skip L2 disk writes and peer write-through when the serving handler only reads through L1 `GetWithTTL`

## Why
Live Sand investigation on current `main` showed that peer-cache traffic is no longer the dominant source of churn, but several Explore and Drilldown response surfaces still write through shared cache layers even though their handlers only ever read those entries back from local memory.

That means the proxy was paying disk-write and peer-write costs for cache entries that did not provide any real fallback benefit. The strongest example is full `query_range` responses: the handler reads them via `GetWithTTL` (L1 only), but the success path still wrote them through the normal cache stack.

## Impact
- lower avoidable east-west traffic from peer write-through on high-cardinality Drilldown queries
- lower L2 disk churn for read surfaces that only use local cache reads
- no change to the fast-path local cache behavior those handlers already rely on

## Validation
- `go test ./internal/proxy -run 'Test(QueryRangeCache_StoresFullResponsesLocallyWhenPeerWriteThroughEnabled|LabelsCache_StoresResponsesLocallyWhenPeerWriteThroughEnabled|SetJSONCacheWithTTL_StoresResponsesLocally|QueryRangeWindow_FetchStoresCacheLocallyWhenPeerWriteThroughEnabled|QueryRangeWindowHitEstimate_CachesLocallyWhenPeerWriteThroughEnabled)'`
- `python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD`

## Root cause
The response-cache contract and the storage path had drifted apart. Several handlers had been upgraded to `GetWithTTL` because they need remaining TTL for local refresh behavior, but the corresponding write path still used the general distributed cache setter. That left us with L1-only read behavior on top of unnecessary L2/L3 write churn.
