### PR TITLE
fix: harden range-function compatibility and parser metric handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- metrics/compat: harden range-function compatibility by requiring explicit `| unwrap <field>` for unwrap-dependent range functions, resolve Grafana range template selectors (`$__auto`, `$__interval`, `$__rate_interval`, `$__range*`) before compatibility handling, and reject unsupported bare metric range queries early instead of silently falling through.
+- metrics/compat: add `rate_counter(...)` support on parser+unwrap compatibility paths, including counter-reset aware rate calculation.
+
+### Tests
+
+- proxy/translator: add regressions for unwrap-required function errors, Grafana template token resolution, parser probe unquoting, template-window resolution for `rate_counter`, and counter-reset handling in compatibility window evaluation.
+
 ## [1.12.2] - 2026-04-21
 
 ### Bug Fixes

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2121,10 +2121,17 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	}
 	p.log.Debug("query_range request", "logql", logqlQuery)
 
+	logqlQuery = resolveGrafanaRangeTemplateTokens(logqlQuery, r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
 	logqlQuery = p.preferWorkingParser(r.Context(), logqlQuery, r.FormValue("start"), r.FormValue("end"))
 
 	if spec, ok := parseBareParserMetricCompatSpec(logqlQuery); ok {
-		p.proxyBareParserMetricQueryRange(w, r, start, logqlQuery, spec)
+		resolvedSpec, resolved := resolveBareParserMetricRangeWindow(spec, r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
+		if !resolved {
+			p.writeError(w, http.StatusBadRequest, "invalid range selector")
+			p.metrics.RecordRequest("query_range", http.StatusBadRequest, time.Since(start))
+			return
+		}
+		p.proxyBareParserMetricQueryRange(w, r, start, logqlQuery, resolvedSpec)
 		return
 	}
 
@@ -2142,6 +2149,11 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	// Extract without() labels for post-processing
 	logsqlQuery, withoutLabels := translator.ParseWithoutMarker(logsqlQuery)
 	logsqlQuery = preserveMetricStreamIdentity(logqlQuery, logsqlQuery, withoutLabels)
+	if isBareMetricFunctionQuery(strings.TrimSpace(logqlQuery)) && !isStatsQuery(logsqlQuery) {
+		p.writeError(w, http.StatusBadRequest, "unsupported metric query: range aggregations require compatible unwrap or translator support")
+		p.metrics.RecordRequest("query_range", http.StatusBadRequest, time.Since(start))
+		return
+	}
 	p.log.Debug("translated query", "logsql", logsqlQuery, "without", withoutLabels)
 
 	r = withOrgID(r)
@@ -2244,10 +2256,17 @@ func (p *Proxy) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logqlQuery = resolveGrafanaRangeTemplateTokens(logqlQuery, r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
 	logqlQuery = p.preferWorkingParser(r.Context(), logqlQuery, r.FormValue("start"), r.FormValue("end"))
 
 	if spec, ok := parseBareParserMetricCompatSpec(logqlQuery); ok {
-		p.proxyBareParserMetricQuery(w, r, start, logqlQuery, spec)
+		resolvedSpec, resolved := resolveBareParserMetricRangeWindow(spec, r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
+		if !resolved {
+			p.writeError(w, http.StatusBadRequest, "invalid range selector")
+			p.metrics.RecordRequest("query", http.StatusBadRequest, time.Since(start))
+			return
+		}
+		p.proxyBareParserMetricQuery(w, r, start, logqlQuery, resolvedSpec)
 		return
 	}
 	if spec, ok := parseAbsentOverTimeCompatSpec(logqlQuery); ok {
@@ -2270,6 +2289,11 @@ func (p *Proxy) handleQuery(w http.ResponseWriter, r *http.Request) {
 	// Extract without() labels for post-processing
 	logsqlQuery, withoutLabels := translator.ParseWithoutMarker(logsqlQuery)
 	logsqlQuery = preserveMetricStreamIdentity(logqlQuery, logsqlQuery, withoutLabels)
+	if isBareMetricFunctionQuery(strings.TrimSpace(logqlQuery)) && !isStatsQuery(logsqlQuery) {
+		p.writeError(w, http.StatusBadRequest, "unsupported metric query: range aggregations require compatible unwrap or translator support")
+		p.metrics.RecordRequest("query", http.StatusBadRequest, time.Since(start))
+		return
+	}
 
 	r = withOrgID(r)
 
@@ -2463,6 +2487,7 @@ func preserveMetricStreamIdentity(originalLogQL, translatedLogsQL string, withou
 func isBareMetricFunctionQuery(logql string) bool {
 	for _, prefix := range []string{
 		"rate(",
+		"rate_counter(",
 		"count_over_time(",
 		"bytes_over_time(",
 		"bytes_rate(",
@@ -10025,11 +10050,12 @@ type requestedBucketRange struct {
 }
 
 type bareParserMetricCompatSpec struct {
-	funcName    string
-	baseQuery   string
-	rangeWindow time.Duration
-	unwrapField string
-	quantile    float64
+	funcName        string
+	baseQuery       string
+	rangeWindow     time.Duration
+	rangeWindowExpr string
+	unwrapField     string
+	quantile        float64
 }
 
 type bareParserMetricSample struct {
@@ -10157,6 +10183,98 @@ func parsePositiveStepDuration(step string) (time.Duration, bool) {
 		return 0, false
 	}
 	return d, true
+}
+
+func resolveGrafanaRangeTemplateTokens(query, start, end, step string) string {
+	if !strings.Contains(query, "$__") {
+		return query
+	}
+
+	replacements := map[string]string{}
+	for _, token := range []string{
+		"$__range_ms",
+		"$__rate_interval",
+		"$__interval",
+		"$__range_s",
+		"$__range",
+		"$__auto",
+	} {
+		if duration, ok := resolveGrafanaTemplateTokenDuration(token, start, end, step); ok {
+			replacements[token] = formatLogQLDuration(duration)
+		}
+	}
+
+	if len(replacements) == 0 {
+		return query
+	}
+
+	normalized := query
+	for _, token := range []string{
+		"$__range_ms",
+		"$__rate_interval",
+		"$__interval",
+		"$__range_s",
+		"$__range",
+		"$__auto",
+	} {
+		replacement, ok := replacements[token]
+		if !ok {
+			continue
+		}
+		normalized = strings.ReplaceAll(normalized, token, replacement)
+	}
+	return normalized
+}
+
+func resolveGrafanaTemplateTokenDuration(token, start, end, step string) (time.Duration, bool) {
+	stepDur, stepOK := parsePositiveStepDuration(step)
+	if !stepOK {
+		stepDur = time.Minute
+	}
+
+	rangeDur := stepDur
+	startNanos, startOK := parseFlexibleUnixNanos(start)
+	endNanos, endOK := parseFlexibleUnixNanos(end)
+	if startOK && endOK && endNanos > startNanos {
+		rangeDur = time.Duration(endNanos - startNanos)
+	}
+	if rangeDur <= 0 {
+		rangeDur = stepDur
+	}
+
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "$__auto", "$__interval":
+		return stepDur, true
+	case "$__rate_interval":
+		rateInterval := stepDur * 4
+		if rateInterval < time.Minute {
+			rateInterval = time.Minute
+		}
+		return rateInterval, true
+	case "$__range", "$__range_s", "$__range_ms":
+		return rangeDur, true
+	default:
+		return 0, false
+	}
+}
+
+func formatLogQLDuration(d time.Duration) string {
+	if d <= 0 {
+		return "1s"
+	}
+	if d%time.Hour == 0 {
+		return strconv.FormatInt(int64(d/time.Hour), 10) + "h"
+	}
+	if d%time.Minute == 0 {
+		return strconv.FormatInt(int64(d/time.Minute), 10) + "m"
+	}
+	if d%time.Second == 0 {
+		return strconv.FormatInt(int64(d/time.Second), 10) + "s"
+	}
+	if d%time.Millisecond == 0 {
+		return strconv.FormatInt(int64(d/time.Millisecond), 10) + "ms"
+	}
+	return strconv.FormatFloat(d.Seconds(), 'f', -1, 64) + "s"
 }
 
 func parseStepSeconds(step string) (int64, bool) {
@@ -12450,11 +12568,11 @@ func (p *Proxy) preferWorkingParser(ctx context.Context, logql, start, end strin
 	}
 }
 
-var metricParserProbeRE = regexp.MustCompile(`(?s)(?:count_over_time|bytes_over_time|rate|bytes_rate|sum_over_time|avg_over_time|max_over_time|min_over_time|first_over_time|last_over_time|stddev_over_time|stdvar_over_time|quantile_over_time)\((.*?)\[[^][]+\]\)`)
+var metricParserProbeRE = regexp.MustCompile(`(?s)(?:count_over_time|bytes_over_time|rate|bytes_rate|rate_counter|sum_over_time|avg_over_time|max_over_time|min_over_time|first_over_time|last_over_time|stddev_over_time|stdvar_over_time|quantile_over_time)\((.*?)\[[^][]+\]\)`)
 
 var (
 	absentOverTimeCompatRE         = regexp.MustCompile(`(?s)^\s*absent_over_time\(\s*(.*)\[([^][]+)\]\s*\)\s*$`)
-	bareParserMetricCompatRE       = regexp.MustCompile(`(?s)^\s*(count_over_time|bytes_over_time|rate|bytes_rate|sum_over_time|avg_over_time|max_over_time|min_over_time|first_over_time|last_over_time|stddev_over_time|stdvar_over_time)\((.*)\[([^][]+)\]\)\s*$`)
+	bareParserMetricCompatRE       = regexp.MustCompile(`(?s)^\s*(count_over_time|bytes_over_time|rate|bytes_rate|rate_counter|sum_over_time|avg_over_time|max_over_time|min_over_time|first_over_time|last_over_time|stddev_over_time|stdvar_over_time)\((.*)\[([^][]+)\]\)\s*$`)
 	bareParserQuantileCompatRE     = regexp.MustCompile(`(?s)^\s*quantile_over_time\(\s*([0-9.]+)\s*,\s*(.*)\[([^][]+)\]\)\s*$`)
 	bareParserUnwrapFieldRE        = regexp.MustCompile(`\|\s*unwrap\s+(?:(?:duration|bytes)\(([^)]+)\)|([A-Za-z0-9_.-]+))`)
 	regexpExtractingParserStageRE  = regexp.MustCompile(`\|\s*regexp(?:\s+[^|]+)?`)
@@ -12463,11 +12581,24 @@ var (
 )
 
 func extractParserProbeQuery(logql string) string {
+	unquote := func(s string) string {
+		s = strings.TrimSpace(s)
+		if len(s) < 2 {
+			return s
+		}
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			if unquoted, err := strconv.Unquote(s); err == nil {
+				return strings.TrimSpace(unquoted)
+			}
+		}
+		return s
+	}
+
 	matches := metricParserProbeRE.FindStringSubmatch(logql)
 	if len(matches) == 2 {
-		return strings.TrimSpace(matches[1])
+		return unquote(matches[1])
 	}
-	return strings.TrimSpace(logql)
+	return unquote(logql)
 }
 
 func hasExtractingParserStage(logql string) bool {
@@ -12491,8 +12622,9 @@ func parseBareParserMetricCompatSpec(logql string) (bareParserMetricCompatSpec, 
 		if baseQuery == "" || !hasExtractingParserStage(baseQuery) {
 			return bareParserMetricCompatSpec{}, false
 		}
-		window, ok := parsePositiveStepDuration(matches[3])
-		if !ok {
+		windowRaw := strings.TrimSpace(matches[3])
+		window, ok := parsePositiveStepDuration(windowRaw)
+		if !ok && !isGrafanaRangeTemplateSelector(windowRaw) {
 			return bareParserMetricCompatSpec{}, false
 		}
 		phi, err := strconv.ParseFloat(matches[1], 64)
@@ -12504,11 +12636,12 @@ func parseBareParserMetricCompatSpec(logql string) (bareParserMetricCompatSpec, 
 			return bareParserMetricCompatSpec{}, false
 		}
 		return bareParserMetricCompatSpec{
-			funcName:    "quantile_over_time",
-			baseQuery:   baseQuery,
-			rangeWindow: window,
-			unwrapField: unwrapField,
-			quantile:    phi,
+			funcName:        "quantile_over_time",
+			baseQuery:       baseQuery,
+			rangeWindow:     window,
+			rangeWindowExpr: windowRaw,
+			unwrapField:     unwrapField,
+			quantile:        phi,
 		}, true
 	}
 
@@ -12520,24 +12653,50 @@ func parseBareParserMetricCompatSpec(logql string) (bareParserMetricCompatSpec, 
 	if baseQuery == "" || !hasExtractingParserStage(baseQuery) {
 		return bareParserMetricCompatSpec{}, false
 	}
-	window, ok := parsePositiveStepDuration(matches[3])
-	if !ok {
+	windowRaw := strings.TrimSpace(matches[3])
+	window, ok := parsePositiveStepDuration(windowRaw)
+	if !ok && !isGrafanaRangeTemplateSelector(windowRaw) {
 		return bareParserMetricCompatSpec{}, false
 	}
 	unwrapField := ""
 	switch matches[1] {
-	case "sum_over_time", "avg_over_time", "max_over_time", "min_over_time", "first_over_time", "last_over_time", "stddev_over_time", "stdvar_over_time":
+	case "rate_counter", "sum_over_time", "avg_over_time", "max_over_time", "min_over_time", "first_over_time", "last_over_time", "stddev_over_time", "stdvar_over_time":
 		unwrapField = extractBareParserUnwrapField(baseQuery)
 		if unwrapField == "" {
 			return bareParserMetricCompatSpec{}, false
 		}
 	}
 	return bareParserMetricCompatSpec{
-		funcName:    matches[1],
-		baseQuery:   baseQuery,
-		rangeWindow: window,
-		unwrapField: unwrapField,
+		funcName:        matches[1],
+		baseQuery:       baseQuery,
+		rangeWindow:     window,
+		rangeWindowExpr: windowRaw,
+		unwrapField:     unwrapField,
 	}, true
+}
+
+func isGrafanaRangeTemplateSelector(window string) bool {
+	switch strings.ToLower(strings.TrimSpace(window)) {
+	case "$__auto", "$__interval", "$__rate_interval", "$__range", "$__range_s", "$__range_ms":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveBareParserMetricRangeWindow(spec bareParserMetricCompatSpec, start, end, step string) (bareParserMetricCompatSpec, bool) {
+	if spec.rangeWindow > 0 {
+		return spec, true
+	}
+	if strings.TrimSpace(spec.rangeWindowExpr) == "" {
+		return spec, false
+	}
+	duration, ok := resolveGrafanaTemplateTokenDuration(spec.rangeWindowExpr, start, end, step)
+	if !ok || duration <= 0 {
+		return spec, false
+	}
+	spec.rangeWindow = duration
+	return spec, true
 }
 
 func extractBareParserUnwrapField(query string) string {
@@ -12698,6 +12857,22 @@ func bareParserMetricWindowValue(funcName string, window []bareParserMetricSampl
 			total += sample.value
 		}
 		return metricWindowValue(funcName, total, spec.rangeWindow)
+	case "rate_counter":
+		if len(window) < 2 || spec.rangeWindow <= 0 {
+			return 0
+		}
+		increase := 0.0
+		prev := window[0].value
+		for _, sample := range window[1:] {
+			if sample.value >= prev {
+				increase += sample.value - prev
+			} else {
+				// Counter reset: treat current value as the post-reset increase.
+				increase += sample.value
+			}
+			prev = sample.value
+		}
+		return increase / spec.rangeWindow.Seconds()
 	case "avg_over_time":
 		total := 0.0
 		for _, sample := range window {

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -1,8 +1,10 @@
 package proxy
 
 import (
+	"math"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +129,61 @@ func TestProxyHelpers_ParseBareParserMetricCompatSpec_AcceptsUnwrapRangeFunction
 	}
 }
 
+func TestProxyHelpers_ParseBareParserMetricCompatSpec_AcceptsRateCounterWithTemplateWindow(t *testing.T) {
+	spec, ok := parseBareParserMetricCompatSpec(`rate_counter({app="api-gateway"} | json | unwrap counter [$__interval])`)
+	if !ok {
+		t.Fatal("expected rate_counter unwrap query to use bare compat handling")
+	}
+	if spec.funcName != "rate_counter" {
+		t.Fatalf("unexpected funcName %q", spec.funcName)
+	}
+	if spec.unwrapField != "counter" {
+		t.Fatalf("unexpected unwrapField %q", spec.unwrapField)
+	}
+	if spec.rangeWindow != 0 {
+		t.Fatalf("expected template window to defer duration resolution, got %v", spec.rangeWindow)
+	}
+	if spec.rangeWindowExpr != "$__interval" {
+		t.Fatalf("unexpected rangeWindowExpr %q", spec.rangeWindowExpr)
+	}
+
+	resolved, ok := resolveBareParserMetricRangeWindow(spec, "2026-01-01T00:00:00Z", "2026-01-01T00:10:00Z", "30s")
+	if !ok {
+		t.Fatal("expected template window to resolve with request step")
+	}
+	if resolved.rangeWindow != 30*time.Second {
+		t.Fatalf("unexpected resolved rangeWindow %v", resolved.rangeWindow)
+	}
+}
+
+func TestProxyHelpers_ResolveGrafanaRangeTemplateTokens(t *testing.T) {
+	query := `rate({app="api-gateway"}[$__auto]) + rate_counter({app="api-gateway"} | json | unwrap counter [$__rate_interval]) + count_over_time({app="api-gateway"}[$__range_s])`
+	got := resolveGrafanaRangeTemplateTokens(query, "2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z", "15s")
+	if strings.Contains(got, "$__") {
+		t.Fatalf("expected all Grafana template tokens to resolve, got %q", got)
+	}
+	if !strings.Contains(got, "[15s]") {
+		t.Fatalf("expected $__auto to resolve to step, got %q", got)
+	}
+	if !strings.Contains(got, "[1m]") {
+		t.Fatalf("expected $__rate_interval to clamp to 1m minimum, got %q", got)
+	}
+	if !strings.Contains(got, "[5m]") {
+		t.Fatalf("expected $__range_s to resolve to query range, got %q", got)
+	}
+}
+
+func TestProxyHelpers_ExtractParserProbeQuery_UnquotesInput(t *testing.T) {
+	got := extractParserProbeQuery("\"rate_counter({app=\\\"api-gateway\\\"} | json | unwrap counter [5m])\"")
+	if strings.HasPrefix(got, `"`) {
+		t.Fatalf("expected parser probe query to be unquoted, got %q", got)
+	}
+	unescaped := strings.ReplaceAll(got, `\"`, `"`)
+	if !strings.Contains(unescaped, `{app="api-gateway"} | json | unwrap counter`) {
+		t.Fatalf("unexpected parser probe extraction %q", got)
+	}
+}
+
 func TestProxyHelpers_ParseAbsentOverTimeCompatSpec(t *testing.T) {
 	spec, ok := parseAbsentOverTimeCompatSpec(`absent_over_time({app="missing"}[5m])`)
 	if !ok {
@@ -167,6 +224,22 @@ func TestProxyHelpers_BuildBareParserMetricMatrix(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected matrix values: got=%v want=%v", got, want)
+	}
+}
+
+func TestProxyHelpers_BareParserMetricWindowValue_RateCounterHandlesResets(t *testing.T) {
+	window := []bareParserMetricSample{
+		{tsNanos: 1, value: 100},
+		{tsNanos: 2, value: 110},
+		{tsNanos: 3, value: 5},
+		{tsNanos: 4, value: 12},
+	}
+	spec := bareParserMetricCompatSpec{rangeWindow: time.Minute}
+
+	got := bareParserMetricWindowValue("rate_counter", window, spec)
+	want := 22.0 / 60.0 // +10, reset then +5, then +7
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("rate_counter reset handling mismatch: got=%v want=%v", got, want)
 	}
 }
 

--- a/internal/translator/fixes_test.go
+++ b/internal/translator/fixes_test.go
@@ -77,3 +77,23 @@ func TestMetricQuery_MissingRangeDoesNotTranslate(t *testing.T) {
 		}
 	}
 }
+
+func TestMetricQuery_UnwrapRequiredRangeFunctionsReturnError(t *testing.T) {
+	tests := []string{
+		`sum_over_time({app="nginx"}[5m])`,
+		`stddev_over_time({app="nginx"}[5m])`,
+		`quantile_over_time(0.95, {app="nginx"}[5m])`,
+		`rate_counter({app="nginx"}[5m])`,
+		`sum(sum_over_time({app="nginx"}[5m])) by (app)`,
+	}
+
+	for _, logql := range tests {
+		_, err := TranslateLogQL(logql)
+		if err == nil {
+			t.Fatalf("expected unwrap-required metric query to return error: %s", logql)
+		}
+		if !strings.Contains(err.Error(), "unwrap") {
+			t.Fatalf("expected unwrap hint in error for %s, got %v", logql, err)
+		}
+	}
+}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -68,6 +68,9 @@ func translateLogQLFull(logql string, labelFn LabelTranslateFunc, streamFields m
 	if metricResult, ok := tryTranslateMetricQuery(logql, labelFn); ok {
 		return appendWithoutMarker(metricResult, withoutLabels), nil
 	}
+	if unwrapFunc := missingUnwrapRangeMetricFunc(logql); unwrapFunc != "" {
+		return "", fmt.Errorf("%s requires `| unwrap <field>` for range aggregation", unwrapFunc)
+	}
 
 	return translateLogQuery(logql, labelFn, streamFields)
 }
@@ -864,10 +867,10 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 		if isUnwrapFunc(funcName) {
 			// For unwrap functions, extract the unwrap field
 			unwrapField := extractUnwrapField(inner)
-			statsExpr := logsqlFunc
-			if unwrapField != "" {
-				statsExpr = fmt.Sprintf("%s(%s)", logsqlFunc, unwrapField)
+			if unwrapField == "" {
+				continue
 			}
+			statsExpr := fmt.Sprintf("%s(%s)", logsqlFunc, unwrapField)
 			innerBy := unwrapInnerGrouping(query, byLabels, outerAgg, labelFn)
 
 			// stdvar_over_time uses stddev + square, since VL doesn't have stdvar().
@@ -1239,6 +1242,57 @@ func isUnwrapFunc(name string) bool {
 	return unwrapFuncs[name]
 }
 
+func missingUnwrapRangeMetricFunc(logql string) string {
+	logql = strings.TrimSpace(logql)
+	if logql == "" {
+		return ""
+	}
+
+	if _, inner, _ := extractOuterAggregation(logql); inner != "" {
+		logql = strings.TrimSpace(inner)
+	}
+
+	funcs := []string{
+		"sum_over_time", "avg_over_time",
+		"max_over_time", "min_over_time",
+		"first_over_time", "last_over_time",
+		"stddev_over_time", "stdvar_over_time",
+		"quantile_over_time", "rate_counter",
+	}
+
+	for _, funcName := range funcs {
+		prefix := funcName + "("
+		if !strings.HasPrefix(logql, prefix) {
+			continue
+		}
+		inner := logql[len(prefix):]
+		end := findLastMatchingParen(inner)
+		if end < 0 {
+			return ""
+		}
+		inner = inner[:end]
+		if funcName == "quantile_over_time" {
+			if strings.Contains(inner, "[") && strings.Contains(inner, "]") && extractUnwrapField(inner) == "" {
+				return funcName
+			}
+			return ""
+		}
+		_, duration := extractQueryAndDuration(inner)
+		if strings.TrimSpace(duration) == "" {
+			return ""
+		}
+		if strings.Contains(duration, ":") {
+			return ""
+		}
+		if extractUnwrapField(inner) == "" {
+			return funcName
+		}
+		return ""
+	}
+
+	return ""
+}
+
 func extractOuterAggregation(logql string) (agg, inner, byLabels string) {
 	// Match two forms:
 	// 1. sum(...) by (labels)     — by AFTER
@@ -1374,7 +1428,7 @@ func tryTranslateQuantileOverTime(innerExpr, outerAgg, byLabels string, labelFn 
 	// Extract unwrap field
 	unwrapField := extractUnwrapField(queryPart)
 	if unwrapField == "" {
-		unwrapField = "_msg"
+		return "", false
 	}
 
 	statsExpr := fmt.Sprintf("quantile(%s, %s)", phi, unwrapField)


### PR DESCRIPTION
## Summary
- stop generating invalid VL stats pipes (for example bare sum, avg, stddev) when unwrap-only LogQL range functions are missing unwrap
- return explicit unwrap-required translation errors for sum/avg/max/min/first/last/stddev/stdvar/quantile_over_time and rate_counter misuse
- fix quantile translation fallback so missing unwrap is no longer coerced to _msg
- add rate_counter to parser-compat matching, including reset-aware rate_counter window math
- resolve Grafana range template tokens (, , , , , ) before translation/compat paths
- unquote parser-probe extracted queries to avoid malformed quoted upstream requests

## Validation
- go test ./internal/translator ./internal/proxy
- added regression tests for unwrap-required errors, template window resolution, parser probe extraction, and rate_counter reset behavior
