### PR TITLE
chart: support extra env aliases for scalar env values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -692,3 +692,6 @@ jobs:
 
       - name: Helm template quoted args regression
         run: helm template loki-vl-proxy charts/loki-vl-proxy -f scripts/ci/helm-quoted-args-values.yaml >/dev/null
+
+      - name: Helm template env alias regression
+        run: helm template loki-vl-proxy charts/loki-vl-proxy -f scripts/ci/helm-env-alias-values.yaml >/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- chart: tolerate reserved scalar `env` values by rendering list-typed `env`/`envFrom` only when they are real lists, and add `extraEnv` / `extraEnvFrom` compatibility aliases for chart consumers that need explicit container env injection without colliding with scalar environment selectors.
+
+### Tests
+
+- chart/ci: add a Helm render regression for scalar `env` combined with `extraEnv` / `extraEnvFrom` so the manifest shape stays valid in CI.
+
 ## [1.12.1] - 2026-04-21
 
 ### Bug Fixes

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -171,7 +171,9 @@ spec:
             - {{ printf "-peer-static=%s" (join "," .Values.peerCache.peers) | quote }}
             {{- end }}
             {{- end }}
-          {{- if or .Values.peerCache.enabled .Values.env $goMemLimitValue $injectOTELFromPod }}
+          {{- $hasChartEnv := and (kindIs "slice" .Values.env) (gt (len .Values.env) 0) }}
+          {{- $hasExtraEnv := and (kindIs "slice" .Values.extraEnv) (gt (len .Values.extraEnv) 0) }}
+          {{- if or .Values.peerCache.enabled $hasChartEnv $hasExtraEnv $goMemLimitValue $injectOTELFromPod }}
           env:
             {{- if $goMemLimitValue }}
             - name: GOMEMLIMIT
@@ -193,13 +195,23 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             {{- end }}
-            {{- with .Values.env }}
-            {{- toYaml . | nindent 12 }}
+            {{- if $hasChartEnv }}
+            {{- toYaml .Values.env | nindent 12 }}
+            {{- end }}
+            {{- if $hasExtraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.envFrom }}
+          {{- $hasChartEnvFrom := and (kindIs "slice" .Values.envFrom) (gt (len .Values.envFrom) 0) }}
+          {{- $hasExtraEnvFrom := and (kindIs "slice" .Values.extraEnvFrom) (gt (len .Values.extraEnvFrom) 0) }}
+          {{- if or $hasChartEnvFrom $hasExtraEnvFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- if $hasChartEnvFrom }}
+            {{- toYaml .Values.envFrom | nindent 12 }}
+            {{- end }}
+            {{- if $hasExtraEnvFrom }}
+            {{- toYaml .Values.extraEnvFrom | nindent 12 }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -354,6 +354,17 @@ envFrom: []
   # - configMapRef:
   #     name: loki-vl-proxy-config
 
+# Compatibility aliases for deployments where `env` is already used as a
+# scalar environment selector instead of a list of container environment vars.
+# When set, these entries are appended after `env` / `envFrom`.
+extraEnv: []
+  # - name: LOG_LEVEL
+  #   value: "info"
+
+extraEnvFrom: []
+  # - secretRef:
+  #     name: loki-vl-proxy-extra-env
+
 # Extra manifests rendered with full Helm chart context.
 # Each entry may be either:
 # - a YAML object/map

--- a/scripts/ci/helm-env-alias-values.yaml
+++ b/scripts/ci/helm-env-alias-values.yaml
@@ -1,0 +1,7 @@
+env: example-environment
+extraEnv:
+  - name: EXAMPLE_FLAG
+    value: enabled
+extraEnvFrom:
+  - secretRef:
+      name: example-secret


### PR DESCRIPTION
Summary:
- make the chart render env and envFrom only when they are real lists
- add extraEnv and extraEnvFrom compatibility aliases for deployments that already use scalar env selectors
- add a Helm CI regression render for scalar env plus explicit env aliases

Validation:
- helm lint charts/loki-vl-proxy
- helm template loki-vl-proxy charts/loki-vl-proxy -f scripts/ci/helm-quoted-args-values.yaml >/dev/null
- helm template loki-vl-proxy charts/loki-vl-proxy -f scripts/ci/helm-env-alias-values.yaml >/dev/null
- python3 scripts/ci/check_changelog_pr.py --base origin/main --head HEAD
