### PR TITLE
proxy: normalize wrapped Loki responses when resultType is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - chart/helm: quote rendered container args in the chart deployment template so values containing JSON, commas, colons, or embedded delimiters survive Helm rendering unchanged instead of being split or reinterpreted by YAML parsing.
+- proxy/wrapping: normalize wrapped stats responses to always include Loki `data.resultType` and `data.result` (including fallback mapping from legacy/top-level `results`) so Grafana Loki datasource queries no longer fail with `no resultType found` when backend payloads omit result metadata.
 
 ### Tests
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9582,19 +9582,51 @@ func wrapAsLokiResponse(vlBody []byte, resultType string) []byte {
 	}
 
 	// If VL already returned status/data format, pass through
-	if _, ok := promResp["data"]; ok {
+	if rawData, ok := promResp["data"]; ok {
+		if dataMap, ok := rawData.(map[string]interface{}); ok {
+			normalizeLokiResultDataShape(dataMap, resultType)
+			result, _ := json.Marshal(map[string]interface{}{
+				"status": "success",
+				"data":   dataMap,
+			})
+			return result
+		}
 		result, _ := json.Marshal(map[string]interface{}{
 			"status": "success",
-			"data":   promResp["data"],
+			"data": map[string]interface{}{
+				"resultType": resultType,
+				"result":     []interface{}{},
+			},
 		})
 		return result
 	}
+
+	normalizeLokiResultDataShape(promResp, resultType)
 
 	result, _ := json.Marshal(map[string]interface{}{
 		"status": "success",
 		"data":   promResp,
 	})
 	return result
+}
+
+func normalizeLokiResultDataShape(data map[string]interface{}, defaultResultType string) {
+	if data == nil {
+		return
+	}
+
+	if _, hasResult := data["result"]; !hasResult {
+		if rawResults, ok := data["results"]; ok {
+			data["result"] = rawResults
+		} else {
+			data["result"] = []interface{}{}
+		}
+	}
+
+	currentResultType, _ := data["resultType"].(string)
+	if strings.TrimSpace(currentResultType) == "" && strings.TrimSpace(defaultResultType) != "" {
+		data["resultType"] = defaultResultType
+	}
 }
 
 // --- VL hits response conversion helpers ---

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -3875,6 +3875,58 @@ func TestContract_WrapAsLokiResponse_VLStatusError(t *testing.T) {
 	}
 }
 
+func TestContract_WrapAsLokiResponse_FillsMissingResultTypeFromContext(t *testing.T) {
+	// Some backend variants omit data.resultType on empty or degraded stats responses.
+	vlBody := []byte(`{"status":"success","data":{"result":[{"metric":{"service_name":"api"},"values":[[1705312200,"1"]]}]}}`)
+	result := wrapAsLokiResponse(vlBody, "matrix")
+
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string            `json:"resultType"`
+			Result     []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("decode wrapped response: %v body=%s", err, string(result))
+	}
+	if resp.Status != "success" {
+		t.Fatalf("expected status=success, got %q", resp.Status)
+	}
+	if resp.Data.ResultType != "matrix" {
+		t.Fatalf("expected fallback resultType=matrix, got %q", resp.Data.ResultType)
+	}
+	if len(resp.Data.Result) != 1 {
+		t.Fatalf("expected one series in result, got %d", len(resp.Data.Result))
+	}
+}
+
+func TestContract_WrapAsLokiResponse_NormalizesTopLevelResultsKey(t *testing.T) {
+	// Older/raw payloads can use "results" instead of Loki's "result".
+	vlBody := []byte(`{"results":[{"metric":{"service_name":"api"},"values":[[1705312200,"1"]]}]}`)
+	result := wrapAsLokiResponse(vlBody, "matrix")
+
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string            `json:"resultType"`
+			Result     []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("decode wrapped response: %v body=%s", err, string(result))
+	}
+	if resp.Status != "success" {
+		t.Fatalf("expected status=success, got %q", resp.Status)
+	}
+	if resp.Data.ResultType != "matrix" {
+		t.Fatalf("expected fallback resultType=matrix, got %q", resp.Data.ResultType)
+	}
+	if len(resp.Data.Result) != 1 {
+		t.Fatalf("expected one series in result, got %d", len(resp.Data.Result))
+	}
+}
+
 func TestContract_Query_MetricsRecordActualStatus(t *testing.T) {
 	// Backend returns 502
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
This fixes intermittent Grafana Loki datasource failures reporting `no resultType found` in Logs Drilldown.

Root cause was `wrapAsLokiResponse` passing backend payloads through even when `data.resultType` was missing (or when payloads used top-level `results`). Grafana's Loki plugin then failed to decode those responses.

## Changes
- normalize wrapped payloads to always provide Loki `data.resultType` (fallback from call context)
- ensure Loki `data.result` exists (fallback empty array)
- map top-level `results` into Loki `result` while keeping legacy `results` for compatibility
- add regression tests for both payload shapes

## Validation
- `go test ./internal/proxy -count=1`
- manual Grafana reproduction showed failing datasource query responses with `error: no resultType found` from plugin
