### PR TITLE
fix: serve stale read data on backend errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- read-path/hardening: stop converting backend failures on Drilldown `detected_fields`, `detected_labels`, detected field values, `/index/volume`, and `/index/volume_range` into empty success payloads; these handlers now serve stale last-good cache entries when available and otherwise return real upstream-style errors, and volume helpers now reject non-success `/select/logsql/hits` responses instead of silently parsing them as empty data.
+
+### Tests
+
+- drilldown/cache: add regression coverage for stale-on-error recovery on detected fields, detected labels, detected field values, and near-now volume refreshes, plus cache coverage for reusing expired L1 entries as last-good fallback data.
+
 ## [1.9.5] - 2026-04-20
 
 ### Bug Fixes

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -148,6 +148,21 @@ func (c *Cache) GetWithTTL(key string) ([]byte, time.Duration, bool) {
 	return nil, 0, false
 }
 
+// GetStaleWithTTL returns a locally retained value even if its TTL has expired.
+// The returned TTL may be negative when the entry is stale. This never falls
+// back to L2/L3 because stale-on-error is only intended to reuse the serving
+// replica's last known-good payload.
+func (c *Cache) GetStaleWithTTL(key string) ([]byte, time.Duration, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	e, ok := c.entries[key]
+	if !ok {
+		return nil, 0, false
+	}
+	return e.value, time.Until(e.expiresAt), true
+}
+
 func (c *Cache) Get(key string) ([]byte, bool) {
 	c.mu.Lock()
 	e, ok := c.entries[key]

--- a/internal/cache/cache_coverage_test.go
+++ b/internal/cache/cache_coverage_test.go
@@ -48,6 +48,25 @@ func TestGetWithTTL_Miss(t *testing.T) {
 	}
 }
 
+func TestGetStaleWithTTL_ReturnsExpiredEntry(t *testing.T) {
+	c := NewWithMaxBytes(1*time.Millisecond, 100, 1024*1024)
+	defer c.Close()
+
+	c.Set("stale", []byte("payload"))
+	time.Sleep(5 * time.Millisecond)
+
+	val, ttl, ok := c.GetStaleWithTTL("stale")
+	if !ok {
+		t.Fatal("expected stale entry to be returned")
+	}
+	if string(val) != "payload" {
+		t.Fatalf("unexpected stale payload %q", string(val))
+	}
+	if ttl >= 0 {
+		t.Fatalf("expected negative remaining TTL for stale entry, got %v", ttl)
+	}
+}
+
 func TestCache_MaxEntrySizeBytes(t *testing.T) {
 	c := NewWithMaxBytes(10*time.Second, 100, 1000)
 	defer c.Close()

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -1301,6 +1301,123 @@ func TestDrilldown_DetectedFieldValues_IgnoreZeroHitNativeValues(t *testing.T) {
 	}
 }
 
+func TestDrilldown_DetectedFields_ServesStaleCacheOnBackendError(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	cacheKey := "detected_fields::query=%7Bservice_name%3D%22cached-svc%22%7D"
+	p.setJSONCacheWithTTL(cacheKey, time.Millisecond, map[string]interface{}{
+		"status": "success",
+		"data": []map[string]interface{}{
+			{"label": "cached_field", "type": "string", "cardinality": 1},
+		},
+		"fields": []map[string]interface{}{
+			{"label": "cached_field", "type": "string", "cardinality": 1},
+		},
+		"limit": 1000,
+	})
+	time.Sleep(5 * time.Millisecond)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_fields?query=%7Bservice_name%3D%22cached-svc%22%7D", nil)
+	p.handleDetectedFields(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected stale cached detected_fields response, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	fields := resp["fields"].([]interface{})
+	if len(fields) != 1 || fields[0].(map[string]interface{})["label"] != "cached_field" {
+		t.Fatalf("expected stale cached detected_fields payload, got %v", resp)
+	}
+}
+
+func TestDrilldown_DetectedFields_ReturnsErrorWithoutCacheOnBackendFailure(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_fields?query=%7Bservice_name%3D%22svc%22%7D", nil)
+	p.handleDetectedFields(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 when detected_fields has no cache fallback, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestDrilldown_DetectedLabels_ServesStaleCacheOnBackendError(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	cacheKey := "detected_labels::query=%7Bk8s_cluster_name%3D%22ops-sand%22%7D"
+	p.setJSONCacheWithTTL(cacheKey, time.Millisecond, map[string]interface{}{
+		"status": "success",
+		"data": []map[string]interface{}{
+			{"label": "service_name", "cardinality": 1},
+		},
+		"detectedLabels": []map[string]interface{}{
+			{"label": "service_name", "cardinality": 1},
+		},
+		"limit": 1000,
+	})
+	time.Sleep(5 * time.Millisecond)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_labels?query=%7Bk8s_cluster_name%3D%22ops-sand%22%7D", nil)
+	p.handleDetectedLabels(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected stale cached detected_labels response, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	items := resp["detectedLabels"].([]interface{})
+	if len(items) != 1 || items[0].(map[string]interface{})["label"] != "service_name" {
+		t.Fatalf("expected stale cached detected_labels payload, got %v", resp)
+	}
+}
+
+func TestDrilldown_DetectedFieldValues_ServesStaleCacheOnBackendError(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	cacheKey := "detected_field_values::service_name:query=%7Bservice_name%3D%22cached-svc%22%7D"
+	p.setJSONCacheWithTTL(cacheKey, time.Millisecond, map[string]interface{}{
+		"status": "success",
+		"data":   []string{"cached-svc"},
+		"values": []string{"cached-svc"},
+		"limit":  1000,
+	})
+	time.Sleep(5 * time.Millisecond)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_field/service_name/values?query=%7Bservice_name%3D%22cached-svc%22%7D", nil)
+	p.handleDetectedFieldValues(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected stale cached detected_field_values response, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	values := resp["values"].([]interface{})
+	if len(values) != 1 || values[0].(string) != "cached-svc" {
+		t.Fatalf("expected stale cached detected_field_values payload, got %v", resp)
+	}
+}
+
 func TestDetectedLabelValuesForField_ResolvesKnownUnderscoreAlias(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/proxy/perf_hardening_test.go
+++ b/internal/proxy/perf_hardening_test.go
@@ -89,7 +89,7 @@ func TestHandleDetectedLabelsReuseCachedScan(t *testing.T) {
 	}
 }
 
-func TestHandleDetectedLabels_BackendErrorReturnsEmptySuccess(t *testing.T) {
+func TestHandleDetectedLabels_BackendErrorReturnsGatewayError(t *testing.T) {
 	backend := httptest.NewServer(http.NotFoundHandler())
 	backendURL := backend.URL
 	backend.Close()
@@ -100,20 +100,8 @@ func TestHandleDetectedLabels_BackendErrorReturnsEmptySuccess(t *testing.T) {
 
 	p.handleDetectedLabels(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
-	var resp struct {
-		Status         string        `json:"status"`
-		Data           []interface{} `json:"data"`
-		DetectedLabels []interface{} `json:"detectedLabels"`
-		Limit          int           `json:"limit"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if resp.Status != "success" || len(resp.Data) != 0 || len(resp.DetectedLabels) != 0 || resp.Limit != 17 {
-		t.Fatalf("expected empty detected_labels success response, got %#v", resp)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
@@ -144,8 +132,8 @@ func TestHandleDetectedLabels_DoesNotCacheTransientErrorFallback(t *testing.T) {
 	w1 := httptest.NewRecorder()
 	r1 := httptest.NewRequest(http.MethodGet, reqPath, nil)
 	p.handleDetectedLabels(w1, r1)
-	if w1.Code != http.StatusOK {
-		t.Fatalf("first call expected 200, got %d body=%s", w1.Code, w1.Body.String())
+	if w1.Code != http.StatusBadGateway {
+		t.Fatalf("first call expected 502, got %d body=%s", w1.Code, w1.Body.String())
 	}
 
 	fail.Store(false)
@@ -208,8 +196,8 @@ func TestHandleDetectedFields_DoesNotCacheTransientErrorFallback(t *testing.T) {
 	w1 := httptest.NewRecorder()
 	r1 := httptest.NewRequest(http.MethodGet, reqPath, nil)
 	p.handleDetectedFields(w1, r1)
-	if w1.Code != http.StatusOK {
-		t.Fatalf("first call expected 200, got %d body=%s", w1.Code, w1.Body.String())
+	if w1.Code != http.StatusBadGateway {
+		t.Fatalf("first call expected 502, got %d body=%s", w1.Code, w1.Body.String())
 	}
 
 	fail.Store(false)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4271,6 +4271,39 @@ func (p *Proxy) setLocalReadCacheWithTTL(cacheKey string, value []byte, ttl time
 	p.cache.SetLocalOnlyWithTTL(cacheKey, value, ttl)
 }
 
+func (p *Proxy) staleReadCacheEntry(cacheKey string) ([]byte, time.Duration, bool) {
+	if p == nil || p.cache == nil || strings.TrimSpace(cacheKey) == "" {
+		return nil, 0, false
+	}
+	return p.cache.GetStaleWithTTL(cacheKey)
+}
+
+func (p *Proxy) serveStaleReadCacheOnError(w http.ResponseWriter, endpoint, cacheKey string, started time.Time, err error) bool {
+	body, remaining, ok := p.staleReadCacheEntry(cacheKey)
+	if !ok || len(body) == 0 {
+		return false
+	}
+	if strings.TrimSpace(w.Header().Get("Content-Type")) == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	_, _ = w.Write(body)
+	if p.metrics != nil {
+		p.metrics.RecordRequest(endpoint, http.StatusOK, time.Since(started))
+	}
+	staleFor := time.Duration(0)
+	if remaining < 0 {
+		staleFor = -remaining
+	}
+	p.log.Warn(
+		"serving stale cached response after backend failure",
+		"endpoint", endpoint,
+		"cache_key", cacheKey,
+		"stale_for", staleFor.String(),
+		"error", err,
+	)
+	return true
+}
+
 func (p *Proxy) refreshDetectedFieldsCacheAsync(orgID, cacheKey, query, start, end string, lineLimit int) {
 	refreshKey := "refresh:detected_fields:" + cacheKey
 	go func() {
@@ -4807,10 +4840,13 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 
 	result, err := p.computeVolumeResult(r.Context(), query, startParam, endParam, targetLabels)
 	if err != nil {
-		result = map[string]interface{}{
-			"status": "success",
-			"data":   map[string]interface{}{"resultType": "vector", "result": []interface{}{}},
+		if p.serveStaleReadCacheOnError(w, "volume", cacheKey, start, err) {
+			return
 		}
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("volume", status, time.Since(start))
+		return
 	}
 	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["volume"], result)
 	p.writeJSON(w, result)
@@ -4860,6 +4896,13 @@ func (p *Proxy) computeVolumeResult(ctx context.Context, query, start, end, targ
 	}
 	defer resp.Body.Close()
 	body, _ := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
 
 	return p.hitsToVolumeVector(body), nil
 }
@@ -4917,10 +4960,13 @@ func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 
 	result, err := p.computeVolumeRangeResult(r.Context(), query, startParam, endParam, stepParam, targetLabels)
 	if err != nil {
-		result = map[string]interface{}{
-			"status": "success",
-			"data":   map[string]interface{}{"resultType": "matrix", "result": []interface{}{}},
+		if p.serveStaleReadCacheOnError(w, "volume_range", cacheKey, start, err) {
+			return
 		}
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("volume_range", status, time.Since(start))
+		return
 	}
 	p.setJSONCacheWithTTL(cacheKey, CacheTTLs["volume_range"], result)
 	p.writeJSON(w, result)
@@ -4969,6 +5015,13 @@ func (p *Proxy) computeVolumeRangeResult(ctx context.Context, query, start, end,
 	}
 	defer resp.Body.Close()
 	body, _ := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
 
 	return p.hitsToVolumeMatrix(body, start, end, step), nil
 }
@@ -5018,14 +5071,12 @@ func (p *Proxy) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	lineLimit := parseDetectedLineLimit(r)
 	fields, _, err := p.detectFields(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
 	if err != nil {
-		payload := map[string]interface{}{
-			"status": "success",
-			"data":   []interface{}{},
-			"fields": []interface{}{},
-			"limit":  lineLimit,
+		if p.serveStaleReadCacheOnError(w, "detected_fields", cacheKey, start, err) {
+			return
 		}
-		p.writeJSON(w, payload)
-		p.metrics.RecordRequest("detected_fields", http.StatusOK, time.Since(start))
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("detected_fields", status, time.Since(start))
 		return
 	}
 	payload := map[string]interface{}{
@@ -5095,14 +5146,12 @@ func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request
 
 	values, err := p.resolveDetectedFieldValues(r.Context(), fieldName, r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit, true)
 	if err != nil {
-		payload := map[string]interface{}{
-			"status": "success",
-			"data":   []string{},
-			"values": []string{},
-			"limit":  lineLimit,
+		if p.serveStaleReadCacheOnError(w, "detected_field_values", cacheKey, start, err) {
+			return
 		}
-		p.writeJSON(w, payload)
-		p.metrics.RecordRequest("detected_field_values", http.StatusOK, time.Since(start))
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("detected_field_values", status, time.Since(start))
 		return
 	}
 
@@ -6478,14 +6527,12 @@ func (p *Proxy) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
 	lineLimit := parseDetectedLineLimit(r)
 	detectedLabels, _, err := p.detectLabels(r.Context(), r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), lineLimit)
 	if err != nil {
-		payload := map[string]interface{}{
-			"status":         "success",
-			"data":           []interface{}{},
-			"detectedLabels": []interface{}{},
-			"limit":          lineLimit,
+		if p.serveStaleReadCacheOnError(w, "detected_labels", cacheKey, start, err) {
+			return
 		}
-		p.writeJSON(w, payload)
-		p.metrics.RecordRequest("detected_labels", http.StatusOK, time.Since(start))
+		status := statusFromUpstreamErr(err)
+		p.writeError(w, status, err.Error())
+		p.metrics.RecordRequest("detected_labels", status, time.Since(start))
 		return
 	}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -731,7 +731,12 @@ func TestContract_IndexStats_ResponseFormat(t *testing.T) {
 // --- /loki/api/v1/index/volume ---
 
 func TestContract_Volume_ResponseFormat(t *testing.T) {
-	p := newTestProxy(t, "http://unused")
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hits":[{"fields":{"service.name":"api"},"timestamps":["2026-01-01T00:00:00Z"],"values":[3]}]}`))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume?query=%7B%7D&start=1&end=2", nil)
 	p.handleVolume(w, r)
@@ -750,7 +755,12 @@ func TestContract_Volume_ResponseFormat(t *testing.T) {
 // --- /loki/api/v1/index/volume_range ---
 
 func TestContract_VolumeRange_ResponseFormat(t *testing.T) {
-	p := newTestProxy(t, "http://unused")
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hits":[{"fields":{"service.name":"api"},"timestamps":["2026-01-01T00:00:00Z"],"values":[3]}]}`))
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume_range?query=%7B%7D&start=1&end=2&step=60", nil)
 	p.handleVolumeRange(w, r)
@@ -1816,6 +1826,67 @@ func TestContract_Volume_BypassesNearNowStaleCache(t *testing.T) {
 	p.handleVolume(w2, httptest.NewRequest("GET", uri, nil))
 	if backendCalls < 2 {
 		t.Fatalf("expected stale near-now cache to be bypassed, backend calls=%d", backendCalls)
+	}
+}
+
+func TestContract_Volume_ServesStaleCacheWhenNearNowRefreshFails(t *testing.T) {
+	var backendCalls int
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls++
+		if backendCalls == 1 {
+			_, _ = w.Write([]byte(`{"hits":[{"fields":{"service.name":"api"},"timestamps":["2026-01-01T00:00:00Z"],"values":[3]}]}`))
+			return
+		}
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+	p.recentTailRefreshEnabled = true
+	p.recentTailRefreshWindow = time.Hour
+	p.recentTailRefreshMaxStaleness = time.Nanosecond
+
+	uri := "/loki/api/v1/index/volume?query=%7Bapp%3D%22api%22%7D&end=now"
+	w1 := httptest.NewRecorder()
+	p.handleVolume(w1, httptest.NewRequest("GET", uri, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("expected first volume call to succeed, got %d body=%s", w1.Code, w1.Body.String())
+	}
+	var firstResp map[string]interface{}
+	mustUnmarshal(t, w1.Body.Bytes(), &firstResp)
+
+	time.Sleep(2 * time.Millisecond)
+
+	w2 := httptest.NewRecorder()
+	p.handleVolume(w2, httptest.NewRequest("GET", uri, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected stale cached volume response, got %d body=%s", w2.Code, w2.Body.String())
+	}
+	var secondResp map[string]interface{}
+	mustUnmarshal(t, w2.Body.Bytes(), &secondResp)
+	if !reflect.DeepEqual(firstResp, secondResp) {
+		t.Fatalf("expected stale volume response %#v, got %#v", firstResp, secondResp)
+	}
+	if backendCalls != 2 {
+		t.Fatalf("expected refresh attempt to still hit backend, got %d calls", backendCalls)
+	}
+}
+
+func TestContract_Volume_ReturnsGatewayErrorWithoutCacheOnBackendFailure(t *testing.T) {
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusBadGateway)
+	}))
+	defer vlBackend.Close()
+
+	p := newTestProxy(t, vlBackend.URL)
+
+	w := httptest.NewRecorder()
+	p.handleVolume(w, httptest.NewRequest("GET", "/loki/api/v1/index/volume?query=%7Bapp%3D%22api%22%7D&end=now", nil))
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 without cached volume fallback, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), "backend unavailable") {
+		t.Fatalf("expected backend error message, got %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop masking backend failures for detected fields, detected labels, detected field values, volume, and volume range as empty successful responses
- serve stale last-good local cache data for these read surfaces when a backend refresh fails, and otherwise return a real upstream-style error
- honor non-success /select/logsql/hits responses in the volume helpers and add regressions for Sand-shaped no-data-after-refresh failures

## Validation
- go test ./internal/cache
- go test ./internal/proxy -run "Test(Drilldown_Detected(Fields|Labels|FieldValues)_|Contract_Volume(ResponseFormat|Range_ResponseFormat|_BypassesNearNowStaleCache|_ServesStaleCacheWhenNearNowRefreshFails|_ReturnsGatewayErrorWithoutCacheOnBackendFailure))"
- go test ./internal/proxy