### PR TITLE
fix: harden detected field values and peer cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/discovery: ignore zero-hit native `field_values` entries so detected field value pickers stop advertising values that are not actually present in the current selector and time window, and query-escape peer-cache GET/SET keys so discovery caches with embedded query strings survive peer transport correctly instead of truncating on `&`-style separators.
+
+### Tests
+
+- drilldown/cache: add regression coverage for zero-hit native detected field values and for peer-cache fetch/write-through round trips using realistic cache keys that include encoded query fragments.
+
 ## [1.9.2] - 2026-04-19
 
 ### Bug Fixes

--- a/internal/cache/peer.go
+++ b/internal/cache/peer.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -323,11 +324,11 @@ func (pc *PeerCache) Get(key string) ([]byte, time.Duration, bool) {
 	}()
 
 	// Fetch from owner
-	url := fmt.Sprintf("http://%s/_cache/get?key=%s", owner, key)
+	endpoint := fmt.Sprintf("http://%s/_cache/get?%s", owner, url.Values{"key": []string{key}}.Encode())
 	ctx, cancel := context.WithTimeout(context.Background(), pc.client.Timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		pc.recordPeerFailure(owner)
 		pc.RecordPeerErrorReason("request_build")
@@ -432,7 +433,14 @@ func (pc *PeerCache) pushToOwner(owner, key string, value []byte, ttl time.Durat
 	if ttl > 0 {
 		ttlMs = ttl.Milliseconds()
 	}
-	endpoint := fmt.Sprintf("http://%s/_cache/set?key=%s&ttl_ms=%d", owner, key, ttlMs)
+	endpoint := fmt.Sprintf(
+		"http://%s/_cache/set?%s",
+		owner,
+		url.Values{
+			"key":    []string{key},
+			"ttl_ms": []string{strconv.FormatInt(ttlMs, 10)},
+		}.Encode(),
+	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(value))
 	if err != nil {
 		pc.recordPeerFailure(owner)

--- a/internal/cache/peer_test.go
+++ b/internal/cache/peer_test.go
@@ -366,6 +366,46 @@ func TestPeerCache_FetchFromPeer(t *testing.T) {
 	t.Log("no key mapped to peer — acceptable for small hash ring")
 }
 
+func TestPeerCache_FetchFromPeer_EncodesCacheKey(t *testing.T) {
+	peerCache := New(60*time.Second, 1000)
+	defer peerCache.Close()
+
+	peerPC := NewPeerCache(PeerConfig{SelfAddr: "peer"})
+	defer peerPC.Close()
+
+	peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerPC.ServeHTTP(w, r, peerCache)
+	}))
+	defer peerServer.Close()
+
+	pc := NewPeerCache(PeerConfig{
+		SelfAddr:      "self:3100",
+		DiscoveryType: "static",
+		StaticPeers:   peerServer.Listener.Addr().String(),
+		Timeout:       2 * time.Second,
+	})
+	defer pc.Close()
+
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("labels:tenant-a:query={service_name=\"api\"}&start=1&end=2:%d", i)
+		peerCache.Set(key, []byte("peer-data"))
+
+		pc.mu.RLock()
+		owner := pc.ring.get(key)
+		pc.mu.RUnlock()
+
+		if owner != peerServer.Listener.Addr().String() {
+			continue
+		}
+		value, _, found := pc.Get(key)
+		if !found || string(value) != "peer-data" {
+			t.Fatalf("expected encoded peer hit for key %q, got found=%v value=%q", key, found, string(value))
+		}
+		return
+	}
+	t.Fatal("no key mapped to peer")
+}
+
 func TestPeerCache_Get_DecodesCompressedPeerPayload(t *testing.T) {
 	payload := []byte(strings.Repeat("peer-data", 128))
 	var badAcceptEncoding atomic.Value
@@ -916,6 +956,48 @@ func TestPeerCache_WriteThroughPushesToOwner(t *testing.T) {
 		}
 		stats := pc.Stats()
 		return stats["wt_pushes"].(int64) >= 1
+	})
+}
+
+func TestPeerCache_WriteThroughPushesEncodedCacheKeyToOwner(t *testing.T) {
+	ownerCache := NewWithMaxBytes(60*time.Second, 1000, 1024*1024)
+	defer ownerCache.Close()
+	ownerPC := NewPeerCache(PeerConfig{SelfAddr: "owner"})
+	defer ownerPC.Close()
+	ownerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ownerPC.ServeHTTP(w, r, ownerCache)
+	}))
+	defer ownerServer.Close()
+
+	pc := NewPeerCache(PeerConfig{
+		SelfAddr:           "self:3100",
+		DiscoveryType:      "static",
+		StaticPeers:        "self:3100," + ownerServer.Listener.Addr().String(),
+		Timeout:            500 * time.Millisecond,
+		WriteThrough:       true,
+		WriteThroughMinTTL: 5 * time.Second,
+	})
+	defer pc.Close()
+
+	var key string
+	for i := 0; i < 512; i++ {
+		candidate := fmt.Sprintf("detected_fields:tenant-a:{service_name=\"api\"}&start=1&end=2:%d", i)
+		pc.mu.RLock()
+		owner := pc.ring.get(candidate)
+		pc.mu.RUnlock()
+		if owner == ownerServer.Listener.Addr().String() {
+			key = candidate
+			break
+		}
+	}
+	if key == "" {
+		t.Fatal("failed to find key mapped to owner peer")
+	}
+
+	pc.SetWithTTL(key, []byte("value"), 30*time.Second)
+	requireEventually(t, 3*time.Second, func() bool {
+		got, ok := ownerCache.Get(key)
+		return ok && string(got) == "value"
 	})
 }
 

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -1574,6 +1574,9 @@ func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, f
 		}
 		values := make([]string, 0, len(parsed.Values))
 		for _, item := range parsed.Values {
+			if item.Hits <= 0 || strings.TrimSpace(item.Value) == "" {
+				continue
+			}
 			values = append(values, item.Value)
 		}
 		sort.Strings(values)

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -1246,6 +1246,61 @@ func TestDrilldown_DetectedFieldValues_ServiceNameUsesFastPath(t *testing.T) {
 	}
 }
 
+func TestDrilldown_DetectedFieldValues_IgnoreZeroHitNativeValues(t *testing.T) {
+	var sawFieldValues bool
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"shared_log_type","hits":4}]}`))
+		case "/select/logsql/field_values":
+			sawFieldValues = true
+			if got := r.URL.Query().Get("field"); got != "shared_log_type" {
+				t.Fatalf("expected shared_log_type lookup, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"values":[{"value":"access","hits":4},{"value":"common","hits":0}]}`))
+		case "/select/logsql/streams", "/select/logsql/query":
+			t.Fatalf("positive-hit native values should avoid fallback scans, got %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	c := cache.New(60*time.Second, 1000)
+	p, err := New(Config{
+		BackendURL: vlBackend.URL,
+		Cache:      c,
+		LogLevel:   "error",
+		LabelStyle: LabelStyleUnderscores,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("query", `{deployment_environment="dev",k8s_cluster_name="ops-sand"}`)
+	params.Set("start", "1")
+	params.Set("end", "2")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_field/shared_log_type/values?"+params.Encode(), nil)
+	p.handleDetectedFieldValues(w, r)
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	values, ok := resp["values"].([]interface{})
+	if !ok {
+		t.Fatalf("expected values array, got %v", resp)
+	}
+	if !sawFieldValues {
+		t.Fatalf("expected native field_values fast path to be used")
+	}
+	if len(values) != 1 || values[0].(string) != "access" {
+		t.Fatalf("expected only positive-hit native values, got %v", values)
+	}
+}
+
 func TestDetectedLabelValuesForField_ResolvesKnownUnderscoreAlias(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Summary
- ignore zero-hit native detected field values so Explore and Drilldown do not advertise values that are absent from the current selector/time window
- query-escape peer-cache GET/SET keys so cache entries with embedded query fragments survive peer transport intact
- add regressions for both the zero-hit field-values case and realistic peer-cache keys containing query separators

## Validation
- go test ./internal/cache
- go test ./internal/proxy -run 'Test(Drilldown_DetectedFieldValues_|DetectedFieldValues_|DetectedFields_|DetectedLabelValuesForField_)'
- python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD