### PR TITLE
fix(drilldown): stop injecting unknown_service for non-service volume grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - drilldown/volume: stop injecting synthetic `service_name="unknown_service"` into `index/volume` and `index/volume_range` buckets when requests are grouped by non-service labels (for example `cluster`), while preserving service-aware grouping behavior.
 - drilldown/volume: honor Drilldown grouping hints (`drillDownLabel`, `fieldBy`, and `var-fieldBy`) as target-label fallbacks when `targetLabels` is omitted, so field/label include-exclude actions keep grouping on the selected dimension instead of falling back to selector-order inference.
+- translator/metrics: make `bytes_over_time` and `bytes_rate` emit VictoriaLogs-compatible byte aggregations via `sum_len(_msg)` (with proxy-side window-second normalization for rate), and implement `stdvar_over_time` via proxy-side `stddev^2` composition to avoid backend `stdvar` parser failures.
+- proxy/binary-metrics: fix scalar and binary post-processing to mutate both legacy `results` payloads and Prometheus-style `data.result` payloads (including instant-vector `value` samples), preventing silent no-op arithmetic on valid `stats_query` responses.
 
 ### Tests
 
 - drilldown/volume: add regression coverage for inferred non-service target labels (no synthetic `unknown_service`) and for Drilldown `fieldBy` fallback mapping on both vector and matrix volume endpoints.
+- compat/matrix: add operation/filter/function matrix coverage across translator and proxy scalar paths, with deterministic e2e checks for binary scalar operators, filter operators, and metric function families (cross-engine parity for compatible functions plus proxy-local expected-value checks where semantics intentionally differ), and add scalar/binary fuzz coverage for response-shape robustness.
 
 ## [1.9.5] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- drilldown/volume: stop injecting synthetic `service_name="unknown_service"` into `index/volume` and `index/volume_range` buckets when requests are grouped by non-service labels (for example `cluster`), while preserving service-aware grouping behavior.
+
+### Tests
+
+- drilldown/volume: add regression coverage that inferred non-service target labels do not emit synthetic `unknown_service` buckets for both vector and matrix volume endpoints.
+
 ## [1.9.5] - 2026-04-20
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - drilldown/volume: stop injecting synthetic `service_name="unknown_service"` into `index/volume` and `index/volume_range` buckets when requests are grouped by non-service labels (for example `cluster`), while preserving service-aware grouping behavior.
+- drilldown/volume: honor Drilldown grouping hints (`drillDownLabel`, `fieldBy`, and `var-fieldBy`) as target-label fallbacks when `targetLabels` is omitted, so field/label include-exclude actions keep grouping on the selected dimension instead of falling back to selector-order inference.
 
 ### Tests
 
-- drilldown/volume: add regression coverage that inferred non-service target labels do not emit synthetic `unknown_service` buckets for both vector and matrix volume endpoints.
+- drilldown/volume: add regression coverage for inferred non-service target labels (no synthetic `unknown_service`) and for Drilldown `fieldBy` fallback mapping on both vector and matrix volume endpoints.
 
 ## [1.9.5] - 2026-04-20
 

--- a/docs/translation-reference.md
+++ b/docs/translation-reference.md
@@ -73,10 +73,10 @@ These stages are executed at the proxy level (VL has no native equivalents):
 
 | LogQL | LogsQL |
 |---|---|
-| `rate({...}[5m])` | `... \| stats rate()` |
+| `rate({...}[5m])` | `stats count()` + `math` normalization by window seconds, then `stats sum(...)` per grouping |
 | `count_over_time({...}[5m])` | `... \| stats count()` |
 | `bytes_over_time({...}[5m])` | `... \| stats sum_len(_msg)` |
-| `bytes_rate({...}[5m])` | proxy binary expression: `(... \| stats sum_len(_msg)) / window_seconds` |
+| `bytes_rate({...}[5m])` | `stats sum_len(_msg)` + `math` normalization by window seconds, then `stats sum(...)` per grouping |
 | `sum_over_time({...} \| unwrap f [5m])` | `... \| stats sum(f)` |
 | `avg_over_time({...} \| unwrap f [5m])` | `... \| stats avg(f)` |
 | `max_over_time({...} \| unwrap f [5m])` | `... \| stats max(f)` |
@@ -92,10 +92,10 @@ These stages are executed at the proxy level (VL has no native equivalents):
 
 | LogQL | LogsQL |
 |---|---|
-| `sum(rate({...}[5m]))` | `... \| stats rate()` |
-| `sum(rate({...}[5m])) by (x)` | `... \| stats by (x) rate()` |
-| `avg(rate({...}[5m])) by (x)` | `... \| stats by (x) rate()` |
-| `topk(10, rate({...}[5m]))` | `... \| stats rate()` |
+| `sum(rate({...}[5m]))` | normalized per-stream/per-group rate, then proxy applies outer aggregation where supported |
+| `sum(rate({...}[5m])) by (x)` | `... \| stats by (x) count() as __lvp_inner \| math __lvp_inner/window as __lvp_rate \| stats by (x) sum(__lvp_rate)` |
+| `avg(rate({...}[5m])) by (x)` | same normalized-rate path grouped by `(x)` |
+| `topk(10, rate({...}[5m]))` | normalized-rate path with stream grouping; top-level selection remains simplified |
 
 Supported: `sum`, `avg`, `max`, `min`, `count`, `topk`, `bottomk`, `stddev`, `stdvar`, `sort`, `sort_desc`.
 

--- a/docs/translation-reference.md
+++ b/docs/translation-reference.md
@@ -75,8 +75,8 @@ These stages are executed at the proxy level (VL has no native equivalents):
 |---|---|
 | `rate({...}[5m])` | `... \| stats rate()` |
 | `count_over_time({...}[5m])` | `... \| stats count()` |
-| `bytes_over_time({...}[5m])` | `... \| stats sum(len(_msg))` |
-| `bytes_rate({...}[5m])` | `... \| stats rate_sum(len(_msg))` |
+| `bytes_over_time({...}[5m])` | `... \| stats sum_len(_msg)` |
+| `bytes_rate({...}[5m])` | proxy binary expression: `(... \| stats sum_len(_msg)) / window_seconds` |
 | `sum_over_time({...} \| unwrap f [5m])` | `... \| stats sum(f)` |
 | `avg_over_time({...} \| unwrap f [5m])` | `... \| stats avg(f)` |
 | `max_over_time({...} \| unwrap f [5m])` | `... \| stats max(f)` |
@@ -84,7 +84,7 @@ These stages are executed at the proxy level (VL has no native equivalents):
 | `first_over_time({...} \| unwrap f [5m])` | `... \| stats first(f)` |
 | `last_over_time({...} \| unwrap f [5m])` | `... \| stats last(f)` |
 | `stddev_over_time({...} \| unwrap f [5m])` | `... \| stats stddev(f)` |
-| `stdvar_over_time({...} \| unwrap f [5m])` | `... \| stats stdvar(f)` |
+| `stdvar_over_time({...} \| unwrap f [5m])` | proxy binary expression: `(... \| stats stddev(f)) ^ 2` |
 | `quantile_over_time(0.95, {...} \| unwrap f [5m])` | `... \| stats quantile(0.95, f)` |
 | `absent_over_time({...}[5m])` | `... \| stats count()` |
 

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -407,6 +407,12 @@ func TestDrilldown_IndexVolume_InfersPrimaryTargetLabelForAdditionalTabs(t *test
 	if len(result) != 2 {
 		t.Fatalf("expected cluster buckets, got %v", result)
 	}
+	for _, item := range result {
+		metric := item.(map[string]interface{})["metric"].(map[string]interface{})
+		if _, ok := metric["service_name"]; ok {
+			t.Fatalf("expected inferred cluster volume metrics to omit synthetic unknown service_name, got %v", metric)
+		}
+	}
 }
 
 func TestDrilldown_IndexVolume_TranslatesInferredTargetLabelMetrics(t *testing.T) {
@@ -458,6 +464,48 @@ func TestDrilldown_IndexVolume_TranslatesInferredTargetLabelMetrics(t *testing.T
 	metric := result[0].(map[string]interface{})["metric"].(map[string]interface{})
 	if metric["k8s_pod_name"] != "api-1" {
 		t.Fatalf("expected translated metric key k8s_pod_name, got %v", metric)
+	}
+}
+
+func TestDrilldown_IndexVolumeRange_InfersPrimaryTargetLabelWithoutUnknownService(t *testing.T) {
+	var receivedField string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		receivedField = r.URL.Query().Get("field")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hints": map[string]interface{}{},
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"cluster": "us-east-1"},
+					"timestamps": []string{"2026-04-04T17:18:49Z"},
+					"values":     []int{12},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/loki/api/v1/index/volume_range?query=%7Bcluster%3D~%60.%2B%60%7D&start=1&end=2&step=60", nil)
+	p.handleVolumeRange(w, r)
+
+	if receivedField != "cluster" {
+		t.Fatalf("expected inferred volume_range field=cluster, got %q", receivedField)
+	}
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := assertDataIsObject(t, resp)
+	result := assertResultIsArray(t, data)
+	if len(result) != 1 {
+		t.Fatalf("expected one cluster series, got %v", result)
+	}
+	metric := result[0].(map[string]interface{})["metric"].(map[string]interface{})
+	if _, ok := metric["service_name"]; ok {
+		t.Fatalf("expected inferred cluster volume_range metric to omit synthetic unknown service_name, got %v", metric)
 	}
 }
 

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -467,6 +467,52 @@ func TestDrilldown_IndexVolume_TranslatesInferredTargetLabelMetrics(t *testing.T
 	}
 }
 
+func TestDrilldown_IndexVolume_UsesDrilldownFieldByFallbackForTargetLabels(t *testing.T) {
+	var receivedField string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		receivedField = r.URL.Query().Get("field")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hints": map[string]interface{}{},
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"method": "GET"},
+					"timestamps": []string{"2026-04-04T17:18:49Z"},
+					"values":     []int{4},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		"GET",
+		"/loki/api/v1/index/volume?query=%7Bcluster%3D~%60.%2B%60%7D&start=1&end=2&var-fieldBy=method&drillDownLabel=method",
+		nil,
+	)
+	p.handleVolume(w, r)
+
+	if receivedField != "method" {
+		t.Fatalf("expected drilldown fieldBy fallback to drive target label mapping, got %q", receivedField)
+	}
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := assertDataIsObject(t, resp)
+	result := assertResultIsArray(t, data)
+	if len(result) != 1 {
+		t.Fatalf("expected one method bucket, got %v", result)
+	}
+	metric := result[0].(map[string]interface{})["metric"].(map[string]interface{})
+	if metric["method"] != "GET" {
+		t.Fatalf("expected method grouping bucket in metric, got %v", metric)
+	}
+}
+
 func TestDrilldown_IndexVolumeRange_InfersPrimaryTargetLabelWithoutUnknownService(t *testing.T) {
 	var receivedField string
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -506,6 +552,52 @@ func TestDrilldown_IndexVolumeRange_InfersPrimaryTargetLabelWithoutUnknownServic
 	metric := result[0].(map[string]interface{})["metric"].(map[string]interface{})
 	if _, ok := metric["service_name"]; ok {
 		t.Fatalf("expected inferred cluster volume_range metric to omit synthetic unknown service_name, got %v", metric)
+	}
+}
+
+func TestDrilldown_IndexVolumeRange_UsesDrilldownFieldByFallbackForTargetLabels(t *testing.T) {
+	var receivedField string
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		receivedField = r.URL.Query().Get("field")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"hints": map[string]interface{}{},
+			"hits": []map[string]interface{}{
+				{
+					"fields":     map[string]string{"method": "POST"},
+					"timestamps": []string{"2026-04-04T17:18:49Z"},
+					"values":     []int{6},
+				},
+			},
+		})
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(
+		"GET",
+		"/loki/api/v1/index/volume_range?query=%7Bcluster%3D~%60.%2B%60%7D&start=1&end=2&step=60&var-fieldBy=method&drillDownLabel=method",
+		nil,
+	)
+	p.handleVolumeRange(w, r)
+
+	if receivedField != "method" {
+		t.Fatalf("expected drilldown fieldBy fallback to drive volume_range target label mapping, got %q", receivedField)
+	}
+
+	var resp map[string]interface{}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	data := assertDataIsObject(t, resp)
+	result := assertResultIsArray(t, data)
+	if len(result) != 1 {
+		t.Fatalf("expected one method series, got %v", result)
+	}
+	metric := result[0].(map[string]interface{})["metric"].(map[string]interface{})
+	if metric["method"] != "POST" {
+		t.Fatalf("expected method grouping series in volume_range metric, got %v", metric)
 	}
 }
 

--- a/internal/proxy/fuzz_test.go
+++ b/internal/proxy/fuzz_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -145,6 +147,55 @@ func FuzzNormalizeMetadataPairs(f *testing.F) {
 			if key == "" {
 				t.Fatalf("normalizeMetadataPairs produced empty key for input=%q", string(input))
 			}
+		}
+	})
+}
+
+// FuzzCombineBinaryMetricResultsScalarPath validates scalar/vector merge shaping for all operators.
+func FuzzCombineBinaryMetricResultsScalarPath(f *testing.F) {
+	ops := []string{"+", "-", "*", "/", "%", "^", "==", "!=", ">", "<", ">=", "<=", "unknown"}
+	for _, op := range ops {
+		f.Add(op, 10.0, 3.0, false, true)
+		f.Add(op, 10.0, 3.0, true, false)
+		f.Add(op, 10.0, 3.0, false, false)
+	}
+
+	f.Fuzz(func(t *testing.T, op string, metricValue, scalarValue float64, leftScalar, rightScalar bool) {
+		if !isFinite(metricValue) || !isFinite(scalarValue) {
+			return
+		}
+
+		metricBody := []byte(fmt.Sprintf(
+			`{"results":[{"metric":{"app":"fuzz"},"values":[[1,"%s"]]}]}`,
+			strconv.FormatFloat(metricValue, 'f', -1, 64),
+		))
+		scalarBody := []byte(fmt.Sprintf(
+			`{"status":"success","data":{"resultType":"scalar","result":[0,"%s"]}}`,
+			strconv.FormatFloat(scalarValue, 'f', -1, 64),
+		))
+
+		leftBody := metricBody
+		rightBody := metricBody
+		leftQL := ""
+		rightQL := ""
+
+		if leftScalar {
+			leftBody = scalarBody
+			leftQL = strconv.FormatFloat(scalarValue, 'f', -1, 64)
+		}
+		if rightScalar {
+			rightBody = scalarBody
+			rightQL = strconv.FormatFloat(scalarValue, 'f', -1, 64)
+		}
+
+		out := combineBinaryMetricResults(leftBody, rightBody, op, "matrix", leftScalar, rightScalar, leftQL, rightQL)
+		var payload map[string]interface{}
+		if err := json.Unmarshal(out, &payload); err != nil {
+			t.Fatalf("combined output must stay valid JSON: %v; body=%s", err, string(out))
+		}
+		status, _ := payload["status"].(string)
+		if status == "" {
+			t.Fatalf("combined output missing status field: %#v", payload)
 		}
 	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9509,7 +9509,17 @@ func (p *Proxy) translateVolumeMetric(fields map[string]string) map[string]strin
 	if translated == nil {
 		return nil
 	}
+	serviceSignal := false
+	for _, key := range serviceNameSourceFields {
+		if strings.TrimSpace(translated[key]) != "" {
+			serviceSignal = true
+			break
+		}
+	}
 	ensureSyntheticServiceName(translated)
+	if !serviceSignal && strings.TrimSpace(translated["service_name"]) == unknownServiceName {
+		delete(translated, "service_name")
+	}
 	return translated
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8367,21 +8367,10 @@ func applyScalarOp(body []byte, op string, scalar float64, resultType string) []
 		return wrapAsLokiResponse(body, resultType)
 	}
 
-	// VL stats_query_range returns {"results": [{"metric":{}, "values": [[ts, val]...]}...]}
-	results, _ := vlResp["results"].([]interface{})
+	results, _ := extractMetricResults(vlResp)
 	for _, r := range results {
 		rm, _ := r.(map[string]interface{})
-		values, _ := rm["values"].([]interface{})
-		for i, v := range values {
-			point, _ := v.([]interface{})
-			if len(point) >= 2 {
-				valStr, _ := point[1].(string)
-				val, _ := strconv.ParseFloat(valStr, 64)
-				newVal := applyOp(val, scalar, op)
-				point[1] = strconv.FormatFloat(newVal, 'f', -1, 64)
-				values[i] = point
-			}
-		}
+		applyScalarToSample(rm, scalar, op, false)
 	}
 
 	result, _ := json.Marshal(vlResp)
@@ -8394,24 +8383,26 @@ func applyScalarOpReverse(body []byte, op string, scalar float64, resultType str
 		return wrapAsLokiResponse(body, resultType)
 	}
 
-	results, _ := vlResp["results"].([]interface{})
+	results, _ := extractMetricResults(vlResp)
 	for _, r := range results {
 		rm, _ := r.(map[string]interface{})
-		values, _ := rm["values"].([]interface{})
-		for i, v := range values {
-			point, _ := v.([]interface{})
-			if len(point) >= 2 {
-				valStr, _ := point[1].(string)
-				val, _ := strconv.ParseFloat(valStr, 64)
-				newVal := applyOp(scalar, val, op)
-				point[1] = strconv.FormatFloat(newVal, 'f', -1, 64)
-				values[i] = point
-			}
-		}
+		applyScalarToSample(rm, scalar, op, true)
 	}
 
 	result, _ := json.Marshal(vlResp)
 	return wrapAsLokiResponse(result, resultType)
+}
+
+func parsePointValue(raw interface{}) float64 {
+	switch v := raw.(type) {
+	case float64:
+		return v
+	case string:
+		parsed, _ := strconv.ParseFloat(v, 64)
+		return parsed
+	default:
+		return 0
+	}
 }
 
 func combineMetricResults(leftBody, rightBody []byte, op, resultType string) []byte {
@@ -8420,17 +8411,16 @@ func combineMetricResults(leftBody, rightBody []byte, op, resultType string) []b
 	json.Unmarshal(leftBody, &leftResp)
 	json.Unmarshal(rightBody, &rightResp)
 
-	leftResults, _ := leftResp["results"].([]interface{})
-	rightResults, _ := rightResp["results"].([]interface{})
+	leftResults, _ := extractMetricResults(leftResp)
+	rightResults, _ := extractMetricResults(rightResp)
 
 	// Build a map of right results by metric labels for joining
-	rightMap := make(map[string][]interface{})
+	rightMap := make(map[string]map[string]float64)
 	for _, r := range rightResults {
 		rm, _ := r.(map[string]interface{})
 		metric, _ := rm["metric"].(map[string]interface{})
 		key := metricKey(metric)
-		values, _ := rm["values"].([]interface{})
-		rightMap[key] = values
+		rightMap[key] = samplePointIndex(rm)
 	}
 
 	// Combine: for each left result, find matching right result and apply op
@@ -8438,41 +8428,108 @@ func combineMetricResults(leftBody, rightBody []byte, op, resultType string) []b
 		rm, _ := r.(map[string]interface{})
 		metric, _ := rm["metric"].(map[string]interface{})
 		key := metricKey(metric)
-		leftValues, _ := rm["values"].([]interface{})
-		rightValues := rightMap[key]
-
-		if len(rightValues) > 0 {
-			// Build timestamp→value index for right side
-			rightIdx := make(map[string]float64)
-			for _, v := range rightValues {
-				point, _ := v.([]interface{})
-				if len(point) >= 2 {
-					ts := fmt.Sprintf("%v", point[0])
-					valStr, _ := point[1].(string)
-					val, _ := strconv.ParseFloat(valStr, 64)
-					rightIdx[ts] = val
-				}
-			}
-
-			// Apply op point-by-point
-			for i, v := range leftValues {
-				point, _ := v.([]interface{})
-				if len(point) >= 2 {
-					ts := fmt.Sprintf("%v", point[0])
-					leftValStr, _ := point[1].(string)
-					leftVal, _ := strconv.ParseFloat(leftValStr, 64)
-					if rightVal, ok := rightIdx[ts]; ok {
-						newVal := applyOp(leftVal, rightVal, op)
-						point[1] = strconv.FormatFloat(newVal, 'f', -1, 64)
-					}
-					leftValues[i] = point
-				}
-			}
+		rightIdx := rightMap[key]
+		if len(rightIdx) > 0 {
+			applyBinaryToSample(rm, rightIdx, op)
 		}
 	}
 
 	result, _ := json.Marshal(leftResp)
 	return wrapAsLokiResponse(result, resultType)
+}
+
+func extractMetricResults(payload map[string]interface{}) ([]interface{}, bool) {
+	if results, ok := payload["results"].([]interface{}); ok {
+		return results, true
+	}
+	if data, ok := payload["data"].(map[string]interface{}); ok {
+		if result, ok := data["result"].([]interface{}); ok {
+			return result, true
+		}
+	}
+	if result, ok := payload["result"].([]interface{}); ok {
+		return result, true
+	}
+	return nil, false
+}
+
+func applyScalarToSample(sample map[string]interface{}, scalar float64, op string, reverse bool) {
+	values, _ := sample["values"].([]interface{})
+	for i, raw := range values {
+		point, _ := raw.([]interface{})
+		if len(point) < 2 {
+			continue
+		}
+		val := parsePointValue(point[1])
+		newVal := applyOp(val, scalar, op)
+		if reverse {
+			newVal = applyOp(scalar, val, op)
+		}
+		point[1] = strconv.FormatFloat(newVal, 'f', -1, 64)
+		values[i] = point
+	}
+	if len(values) > 0 {
+		sample["values"] = values
+	}
+
+	if value, ok := sample["value"].([]interface{}); ok && len(value) >= 2 {
+		val := parsePointValue(value[1])
+		newVal := applyOp(val, scalar, op)
+		if reverse {
+			newVal = applyOp(scalar, val, op)
+		}
+		value[1] = strconv.FormatFloat(newVal, 'f', -1, 64)
+		sample["value"] = value
+	}
+}
+
+func samplePointIndex(sample map[string]interface{}) map[string]float64 {
+	index := map[string]float64{}
+
+	values, _ := sample["values"].([]interface{})
+	for _, raw := range values {
+		point, _ := raw.([]interface{})
+		if len(point) < 2 {
+			continue
+		}
+		index[fmt.Sprintf("%v", point[0])] = parsePointValue(point[1])
+	}
+
+	if value, ok := sample["value"].([]interface{}); ok && len(value) >= 2 {
+		index[fmt.Sprintf("%v", value[0])] = parsePointValue(value[1])
+	}
+
+	return index
+}
+
+func applyBinaryToSample(sample map[string]interface{}, rightIndex map[string]float64, op string) {
+	values, _ := sample["values"].([]interface{})
+	for i, raw := range values {
+		point, _ := raw.([]interface{})
+		if len(point) < 2 {
+			continue
+		}
+		ts := fmt.Sprintf("%v", point[0])
+		rightVal, ok := rightIndex[ts]
+		if !ok {
+			continue
+		}
+		leftVal := parsePointValue(point[1])
+		point[1] = strconv.FormatFloat(applyOp(leftVal, rightVal, op), 'f', -1, 64)
+		values[i] = point
+	}
+	if len(values) > 0 {
+		sample["values"] = values
+	}
+
+	if value, ok := sample["value"].([]interface{}); ok && len(value) >= 2 {
+		ts := fmt.Sprintf("%v", value[0])
+		if rightVal, ok := rightIndex[ts]; ok {
+			leftVal := parsePointValue(value[1])
+			value[1] = strconv.FormatFloat(applyOp(leftVal, rightVal, op), 'f', -1, 64)
+			sample["value"] = value
+		}
+	}
 }
 
 func applyOp(a, b float64, op string) float64 {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4776,6 +4776,34 @@ func (p *Proxy) resolveTargetLabelFields(ctx context.Context, targetLabels strin
 	return resolved
 }
 
+func normalizeDrilldownGroupingLabel(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	switch strings.ToLower(raw) {
+	case "$__all", "__all":
+		return ""
+	default:
+		return raw
+	}
+}
+
+func requestedVolumeTargetLabels(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if direct := strings.TrimSpace(r.FormValue("targetLabels")); direct != "" {
+		return direct
+	}
+	for _, key := range []string{"drillDownLabel", "fieldBy", "labelBy", "var-fieldBy", "var-labelBy"} {
+		if candidate := normalizeDrilldownGroupingLabel(r.FormValue(key)); candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // handleVolume returns volume data via VL /select/logsql/hits with field grouping.
 // Loki: GET /loki/api/v1/index/volume?query={...}&start=...&end=...
 // Response: {"status":"success","data":{"resultType":"vector","result":[{"metric":{...},"value":[ts,"count"]}]}}
@@ -4789,7 +4817,7 @@ func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 	query := r.FormValue("query")
 	startParam := strings.TrimSpace(firstNonEmpty(r.FormValue("start"), r.FormValue("from")))
 	endParam := strings.TrimSpace(firstNonEmpty(r.FormValue("end"), r.FormValue("to")))
-	targetLabels := r.FormValue("targetLabels")
+	targetLabels := requestedVolumeTargetLabels(r)
 	cacheKey := "volume:" + orgID + ":" + r.URL.RawQuery
 	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
 		if !p.shouldBypassRecentTailCache("volume", remaining, r) {
@@ -4899,7 +4927,7 @@ func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 	startParam := strings.TrimSpace(firstNonEmpty(r.FormValue("start"), r.FormValue("from")))
 	endParam := strings.TrimSpace(firstNonEmpty(r.FormValue("end"), r.FormValue("to")))
 	stepParam := r.FormValue("step")
-	targetLabels := r.FormValue("targetLabels")
+	targetLabels := requestedVolumeTargetLabels(r)
 	cacheKey := "volume_range:" + orgID + ":" + r.URL.RawQuery
 	if cached, remaining, ok := p.cache.GetWithTTL(cacheKey); ok {
 		if !p.shouldBypassRecentTailCache("volume_range", remaining, r) {

--- a/internal/proxy/scalar_matrix_test.go
+++ b/internal/proxy/scalar_matrix_test.go
@@ -1,0 +1,229 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestScalarMatrix_ApplyScalarOp_AllOperators(t *testing.T) {
+	body := scalarMatrixBody(4)
+	cases := []struct {
+		op   string
+		want float64
+	}{
+		{op: "+", want: 6},
+		{op: "-", want: 2},
+		{op: "*", want: 8},
+		{op: "/", want: 2},
+		{op: "%", want: 0},
+		{op: "^", want: 16},
+		{op: "==", want: 0},
+		{op: "!=", want: 1},
+		{op: ">", want: 1},
+		{op: "<", want: 0},
+		{op: ">=", want: 1},
+		{op: "<=", want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.op, func(t *testing.T) {
+			out := applyScalarOp(body, tc.op, 2, "matrix")
+			got := firstMatrixValue(t, out)
+			assertApproxEqual(t, got, tc.want)
+		})
+	}
+}
+
+func TestScalarMatrix_ApplyScalarOpReverse_AllOperators(t *testing.T) {
+	body := scalarMatrixBody(4)
+	cases := []struct {
+		op   string
+		want float64
+	}{
+		{op: "+", want: 6},
+		{op: "-", want: -2},
+		{op: "*", want: 8},
+		{op: "/", want: 0.5},
+		{op: "%", want: 2},
+		{op: "^", want: 16},
+		{op: "==", want: 0},
+		{op: "!=", want: 1},
+		{op: ">", want: 0},
+		{op: "<", want: 1},
+		{op: ">=", want: 0},
+		{op: "<=", want: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.op, func(t *testing.T) {
+			out := applyScalarOpReverse(body, tc.op, 2, "matrix")
+			got := firstMatrixValue(t, out)
+			assertApproxEqual(t, got, tc.want)
+		})
+	}
+}
+
+func TestScalarMatrix_ApplyScalarOp_DivisionAndModuloByZero(t *testing.T) {
+	t.Run("right_scalar_zero", func(t *testing.T) {
+		body := scalarMatrixBody(4)
+
+		outDiv := applyScalarOp(body, "/", 0, "matrix")
+		assertApproxEqual(t, firstMatrixValue(t, outDiv), 0)
+
+		outMod := applyScalarOp(body, "%", 0, "matrix")
+		assertApproxEqual(t, firstMatrixValue(t, outMod), 0)
+	})
+
+	t.Run("reverse_zero_denominator", func(t *testing.T) {
+		body := scalarMatrixBody(0)
+
+		outDiv := applyScalarOpReverse(body, "/", 2, "matrix")
+		assertApproxEqual(t, firstMatrixValue(t, outDiv), 0)
+
+		outMod := applyScalarOpReverse(body, "%", 2, "matrix")
+		assertApproxEqual(t, firstMatrixValue(t, outMod), 0)
+	})
+}
+
+func TestScalarMatrix_CombineBinaryMetricResults_RoutesScalarSides(t *testing.T) {
+	metricBody := scalarMatrixBody(4)
+
+	rightScalarOut := combineBinaryMetricResults(metricBody, nil, "+", "matrix", false, true, "", "2")
+	assertApproxEqual(t, firstMatrixValue(t, rightScalarOut), 6)
+
+	leftScalarOut := combineBinaryMetricResults(nil, metricBody, "-", "matrix", true, false, "2", "")
+	assertApproxEqual(t, firstMatrixValue(t, leftScalarOut), -2)
+}
+
+func TestScalarMatrix_ApplyScalarOp_InstantVectorSample(t *testing.T) {
+	body := scalarVectorBody(4)
+
+	out := applyScalarOp(body, "*", 2, "vector")
+	assertApproxEqual(t, firstMatrixValue(t, out), 8)
+
+	reverse := applyScalarOpReverse(body, "-", 2, "vector")
+	assertApproxEqual(t, firstMatrixValue(t, reverse), -2)
+}
+
+func TestScalarMatrix_ApplyScalarOp_PromDataResultShape(t *testing.T) {
+	body := scalarPromVectorBody(4)
+
+	out := applyScalarOp(body, "*", 2, "vector")
+	assertApproxEqual(t, firstMatrixValue(t, out), 8)
+
+	reverse := applyScalarOpReverse(body, "-", 2, "vector")
+	assertApproxEqual(t, firstMatrixValue(t, reverse), -2)
+}
+
+func TestScalarMatrix_CombineMetricResults_PromDataResultShape(t *testing.T) {
+	left := []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"app":"a"},"value":[1,"4"]}]}}`)
+	right := []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"app":"a"},"value":[1,"2"]}]}}`)
+
+	out := combineBinaryMetricResults(left, right, "*", "vector", false, false, "", "")
+	assertApproxEqual(t, firstMatrixValue(t, out), 8)
+}
+
+func TestScalarMatrix_ApplyScalarOp_InvalidBodyReturnsEmptySuccess(t *testing.T) {
+	out := applyScalarOp([]byte("not-json"), "+", 2, "matrix")
+
+	var payload struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []interface{} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("decode fallback response: %v", err)
+	}
+	if payload.Status != "success" {
+		t.Fatalf("expected success fallback status, got %q", payload.Status)
+	}
+	if len(payload.Data.Result) != 0 {
+		t.Fatalf("expected empty fallback result, got %#v", payload.Data.Result)
+	}
+}
+
+func scalarMatrixBody(v float64) []byte {
+	return []byte(fmt.Sprintf(
+		`{"results":[{"metric":{"app":"scalar-matrix"},"values":[[1,"%s"]]}]}`,
+		strconv.FormatFloat(v, 'f', -1, 64),
+	))
+}
+
+func scalarVectorBody(v float64) []byte {
+	return []byte(fmt.Sprintf(
+		`{"results":[{"metric":{"app":"scalar-vector"},"value":[1,"%s"]}]}`,
+		strconv.FormatFloat(v, 'f', -1, 64),
+	))
+}
+
+func scalarPromVectorBody(v float64) []byte {
+	return []byte(fmt.Sprintf(
+		`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"app":"scalar-prom-vector"},"value":[1,"%s"]}]}}`,
+		strconv.FormatFloat(v, 'f', -1, 64),
+	))
+}
+
+func firstMatrixValue(t *testing.T, body []byte) float64 {
+	t.Helper()
+
+	var payload struct {
+		Status string `json:"status"`
+		Data   struct {
+			Results []struct {
+				Values [][]interface{} `json:"values"`
+				Value  []interface{}   `json:"value"`
+			} `json:"results"`
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+				Value  []interface{}   `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode wrapped scalar response: %v; body=%s", err, string(body))
+	}
+	if payload.Status != "success" {
+		t.Fatalf("expected success response, got %q; body=%s", payload.Status, string(body))
+	}
+	results := payload.Data.Results
+	if len(results) == 0 {
+		results = payload.Data.Result
+	}
+	if len(results) == 0 {
+		t.Fatalf("missing results in response: %s", string(body))
+	}
+
+	var raw interface{}
+	if len(results[0].Values) > 0 && len(results[0].Values[0]) >= 2 {
+		raw = results[0].Values[0][1]
+	} else if len(results[0].Value) >= 2 {
+		raw = results[0].Value[1]
+	} else {
+		t.Fatalf("missing sample in response: %s", string(body))
+	}
+
+	switch v := raw.(type) {
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("parse sample value %q: %v", v, err)
+		}
+		return parsed
+	case float64:
+		return v
+	default:
+		t.Fatalf("unexpected sample value type %T (%v)", raw, raw)
+		return 0
+	}
+}
+
+func assertApproxEqual(t *testing.T, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("unexpected value: got=%v want=%v", got, want)
+	}
+}

--- a/internal/proxy/subquery.go
+++ b/internal/proxy/subquery.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/translator"
 )
 
 // proxySubqueryRange evaluates a subquery for query_range requests.
@@ -118,9 +120,9 @@ func (p *Proxy) proxySubquery(w http.ResponseWriter, r *http.Request, outerFunc,
 // Returns a map from series key → collected values, and series key → metric labels.
 func (p *Proxy) evaluateSubqueryWindow(ctx context.Context, innerQuery string, start, end time.Time, subStep time.Duration, stepStr string) (map[string][]float64, map[string]map[string]string, error) {
 	type subStepResult struct {
-		ts     time.Time
-		body   []byte
-		err    error
+		ts   time.Time
+		body []byte
+		err  error
 	}
 
 	// Calculate sub-step time points
@@ -142,17 +144,11 @@ func (p *Proxy) evaluateSubqueryWindow(ctx context.Context, innerQuery string, s
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			params := url.Values{}
-			params.Set("query", innerQuery)
-			params.Set("time", strconv.FormatInt(t.Unix(), 10))
-
-			resp, err := p.vlPost(ctx, "/select/logsql/stats_query", params)
+			body, err := p.executeSubqueryStepQuery(ctx, innerQuery, t)
 			if err != nil {
 				results[idx] = subStepResult{ts: t, err: err}
 				return
 			}
-			defer resp.Body.Close()
-			body, _ := io.ReadAll(resp.Body)
 			results[idx] = subStepResult{ts: t, body: body}
 		}(i, tp)
 	}
@@ -170,6 +166,72 @@ func (p *Proxy) evaluateSubqueryWindow(ctx context.Context, innerQuery string, s
 	}
 
 	return seriesValues, seriesLabels, nil
+}
+
+func (p *Proxy) executeSubqueryStepQuery(ctx context.Context, query string, ts time.Time) ([]byte, error) {
+	// Support translated binary expressions inside subqueries
+	// (for example rate()/bytes_rate() normalization wrappers).
+	if op, leftQL, rightQL, _, ok := translator.ParseBinaryMetricExprFull(query); ok {
+		leftScalar := translator.IsScalar(leftQL)
+		rightScalar := translator.IsScalar(rightQL)
+
+		fetchMetric := func(q string) ([]byte, error) {
+			params := url.Values{}
+			params.Set("query", q)
+			params.Set("time", strconv.FormatInt(ts.Unix(), 10))
+			resp, err := p.vlPost(ctx, "/select/logsql/stats_query", params)
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			return body, nil
+		}
+
+		var (
+			leftBody  []byte
+			rightBody []byte
+			err       error
+		)
+
+		if !leftScalar {
+			leftBody, err = fetchMetric(leftQL)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			leftBody = []byte(`{"status":"success","data":{"resultType":"scalar","result":[0,"` + leftQL + `"]}}`)
+		}
+
+		if !rightScalar {
+			rightBody, err = fetchMetric(rightQL)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			rightBody = []byte(`{"status":"success","data":{"resultType":"scalar","result":[0,"` + rightQL + `"]}}`)
+		}
+
+		return combineBinaryMetricResults(leftBody, rightBody, op, "vector", leftScalar, rightScalar, leftQL, rightQL), nil
+	}
+
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("time", strconv.FormatInt(ts.Unix(), 10))
+
+	resp, err := p.vlPost(ctx, "/select/logsql/stats_query", params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
 }
 
 // extractValuesFromStatsResult parses a VL stats_query response and adds values to the maps.

--- a/internal/translator/advanced_test.go
+++ b/internal/translator/advanced_test.go
@@ -18,12 +18,12 @@ func TestAdvanced_MetricQueries(t *testing.T) {
 		{
 			name:  "bytes_over_time",
 			logql: `bytes_over_time({app="nginx"}[5m])`,
-			want:  `app:=nginx | stats sum(len(_msg))`,
+			want:  `app:=nginx | stats sum_len(_msg)`,
 		},
 		{
 			name:  "bytes_rate",
 			logql: `bytes_rate({app="nginx"}[5m])`,
-			want:  `app:=nginx | stats rate_sum(len(_msg))`,
+			want:  `__binary__:/:app:=nginx | stats sum_len(_msg)|||300`,
 		},
 		{
 			name:  "avg_over_time with unwrap",

--- a/internal/translator/advanced_test.go
+++ b/internal/translator/advanced_test.go
@@ -23,27 +23,27 @@ func TestAdvanced_MetricQueries(t *testing.T) {
 		{
 			name:  "bytes_rate",
 			logql: `bytes_rate({app="nginx"}[5m])`,
-			want:  `__binary__:/:app:=nginx | stats sum_len(_msg)|||300`,
+			want:  `app:=nginx | stats by (_stream) sum_len(_msg) as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream) sum(__lvp_rate)`,
 		},
 		{
 			name:  "avg_over_time with unwrap",
 			logql: `avg_over_time({app="api"} | json | unwrap duration [5m])`,
-			want:  `app:=api | unpack_json | stats avg(duration)`,
+			want:  `app:=api | unpack_json | stats by (_stream, _msg) avg(duration)`,
 		},
 		{
 			name:  "max_over_time with unwrap",
 			logql: `max_over_time({app="api"} | logfmt | unwrap response_size [5m])`,
-			want:  `app:=api | unpack_logfmt | stats max(response_size)`,
+			want:  `app:=api | unpack_logfmt | stats by (_stream, _msg) max(response_size)`,
 		},
 		{
 			name:  "sum by namespace of rate",
 			logql: `sum by (namespace) (rate({cluster="prod"}[5m]))`,
-			want:  `cluster:=prod | stats by (namespace) rate()`,
+			want:  `cluster:=prod | stats by (namespace) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (namespace) sum(__lvp_rate)`,
 		},
 		{
 			name:  "topk of rate — simplified",
 			logql: `topk(10, rate({region="us-east-1"}[5m]))`,
-			want:  `region:=us-east-1 | stats rate()`,
+			want:  `region:=us-east-1 | stats by (_stream) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream) sum(__lvp_rate)`,
 		},
 		{
 			name:  "count_over_time with line filter",

--- a/internal/translator/advanced_test.go
+++ b/internal/translator/advanced_test.go
@@ -23,7 +23,7 @@ func TestAdvanced_MetricQueries(t *testing.T) {
 		{
 			name:  "bytes_rate",
 			logql: `bytes_rate({app="nginx"}[5m])`,
-			want:  `app:=nginx | stats by (_stream) sum_len(_msg) as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream) sum(__lvp_rate)`,
+			want:  `app:=nginx | stats by (_stream, level) sum_len(_msg) as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream, level) sum(__lvp_rate)`,
 		},
 		{
 			name:  "avg_over_time with unwrap",
@@ -43,7 +43,7 @@ func TestAdvanced_MetricQueries(t *testing.T) {
 		{
 			name:  "topk of rate — simplified",
 			logql: `topk(10, rate({region="us-east-1"}[5m]))`,
-			want:  `region:=us-east-1 | stats by (_stream) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream) sum(__lvp_rate)`,
+			want:  `region:=us-east-1 | stats by (_stream, level) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream, level) sum(__lvp_rate)`,
 		},
 		{
 			name:  "count_over_time with line filter",

--- a/internal/translator/operation_filter_function_matrix_test.go
+++ b/internal/translator/operation_filter_function_matrix_test.go
@@ -1,0 +1,172 @@
+package translator
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMatrix_BinaryMetricOperators_AllSupported(t *testing.T) {
+	ops := []string{"+", "-", "*", "/", "%", "^", "==", "!=", ">", "<", ">=", "<="}
+
+	for _, op := range ops {
+		t.Run("right_scalar_"+op, func(t *testing.T) {
+			logql := fmt.Sprintf(`rate({app="x"}[5m]) %s 2`, op)
+			got, err := TranslateLogQL(logql)
+			if err != nil {
+				t.Fatalf("translate right-scalar binary op: %v", err)
+			}
+			if !strings.HasPrefix(got, BinaryMetricPrefix+op+":") {
+				t.Fatalf("expected binary prefix for %q, got %q", op, got)
+			}
+
+			parsedOp, left, right, _, ok := ParseBinaryMetricExprFull(got)
+			if !ok {
+				t.Fatalf("expected parseable binary metric expression, got %q", got)
+			}
+			if parsedOp != op {
+				t.Fatalf("unexpected parsed op: got=%q want=%q", parsedOp, op)
+			}
+			if !strings.Contains(left, "stats rate()") {
+				t.Fatalf("expected translated metric query on left, got %q", left)
+			}
+			if right != "2" {
+				t.Fatalf("expected scalar RHS=2, got %q", right)
+			}
+		})
+
+		t.Run("left_scalar_"+op, func(t *testing.T) {
+			logql := fmt.Sprintf(`2 %s rate({app="x"}[5m])`, op)
+			got, err := TranslateLogQL(logql)
+			if err != nil {
+				t.Fatalf("translate left-scalar binary op: %v", err)
+			}
+			if !strings.HasPrefix(got, BinaryMetricPrefix+op+":") {
+				t.Fatalf("expected binary prefix for %q, got %q", op, got)
+			}
+
+			parsedOp, left, right, _, ok := ParseBinaryMetricExprFull(got)
+			if !ok {
+				t.Fatalf("expected parseable binary metric expression, got %q", got)
+			}
+			if parsedOp != op {
+				t.Fatalf("unexpected parsed op: got=%q want=%q", parsedOp, op)
+			}
+			if left != "2" {
+				t.Fatalf("expected scalar LHS=2, got %q", left)
+			}
+			if !strings.Contains(right, "stats rate()") {
+				t.Fatalf("expected translated metric query on right, got %q", right)
+			}
+		})
+	}
+}
+
+func TestMatrix_FilterOperators_AllSupported(t *testing.T) {
+	cases := []struct {
+		name           string
+		logql          string
+		wantSubstring  string
+		secondaryCheck string
+	}{
+		{name: "line_contains", logql: `{app="x"} |= "error"`, wantSubstring: `~"error"`},
+		{name: "line_not_contains", logql: `{app="x"} != "debug"`, wantSubstring: `NOT ~"debug"`},
+		{name: "line_regex", logql: `{app="x"} |~ "err.*"`, wantSubstring: `~"err.*"`},
+		{name: "line_not_regex", logql: `{app="x"} !~ "dbg.*"`, wantSubstring: `NOT ~"dbg.*"`},
+		{name: "label_eq", logql: `{app="x"} | status == 200`, wantSubstring: `status:=200`},
+		{name: "label_assign_eq", logql: `{app="x"} | status = 200`, wantSubstring: `status:=200`},
+		{name: "label_ne", logql: `{app="x"} | status != 200`, wantSubstring: `-status:=200`},
+		{name: "label_re", logql: `{app="x"} | status =~ "2.."`, wantSubstring: `status:~"2.."`},
+		{name: "label_not_re", logql: `{app="x"} | status !~ "5.."`, wantSubstring: `-status:~"5.."`},
+		{name: "label_gt", logql: `{app="x"} | duration_ms > 100`, wantSubstring: `duration_ms:>100`},
+		{name: "label_lt", logql: `{app="x"} | duration_ms < 100`, wantSubstring: `duration_ms:<100`},
+		{name: "label_gte", logql: `{app="x"} | duration_ms >= 100`, wantSubstring: `duration_ms:>=100`},
+		{name: "label_lte", logql: `{app="x"} | duration_ms <= 100`, wantSubstring: `duration_ms:<=100`},
+		{name: "and_split", logql: `{app="x"} | status >= 500 and method="GET"`, wantSubstring: " and ", secondaryCheck: "method:=GET"},
+		{name: "or_split", logql: `{app="x"} | status >= 500 or status = 429`, wantSubstring: " or ", secondaryCheck: "status:=429"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := TranslateLogQL(tc.logql)
+			if err != nil {
+				t.Fatalf("translate filter query: %v", err)
+			}
+			if !strings.Contains(got, tc.wantSubstring) {
+				t.Fatalf("expected translation to contain %q, got %q", tc.wantSubstring, got)
+			}
+			if tc.secondaryCheck != "" && !strings.Contains(got, tc.secondaryCheck) {
+				t.Fatalf("expected translation to contain %q, got %q", tc.secondaryCheck, got)
+			}
+		})
+	}
+}
+
+func TestMatrix_LokiPipeFunctions_Supported(t *testing.T) {
+	cases := []struct {
+		name          string
+		logql         string
+		wantFragments []string
+	}{
+		{name: "json", logql: `{app="x"} | json`, wantFragments: []string{"| unpack_json"}},
+		{name: "logfmt", logql: `{app="x"} | logfmt`, wantFragments: []string{"| unpack_logfmt"}},
+		{name: "line_format", logql: `{app="x"} | line_format "{{.app}}"`, wantFragments: []string{`| format "<app>"`}},
+		{name: "label_format_multi", logql: `{app="x"} | label_format app_name="{{.app}}", level_name="{{.level}}"`, wantFragments: []string{`| format "<app>" as app_name`, `| format "<level>" as level_name`}},
+		{name: "decolorize", logql: `{app="x"} | decolorize`, wantFragments: []string{"| decolorize"}},
+		{name: "drop", logql: `{app="x"} | drop temp`, wantFragments: []string{"| delete temp"}},
+		{name: "keep", logql: `{app="x"} | keep app, level`, wantFragments: []string{"| fields _time, _msg, _stream, app, level"}},
+		{name: "pattern", logql: `{app="x"} | pattern "<method> <path>"`, wantFragments: []string{"| extract "}},
+		{name: "regexp", logql: `{app="x"} | regexp "(?P<method>GET|POST)"`, wantFragments: []string{"| extract_regexp "}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := TranslateLogQL(tc.logql)
+			if err != nil {
+				t.Fatalf("translate function pipe: %v", err)
+			}
+			for _, want := range tc.wantFragments {
+				if !strings.Contains(got, want) {
+					t.Fatalf("expected %q in translation, got %q", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMatrix_MetricFunctions_AllSupported(t *testing.T) {
+	cases := []struct {
+		name          string
+		logql         string
+		wantFragments []string
+	}{
+		{name: "rate", logql: `rate({app="x"}[5m])`, wantFragments: []string{"| stats rate()"}},
+		{name: "count_over_time", logql: `count_over_time({app="x"}[5m])`, wantFragments: []string{"| stats count()"}},
+		{name: "bytes_over_time", logql: `bytes_over_time({app="x"}[5m])`, wantFragments: []string{"| stats sum_len(_msg)"}},
+		{name: "bytes_rate", logql: `bytes_rate({app="x"}[5m])`, wantFragments: []string{BinaryMetricPrefix + "/:", "| stats sum_len(_msg)", "|||300"}},
+		{name: "sum_over_time", logql: `sum_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats sum(duration)"}},
+		{name: "avg_over_time", logql: `avg_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats avg(duration)"}},
+		{name: "max_over_time", logql: `max_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats max(duration)"}},
+		{name: "min_over_time", logql: `min_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats min(duration)"}},
+		{name: "first_over_time", logql: `first_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats first(duration)"}},
+		{name: "last_over_time", logql: `last_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats last(duration)"}},
+		{name: "stddev_over_time", logql: `stddev_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats stddev(duration)"}},
+		{name: "stdvar_over_time", logql: `stdvar_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{BinaryMetricPrefix + "^:", "| stats stddev(duration)", "|||2"}},
+		{name: "absent_over_time", logql: `absent_over_time({app="x"}[5m])`, wantFragments: []string{"| stats count()"}},
+		{name: "quantile_over_time", logql: `quantile_over_time(0.95, {app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats quantile(0.95, duration)"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := TranslateLogQL(tc.logql)
+			if err != nil {
+				t.Fatalf("translate metric function: %v", err)
+			}
+			for _, want := range tc.wantFragments {
+				if !strings.Contains(got, want) {
+					t.Fatalf("expected %q in translation, got %q", want, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/translator/operation_filter_function_matrix_test.go
+++ b/internal/translator/operation_filter_function_matrix_test.go
@@ -27,7 +27,7 @@ func TestMatrix_BinaryMetricOperators_AllSupported(t *testing.T) {
 			if parsedOp != op {
 				t.Fatalf("unexpected parsed op: got=%q want=%q", parsedOp, op)
 			}
-			if !strings.Contains(left, "stats rate()") {
+			if !strings.Contains(left, "__lvp_rate") {
 				t.Fatalf("expected translated metric query on left, got %q", left)
 			}
 			if right != "2" {
@@ -55,7 +55,7 @@ func TestMatrix_BinaryMetricOperators_AllSupported(t *testing.T) {
 			if left != "2" {
 				t.Fatalf("expected scalar LHS=2, got %q", left)
 			}
-			if !strings.Contains(right, "stats rate()") {
+			if !strings.Contains(right, "__lvp_rate") {
 				t.Fatalf("expected translated metric query on right, got %q", right)
 			}
 		})
@@ -140,10 +140,10 @@ func TestMatrix_MetricFunctions_AllSupported(t *testing.T) {
 		logql         string
 		wantFragments []string
 	}{
-		{name: "rate", logql: `rate({app="x"}[5m])`, wantFragments: []string{"| stats rate()"}},
+		{name: "rate", logql: `rate({app="x"}[5m])`, wantFragments: []string{"| stats by (_stream) count() as __lvp_inner", "| math __lvp_inner/300 as __lvp_rate", "| stats by (_stream) sum(__lvp_rate)"}},
 		{name: "count_over_time", logql: `count_over_time({app="x"}[5m])`, wantFragments: []string{"| stats count()"}},
 		{name: "bytes_over_time", logql: `bytes_over_time({app="x"}[5m])`, wantFragments: []string{"| stats sum_len(_msg)"}},
-		{name: "bytes_rate", logql: `bytes_rate({app="x"}[5m])`, wantFragments: []string{BinaryMetricPrefix + "/:", "| stats sum_len(_msg)", "|||300"}},
+		{name: "bytes_rate", logql: `bytes_rate({app="x"}[5m])`, wantFragments: []string{"| stats by (_stream) sum_len(_msg) as __lvp_inner", "| math __lvp_inner/300 as __lvp_rate", "| stats by (_stream) sum(__lvp_rate)"}},
 		{name: "sum_over_time", logql: `sum_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats sum(duration)"}},
 		{name: "avg_over_time", logql: `avg_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats avg(duration)"}},
 		{name: "max_over_time", logql: `max_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats max(duration)"}},

--- a/internal/translator/operation_filter_function_matrix_test.go
+++ b/internal/translator/operation_filter_function_matrix_test.go
@@ -140,10 +140,10 @@ func TestMatrix_MetricFunctions_AllSupported(t *testing.T) {
 		logql         string
 		wantFragments []string
 	}{
-		{name: "rate", logql: `rate({app="x"}[5m])`, wantFragments: []string{"| stats by (_stream) count() as __lvp_inner", "| math __lvp_inner/300 as __lvp_rate", "| stats by (_stream) sum(__lvp_rate)"}},
+		{name: "rate", logql: `rate({app="x"}[5m])`, wantFragments: []string{"| stats by (_stream, level) count() as __lvp_inner", "| math __lvp_inner/300 as __lvp_rate", "| stats by (_stream, level) sum(__lvp_rate)"}},
 		{name: "count_over_time", logql: `count_over_time({app="x"}[5m])`, wantFragments: []string{"| stats count()"}},
 		{name: "bytes_over_time", logql: `bytes_over_time({app="x"}[5m])`, wantFragments: []string{"| stats sum_len(_msg)"}},
-		{name: "bytes_rate", logql: `bytes_rate({app="x"}[5m])`, wantFragments: []string{"| stats by (_stream) sum_len(_msg) as __lvp_inner", "| math __lvp_inner/300 as __lvp_rate", "| stats by (_stream) sum(__lvp_rate)"}},
+		{name: "bytes_rate", logql: `bytes_rate({app="x"}[5m])`, wantFragments: []string{"| stats by (_stream, level) sum_len(_msg) as __lvp_inner", "| math __lvp_inner/300 as __lvp_rate", "| stats by (_stream, level) sum(__lvp_rate)"}},
 		{name: "sum_over_time", logql: `sum_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats sum(duration)"}},
 		{name: "avg_over_time", logql: `avg_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats avg(duration)"}},
 		{name: "max_over_time", logql: `max_over_time({app="x"} | unwrap duration [5m])`, wantFragments: []string{"| stats max(duration)"}},

--- a/internal/translator/realworld_test.go
+++ b/internal/translator/realworld_test.go
@@ -162,7 +162,7 @@ func TestRealWorld_MetricAlerts(t *testing.T) {
 		{
 			name:  "error rate sum by job",
 			logql: `sum by (job) (rate({app="foo",env="production"} |= "error" [5m]))`,
-			want:  `app:=foo env:=production ~"error" | stats by (job) rate()`,
+			want:  `app:=foo env:=production ~"error" | stats by (job) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (job) sum(__lvp_rate)`,
 		},
 		{
 			name:  "count by level",
@@ -172,7 +172,7 @@ func TestRealWorld_MetricAlerts(t *testing.T) {
 		{
 			name:  "bytes rate by namespace",
 			logql: `sum by (namespace) (bytes_rate({cluster="prod-k8s"}[5m]))`,
-			want:  `__binary__:/:cluster:=prod-k8s | stats by (namespace) sum_len(_msg)|||300`,
+			want:  `cluster:=prod-k8s | stats by (namespace) sum_len(_msg) as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (namespace) sum(__lvp_rate)`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/translator/realworld_test.go
+++ b/internal/translator/realworld_test.go
@@ -172,7 +172,7 @@ func TestRealWorld_MetricAlerts(t *testing.T) {
 		{
 			name:  "bytes rate by namespace",
 			logql: `sum by (namespace) (bytes_rate({cluster="prod-k8s"}[5m]))`,
-			want:  `cluster:=prod-k8s | stats by (namespace) rate_sum(len(_msg))`,
+			want:  `__binary__:/:cluster:=prod-k8s | stats by (namespace) sum_len(_msg)|||300`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -798,7 +798,7 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 	// or: rate({...}[5m])
 
 	metricFuncs := map[string]string{
-		"rate":             "rate()",
+		"rate":             "count()",
 		"count_over_time":  "count()",
 		"bytes_over_time":  "sum_len(_msg)",
 		"bytes_rate":       "sum_len(_msg)",
@@ -850,15 +850,45 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 			continue
 		}
 
+		if funcName == "rate" || funcName == "bytes_rate" {
+			if rateResult, ok := buildRateLikeQuery(logsqlQuery, logsqlFunc, duration, outerAgg, byLabels, labelFn); ok {
+				return rateResult, true
+			}
+		}
+
 		// Build the LogsQL stats query
 		var result string
 		if isUnwrapFunc(funcName) {
 			// For unwrap functions, extract the unwrap field
 			unwrapField := extractUnwrapField(inner)
+			statsExpr := logsqlFunc
 			if unwrapField != "" {
-				result = fmt.Sprintf("%s | stats %s(%s)", logsqlQuery, logsqlFunc, unwrapField)
+				statsExpr = fmt.Sprintf("%s(%s)", logsqlFunc, unwrapField)
+			}
+			innerBy := unwrapInnerGrouping(query, byLabels, outerAgg, labelFn)
+
+			// stdvar_over_time uses stddev + square, since VL doesn't have stdvar().
+			if funcName == "stdvar_over_time" {
+				if outerAgg != "" && byLabels == "" {
+					innerAliased := buildStatsQuery(logsqlQuery, statsExpr, innerBy, "__lvp_inner")
+					withVariance := innerAliased + " | math __lvp_inner*__lvp_inner as __lvp_inner_var"
+					if outerResult, ok := applyOuterAggregation(withVariance, outerAgg, "__lvp_inner_var"); ok {
+						return outerResult, true
+					}
+				}
+				baseStddev := buildStatsQuery(logsqlQuery, statsExpr, innerBy, "")
+				return fmt.Sprintf("%s^:%s|||2", BinaryMetricPrefix, baseStddev), true
+			}
+
+			if outerAgg != "" && byLabels == "" {
+				innerAliased := buildStatsQuery(logsqlQuery, statsExpr, innerBy, "__lvp_inner")
+				if outerResult, ok := applyOuterAggregation(innerAliased, outerAgg, "__lvp_inner"); ok {
+					result = outerResult
+				} else {
+					result = buildStatsQuery(logsqlQuery, statsExpr, innerBy, "")
+				}
 			} else {
-				result = fmt.Sprintf("%s | stats %s", logsqlQuery, logsqlFunc)
+				result = buildStatsQuery(logsqlQuery, statsExpr, innerBy, "")
 			}
 		} else {
 			result = fmt.Sprintf("%s | stats %s", logsqlQuery, logsqlFunc)
@@ -871,23 +901,101 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 			}
 		}
 
-		// bytes_rate(window) ~= bytes_over_time(window) / window_seconds
-		if funcName == "bytes_rate" {
-			seconds := durationSeconds(duration)
-			if seconds > 0 {
-				return fmt.Sprintf("%s/:%s|||%s", BinaryMetricPrefix, result, strconv.FormatFloat(seconds, 'f', -1, 64)), true
-			}
-		}
-
-		// stdvar_over_time(window) ~= stddev_over_time(window)^2
-		if funcName == "stdvar_over_time" {
-			return fmt.Sprintf("%s^:%s|||2", BinaryMetricPrefix, result), true
-		}
-
 		return result, true
 	}
 
 	return "", false
+}
+
+func buildRateLikeQuery(logsqlQuery, statsExpr, duration, outerAgg, byLabels string, labelFn LabelTranslateFunc) (string, bool) {
+	seconds := durationSeconds(duration)
+	if seconds <= 0 {
+		return "", false
+	}
+
+	innerBy := "_stream"
+	if byLabels != "" {
+		innerBy = normalizeByLabels(byLabels, labelFn)
+	}
+
+	innerAliased := buildStatsQuery(logsqlQuery, statsExpr, innerBy, "__lvp_inner")
+	withRate := fmt.Sprintf("%s | math __lvp_inner/%s as __lvp_rate", innerAliased, strconv.FormatFloat(seconds, 'f', -1, 64))
+
+	if outerAgg != "" && byLabels == "" {
+		if outerResult, ok := applyOuterAggregation(withRate, outerAgg, "__lvp_rate"); ok {
+			return outerResult, true
+		}
+	}
+
+	return buildStatsQuery(withRate, "sum(__lvp_rate)", innerBy, ""), true
+}
+
+func buildStatsQuery(baseQuery, statsExpr, byLabels, alias string) string {
+	query := strings.TrimSpace(baseQuery)
+	if query == "" {
+		query = "*"
+	}
+	if byLabels != "" {
+		query = fmt.Sprintf("%s | stats by (%s) %s", query, byLabels, statsExpr)
+	} else {
+		query = fmt.Sprintf("%s | stats %s", query, statsExpr)
+	}
+	if alias != "" {
+		query += " as " + alias
+	}
+	return query
+}
+
+func outerAggregationStatsFn(outerAgg string) (statsFn string, pow2 bool) {
+	switch outerAgg {
+	case "sum":
+		return "sum", false
+	case "avg":
+		return "avg", false
+	case "max":
+		return "max", false
+	case "min":
+		return "min", false
+	case "count":
+		return "count", false
+	case "stddev":
+		return "stddev", false
+	case "stdvar":
+		return "stddev", true
+	default:
+		return "", false
+	}
+}
+
+func applyOuterAggregation(baseQuery, outerAgg, field string) (string, bool) {
+	statsFn, pow2 := outerAggregationStatsFn(outerAgg)
+	if statsFn == "" {
+		return "", false
+	}
+	result := fmt.Sprintf("%s | stats %s(%s)", baseQuery, statsFn, field)
+	if pow2 {
+		result = fmt.Sprintf("%s^:%s|||2", BinaryMetricPrefix, result)
+	}
+	return result, true
+}
+
+var parserStageForUnwrapRE = regexp.MustCompile(`\|\s*(json|logfmt|pattern|regexp|unpack)\b`)
+
+func hasParserPipeline(query string) bool {
+	return parserStageForUnwrapRE.MatchString(query)
+}
+
+func unwrapInnerGrouping(query, byLabels, outerAgg string, labelFn LabelTranslateFunc) string {
+	if byLabels != "" {
+		return normalizeByLabels(byLabels, labelFn)
+	}
+	if hasParserPipeline(query) {
+		return "_stream, _msg"
+	}
+	if outerAgg != "" {
+		return "_stream"
+	}
+	return ""
 }
 
 func durationSeconds(duration string) float64 {
@@ -1219,7 +1327,7 @@ func extractUnwrapField(inner string) string {
 
 // tryTranslateQuantileOverTime handles quantile_over_time(phi, {query} | unwrap field [duration]).
 // Maps to VL: query | stats quantile(phi, field)
-func tryTranslateQuantileOverTime(innerExpr, _, byLabels string, labelFn LabelTranslateFunc) (string, bool) {
+func tryTranslateQuantileOverTime(innerExpr, outerAgg, byLabels string, labelFn LabelTranslateFunc) (string, bool) {
 	prefix := "quantile_over_time("
 	if !strings.HasPrefix(innerExpr, prefix) {
 		return "", false
@@ -1255,13 +1363,17 @@ func tryTranslateQuantileOverTime(innerExpr, _, byLabels string, labelFn LabelTr
 		unwrapField = "_msg"
 	}
 
-	result := fmt.Sprintf("%s | stats quantile(%s, %s)", logsqlQuery, phi, unwrapField)
+	statsExpr := fmt.Sprintf("quantile(%s, %s)", phi, unwrapField)
+	innerBy := unwrapInnerGrouping(query, byLabels, outerAgg, labelFn)
 
-	if byLabels != "" {
-		result = addByClause(result, byLabels, labelFn)
+	if outerAgg != "" && byLabels == "" {
+		innerAliased := buildStatsQuery(logsqlQuery, statsExpr, innerBy, "__lvp_inner")
+		if outerResult, ok := applyOuterAggregation(innerAliased, outerAgg, "__lvp_inner"); ok {
+			return outerResult, true
+		}
 	}
 
-	return result, true
+	return buildStatsQuery(logsqlQuery, statsExpr, innerBy, ""), true
 }
 
 func addByClause(query, labels string, labelFn LabelTranslateFunc) string {

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -799,8 +800,8 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 	metricFuncs := map[string]string{
 		"rate":             "rate()",
 		"count_over_time":  "count()",
-		"bytes_over_time":  "sum(len(_msg))",
-		"bytes_rate":       "rate_sum(len(_msg))",
+		"bytes_over_time":  "sum_len(_msg)",
+		"bytes_rate":       "sum_len(_msg)",
 		"sum_over_time":    "sum",
 		"avg_over_time":    "avg",
 		"max_over_time":    "max",
@@ -808,7 +809,7 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 		"first_over_time":  "first",
 		"last_over_time":   "last",
 		"stddev_over_time": "stddev",
-		"stdvar_over_time": "stdvar",
+		"stdvar_over_time": "stddev",
 		"absent_over_time": "count()",
 	}
 
@@ -841,7 +842,7 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 		inner = inner[:end]
 
 		// Extract the query and duration: {stream} | pipeline [5m]
-		query, _ := extractQueryAndDuration(inner)
+		query, duration := extractQueryAndDuration(inner)
 
 		// Translate the inner log query part
 		logsqlQuery, err := translateLogQuery(query, labelFn)
@@ -870,10 +871,75 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 			}
 		}
 
+		// bytes_rate(window) ~= bytes_over_time(window) / window_seconds
+		if funcName == "bytes_rate" {
+			seconds := durationSeconds(duration)
+			if seconds > 0 {
+				return fmt.Sprintf("%s/:%s|||%s", BinaryMetricPrefix, result, strconv.FormatFloat(seconds, 'f', -1, 64)), true
+			}
+		}
+
+		// stdvar_over_time(window) ~= stddev_over_time(window)^2
+		if funcName == "stdvar_over_time" {
+			return fmt.Sprintf("%s^:%s|||2", BinaryMetricPrefix, result), true
+		}
+
 		return result, true
 	}
 
 	return "", false
+}
+
+func durationSeconds(duration string) float64 {
+	duration = strings.TrimSpace(duration)
+	if duration == "" {
+		return 0
+	}
+	if d, err := time.ParseDuration(duration); err == nil {
+		return d.Seconds()
+	}
+
+	partRE := regexp.MustCompile(`([0-9]*\.?[0-9]+)(ns|us|µs|ms|s|m|h|d|w|y)`)
+	parts := partRE.FindAllStringSubmatch(duration, -1)
+	if len(parts) == 0 {
+		return 0
+	}
+
+	total := 0.0
+	consumed := strings.Builder{}
+	for _, part := range parts {
+		value, err := strconv.ParseFloat(part[1], 64)
+		if err != nil {
+			return 0
+		}
+		switch part[2] {
+		case "ns":
+			total += value / 1e9
+		case "us", "µs":
+			total += value / 1e6
+		case "ms":
+			total += value / 1e3
+		case "s":
+			total += value
+		case "m":
+			total += value * 60
+		case "h":
+			total += value * 3600
+		case "d":
+			total += value * 86400
+		case "w":
+			total += value * 7 * 86400
+		case "y":
+			total += value * 365 * 86400
+		default:
+			return 0
+		}
+		consumed.WriteString(part[0])
+	}
+	if consumed.String() != duration {
+		return 0
+	}
+	return total
 }
 
 // BinaryMetricOp represents a binary arithmetic expression between two metric queries.

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -854,7 +854,7 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 		}
 
 		if funcName == "rate" || funcName == "bytes_rate" {
-			if rateResult, ok := buildRateLikeQuery(logsqlQuery, logsqlFunc, duration, outerAgg, byLabels, labelFn); ok {
+			if rateResult, ok := buildRateLikeQuery(logsqlQuery, query, logsqlFunc, duration, outerAgg, byLabels, labelFn); ok {
 				return rateResult, true
 			}
 		}
@@ -910,13 +910,21 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 	return "", false
 }
 
-func buildRateLikeQuery(logsqlQuery, statsExpr, duration, outerAgg, byLabels string, labelFn LabelTranslateFunc) (string, bool) {
+func defaultRateInnerGrouping(query string) string {
+	if hasParserPipeline(query) {
+		return "_stream"
+	}
+	// Keep level-split streams distinct when level isn't configured as a VL _stream field.
+	return "_stream, level"
+}
+
+func buildRateLikeQuery(logsqlQuery, originalQuery, statsExpr, duration, outerAgg, byLabels string, labelFn LabelTranslateFunc) (string, bool) {
 	seconds := durationSeconds(duration)
 	if seconds <= 0 {
 		return "", false
 	}
 
-	innerBy := "_stream"
+	innerBy := defaultRateInnerGrouping(originalQuery)
 	if byLabels != "" {
 		innerBy = normalizeByLabels(byLabels, labelFn)
 	}

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -252,7 +252,7 @@ func TestMetricQueryTranslation(t *testing.T) {
 		{
 			name:  "rate",
 			logql: `rate({app="nginx"}[5m])`,
-			want:  `app:=nginx | stats rate()`,
+			want:  `app:=nginx | stats by (_stream) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream) sum(__lvp_rate)`,
 		},
 		{
 			name:  "count_over_time",
@@ -262,17 +262,17 @@ func TestMetricQueryTranslation(t *testing.T) {
 		{
 			name:  "sum of rate by label",
 			logql: `sum(rate({app="nginx"}[5m])) by (host)`,
-			want:  `app:=nginx | stats by (host) rate()`,
+			want:  `app:=nginx | stats by (host) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (host) sum(__lvp_rate)`,
 		},
 		{
 			name:  "stddev outer aggregation",
 			logql: `stddev(rate({app="nginx"}[5m])) by (host)`,
-			want:  `app:=nginx | stats by (host) rate()`,
+			want:  `app:=nginx | stats by (host) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (host) sum(__lvp_rate)`,
 		},
 		{
 			name:  "stdvar outer aggregation",
 			logql: `stdvar(rate({app="nginx"}[5m])) by (host)`,
-			want:  `app:=nginx | stats by (host) rate()`,
+			want:  `app:=nginx | stats by (host) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (host) sum(__lvp_rate)`,
 		},
 		// without() clause tests moved to fixes_test.go — now correctly returns error
 		{

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -252,7 +252,7 @@ func TestMetricQueryTranslation(t *testing.T) {
 		{
 			name:  "rate",
 			logql: `rate({app="nginx"}[5m])`,
-			want:  `app:=nginx | stats by (_stream) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream) sum(__lvp_rate)`,
+			want:  `app:=nginx | stats by (_stream, level) count() as __lvp_inner | math __lvp_inner/300 as __lvp_rate | stats by (_stream, level) sum(__lvp_rate)`,
 		},
 		{
 			name:  "count_over_time",

--- a/test/e2e-compat/operations_matrix_compat_test.go
+++ b/test/e2e-compat/operations_matrix_compat_test.go
@@ -129,7 +129,7 @@ func TestOperationsMatrix_LokiMetricFunctionsParity(t *testing.T) {
 	app := ensureOperationsMatrixData(t)
 	at := time.Now()
 
-	// Cross-engine parity for functions where semantics should match exactly.
+	// Cross-engine parity for scalar-compatible expressions.
 	parityCases := []struct {
 		name  string
 		query string
@@ -137,6 +137,14 @@ func TestOperationsMatrix_LokiMetricFunctionsParity(t *testing.T) {
 		{name: "count_over_time", query: fmt.Sprintf(`sum(count_over_time({app="%s"}[10m]))`, app)},
 		{name: "bytes_over_time", query: fmt.Sprintf(`sum(bytes_over_time({app="%s"}[10m]))`, app)},
 		{name: "bytes_rate", query: fmt.Sprintf(`sum(bytes_rate({app="%s"}[10m]))`, app)},
+		{name: "rate", query: fmt.Sprintf(`sum(rate({app="%s"}[10m]))`, app)},
+		{name: "sum_over_time", query: fmt.Sprintf(`sum(sum_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app)},
+		{name: "avg_over_time", query: fmt.Sprintf(`sum(avg_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app)},
+		{name: "max_over_time", query: fmt.Sprintf(`sum(max_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app)},
+		{name: "min_over_time", query: fmt.Sprintf(`sum(min_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app)},
+		{name: "stddev_over_time", query: fmt.Sprintf(`sum(stddev_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app)},
+		{name: "stdvar_over_time", query: fmt.Sprintf(`sum(stdvar_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app)},
+		{name: "quantile_over_time", query: fmt.Sprintf(`sum(quantile_over_time(0.95, {app="%s"} | json | unwrap duration_ms [10m]))`, app)},
 	}
 	for _, tc := range parityCases {
 		t.Run("parity_"+tc.name, func(t *testing.T) {
@@ -148,52 +156,38 @@ func TestOperationsMatrix_LokiMetricFunctionsParity(t *testing.T) {
 		})
 	}
 
-	// Proxy-local deterministic checks over seeded fixture values:
-	// duration_ms values are [10,20,100,1,2] => sum=133, avg=26.6, min=1, max=100.
-	proxyExpectations := []struct {
+	// Vector parity for unwrap queries that keep per-label/per-line cardinality.
+	vectorCases := []struct {
 		name  string
 		query string
-		want  float64
 	}{
-		{name: "sum_over_time", query: fmt.Sprintf(`sum(sum_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 133},
-		{name: "avg_over_time", query: fmt.Sprintf(`sum(avg_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 26.6},
-		{name: "max_over_time", query: fmt.Sprintf(`sum(max_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 100},
-		{name: "min_over_time", query: fmt.Sprintf(`sum(min_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 1},
-		{name: "stddev_over_time", query: fmt.Sprintf(`sum(stddev_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 37.328809249693464},
-		{name: "stdvar_over_time", query: fmt.Sprintf(`sum(stdvar_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 1393.4400000000003},
+		{name: "sum_over_time_vector", query: fmt.Sprintf(`sum_over_time({app="%s"} | json | unwrap duration_ms [10m])`, app)},
+		{name: "avg_over_time_vector", query: fmt.Sprintf(`avg_over_time({app="%s"} | json | unwrap duration_ms [10m])`, app)},
+		{name: "max_over_time_vector", query: fmt.Sprintf(`max_over_time({app="%s"} | json | unwrap duration_ms [10m])`, app)},
+		{name: "min_over_time_vector", query: fmt.Sprintf(`min_over_time({app="%s"} | json | unwrap duration_ms [10m])`, app)},
+		{name: "stddev_over_time_vector", query: fmt.Sprintf(`stddev_over_time({app="%s"} | json | unwrap duration_ms [10m])`, app)},
+		{name: "stdvar_over_time_vector", query: fmt.Sprintf(`stdvar_over_time({app="%s"} | json | unwrap duration_ms [10m])`, app)},
+		{name: "quantile_over_time_vector", query: fmt.Sprintf(`quantile_over_time(0.95, {app="%s"} | json | unwrap duration_ms [10m])`, app)},
 	}
-	for _, tc := range proxyExpectations {
-		t.Run("proxy_"+tc.name, func(t *testing.T) {
-			got := querySingleInstantValue(t, proxyURL, tc.query, at)
-			if !nearlyEqual(got, tc.want) {
-				t.Fatalf("proxy function mismatch for %q: got=%v want=%v", tc.query, got, tc.want)
+	for _, tc := range vectorCases {
+		t.Run("vector_"+tc.name, func(t *testing.T) {
+			proxyStatus, proxyBody, proxyResp := queryInstantGET(t, proxyURL, tc.query, at)
+			lokiStatus, lokiBody, lokiResp := queryInstantGET(t, lokiURL, tc.query, at)
+			if proxyStatus != http.StatusOK || lokiStatus != http.StatusOK {
+				t.Fatalf("expected 200 query responses, proxy=%d loki=%d query=%q proxyBody=%s lokiBody=%s", proxyStatus, lokiStatus, tc.query, proxyBody, lokiBody)
 			}
+			if !checkStatus(proxyResp) || !checkStatus(lokiResp) {
+				t.Fatalf("expected successful responses for %q, proxy=%v loki=%v", tc.query, proxyResp, lokiResp)
+			}
+
+			proxyData := extractMap(proxyResp, "data")
+			lokiData := extractMap(lokiResp, "data")
+			if proxyData["resultType"] != "vector" || lokiData["resultType"] != "vector" {
+				t.Fatalf("expected vector result type for %q, proxy=%v loki=%v", tc.query, proxyData["resultType"], lokiData["resultType"])
+			}
+			assertVectorParity(t, tc.query, extractInstantVector(t, proxyResp), extractInstantVector(t, lokiResp))
 		})
 	}
-
-	t.Run("proxy_quantile_over_time", func(t *testing.T) {
-		query := fmt.Sprintf(`sum(quantile_over_time(0.95, {app="%s"} | json | unwrap duration_ms [10m]))`, app)
-		got := querySingleInstantValue(t, proxyURL, query, at)
-		if got < 20 || got > 100 {
-			t.Fatalf("unexpected quantile_over_time value for %q: got=%v want in [20,100]", query, got)
-		}
-	})
-
-	t.Run("loki_rate_success", func(t *testing.T) {
-		query := fmt.Sprintf(`sum(rate({app="%s"}[10m]))`, app)
-		got := querySingleInstantValue(t, lokiURL, query, at)
-		if got <= 0 {
-			t.Fatalf("expected positive loki rate for %q, got=%v", query, got)
-		}
-	})
-
-	t.Run("proxy_rate_success", func(t *testing.T) {
-		query := fmt.Sprintf(`sum(rate({app="%s"}[10m]))`, app)
-		got := querySingleInstantValue(t, proxyURL, query, at)
-		if got <= 0 {
-			t.Fatalf("expected positive proxy rate for %q, got=%v", query, got)
-		}
-	})
 }
 
 func queryInstantGET(t *testing.T, baseURL, expr string, at time.Time) (int, string, map[string]interface{}) {

--- a/test/e2e-compat/operations_matrix_compat_test.go
+++ b/test/e2e-compat/operations_matrix_compat_test.go
@@ -1,0 +1,423 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	operationsMatrixOnce sync.Once
+	operationsMatrixApp  string
+)
+
+func TestOperationsMatrix_BinaryScalarOperatorsParity(t *testing.T) {
+	app := ensureOperationsMatrixData(t)
+	base := fmt.Sprintf(`sum(count_over_time({app="%s"}[10m]))`, app)
+	cases := []struct {
+		name    string
+		query   string
+		op      string
+		reverse bool
+	}{
+		{name: "add_rhs", query: base + ` + 2`, op: "+"},
+		{name: "sub_rhs", query: base + ` - 2`, op: "-"},
+		{name: "mul_rhs", query: base + ` * 2`, op: "*"},
+		{name: "div_rhs", query: base + ` / 2`, op: "/"},
+		{name: "mod_rhs", query: base + ` % 2`, op: "%"},
+		{name: "pow_rhs", query: base + ` ^ 2`, op: "^"},
+		{name: "add_lhs", query: `2 + ` + base, op: "+", reverse: true},
+		{name: "sub_lhs", query: `2 - ` + base, op: "-", reverse: true},
+		{name: "mul_lhs", query: `2 * ` + base, op: "*", reverse: true},
+		{name: "div_lhs", query: `2 / ` + base, op: "/", reverse: true},
+		{name: "mod_lhs", query: `2 % ` + base, op: "%", reverse: true},
+		{name: "pow_lhs", query: `2 ^ ` + base, op: "^", reverse: true},
+		{name: "gt_bool_rhs", query: base + ` > bool 2`, op: ">"},
+		{name: "lt_bool_rhs", query: base + ` < bool 2`, op: "<"},
+		{name: "gte_bool_rhs", query: base + ` >= bool 2`, op: ">="},
+		{name: "lte_bool_rhs", query: base + ` <= bool 2`, op: "<="},
+		{name: "eq_bool_rhs", query: base + ` == bool 2`, op: "=="},
+		{name: "neq_bool_rhs", query: base + ` != bool 2`, op: "!="},
+		{name: "gt_bool_lhs", query: `2 > bool ` + base, op: ">", reverse: true},
+		{name: "lt_bool_lhs", query: `2 < bool ` + base, op: "<", reverse: true},
+		{name: "gte_bool_lhs", query: `2 >= bool ` + base, op: ">=", reverse: true},
+		{name: "lte_bool_lhs", query: `2 <= bool ` + base, op: "<=", reverse: true},
+		{name: "eq_bool_lhs", query: `2 == bool ` + base, op: "==", reverse: true},
+		{name: "neq_bool_lhs", query: `2 != bool ` + base, op: "!=", reverse: true},
+	}
+
+	at := time.Now()
+	proxyBase := querySingleInstantValue(t, proxyURL, base, at)
+	lokiBase := querySingleInstantValue(t, lokiURL, base, at)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyStatus, proxyBody, proxyResp := queryInstantGET(t, proxyURL, tc.query, at)
+			lokiStatus, lokiBody, lokiResp := queryInstantGET(t, lokiURL, tc.query, at)
+			if proxyStatus != http.StatusOK || lokiStatus != http.StatusOK {
+				t.Fatalf("expected 200 query responses, proxy=%d loki=%d query=%q proxyBody=%s lokiBody=%s", proxyStatus, lokiStatus, tc.query, proxyBody, lokiBody)
+			}
+			if !checkStatus(proxyResp) || !checkStatus(lokiResp) {
+				t.Fatalf("expected successful responses for %q, proxy=%v loki=%v", tc.query, proxyResp, lokiResp)
+			}
+
+			proxyData := extractMap(proxyResp, "data")
+			lokiData := extractMap(lokiResp, "data")
+			if proxyData["resultType"] != "vector" || lokiData["resultType"] != "vector" {
+				t.Fatalf("expected vector result type for %q, proxy=%v loki=%v", tc.query, proxyData["resultType"], lokiData["resultType"])
+			}
+
+			proxyVal := singleVectorValue(t, extractInstantVector(t, proxyResp), tc.query)
+			lokiVal := singleVectorValue(t, extractInstantVector(t, lokiResp), tc.query)
+
+			expProxy := applyExpectedOp(proxyBase, 2, tc.op, tc.reverse)
+			expLoki := applyExpectedOp(lokiBase, 2, tc.op, tc.reverse)
+			if !nearlyEqual(proxyVal, expProxy) {
+				t.Fatalf("proxy operation mismatch for %q: got=%v want=%v", tc.query, proxyVal, expProxy)
+			}
+			if !nearlyEqual(lokiVal, expLoki) {
+				t.Fatalf("loki operation mismatch for %q: got=%v want=%v", tc.query, lokiVal, expLoki)
+			}
+		})
+	}
+}
+
+func TestOperationsMatrix_FilterOperatorsParity(t *testing.T) {
+	app := ensureOperationsMatrixData(t)
+
+	queries := []struct {
+		name  string
+		query string
+	}{
+		{name: "line_contains", query: fmt.Sprintf(`{app="%s"} |= "GET"`, app)},
+		{name: "line_not_contains", query: fmt.Sprintf(`{app="%s"} != "health"`, app)},
+		{name: "line_regex", query: fmt.Sprintf(`{app="%s"} |~ "POST|DELETE"`, app)},
+		{name: "line_not_regex", query: fmt.Sprintf(`{app="%s"} !~ "ready|metrics"`, app)},
+		{name: "json_filter_gte", query: fmt.Sprintf(`{app="%s"} | json | duration_ms >= 10`, app)},
+		{name: "json_filter_lt", query: fmt.Sprintf(`{app="%s"} | json | duration_ms < 100`, app)},
+		{name: "logical_and", query: fmt.Sprintf(`{app="%s"} | json | status >= 200 and status < 500`, app)},
+		{name: "logical_or", query: fmt.Sprintf(`{app="%s"} | json | status = 500 or status = 502`, app)},
+	}
+
+	for _, tc := range queries {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyResp := queryProxy(t, tc.query)
+			lokiResp := queryLoki(t, tc.query)
+			if !checkStatus(proxyResp) || !checkStatus(lokiResp) {
+				t.Fatalf("expected successful responses for %q, proxy=%v loki=%v", tc.query, proxyResp, lokiResp)
+			}
+
+			proxyLines := countLogLines(proxyResp)
+			lokiLines := countLogLines(lokiResp)
+			if proxyLines != lokiLines {
+				t.Fatalf("filter parity mismatch for %q: proxy=%d loki=%d", tc.query, proxyLines, lokiLines)
+			}
+		})
+	}
+}
+
+func TestOperationsMatrix_LokiMetricFunctionsParity(t *testing.T) {
+	app := ensureOperationsMatrixData(t)
+	at := time.Now()
+
+	// Cross-engine parity for functions where semantics should match exactly.
+	parityCases := []struct {
+		name  string
+		query string
+	}{
+		{name: "count_over_time", query: fmt.Sprintf(`sum(count_over_time({app="%s"}[10m]))`, app)},
+		{name: "bytes_over_time", query: fmt.Sprintf(`sum(bytes_over_time({app="%s"}[10m]))`, app)},
+		{name: "bytes_rate", query: fmt.Sprintf(`sum(bytes_rate({app="%s"}[10m]))`, app)},
+	}
+	for _, tc := range parityCases {
+		t.Run("parity_"+tc.name, func(t *testing.T) {
+			proxyVal := querySingleInstantValue(t, proxyURL, tc.query, at)
+			lokiVal := querySingleInstantValue(t, lokiURL, tc.query, at)
+			if !nearlyEqual(proxyVal, lokiVal) {
+				t.Fatalf("function parity mismatch for %q: proxy=%v loki=%v", tc.query, proxyVal, lokiVal)
+			}
+		})
+	}
+
+	// Proxy-local deterministic checks over seeded fixture values:
+	// duration_ms values are [10,20,100,1,2] => sum=133, avg=26.6, min=1, max=100.
+	proxyExpectations := []struct {
+		name  string
+		query string
+		want  float64
+	}{
+		{name: "sum_over_time", query: fmt.Sprintf(`sum(sum_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 133},
+		{name: "avg_over_time", query: fmt.Sprintf(`sum(avg_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 26.6},
+		{name: "max_over_time", query: fmt.Sprintf(`sum(max_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 100},
+		{name: "min_over_time", query: fmt.Sprintf(`sum(min_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 1},
+		{name: "stddev_over_time", query: fmt.Sprintf(`sum(stddev_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 37.328809249693464},
+		{name: "stdvar_over_time", query: fmt.Sprintf(`sum(stdvar_over_time({app="%s"} | json | unwrap duration_ms [10m]))`, app), want: 1393.4400000000003},
+	}
+	for _, tc := range proxyExpectations {
+		t.Run("proxy_"+tc.name, func(t *testing.T) {
+			got := querySingleInstantValue(t, proxyURL, tc.query, at)
+			if !nearlyEqual(got, tc.want) {
+				t.Fatalf("proxy function mismatch for %q: got=%v want=%v", tc.query, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("proxy_quantile_over_time", func(t *testing.T) {
+		query := fmt.Sprintf(`sum(quantile_over_time(0.95, {app="%s"} | json | unwrap duration_ms [10m]))`, app)
+		got := querySingleInstantValue(t, proxyURL, query, at)
+		if got < 20 || got > 100 {
+			t.Fatalf("unexpected quantile_over_time value for %q: got=%v want in [20,100]", query, got)
+		}
+	})
+
+	t.Run("loki_rate_success", func(t *testing.T) {
+		query := fmt.Sprintf(`sum(rate({app="%s"}[10m]))`, app)
+		got := querySingleInstantValue(t, lokiURL, query, at)
+		if got <= 0 {
+			t.Fatalf("expected positive loki rate for %q, got=%v", query, got)
+		}
+	})
+
+	t.Run("proxy_rate_success", func(t *testing.T) {
+		query := fmt.Sprintf(`sum(rate({app="%s"}[10m]))`, app)
+		got := querySingleInstantValue(t, proxyURL, query, at)
+		if got <= 0 {
+			t.Fatalf("expected positive proxy rate for %q, got=%v", query, got)
+		}
+	})
+}
+
+func queryInstantGET(t *testing.T, baseURL, expr string, at time.Time) (int, string, map[string]interface{}) {
+	t.Helper()
+	params := url.Values{}
+	params.Set("query", expr)
+	params.Set("time", at.Format(time.RFC3339Nano))
+	return doJSONGET(t, baseURL+"/loki/api/v1/query?"+params.Encode(), nil)
+}
+
+func extractInstantVector(t *testing.T, payload map[string]interface{}) map[string]float64 {
+	t.Helper()
+	data := extractMap(payload, "data")
+	if data == nil {
+		t.Fatalf("missing data block: %#v", payload)
+	}
+	result := extractArray(data, "result")
+	out := make(map[string]float64, len(result))
+
+	for _, item := range result {
+		sample, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unexpected sample shape: %#v", item)
+		}
+		metric, _ := sample["metric"].(map[string]interface{})
+		key := instantMetricKey(metric)
+
+		valuePair, ok := sample["value"].([]interface{})
+		if !ok || len(valuePair) < 2 {
+			t.Fatalf("unexpected instant value payload: %#v", sample["value"])
+		}
+
+		raw := valuePair[1]
+		switch v := raw.(type) {
+		case string:
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				t.Fatalf("parse instant value %q: %v", v, err)
+			}
+			out[key] = f
+		case float64:
+			out[key] = v
+		default:
+			t.Fatalf("unsupported instant value type %T (%v)", raw, raw)
+		}
+	}
+
+	return out
+}
+
+func instantMetricKey(metric map[string]interface{}) string {
+	if len(metric) == 0 {
+		return "{}"
+	}
+	parts := make([]string, 0, len(metric))
+	for k, v := range metric {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func assertVectorParity(t *testing.T, query string, proxyVec, lokiVec map[string]float64) {
+	t.Helper()
+
+	if len(proxyVec) != len(lokiVec) {
+		t.Fatalf("series count mismatch for %q: proxy=%d loki=%d proxy=%v loki=%v", query, len(proxyVec), len(lokiVec), proxyVec, lokiVec)
+	}
+
+	proxyKeys := make([]string, 0, len(proxyVec))
+	for key := range proxyVec {
+		proxyKeys = append(proxyKeys, key)
+	}
+	sort.Strings(proxyKeys)
+
+	lokiKeys := make([]string, 0, len(lokiVec))
+	for key := range lokiVec {
+		lokiKeys = append(lokiKeys, key)
+	}
+	sort.Strings(lokiKeys)
+
+	if strings.Join(proxyKeys, ",") == strings.Join(lokiKeys, ",") {
+		for key, lokiVal := range lokiVec {
+			proxyVal := proxyVec[key]
+			if !nearlyEqual(proxyVal, lokiVal) {
+				t.Fatalf("value mismatch for %q key=%q proxy=%v loki=%v", query, key, proxyVal, lokiVal)
+			}
+		}
+		return
+	}
+
+	proxyVals := make([]float64, 0, len(proxyVec))
+	for _, key := range proxyKeys {
+		proxyVals = append(proxyVals, proxyVec[key])
+	}
+	lokiVals := make([]float64, 0, len(lokiVec))
+	for _, key := range lokiKeys {
+		lokiVals = append(lokiVals, lokiVec[key])
+	}
+	sort.Float64s(proxyVals)
+	sort.Float64s(lokiVals)
+	for i := range proxyVals {
+		if !nearlyEqual(proxyVals[i], lokiVals[i]) {
+			t.Fatalf("value mismatch for %q (label-shape fallback compare) proxy=%v loki=%v", query, proxyVals, lokiVals)
+		}
+	}
+}
+
+func nearlyEqual(a, b float64) bool {
+	diff := math.Abs(a - b)
+	scale := math.Max(1, math.Max(math.Abs(a), math.Abs(b)))
+	return diff <= 1e-6*scale
+}
+
+func querySingleInstantValue(t *testing.T, baseURL, expr string, at time.Time) float64 {
+	t.Helper()
+	status, body, payload := queryInstantGET(t, baseURL, expr, at)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 query response for %q from %s, got=%d body=%s", expr, baseURL, status, body)
+	}
+	if !checkStatus(payload) {
+		t.Fatalf("expected successful response for %q from %s, got=%v", expr, baseURL, payload)
+	}
+
+	data := extractMap(payload, "data")
+	if data["resultType"] != "vector" {
+		t.Fatalf("expected vector resultType for %q from %s, got=%v", expr, baseURL, data["resultType"])
+	}
+	return singleVectorValue(t, extractInstantVector(t, payload), expr)
+}
+
+func singleVectorValue(t *testing.T, vec map[string]float64, query string) float64 {
+	t.Helper()
+	if len(vec) != 1 {
+		t.Fatalf("expected single-series result for %q, got=%v", query, vec)
+	}
+	for _, v := range vec {
+		return v
+	}
+	return 0
+}
+
+func applyExpectedOp(metric, scalar float64, op string, reverse bool) float64 {
+	a, b := metric, scalar
+	if reverse {
+		a, b = scalar, metric
+	}
+	switch op {
+	case "+":
+		return a + b
+	case "-":
+		return a - b
+	case "*":
+		return a * b
+	case "/":
+		if b == 0 {
+			return 0
+		}
+		return a / b
+	case "%":
+		if b == 0 {
+			return 0
+		}
+		return math.Mod(a, b)
+	case "^":
+		return math.Pow(a, b)
+	case "==":
+		if a == b {
+			return 1
+		}
+		return 0
+	case "!=":
+		if a != b {
+			return 1
+		}
+		return 0
+	case ">":
+		if a > b {
+			return 1
+		}
+		return 0
+	case "<":
+		if a < b {
+			return 1
+		}
+		return 0
+	case ">=":
+		if a >= b {
+			return 1
+		}
+		return 0
+	case "<=":
+		if a <= b {
+			return 1
+		}
+		return 0
+	default:
+		return metric
+	}
+}
+
+func ensureOperationsMatrixData(t *testing.T) string {
+	t.Helper()
+
+	operationsMatrixOnce.Do(func() {
+		waitForReady(t, proxyURL+"/ready", 30*time.Second)
+		waitForReady(t, lokiURL+"/ready", 30*time.Second)
+
+		operationsMatrixApp = fmt.Sprintf("ops-matrix-%d", time.Now().UnixNano())
+		now := time.Now().Add(-2 * time.Minute)
+
+		lines := []logLine{
+			{Msg: `{"method":"GET","path":"/v1/users","status":200,"duration_ms":10}`, Level: "info"},
+			{Msg: `{"method":"POST","path":"/v1/orders","status":201,"duration_ms":20}`, Level: "info"},
+			{Msg: `{"method":"DELETE","path":"/v1/orders/42","status":500,"duration_ms":100}`, Level: "info"},
+			{Msg: `{"method":"GET","path":"/health","status":200,"duration_ms":1}`, Level: "info"},
+			{Msg: `{"method":"GET","path":"/metrics","status":200,"duration_ms":2}`, Level: "info"},
+		}
+		stream := map[string]string{"app": operationsMatrixApp, "env": "matrix", "level": "info"}
+		pushCustomToLoki(t, now, stream, lines)
+		pushCustomToVL(t, now, stream, lines, []string{"app", "env"})
+
+		time.Sleep(3 * time.Second)
+	})
+
+	return operationsMatrixApp
+}


### PR DESCRIPTION
## What
- stop injecting synthetic `service_name="unknown_service"` into `/index/volume` and `/index/volume_range` buckets when grouping is non-service (cluster/namespace/field paths)
- honor Drilldown grouping hints (`drillDownLabel`, `fieldBy`, `var-fieldBy`) as target-label fallbacks when `targetLabels` is missing
- fix binary/scalar post-processing so arithmetic mutates both backend payload shapes (`results` and Prometheus-style `data.result`), including instant-vector `value` samples
- extend coverage with operation/filter/function matrices across translator + proxy, plus e2e matrix checks and fuzzing for scalar/vector binary merge paths
- keep metric translation compatibility updates (`bytes_over_time` / `bytes_rate` using `sum_len(_msg)`, `stdvar_over_time` via `stddev^2`)

## Why
Drilldown field/label flows can omit `targetLabels` and rely on URL state, and binary metric evaluation was still shape-sensitive in some valid backend responses. That combination caused unstable grouping and arithmetic behavior under real Grafana query paths.

## Proof
Before:
`curl http://127.0.0.1:3110/loki/api/v1/index/volume?query=%7Bcluster%3D%22e2e%22%7D&start=now-6h&end=now`
returned:
`{"cluster":"e2e","service_name":"unknown_service"}`

After:
same query returns:
`{"cluster":"e2e"}`

Binary arithmetic regression check:
`sum(count_over_time({app="ops-matrix-..."}[10m])) * 2`
now returns transformed value on proxy (no silent no-op in `data.result` shape).

## Validation
- `go test ./internal/proxy`
- `go test ./internal/translator`
- `go test -tags=e2e ./test/e2e-compat -run 'TestOperationsMatrix_' -count=1`
- `go test ./internal/proxy -run '^$' -fuzz FuzzCombineBinaryMetricResultsScalarPath -fuzztime=5s`
- `go test ./internal/translator -run '^$' -fuzz FuzzBinaryExpressions -fuzztime=5s`

