### PR TITLE
compat: close range-metric parity gaps and expand e2e coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- metrics/query-range-compat: route parser-stage metric queries (translated `unpack_*` / `extract*`) through proxy-side range evaluation for `query` and `query_range`, preserving parser label cardinality and unwrap semantics when direct `stats_query(_range)` behavior diverges from Loki.
+- metrics/rate-counter: force `rate_counter` onto the compatibility path so counter-reset-aware behavior is consistent across parser and non-parser shapes instead of depending on backend parser acceptance.
+- query-range/windowing: return explicit Loki-style backend errors when split-window fetches fail after retries instead of silently falling back to full-range direct query execution.
+- query-range/error-contract: keep failure shape stable for Grafana and API clients by surfacing the real upstream failure class on split execution errors.
+- drilldown/cache: normalize empty detected-field-value refresh payloads to `[]` (not `null`) to keep downstream consumers stable during cache refreshes.
+
+### Tests
+
+- compat/query-range: add parser-stage/manual evaluation coverage for `rate`, `bytes_rate`, `first_over_time`, `quantile_over_time`, and `rate_counter`, and keep `stdvar_over_time` compatibility covered through matrix/binary evaluation paths.
+- compat/query-range: add explicit parser-probe and path-selection coverage to enforce when manual compatibility evaluation is required vs when backend stats execution remains valid.
+- query-range/windowing: add regressions proving split-window failures return upstream errors and transient per-window backend failures are retried.
+- drilldown/compat: harden parser-probe expectations so metric compatibility tests accept both direct stats and manual compatibility execution paths while still enforcing "single working parser" behavior.
+
+### Documentation
+
+- docs/translation-reference: document `rate_counter` translation and parser-stage range-metric compatibility behavior, including path-selection rules for manual evaluation vs single-shot `stats_query_range`.
+- docs/testing: expand required matrix edge cases for parser-stage range metrics, `rate_counter`, unwrap error shapes, and comparison expectations across Loki/proxy parity checks.
+
 ## [1.12.3] - 2026-04-23
 
 ### Bug Fixes

--- a/docs/compatibility-loki.md
+++ b/docs/compatibility-loki.md
@@ -44,6 +44,8 @@ The Loki matrix is a moving window. When a new Loki minor becomes current, the m
 - `detected_level` grouped metric queries used by Grafana log volume panels
 - OTel dotted and underscore label parity through the underscore proxy
 - Series and label-value parity for labels synthesized by the proxy
+- parser-stage range metrics where labelset parity must match Loki under compatibility execution
+- `rate_counter(... | unwrap ...)` reset-aware semantics and error-class parity
 
 ## Query Families In The Loki Semantics Matrix
 
@@ -120,6 +122,8 @@ The required matrix is intentionally not limited to happy-path selectors. It now
 - `pattern` parser extraction semantics
 - set-style binary operators such as `or` and `unless`
 - `bool` comparison semantics on metric expressions
+- parser-stage metric compatibility path selection for `query` and `query_range` when backend stats semantics diverge
+- `rate_counter` parity for parser and non-parser query forms
 - metric aggregations that do not group by service labels must not receive synthetic `service_name="unknown_service"` in query/query_range responses
 - invalid log/metric shape rejections that must fail with the same class of error as Loki
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -291,6 +291,13 @@ This is where the repo makes tricky edge cases explicit instead of relying on sc
 - invalid forms like `topk(2, {selector})` and `sort({selector})`
 - invalid forms like `rate({selector})` without a range
 
+Additional required parity edge cases for parser-stage metric compatibility:
+
+- `rate_counter(... | unwrap <field> [window])` must keep reset-aware behavior and match Loki outcome class while preserving parser-derived labels
+- parser-stage range metrics must preserve exact metric label-set parity (not only result counts) against Loki
+- unwrap-required range functions without `unwrap` must fail with Loki-style invalid-aggregation errors
+- parser-probe compatibility fallback must be deterministic (single working parser path), so repeated runs do not switch between incompatible query plans
+
 Proxy-only Grafana helper behavior such as synthetic labels, Drilldown fields, stale-on-error helpers, and detected-label recovery stays outside this matrix and belongs in the dedicated proxy contract tests.
 
 Valid Loki behavior is not an accepted exclusion class. If a query works in real Loki and diverges in the proxy, it should be fixed and added to the required matrix or tracked immediately as a parity bug with a dedicated regression target.

--- a/docs/translation-reference.md
+++ b/docs/translation-reference.md
@@ -86,6 +86,7 @@ These stages are executed at the proxy level (VL has no native equivalents):
 | `stddev_over_time({...} \| unwrap f [5m])` | `... \| stats stddev(f)` |
 | `stdvar_over_time({...} \| unwrap f [5m])` | proxy binary expression: `(... \| stats stddev(f)) ^ 2` |
 | `quantile_over_time(0.95, {...} \| unwrap f [5m])` | `... \| stats quantile(0.95, f)` |
+| `rate_counter({...} \| unwrap f [5m])` | `... \| stats __rate_counter__(f)` |
 | `absent_over_time({...}[5m])` | `... \| stats count()` |
 
 ### Outer Aggregations
@@ -120,6 +121,32 @@ The following Loki semantics are implemented in the proxy to bridge gaps where V
 | `offset` modifier | Normalized in translation; query time bounds handled by the proxy request path |
 | `@ <timestamp>` modifier | Normalized/stripped in translation for VictoriaLogs backend requests |
 | Subquery `rate(...)[1h:5m]` | Proxy runs inner query across sub-steps and applies outer aggregation |
+| Range-vector metric windows (`*_over_time`, `rate`, `count_over_time`, `bytes_*`, `rate_counter`) | Proxy applies Loki-compatible sliding-window evaluation over step-aligned timestamps and emits matrix/vector responses |
+
+### Parser-Stage Metric Compatibility Path
+
+For metric queries that include parser stages after translation (`unpack_*` or `extract*`), the proxy can switch from direct `stats_query(_range)` execution to proxy-side range evaluation so Loki behavior is preserved:
+
+- parser-derived labels remain available in metric output cardinality
+- unwrap-required functions keep Loki unwrap/error semantics
+- `rate_counter` uses the proxy compatibility path by default (including reset-aware handling)
+
+For non-parser metric queries, the default path remains single-shot `stats_query` / `stats_query_range` against VictoriaLogs.
+
+#### Path Selection Rules
+
+| Query shape | Selected execution path | Why |
+|---|---|---|
+| range metric family with parser stages (`unpack_*`, `extract*`) | proxy-side compatibility evaluation | preserves Loki parser-derived labelsets and unwrap semantics |
+| `rate_counter(... \| unwrap ...)` | proxy-side compatibility evaluation | keeps counter-reset handling and behavior stable regardless of backend parser support |
+| range metric family without parser stages | direct `stats_query_range` | fastest path when backend semantics match Loki expectations |
+| instant metric family without parser stages | direct `stats_query` | keeps instant-path behavior aligned with existing VL fast path |
+
+#### Compatibility Guarantees For This Path
+
+- parser labels produced in the query pipeline remain visible in resulting series labels
+- unwrap-required functions fail with Loki-style `invalid aggregation <func> without unwrap` errors when unwrap is omitted
+- manual compatibility execution is scoped to affected metric families and does not replace direct backend stats execution globally
 
 ### Formatting and Normalization
 
@@ -128,6 +155,7 @@ The following Loki semantics are implemented in the proxy to bridge gaps where V
 | `line_format` / `label_format` templates | Go-template based compatibility formatting in response pipeline |
 | `decolorize` | ANSI escape sequence stripping |
 | `unwrap duration()/bytes()` helpers | Unit-aware unwrap compatibility logic before aggregation |
+| Missing unwrap on unwrap-required functions | Proxy returns Loki-style `invalid aggregation <func> without unwrap` error |
 | `bool` modifier on comparisons | Compatibility normalization to Loki-style boolean vector output |
 | `without()` grouping | Compatibility label projection after backend aggregation |
 | `on()` / `ignoring()` / `group_left()` / `group_right()` | Loki-style vector matching and join cardinality handling in proxy evaluation |

--- a/internal/proxy/compat_coverage_helpers_test.go
+++ b/internal/proxy/compat_coverage_helpers_test.go
@@ -1,0 +1,344 @@
+package proxy
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestCompatHelpers_ParseQuantileAndUnwrapErrorName(t *testing.T) {
+	if got := unwrapErrorFuncName(""); got != "range_aggregation" {
+		t.Fatalf("expected default unwrap error func, got %q", got)
+	}
+	if got := unwrapErrorFuncName(" sum_over_time "); got != "sum_over_time" {
+		t.Fatalf("expected trimmed unwrap func name, got %q", got)
+	}
+
+	phi, field, ok := parseStatsQuantileSpec("0.95, latency_ms")
+	if !ok {
+		t.Fatal("expected quantile spec to parse")
+	}
+	if phi != 0.95 || field != "latency_ms" {
+		t.Fatalf("unexpected quantile spec parse: phi=%v field=%q", phi, field)
+	}
+
+	if _, _, ok := parseStatsQuantileSpec("bad"); ok {
+		t.Fatal("expected invalid quantile spec without comma to fail")
+	}
+	if _, _, ok := parseStatsQuantileSpec("x,latency"); ok {
+		t.Fatal("expected invalid quantile phi to fail")
+	}
+
+	field, conv := parseUnwrapExpression(`duration("latency_ms")`)
+	if field != "latency_ms" || conv != "duration" {
+		t.Fatalf("expected duration unwrap parse, got field=%q conv=%q", field, conv)
+	}
+	field, conv = parseUnwrapExpression("bytes(size)")
+	if field != "size" || conv != "bytes" {
+		t.Fatalf("expected bytes unwrap parse, got field=%q conv=%q", field, conv)
+	}
+	field, conv = parseUnwrapExpression("`custom.value`")
+	if field != "custom.value" || conv != "" {
+		t.Fatalf("expected passthrough unwrap parse, got field=%q conv=%q", field, conv)
+	}
+	if !metricFuncRequiresUnwrap("sum_over_time") {
+		t.Fatal("expected sum_over_time to require unwrap")
+	}
+	if metricFuncRequiresUnwrap("count_over_time") {
+		t.Fatal("expected count_over_time not to require unwrap")
+	}
+	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "avg") {
+		t.Fatal("expected parser-stage avg to use manual fallback")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time") {
+		t.Fatal("expected parser-stage count_over_time to stay on direct stats path")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"}`, "avg") {
+		t.Fatal("expected non-parser query not to use manual fallback for avg")
+	}
+	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "rate_counter") {
+		t.Fatal("expected rate_counter to always use manual fallback")
+	}
+}
+
+func TestCompatHelpers_AddParsedEntryLabels(t *testing.T) {
+	metricLabels := map[string]string{
+		"service_name": "api",
+		"level":        "info",
+	}
+	entry := map[string]interface{}{
+		"_time":        "ignored",
+		"_stream_id":   "ignored",
+		"latency.ms":   "10",
+		"latency_ms":   "11",
+		"service_name": "existing",
+		"trace_id":     "abc123",
+		"status":       200,
+		"empty":        "   ",
+	}
+
+	addParsedEntryLabels(metricLabels, entry, "latency.ms")
+
+	if got := metricLabels["service_name"]; got != "api" {
+		t.Fatalf("expected existing label to remain unchanged, got %q", got)
+	}
+	if _, exists := metricLabels["latency.ms"]; exists {
+		t.Fatal("expected unwrap field to be excluded from parsed labels")
+	}
+	if _, exists := metricLabels["latency_ms"]; exists {
+		t.Fatal("expected unwrap underscore alias to be excluded from parsed labels")
+	}
+	if got := metricLabels["trace_id"]; got != "abc123" {
+		t.Fatalf("expected trace_id to be added, got %q", got)
+	}
+	if got := metricLabels["status"]; got != "200" {
+		t.Fatalf("expected numeric parsed value to stringify, got %q", got)
+	}
+	if _, exists := metricLabels["_time"]; exists {
+		t.Fatal("expected internal _time field to remain excluded")
+	}
+}
+
+func TestCompatHelpers_AggregateManualWindow(t *testing.T) {
+	samples := []rangeMetricSample{
+		{ts: 0, value: 1},
+		{ts: 10, value: 2},
+		{ts: 20, value: 3},
+	}
+
+	assertClose := func(name string, got, want float64) {
+		t.Helper()
+		if math.Abs(got-want) > 0.000001 {
+			t.Fatalf("%s: expected %v, got %v", name, want, got)
+		}
+	}
+
+	if got, ok := aggregateManualWindow("count_over_time", 0, samples, 0, 20, 20); !ok || got != 3 {
+		t.Fatalf("count_over_time: expected 3,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("rate", 0, samples, 0, 20, 20); !ok {
+		t.Fatal("rate: expected success")
+	} else {
+		assertClose("rate", got, 0.15)
+	}
+	if got, ok := aggregateManualWindow("bytes_over_time", 0, samples, 0, 20, 20); !ok || got != 6 {
+		t.Fatalf("bytes_over_time: expected 6,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("bytes_rate", 0, samples, 0, 20, 20); !ok {
+		t.Fatal("bytes_rate: expected success")
+	} else {
+		assertClose("bytes_rate", got, 0.3)
+	}
+	if got, ok := aggregateManualWindow("sum", 0, samples, 0, 20, 20); !ok || got != 6 {
+		t.Fatalf("sum: expected 6,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("avg", 0, samples, 0, 20, 20); !ok || got != 2 {
+		t.Fatalf("avg: expected 2,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("min", 0, samples, 0, 20, 20); !ok || got != 1 {
+		t.Fatalf("min: expected 1,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("max", 0, samples, 0, 20, 20); !ok || got != 3 {
+		t.Fatalf("max: expected 3,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("stddev", 0, samples, 0, 20, 20); !ok {
+		t.Fatal("stddev: expected success")
+	} else {
+		assertClose("stddev", got, math.Sqrt(2.0/3.0))
+	}
+	if got, ok := aggregateManualWindow("stdvar", 0, samples, 0, 20, 20); !ok {
+		t.Fatal("stdvar: expected success")
+	} else {
+		assertClose("stdvar", got, 2.0/3.0)
+	}
+	if got, ok := aggregateManualWindow("quantile", 0.5, samples, 0, 20, 20); !ok || got != 2 {
+		t.Fatalf("quantile: expected 2,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("first", 0, samples, 0, 20, 20); !ok || got != 1 {
+		t.Fatalf("first: expected 1,true got %v,%v", got, ok)
+	}
+	if got, ok := aggregateManualWindow("last", 0, samples, 0, 20, 20); !ok || got != 3 {
+		t.Fatalf("last: expected 3,true got %v,%v", got, ok)
+	}
+
+	counterSamples := []rangeMetricSample{
+		{ts: 0, value: 100},
+		{ts: 10, value: 130},
+		{ts: 20, value: 10},
+		{ts: 30, value: 30},
+	}
+	if got, ok := aggregateManualWindow("rate_counter", 0, counterSamples, 0, 30, 30); !ok {
+		t.Fatal("rate_counter: expected success")
+	} else {
+		assertClose("rate_counter", got, 2.0)
+	}
+
+	if _, ok := aggregateManualWindow("unknown", 0, samples, 0, 20, 20); ok {
+		t.Fatal("expected unknown aggregate function to fail")
+	}
+	if _, ok := aggregateManualWindow("rate", 0, samples, 0, 20, 0); ok {
+		t.Fatal("expected rate with non-positive windowSeconds to fail")
+	}
+	if _, ok := aggregateManualWindow("sum", 0, samples, 999, 1000, 1); ok {
+		t.Fatal("expected aggregate on empty sample window to fail")
+	}
+}
+
+func TestCompatHelpers_BuildManualRangeResponses(t *testing.T) {
+	start := time.Unix(0, 0).UTC()
+	end := start.Add(2 * time.Minute)
+	step := time.Minute
+	window := time.Minute
+	series := map[string]manualSeriesSamples{
+		"{app=\"api\"}": {
+			Metric: map[string]string{"app": "api"},
+			Samples: []rangeMetricSample{
+				{ts: start.UnixNano(), value: 1},
+				{ts: start.Add(time.Minute).UnixNano(), value: 2},
+				{ts: end.UnixNano(), value: 3},
+			},
+		},
+	}
+
+	var matrixResp struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]interface{}   `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buildManualRangeMetricMatrix("count_over_time", 0, series, start, end, step, window), &matrixResp); err != nil {
+		t.Fatalf("decode matrix response: %v", err)
+	}
+	if matrixResp.Status != "success" || matrixResp.Data.ResultType != "matrix" {
+		t.Fatalf("unexpected matrix response envelope: %+v", matrixResp)
+	}
+	if len(matrixResp.Data.Result) != 1 || len(matrixResp.Data.Result[0].Values) == 0 {
+		t.Fatalf("expected non-empty matrix points, got %+v", matrixResp.Data.Result)
+	}
+
+	var vectorResp struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []interface{}     `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buildManualRangeMetricVector("last", 0, series, end, window), &vectorResp); err != nil {
+		t.Fatalf("decode vector response: %v", err)
+	}
+	if vectorResp.Status != "success" || vectorResp.Data.ResultType != "vector" {
+		t.Fatalf("unexpected vector response envelope: %+v", vectorResp)
+	}
+	if len(vectorResp.Data.Result) != 1 || len(vectorResp.Data.Result[0].Value) != 2 {
+		t.Fatalf("expected single vector point, got %+v", vectorResp.Data.Result)
+	}
+
+	var emptyMatrix struct {
+		Data struct {
+			Result []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buildManualRangeMetricMatrix("sum", 0, series, end, start, step, window), &emptyMatrix); err != nil {
+		t.Fatalf("decode empty matrix response: %v", err)
+	}
+	if len(emptyMatrix.Data.Result) != 0 {
+		t.Fatalf("expected empty matrix result for end<start, got %+v", emptyMatrix.Data.Result)
+	}
+}
+
+func TestCompatHelpers_TimeParsingAndDurationFormatting(t *testing.T) {
+	ref := time.Date(2026, time.April, 23, 15, 0, 0, 0, time.UTC)
+
+	if got, ok := parseFlexibleUnixNanos(ref.Format(time.RFC3339Nano)); !ok || got != ref.UnixNano() {
+		t.Fatalf("expected RFC3339 nanos parse, got %v,%v", got, ok)
+	}
+	if got, ok := parseFlexibleUnixNanos("1700000000"); !ok || got != 1700000000*int64(time.Second) {
+		t.Fatalf("expected seconds integer to normalize to nanos, got %v,%v", got, ok)
+	}
+	if got, ok := parseFlexibleUnixNanos("1700000000000"); !ok || got != 1700000000000*int64(time.Millisecond) {
+		t.Fatalf("expected millis integer to normalize to nanos, got %v,%v", got, ok)
+	}
+	if got, ok := parseFlexibleUnixNanos("1700000000.5"); !ok || got != 1700000000500000000 {
+		t.Fatalf("expected float seconds to normalize to nanos, got %v,%v", got, ok)
+	}
+	if _, ok := parseFlexibleUnixNanos("not-a-time"); ok {
+		t.Fatal("expected invalid nanos parse to fail")
+	}
+
+	if got, ok := parseFlexibleUnixSeconds(ref.Format(time.RFC3339)); !ok || got != ref.Unix() {
+		t.Fatalf("expected RFC3339 seconds parse, got %v,%v", got, ok)
+	}
+	if got := normalizeUnixNanos(1700000000); got != 1700000000*int64(time.Second) {
+		t.Fatalf("expected normalizeUnixNanos(seconds) to scale, got %v", got)
+	}
+	if got := normalizeUnixNanos(1700000000000); got != 1700000000000*int64(time.Millisecond) {
+		t.Fatalf("expected normalizeUnixNanos(millis) to scale, got %v", got)
+	}
+
+	if got := formatLogQLDuration(0); got != "1s" {
+		t.Fatalf("expected non-positive duration to clamp to 1s, got %q", got)
+	}
+	if got := formatLogQLDuration(2 * time.Hour); got != "2h" {
+		t.Fatalf("expected hour formatting, got %q", got)
+	}
+	if got := formatLogQLDuration(3 * time.Minute); got != "3m" {
+		t.Fatalf("expected minute formatting, got %q", got)
+	}
+	if got := formatLogQLDuration(4 * time.Second); got != "4s" {
+		t.Fatalf("expected second formatting, got %q", got)
+	}
+	if got := formatLogQLDuration(1500 * time.Millisecond); got != "1500ms" {
+		t.Fatalf("expected millisecond formatting, got %q", got)
+	}
+
+	if d, ok := parsePositiveStepDuration("30s"); !ok || d != 30*time.Second {
+		t.Fatalf("expected duration step parse, got %v,%v", d, ok)
+	}
+	if d, ok := parsePositiveStepDuration("2.5"); !ok || d != 2500*time.Millisecond {
+		t.Fatalf("expected float step parse, got %v,%v", d, ok)
+	}
+	if _, ok := parsePositiveStepDuration("-1"); ok {
+		t.Fatal("expected negative step parse to fail")
+	}
+	if _, ok := parsePositiveStepDuration("not-a-step"); ok {
+		t.Fatal("expected invalid step parse to fail")
+	}
+
+	if d, ok := resolveGrafanaTemplateTokenDuration("$__rate_interval", "1700000000", "1700000600", "30s"); !ok || d != time.Minute*2 {
+		t.Fatalf("expected $__rate_interval to resolve to 2m, got %v,%v", d, ok)
+	}
+	if d, ok := resolveGrafanaTemplateTokenDuration("$__range", "1700000000", "1700000600", "30s"); !ok || d != 10*time.Minute {
+		t.Fatalf("expected $__range to resolve to 10m, got %v,%v", d, ok)
+	}
+	if d, ok := resolveGrafanaTemplateTokenDuration("$__interval", "1700000000", "1700000600", "30s"); !ok || d != 30*time.Second {
+		t.Fatalf("expected $__interval to resolve to step, got %v,%v", d, ok)
+	}
+	if _, ok := resolveGrafanaTemplateTokenDuration("$__unknown", "1700000000", "1700000600", "30s"); ok {
+		t.Fatal("expected unknown grafana token to fail resolution")
+	}
+	if got := resolveGrafanaRangeTemplateTokens(`rate({app="api"}[$__auto])`, "1700000000", "1700000600", "30s"); got != `rate({app="api"}[30s])` {
+		t.Fatalf("expected $__auto replacement, got %q", got)
+	}
+
+	if bucketRange, ok := parseRequestedBucketRange("1700000000", "1700000060", "30s"); !ok {
+		t.Fatal("expected requested bucket range to parse")
+	} else {
+		if bucketRange.count != 3 {
+			t.Fatalf("expected bucket count 3, got %d", bucketRange.count)
+		}
+		if bucket, ok := bucketRange.bucketFor(1700000045); !ok || bucket != 1700000030 {
+			t.Fatalf("expected bucket alignment to 1700000030, got %d,%v", bucket, ok)
+		}
+		if _, ok := bucketRange.bucketFor(1699999999); ok {
+			t.Fatal("expected out-of-range bucket lookup to fail")
+		}
+	}
+}

--- a/internal/proxy/drilldown_compat_test.go
+++ b/internal/proxy/drilldown_compat_test.go
@@ -1637,6 +1637,7 @@ func TestDrilldown_InstantMetricQueriesPreferSingleWorkingParser(t *testing.T) {
 	var (
 		sampleQueries []string
 		statsQuery    string
+		manualQuery   string
 	)
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -1644,6 +1645,9 @@ func TestDrilldown_InstantMetricQueriesPreferSingleWorkingParser(t *testing.T) {
 		}
 		switch r.URL.Path {
 		case "/select/logsql/query":
+			if r.Form.Get("limit") == "1000000" {
+				manualQuery = r.Form.Get("query")
+			}
 			sampleQueries = append(sampleQueries, r.Form.Get("query"))
 			w.Header().Set("Content-Type", "application/x-ndjson")
 			w.Write([]byte(`{"_time":"2026-04-04T17:18:49.971082Z","_msg":"{\"method\":\"GET\",\"path\":\"/api/v1/users\",\"status\":200}","_stream":"{app=\"api-gateway\"}","app":"api-gateway","level":"info"}` + "\n"))
@@ -1680,11 +1684,19 @@ func TestDrilldown_InstantMetricQueriesPreferSingleWorkingParser(t *testing.T) {
 	if strings.Contains(sampleQueries[0], "count_over_time") {
 		t.Fatalf("expected parser probe to use extracted inner log query, got %q", sampleQueries[0])
 	}
-	if strings.Contains(statsQuery, "unpack_logfmt") {
-		t.Fatalf("expected stats query to keep only the working parser, got %q", statsQuery)
+
+	effectiveMetricQuery := statsQuery
+	if effectiveMetricQuery == "" {
+		effectiveMetricQuery = manualQuery
 	}
-	if !strings.Contains(statsQuery, "unpack_json") {
-		t.Fatalf("expected stats query to keep json parser, got %q", statsQuery)
+	if effectiveMetricQuery == "" {
+		t.Fatalf("expected either stats query or manual metric query to be issued")
+	}
+	if strings.Contains(effectiveMetricQuery, "unpack_logfmt") {
+		t.Fatalf("expected metric query to keep only the working parser, got %q", effectiveMetricQuery)
+	}
+	if !strings.Contains(effectiveMetricQuery, "unpack_json") {
+		t.Fatalf("expected metric query to keep json parser, got %q", effectiveMetricQuery)
 	}
 }
 

--- a/internal/proxy/drilldown_coverage_test.go
+++ b/internal/proxy/drilldown_coverage_test.go
@@ -57,10 +57,11 @@ func TestDrilldownHelpers_AdditionalCoverage(t *testing.T) {
 		addDetectedField(fields, "timestamp_end", "json", "string", nil, "2026-04-21T10:00:00Z")
 		addDetectedField(fields, "observed_timestamp_end", "json", "string", nil, "2026-04-21T10:00:00Z")
 
-		summary := fields["duration"]
-		if summary == nil {
-			t.Fatal("expected detected field summary")
-		}
+			summary := fields["duration"]
+			if summary == nil {
+				t.Fatal("expected detected field summary")
+				return
+			}
 		if summary.typ != "string" {
 			t.Fatalf("expected detected type to widen to string, got %q", summary.typ)
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4878,6 +4878,9 @@ func (p *Proxy) refreshDetectedFieldValuesCacheAsync(orgID, cacheKey, fieldName,
 			if err != nil {
 				return nil, err
 			}
+			if values == nil {
+				values = []string{}
+			}
 
 			payload := map[string]interface{}{
 				"status": "success",
@@ -8605,6 +8608,10 @@ func (p *Proxy) vlPostCoalesced(ctx context.Context, key, path string, params ur
 // --- Stats query proxying ---
 
 func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	if p.handleStatsCompatRange(w, r, r.FormValue("query"), logsqlQuery) {
+		return
+	}
+
 	// Keep metric query_range as a single backend request. Window splitting and
 	// window-level cache reuse are for raw log queries only.
 	params := buildStatsQueryRangeParams(logsqlQuery, r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
@@ -8751,6 +8758,10 @@ func statsQueryRangePointUnixNano(point []interface{}) int64 {
 }
 
 func (p *Proxy) proxyStatsQuery(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	if p.handleStatsCompatInstant(w, r, r.FormValue("query"), logsqlQuery) {
+		return
+	}
+
 	params := url.Values{}
 	params.Set("query", logsqlQuery)
 	if t := r.FormValue("time"); t != "" {

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -193,7 +193,8 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 				"batch_size", batchSize,
 				"status", status,
 			)
-			return false
+			p.writeError(w, status, err.Error())
+			return true
 		}
 
 		for _, result := range results {

--- a/internal/proxy/query_range_windowing_test.go
+++ b/internal/proxy/query_range_windowing_test.go
@@ -1024,18 +1024,10 @@ func TestQueryRangeWindow_FallsBackToDirectQueryOnWindowFetchError(t *testing.T)
 		reqStart, _ := strconv.ParseInt(startParam, 10, 64)
 		reqEnd, _ := strconv.ParseInt(endParam, 10, 64)
 
-		// Windowed calls should fail to force fallback.
-		if reqStart != start || reqEnd != end {
-			http.Error(w, "all backends unavailable", http.StatusBadGateway)
-			return
+		if reqStart == start && reqEnd == end {
+			fullRangeCalls.Add(1)
 		}
-
-		fullRangeCalls.Add(1)
-		_, _ = fmt.Fprintf(
-			w,
-			"{\"_time\":%q,\"_msg\":\"fallback-ok\",\"_stream\":\"{app=\\\"nginx\\\"}\"}\n",
-			time.Unix(0, reqStart).UTC().Format(time.RFC3339Nano),
-		)
+		http.Error(w, "all backends unavailable", http.StatusBadGateway)
 	}))
 	defer vlBackend.Close()
 
@@ -1053,21 +1045,22 @@ func TestQueryRangeWindow_FallsBackToDirectQueryOnWindowFetchError(t *testing.T)
 	resp := httptest.NewRecorder()
 	p.handleQueryRange(resp, req)
 
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected fallback query_range status=200, got=%d body=%s", resp.Code, resp.Body.String())
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("expected windowed query failure status=502, got=%d body=%s", resp.Code, resp.Body.String())
 	}
-	if got := fullRangeCalls.Load(); got != 1 {
-		t.Fatalf("expected exactly one direct full-range fallback call, got %d", got)
+	if got := fullRangeCalls.Load(); got != 0 {
+		t.Fatalf("expected no direct full-range fallback call, got %d", got)
 	}
 
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(resp.Body.Bytes(), &parsed); err != nil {
-		t.Fatalf("failed to decode fallback response: %v body=%s", err, resp.Body.String())
+		t.Fatalf("failed to decode error response: %v body=%s", err, resp.Body.String())
 	}
-	data, _ := parsed["data"].(map[string]interface{})
-	result, _ := data["result"].([]interface{})
-	if len(result) == 0 {
-		t.Fatalf("expected non-empty result from direct fallback, body=%s", resp.Body.String())
+	if parsed["status"] != "error" {
+		t.Fatalf("expected Loki error response status=error, body=%s", resp.Body.String())
+	}
+	if parsed["errorType"] != "unavailable" {
+		t.Fatalf("expected Loki errorType=unavailable, body=%s", resp.Body.String())
 	}
 }
 

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -1,0 +1,859 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type statsCompatSpec struct {
+	BaseQuery string
+	GroupBy   []string
+	Func      string
+	Field     string
+}
+
+type originalRangeMetricSpec struct {
+	Func        string
+	Window      time.Duration
+	UnwrapField string
+	UnwrapConv  string
+	HasUnwrap   bool
+}
+
+type rangeMetricSample struct {
+	ts    int64
+	value float64
+}
+
+var (
+	rangeMetricUnwrapRE = regexp.MustCompile(`(?s)\|\s*unwrap\s+([^|\[]+)`)
+)
+
+func parseStatsCompatSpec(logsqlQuery string) (statsCompatSpec, bool) {
+	idx := strings.Index(logsqlQuery, "| stats ")
+	if idx < 0 {
+		return statsCompatSpec{}, false
+	}
+
+	spec := statsCompatSpec{
+		BaseQuery: strings.TrimSpace(logsqlQuery[:idx]),
+	}
+	rest := strings.TrimSpace(logsqlQuery[idx+len("| stats "):])
+	if rest == "" {
+		return statsCompatSpec{}, false
+	}
+
+	if strings.HasPrefix(rest, "by (") {
+		closeIdx := strings.Index(rest, ")")
+		if closeIdx > len("by (") {
+			labels := strings.TrimSpace(rest[len("by ("):closeIdx])
+			if labels != "" {
+				for _, label := range strings.Split(labels, ",") {
+					label = strings.TrimSpace(label)
+					if label != "" {
+						spec.GroupBy = append(spec.GroupBy, label)
+					}
+				}
+			}
+			rest = strings.TrimSpace(rest[closeIdx+1:])
+		}
+	}
+
+	openIdx := strings.Index(rest, "(")
+	switch {
+	case openIdx < 0:
+		spec.Func = strings.TrimSpace(rest)
+	case strings.HasSuffix(rest, ")"):
+		spec.Func = strings.TrimSpace(rest[:openIdx])
+		spec.Field = strings.TrimSpace(rest[openIdx+1 : len(rest)-1])
+	default:
+		return statsCompatSpec{}, false
+	}
+
+	if spec.BaseQuery == "" || spec.Func == "" {
+		return statsCompatSpec{}, false
+	}
+
+	return spec, true
+}
+
+func parseOriginalRangeMetricSpec(logql string) (originalRangeMetricSpec, bool) {
+	logql = strings.TrimSpace(logql)
+	openIdx := strings.Index(logql, "(")
+	closeIdx := strings.LastIndex(logql, ")")
+	if openIdx <= 0 || closeIdx <= openIdx {
+		return originalRangeMetricSpec{}, false
+	}
+
+	spec := originalRangeMetricSpec{
+		Func: strings.TrimSpace(logql[:openIdx]),
+	}
+	body := strings.TrimSpace(logql[openIdx+1 : closeIdx])
+	bracketOpen := strings.LastIndex(body, "[")
+	bracketClose := strings.LastIndex(body, "]")
+	if bracketOpen < 0 || bracketClose <= bracketOpen {
+		return originalRangeMetricSpec{}, false
+	}
+	spec.Window = parseLokiDuration(strings.TrimSpace(body[bracketOpen+1 : bracketClose]))
+
+	unwrap := rangeMetricUnwrapRE.FindStringSubmatch(body)
+	if len(unwrap) == 2 {
+		spec.HasUnwrap = true
+		spec.UnwrapField, spec.UnwrapConv = parseUnwrapExpression(unwrap[1])
+	}
+
+	return spec, true
+}
+
+func isManualRangeStatsFunc(funcName string) bool {
+	switch strings.TrimSpace(funcName) {
+	case "rate", "count", "sum_len", "sum", "avg", "max", "min", "stddev", "stdvar", "quantile", "first", "last", "__rate_counter__":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeManualMetricFunction(spec statsCompatSpec, origSpec originalRangeMetricSpec) string {
+	switch strings.TrimSpace(origSpec.Func) {
+	case "rate":
+		return "rate"
+	case "count_over_time":
+		return "count_over_time"
+	case "bytes_over_time":
+		return "bytes_over_time"
+	case "bytes_rate":
+		return "bytes_rate"
+	case "sum_over_time":
+		return "sum"
+	case "avg_over_time":
+		return "avg"
+	case "max_over_time":
+		return "max"
+	case "min_over_time":
+		return "min"
+	case "stddev_over_time":
+		return "stddev"
+	case "stdvar_over_time":
+		return "stdvar"
+	case "first_over_time":
+		return "first"
+	case "last_over_time":
+		return "last"
+	case "rate_counter":
+		return "rate_counter"
+	case "quantile_over_time":
+		return "quantile"
+	}
+
+	switch strings.TrimSpace(spec.Func) {
+	case "rate":
+		return "rate"
+	case "count":
+		return "count_over_time"
+	case "sum_len":
+		if strings.TrimSpace(origSpec.Func) == "bytes_rate" {
+			return "bytes_rate"
+		}
+		return "bytes_over_time"
+	case "sum":
+		return "sum"
+	case "avg":
+		return "avg"
+	case "max":
+		return "max"
+	case "min":
+		return "min"
+	case "stddev":
+		return "stddev"
+	case "stdvar":
+		return "stdvar"
+	case "quantile":
+		return "quantile"
+	case "first":
+		return "first"
+	case "last":
+		return "last"
+	case "__rate_counter__":
+		return "rate_counter"
+	default:
+		return ""
+	}
+}
+
+func metricFuncRequiresUnwrap(funcName string) bool {
+	switch strings.TrimSpace(funcName) {
+	case "sum_over_time", "avg_over_time", "max_over_time", "min_over_time", "stddev_over_time", "stdvar_over_time", "first_over_time", "last_over_time", "quantile_over_time", "rate_counter":
+		return true
+	default:
+		return false
+	}
+}
+
+func unwrapErrorFuncName(funcName string) string {
+	funcName = strings.TrimSpace(funcName)
+	if funcName != "" {
+		return funcName
+	}
+	return "range_aggregation"
+}
+
+func parseStatsQuantileSpec(field string) (float64, string, bool) {
+	parts := strings.SplitN(field, ",", 2)
+	if len(parts) != 2 {
+		return 0, "", false
+	}
+	phi, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return phi, strings.TrimSpace(parts[1]), true
+}
+
+func parseUnwrapExpression(expr string) (field, conv string) {
+	expr = strings.TrimSpace(expr)
+	expr = strings.Trim(expr, "`\"")
+
+	switch {
+	case strings.HasPrefix(expr, "duration(") && strings.HasSuffix(expr, ")"):
+		field = strings.TrimSpace(expr[len("duration(") : len(expr)-1])
+		conv = "duration"
+	case strings.HasPrefix(expr, "bytes(") && strings.HasSuffix(expr, ")"):
+		field = strings.TrimSpace(expr[len("bytes(") : len(expr)-1])
+		conv = "bytes"
+	default:
+		field = strings.TrimSpace(expr)
+	}
+
+	field = strings.Trim(field, "`\"")
+	return field, conv
+}
+
+func (p *Proxy) handleStatsCompatRange(w http.ResponseWriter, r *http.Request, originalLogql, logsqlQuery string) bool {
+	spec, ok := parseStatsCompatSpec(logsqlQuery)
+	if !ok {
+		return false
+	}
+	if !isManualRangeStatsFunc(spec.Func) {
+		return false
+	}
+	origSpec, hasOrigSpec := parseOriginalRangeMetricSpec(originalLogql)
+
+	manualFunc := normalizeManualMetricFunction(spec, origSpec)
+	if manualFunc == "" {
+		return false
+	}
+	if !shouldUseManualRangeMetricCompat(spec.BaseQuery, manualFunc) {
+		return false
+	}
+	if !hasOrigSpec || origSpec.Window <= 0 {
+		p.writeError(w, http.StatusBadRequest, "invalid range metric query")
+		return true
+	}
+	if metricFuncRequiresUnwrap(origSpec.Func) && (!origSpec.HasUnwrap || strings.TrimSpace(origSpec.UnwrapField) == "") {
+		p.writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid aggregation %s without unwrap", unwrapErrorFuncName(origSpec.Func)))
+		return true
+	}
+	return p.proxyManualRangeMetricRange(w, r, spec, origSpec, manualFunc)
+}
+
+func (p *Proxy) handleStatsCompatInstant(w http.ResponseWriter, r *http.Request, originalLogql, logsqlQuery string) bool {
+	spec, ok := parseStatsCompatSpec(logsqlQuery)
+	if !ok {
+		return false
+	}
+	if !isManualRangeStatsFunc(spec.Func) {
+		return false
+	}
+	origSpec, hasOrigSpec := parseOriginalRangeMetricSpec(originalLogql)
+
+	manualFunc := normalizeManualMetricFunction(spec, origSpec)
+	if manualFunc == "" {
+		return false
+	}
+	if !shouldUseManualRangeMetricCompat(spec.BaseQuery, manualFunc) {
+		return false
+	}
+	if !hasOrigSpec || origSpec.Window <= 0 {
+		p.writeError(w, http.StatusBadRequest, "invalid range metric query")
+		return true
+	}
+	if metricFuncRequiresUnwrap(origSpec.Func) && (!origSpec.HasUnwrap || strings.TrimSpace(origSpec.UnwrapField) == "") {
+		p.writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid aggregation %s without unwrap", unwrapErrorFuncName(origSpec.Func)))
+		return true
+	}
+	return p.proxyManualRangeMetricInstant(w, r, spec, origSpec, manualFunc)
+}
+
+func shouldUseManualRangeMetricCompat(baseQuery, manualFunc string) bool {
+	manualFunc = strings.TrimSpace(manualFunc)
+	if manualFunc == "rate_counter" {
+		return true
+	}
+	if !queryUsesParserStages(baseQuery) {
+		return false
+	}
+	// Keep parser-stage count/bytes-over-time on backend stats_query_range.
+	// These families already preserve expected grouping there and avoiding
+	// manual fallback prevents dropping native level-based grouping in
+	// scorecard queries (for example detected_level series checks).
+	switch manualFunc {
+	case "count_over_time", "bytes_over_time":
+		return false
+	default:
+		return true
+	}
+}
+
+func (p *Proxy) proxyManualRangeMetricRange(w http.ResponseWriter, r *http.Request, spec statsCompatSpec, origSpec originalRangeMetricSpec, manualFunc string) bool {
+	startTS, err := parseTimestamp(r.FormValue("start"))
+	if err != nil {
+		p.writeError(w, http.StatusBadRequest, "invalid start timestamp: "+err.Error())
+		return true
+	}
+	endTS, err := parseTimestamp(r.FormValue("end"))
+	if err != nil {
+		p.writeError(w, http.StatusBadRequest, "invalid end timestamp: "+err.Error())
+		return true
+	}
+	step := parseLokiDuration(formatVLStep(r.FormValue("step")))
+	if step <= 0 {
+		step = time.Minute
+	}
+	field, quantile, fieldErr := p.resolveManualMetricField(spec, origSpec, manualFunc)
+	if fieldErr != nil {
+		p.writeError(w, http.StatusBadRequest, fieldErr.Error())
+		return true
+	}
+	if field == "" {
+		p.writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid aggregation %s without unwrap", unwrapErrorFuncName(origSpec.Func)))
+		return true
+	}
+
+	series, err := p.collectRangeMetricSamples(r.Context(), spec.BaseQuery, spec.GroupBy, field, origSpec.UnwrapConv, startTS.Add(-origSpec.Window), endTS)
+	if err != nil {
+		p.writeError(w, http.StatusBadGateway, err.Error())
+		return true
+	}
+
+	result := buildManualRangeMetricMatrix(manualFunc, quantile, series, startTS, endTS, step, origSpec.Window)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(result)
+	return true
+}
+
+func (p *Proxy) proxyManualRangeMetricInstant(w http.ResponseWriter, r *http.Request, spec statsCompatSpec, origSpec originalRangeMetricSpec, manualFunc string) bool {
+	evalTS, err := parseTimestamp(r.FormValue("time"))
+	if err != nil {
+		evalTS = time.Now()
+	}
+	field, quantile, fieldErr := p.resolveManualMetricField(spec, origSpec, manualFunc)
+	if fieldErr != nil {
+		p.writeError(w, http.StatusBadRequest, fieldErr.Error())
+		return true
+	}
+	if field == "" {
+		p.writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid aggregation %s without unwrap", unwrapErrorFuncName(origSpec.Func)))
+		return true
+	}
+
+	series, err := p.collectRangeMetricSamples(r.Context(), spec.BaseQuery, spec.GroupBy, field, origSpec.UnwrapConv, evalTS.Add(-origSpec.Window), evalTS)
+	if err != nil {
+		p.writeError(w, http.StatusBadGateway, err.Error())
+		return true
+	}
+
+	result := buildManualRangeMetricVector(manualFunc, quantile, series, evalTS, origSpec.Window)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(result)
+	return true
+}
+
+func (p *Proxy) resolveManualMetricField(spec statsCompatSpec, origSpec originalRangeMetricSpec, manualFunc string) (string, float64, error) {
+	switch manualFunc {
+	case "rate", "count_over_time":
+		return "__count__", 0, nil
+	case "bytes_over_time", "bytes_rate":
+		return "__bytes__", 0, nil
+	}
+
+	if manualFunc == "quantile" {
+		phi, field, ok := parseStatsQuantileSpec(spec.Field)
+		if !ok {
+			return "", 0, fmt.Errorf("invalid quantile query")
+		}
+		field = p.labelTranslator.ToVL(field)
+		if strings.TrimSpace(field) == "" {
+			return "", 0, fmt.Errorf("invalid aggregation %s without unwrap", unwrapErrorFuncName(origSpec.Func))
+		}
+		return field, phi, nil
+	}
+
+	if origSpec.UnwrapField != "" {
+		return p.labelTranslator.ToVL(origSpec.UnwrapField), 0, nil
+	}
+	field := strings.TrimSpace(spec.Field)
+	if field == "" {
+		return "", 0, nil
+	}
+	return p.labelTranslator.ToVL(field), 0, nil
+}
+
+func (p *Proxy) collectRangeMetricSamples(ctx context.Context, baseQuery string, groupBy []string, field, unwrapConv string, start, end time.Time) (map[string]manualSeriesSamples, error) {
+	params := url.Values{}
+	params.Set("query", baseQuery)
+	params.Set("start", formatVLTimestamp(start.UTC().Format(time.RFC3339Nano)))
+	params.Set("end", formatVLTimestamp(end.UTC().Format(time.RFC3339Nano)))
+	// Keep this high to avoid truncating series for compatibility stats functions.
+	params.Set("limit", "1000000")
+
+	resp, err := p.vlPost(ctx, "/select/logsql/query", params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("backend returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	seriesMap := make(map[string]manualSeriesSamples)
+	includeParsedLabels := queryUsesParserStages(baseQuery)
+	lines := bytes.Split(body, []byte{'\n'})
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var entry map[string]interface{}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+
+		rawTS, ok := stringifyEntryValue(entry["_time"])
+		if !ok || rawTS == "" {
+			continue
+		}
+		normTS, ok := formatEntryTimestamp(rawTS)
+		if !ok {
+			continue
+		}
+		ts, err := strconv.ParseInt(normTS, 10, 64)
+		if err != nil {
+			continue
+		}
+		if ts < 1e12 {
+			ts *= int64(time.Second)
+		}
+
+		value, ok := p.extractManualSampleValue(entry, field, unwrapConv)
+		if !ok {
+			continue
+		}
+
+		streamLabels := parseStreamLabels(asString(entry["_stream"]))
+		if level := strings.TrimSpace(asString(entry["level"])); level != "" {
+			streamLabels["level"] = level
+			streamLabels["detected_level"] = level
+		}
+		if strings.TrimSpace(streamLabels["detected_level"]) == "" {
+			streamLabels["detected_level"] = "unknown"
+		}
+		ensureSyntheticServiceName(streamLabels)
+		metricLabels := buildManualMetricLabels(streamLabels, groupBy)
+		if includeParsedLabels {
+			addParsedEntryLabels(metricLabels, entry, field)
+		}
+		translated := p.labelTranslator.TranslateLabelsMap(metricLabels)
+		key := seriesKeyFromMetric(translated)
+
+		current := seriesMap[key]
+		if current.Metric == nil {
+			current.Metric = translated
+		}
+		current.Samples = append(current.Samples, rangeMetricSample{ts: ts, value: value})
+		seriesMap[key] = current
+	}
+
+	for key, series := range seriesMap {
+		sort.Slice(series.Samples, func(i, j int) bool { return series.Samples[i].ts < series.Samples[j].ts })
+		seriesMap[key] = series
+	}
+
+	return seriesMap, nil
+}
+
+func queryUsesParserStages(baseQuery string) bool {
+	if strings.Contains(baseQuery, "| unpack_") {
+		return true
+	}
+	if strings.Contains(baseQuery, "| extract ") {
+		return true
+	}
+	return false
+}
+
+func addParsedEntryLabels(metricLabels map[string]string, entry map[string]interface{}, unwrapField string) {
+	if metricLabels == nil {
+		return
+	}
+	excluded := map[string]struct{}{}
+	addExcludedField(excluded, unwrapField)
+	addExcludedField(excluded, strings.ReplaceAll(unwrapField, ".", "_"))
+	addExcludedField(excluded, strings.ReplaceAll(unwrapField, "_", "."))
+
+	for key, raw := range entry {
+		if isVLInternalField(key) || key == "_stream_id" {
+			continue
+		}
+		if _, skip := excluded[key]; skip {
+			continue
+		}
+		value, ok := stringifyEntryValue(raw)
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := metricLabels[key]; exists {
+			continue
+		}
+		metricLabels[key] = value
+	}
+}
+
+func addExcludedField(excluded map[string]struct{}, key string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	excluded[key] = struct{}{}
+}
+
+type manualSeriesSamples struct {
+	Metric  map[string]string
+	Samples []rangeMetricSample
+}
+
+func buildManualMetricLabels(streamLabels map[string]string, groupBy []string) map[string]string {
+	if len(groupBy) == 0 {
+		labels := make(map[string]string, len(streamLabels))
+		for k, v := range streamLabels {
+			labels[k] = v
+		}
+		return labels
+	}
+
+	labels := make(map[string]string, len(groupBy))
+	for _, key := range groupBy {
+		if value, ok := streamLabels[key]; ok {
+			labels[key] = value
+		}
+	}
+	return labels
+}
+
+func (p *Proxy) extractManualSampleValue(entry map[string]interface{}, field, unwrapConv string) (float64, bool) {
+	switch field {
+	case "__count__":
+		return 1, true
+	case "__bytes__":
+		return float64(len(asString(entry["_msg"]))), true
+	}
+
+	raw, ok := lookupEntryField(entry, p.manualValueCandidateFields(field))
+	if !ok {
+		return 0, false
+	}
+
+	switch unwrapConv {
+	case "duration":
+		value, ok := parseDuration(asString(raw))
+		return value, ok
+	case "bytes":
+		value, ok := parseBytes(asString(raw))
+		return value, ok
+	default:
+		value, ok := parseFloatValue(raw)
+		return value, ok
+	}
+}
+
+func (p *Proxy) manualValueCandidateFields(field string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+
+	add(field)
+	add(p.labelTranslator.ToVL(field))
+	add(strings.ReplaceAll(field, "_", "."))
+	return out
+}
+
+func lookupEntryField(entry map[string]interface{}, keys []string) (interface{}, bool) {
+	for _, key := range keys {
+		if raw, ok := entry[key]; ok {
+			return raw, true
+		}
+	}
+	return nil, false
+}
+
+func parseFloatValue(raw interface{}) (float64, bool) {
+	switch value := raw.(type) {
+	case float64:
+		return value, true
+	case json.Number:
+		f, err := value.Float64()
+		return f, err == nil
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		return f, err == nil
+	default:
+		f, err := strconv.ParseFloat(strings.TrimSpace(asString(raw)), 64)
+		return f, err == nil
+	}
+}
+
+func buildManualRangeMetricMatrix(functionName string, quantile float64, series map[string]manualSeriesSamples, start, end time.Time, step, window time.Duration) []byte {
+	if end.Before(start) {
+		return marshalManualMetricResponse("matrix", []map[string]interface{}{})
+	}
+
+	perSeries := make(map[string]map[string]interface{}, len(series))
+	keys := make([]string, 0, len(series))
+	for key := range series {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for t := start; !t.After(end); t = t.Add(step) {
+		windowStart := t.Add(-window).UnixNano()
+		windowEnd := t.UnixNano()
+		for _, key := range keys {
+			seriesEntry := series[key]
+			value, ok := aggregateManualWindow(functionName, quantile, seriesEntry.Samples, windowStart, windowEnd, window.Seconds())
+			if !ok {
+				continue
+			}
+
+			dst := perSeries[key]
+			if dst == nil {
+				dst = map[string]interface{}{
+					"metric": seriesEntry.Metric,
+					"values": make([][]interface{}, 0, 16),
+				}
+				perSeries[key] = dst
+			}
+
+			points := dst["values"].([][]interface{})
+			points = append(points, []interface{}{float64(t.Unix()), strconv.FormatFloat(value, 'f', -1, 64)})
+			dst["values"] = points
+		}
+	}
+
+	results := make([]map[string]interface{}, 0, len(perSeries))
+	for _, key := range keys {
+		if seriesResult, ok := perSeries[key]; ok {
+			results = append(results, seriesResult)
+		}
+	}
+	return marshalManualMetricResponse("matrix", results)
+}
+
+func buildManualRangeMetricVector(functionName string, quantile float64, series map[string]manualSeriesSamples, evalTime time.Time, window time.Duration) []byte {
+	keys := make([]string, 0, len(series))
+	for key := range series {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	windowStart := evalTime.Add(-window).UnixNano()
+	windowEnd := evalTime.UnixNano()
+	results := make([]map[string]interface{}, 0, len(series))
+
+	for _, key := range keys {
+		seriesEntry := series[key]
+		value, ok := aggregateManualWindow(functionName, quantile, seriesEntry.Samples, windowStart, windowEnd, window.Seconds())
+		if !ok {
+			continue
+		}
+		results = append(results, map[string]interface{}{
+			"metric": seriesEntry.Metric,
+			"value":  []interface{}{float64(evalTime.Unix()), strconv.FormatFloat(value, 'f', -1, 64)},
+		})
+	}
+
+	return marshalManualMetricResponse("vector", results)
+}
+
+func marshalManualMetricResponse(resultType string, result []map[string]interface{}) []byte {
+	if result == nil {
+		result = []map[string]interface{}{}
+	}
+	payload, _ := json.Marshal(map[string]interface{}{
+		"status": "success",
+		"data": map[string]interface{}{
+			"resultType": resultType,
+			"result":     result,
+		},
+	})
+	return payload
+}
+
+func aggregateManualWindow(functionName string, quantile float64, samples []rangeMetricSample, windowStart, windowEnd int64, windowSeconds float64) (float64, bool) {
+	values := make([]float64, 0, len(samples))
+	for _, sample := range samples {
+		if sample.ts < windowStart || sample.ts > windowEnd {
+			continue
+		}
+		values = append(values, sample.value)
+	}
+
+	if len(values) == 0 {
+		return 0, false
+	}
+
+	switch functionName {
+	case "count_over_time":
+		return float64(len(values)), true
+	case "rate":
+		if windowSeconds <= 0 {
+			return 0, false
+		}
+		return float64(len(values)) / windowSeconds, true
+	case "bytes_over_time", "sum":
+		return sumFloat64(values), true
+	case "bytes_rate":
+		if windowSeconds <= 0 {
+			return 0, false
+		}
+		return sumFloat64(values) / windowSeconds, true
+	case "avg":
+		return sumFloat64(values) / float64(len(values)), true
+	case "min":
+		return minFloat64(values), true
+	case "max":
+		return maxFloat64(values), true
+	case "stddev":
+		return stddevFloat64(values), true
+	case "stdvar":
+		v := stddevFloat64(values)
+		return v * v, true
+	case "quantile":
+		return quantileFloat64(values, quantile), true
+	case "first":
+		return values[0], true
+	case "last":
+		return values[len(values)-1], true
+	case "rate_counter":
+		if windowSeconds <= 0 {
+			return 0, false
+		}
+		if len(values) == 1 {
+			return 0, true
+		}
+		return rateCounterWindow(values, windowSeconds), true
+	default:
+		return 0, false
+	}
+}
+
+func sumFloat64(values []float64) float64 {
+	var out float64
+	for _, value := range values {
+		out += value
+	}
+	return out
+}
+
+func minFloat64(values []float64) float64 {
+	out := values[0]
+	for _, value := range values[1:] {
+		if value < out {
+			out = value
+		}
+	}
+	return out
+}
+
+func maxFloat64(values []float64) float64 {
+	out := values[0]
+	for _, value := range values[1:] {
+		if value > out {
+			out = value
+		}
+	}
+	return out
+}
+
+func stddevFloat64(values []float64) float64 {
+	mean := sumFloat64(values) / float64(len(values))
+	var variance float64
+	for _, value := range values {
+		diff := value - mean
+		variance += diff * diff
+	}
+	variance /= float64(len(values))
+	return math.Sqrt(variance)
+}
+
+func quantileFloat64(values []float64, phi float64) float64 {
+	if phi < 0 {
+		return math.Inf(-1)
+	}
+	if phi > 1 {
+		return math.Inf(1)
+	}
+	ordered := append([]float64(nil), values...)
+	sort.Float64s(ordered)
+	if len(ordered) == 1 {
+		return ordered[0]
+	}
+	rank := phi * float64(len(ordered)-1)
+	lower := int(math.Floor(rank))
+	upper := int(math.Ceil(rank))
+	if lower == upper {
+		return ordered[lower]
+	}
+	weight := rank - float64(lower)
+	return ordered[lower]*(1-weight) + ordered[upper]*weight
+}
+
+func rateCounterWindow(values []float64, windowSeconds float64) float64 {
+	var increase float64
+	prev := values[0]
+	for _, current := range values[1:] {
+		if current >= prev {
+			increase += current - prev
+		} else {
+			increase += current
+		}
+		prev = current
+	}
+	return increase / windowSeconds
+}

--- a/internal/proxy/range_metric_compat_test.go
+++ b/internal/proxy/range_metric_compat_test.go
@@ -1,0 +1,465 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseStatsCompatSpec(t *testing.T) {
+	spec, ok := parseStatsCompatSpec(`app:=nginx | unpack_json | stats by (namespace, app) first(duration)`)
+	if !ok {
+		t.Fatalf("expected parse success")
+	}
+	if spec.BaseQuery != `app:=nginx | unpack_json` {
+		t.Fatalf("unexpected base query: %q", spec.BaseQuery)
+	}
+	if spec.Func != "first" || spec.Field != "duration" {
+		t.Fatalf("unexpected function spec: %+v", spec)
+	}
+	if len(spec.GroupBy) != 2 || spec.GroupBy[0] != "namespace" || spec.GroupBy[1] != "app" {
+		t.Fatalf("unexpected by labels: %v", spec.GroupBy)
+	}
+}
+
+func TestParseOriginalRangeMetricSpecRate(t *testing.T) {
+	spec, ok := parseOriginalRangeMetricSpec(`rate({app="nginx"}[5m])`)
+	if !ok {
+		t.Fatalf("expected parse success")
+	}
+	if spec.Func != "rate" {
+		t.Fatalf("unexpected func: %q", spec.Func)
+	}
+	if spec.Window != 5*time.Minute {
+		t.Fatalf("unexpected window: %v", spec.Window)
+	}
+}
+
+func TestQueryRange_RateManualFallback(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/query":
+			lines := []string{
+				fmt.Sprintf(`{"_time":%q,"_msg":"a","_stream":"{app=\"nginx\",level=\"info\"}"}`, base.Format(time.RFC3339Nano)),
+				fmt.Sprintf(`{"_time":%q,"_msg":"b","_stream":"{app=\"nginx\",level=\"info\"}"}`, base.Add(60*time.Second).Format(time.RFC3339Nano)),
+				fmt.Sprintf(`{"_time":%q,"_msg":"c","_stream":"{app=\"nginx\",level=\"error\"}"}`, base.Add(120*time.Second).Format(time.RFC3339Nano)),
+			}
+			_, _ = w.Write([]byte(strings.Join(lines, "\n") + "\n"))
+		case "/select/logsql/stats_query_range":
+			t.Fatalf("expected manual fallback, stats_query_range must not be called")
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `rate({app="nginx"} | json [2m])`)
+	params.Set("start", strconv.FormatInt(base.Add(120*time.Second).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(180*time.Second).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]interface{}   `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Result) == 0 {
+		t.Fatalf("expected non-empty series, got %s", rec.Body.String())
+	}
+}
+
+func TestQueryRange_CountOverTimeParserUsesDirectStatsRange(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	var (
+		manualCalled bool
+		statsCalled  bool
+	)
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		switch r.URL.Path {
+		case "/select/logsql/query":
+			// Parser probe may hit this endpoint, but manual metric fallback
+			// should not for parser count_over_time.
+			if r.Form.Get("limit") == "1000000" {
+				manualCalled = true
+			}
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"_time":%q,"_msg":"{\"method\":\"GET\",\"status\":200}","_stream":"{service_name=\"api-gateway\"}","service_name":"api-gateway","level":"info"}`+"\n",
+				base.Format(time.RFC3339Nano),
+			)))
+		case "/select/logsql/stats_query_range":
+			statsCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"level":"info"},"values":[[1700000000,"2"]]},{"metric":{"level":"error"},"values":[[1700000000,"1"]]}]}}`))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `sum by (detected_level) (count_over_time({service_name="api-gateway"} | json | logfmt | drop __error__, __error_details__ [1m]))`)
+	params.Set("start", strconv.FormatInt(base.Add(-time.Minute).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(time.Minute).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if manualCalled {
+		t.Fatalf("unexpected manual fallback for parser count_over_time")
+	}
+	if !statsCalled {
+		t.Fatalf("expected stats_query_range to be called")
+	}
+
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Metric map[string]string `json:"metric"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, series := range resp.Data.Result {
+		seen[series.Metric["detected_level"]] = true
+	}
+	if !seen["info"] || !seen["error"] {
+		t.Fatalf("expected detected_level info/error series, got %v", resp.Data.Result)
+	}
+}
+
+func TestQueryRange_BytesRateCompatScalesFromSumLen(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	msg := strings.Repeat("x", 100)
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		if got := r.FormValue("query"); !strings.Contains(got, `app:=nginx`) {
+			t.Fatalf("expected translated query, got %q", got)
+		}
+		lines := []string{
+			fmt.Sprintf(`{"_time":%q,"_msg":%q,"_stream":"{app=\"nginx\"}"}`, base.Format(time.RFC3339Nano), msg),
+			fmt.Sprintf(`{"_time":%q,"_msg":%q,"_stream":"{app=\"nginx\"}"}`, base.Add(60*time.Second).Format(time.RFC3339Nano), msg),
+			fmt.Sprintf(`{"_time":%q,"_msg":%q,"_stream":"{app=\"nginx\"}"}`, base.Add(120*time.Second).Format(time.RFC3339Nano), msg),
+		}
+		_, _ = w.Write([]byte(strings.Join(lines, "\n") + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `bytes_rate({app="nginx"} | json [5m])`)
+	params.Set("start", strconv.FormatInt(base.Add(180*time.Second).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(180*time.Second).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "success" || len(resp.Data.Result) != 1 || len(resp.Data.Result[0].Values) != 1 {
+		t.Fatalf("unexpected response: %s", rec.Body.String())
+	}
+	got := resp.Data.Result[0].Values[0][1]
+	if got != "1" {
+		t.Fatalf("expected bytes_rate value 1 after normalization, got %v", got)
+	}
+}
+
+func TestQueryRange_StdvarCompatSquaresStddev(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stats_query_range" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		_, _ = fmt.Fprintf(
+			w,
+			`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"app":"nginx"},"values":[[%d,"1"]]}]}}`,
+			base.Add(120*time.Second).Unix(),
+		)
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `stdvar_over_time({app="nginx"} | unwrap latency [5m])`)
+	params.Set("start", strconv.FormatInt(base.Add(120*time.Second).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(120*time.Second).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	got := resp.Data.Result[0].Values[0][1]
+	if got != "1" {
+		t.Fatalf("expected stdvar value 1, got %v", got)
+	}
+}
+
+func TestQueryRange_FirstOverTimeManualFallback(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		lines := []string{
+			fmt.Sprintf(`{"_time":%q,"_msg":"a","_stream":"{app=\"nginx\"}","latency":10}`, base.Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"b","_stream":"{app=\"nginx\"}","latency":20}`, base.Add(60*time.Second).Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"c","_stream":"{app=\"nginx\"}","latency":30}`, base.Add(120*time.Second).Format(time.RFC3339Nano)),
+		}
+		_, _ = w.Write([]byte(strings.Join(lines, "\n") + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `first_over_time({app="nginx"} | json | unwrap latency [2m])`)
+	params.Set("start", strconv.FormatInt(base.Add(60*time.Second).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(120*time.Second).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Result) != 1 || len(resp.Data.Result[0].Values) != 2 {
+		t.Fatalf("unexpected response: %s", rec.Body.String())
+	}
+	for _, pair := range resp.Data.Result[0].Values {
+		if pair[1] != "10" {
+			t.Fatalf("expected first_over_time value 10, got %v", pair[1])
+		}
+	}
+}
+
+func TestQueryInstant_RateCounterRequiresUnwrap(t *testing.T) {
+	p := newGapTestProxy(t, "http://unused")
+	params := url.Values{}
+	params.Set("query", `rate_counter({app="nginx"}[5m])`)
+	params.Set("time", "1700000180")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQuery(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "unwrap") {
+		t.Fatalf("expected unwrap error, got %s", rec.Body.String())
+	}
+}
+
+func TestQueryInstant_RateCounterManualFallback(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		lines := []string{
+			fmt.Sprintf(`{"_time":%q,"_msg":"a","_stream":"{app=\"nginx\"}","counter":100}`, base.Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"b","_stream":"{app=\"nginx\"}","counter":130}`, base.Add(60*time.Second).Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"c","_stream":"{app=\"nginx\"}","counter":10}`, base.Add(120*time.Second).Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"d","_stream":"{app=\"nginx\"}","counter":30}`, base.Add(180*time.Second).Format(time.RFC3339Nano)),
+		}
+		_, _ = w.Write([]byte(strings.Join(lines, "\n") + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `rate_counter({app="nginx"} | unwrap counter [5m])`)
+	params.Set("time", strconv.FormatInt(base.Add(180*time.Second).Unix(), 10))
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQuery(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Value []interface{} `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Result) != 1 || len(resp.Data.Result[0].Value) != 2 {
+		t.Fatalf("unexpected response: %s", rec.Body.String())
+	}
+	if got := resp.Data.Result[0].Value[1]; got != "0.2" {
+		t.Fatalf("expected rate_counter value 0.2, got %v", got)
+	}
+}
+
+func TestQueryRange_SumOverTimeRequiresUnwrap(t *testing.T) {
+	p := newGapTestProxy(t, "http://unused")
+	params := url.Values{}
+	params.Set("query", `sum_over_time({app="nginx"}[5m])`)
+	params.Set("start", "1700000000")
+	params.Set("end", "1700000300")
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "unwrap") {
+		t.Fatalf("expected unwrap error, got %s", rec.Body.String())
+	}
+}
+
+func TestQueryRange_QuantileManualFallback(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+		lines := []string{
+			fmt.Sprintf(`{"_time":%q,"_msg":"a","_stream":"{app=\"nginx\",level=\"info\"}","latency":10}`, base.Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"b","_stream":"{app=\"nginx\",level=\"info\"}","latency":20}`, base.Add(60*time.Second).Format(time.RFC3339Nano)),
+			fmt.Sprintf(`{"_time":%q,"_msg":"c","_stream":"{app=\"nginx\",level=\"info\"}","latency":30}`, base.Add(120*time.Second).Format(time.RFC3339Nano)),
+		}
+		_, _ = w.Write([]byte(strings.Join(lines, "\n") + "\n"))
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	params.Set("query", `quantile_over_time(0.5, {app="nginx"} | json | unwrap latency [5m])`)
+	params.Set("start", strconv.FormatInt(base.Add(180*time.Second).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(180*time.Second).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Result []struct {
+				Values [][]interface{} `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Result) != 1 || len(resp.Data.Result[0].Values) != 1 {
+		t.Fatalf("unexpected response: %s", rec.Body.String())
+	}
+	if got := resp.Data.Result[0].Values[0][1]; got != "20" {
+		t.Fatalf("expected median quantile value 20, got %v", got)
+	}
+}
+
+func FuzzParseOriginalRangeMetricSpec(f *testing.F) {
+	seeds := []string{
+		`rate({app="api"}[5m])`,
+		`bytes_rate({app="api"}[1m])`,
+		`sum_over_time({app="api"} | unwrap duration_ms [5m])`,
+		`quantile_over_time(0.95, {app="api"} | unwrap latency [5m])`,
+		`not a metric`,
+		``,
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, query string) {
+		spec, ok := parseOriginalRangeMetricSpec(query)
+		if !ok {
+			return
+		}
+		if strings.TrimSpace(spec.Func) == "" {
+			t.Fatalf("parsed spec must include function: %+v", spec)
+		}
+		if spec.Window < 0 {
+			t.Fatalf("window must be non-negative: %+v", spec)
+		}
+	})
+}

--- a/internal/proxy/range_metric_compat_test.go
+++ b/internal/proxy/range_metric_compat_test.go
@@ -108,10 +108,11 @@ func TestQueryRange_CountOverTimeParserUsesDirectStatsRange(t *testing.T) {
 				manualCalled = true
 			}
 			w.Header().Set("Content-Type", "application/x-ndjson")
-			_, _ = w.Write([]byte(fmt.Sprintf(
+			_, _ = fmt.Fprintf(
+				w,
 				`{"_time":%q,"_msg":"{\"method\":\"GET\",\"status\":200}","_stream":"{service_name=\"api-gateway\"}","service_name":"api-gateway","level":"info"}`+"\n",
 				base.Format(time.RFC3339Nano),
-			)))
+			)
 		case "/select/logsql/stats_query_range":
 			statsCalled = true
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -814,6 +814,7 @@ func tryTranslateMetricQuery(logql string, labelFn LabelTranslateFunc) (string, 
 		"stddev_over_time": "stddev",
 		"stdvar_over_time": "stddev",
 		"absent_over_time": "count()",
+		"rate_counter":     "__rate_counter__",
 	}
 
 	// Try to match outer aggregation: sum(...) by (labels)
@@ -1237,7 +1238,7 @@ func isUnwrapFunc(name string) bool {
 		"max_over_time": true, "min_over_time": true,
 		"first_over_time": true, "last_over_time": true,
 		"stddev_over_time": true, "stdvar_over_time": true,
-		"quantile_over_time": true,
+		"quantile_over_time": true, "rate_counter": true,
 	}
 	return unwrapFuncs[name]
 }

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -295,6 +295,11 @@ func TestMetricQueryTranslation(t *testing.T) {
 			logql: `avg_over_time({app="nginx"} | unwrap response_time [5m])`,
 			want:  `app:=nginx | stats avg(response_time)`,
 		},
+		{
+			name:  "rate_counter with unwrap",
+			logql: `rate_counter({app="nginx"} | unwrap requests_total [5m])`,
+			want:  `app:=nginx | stats __rate_counter__(requests_total)`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e-compat/range_metric_compat_test.go
+++ b/test/e2e-compat/range_metric_compat_test.go
@@ -1,0 +1,239 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var rangeMetricCompatOnce sync.Once
+
+func ensureRangeMetricCompatData(t *testing.T) {
+	t.Helper()
+	ensureDataIngested(t)
+	rangeMetricCompatOnce.Do(func() {
+		now := time.Now()
+		pushStream(t, now, streamDef{
+			Labels: map[string]string{
+				"app":       "range-metric-counter",
+				"namespace": "prod",
+				"cluster":   "us-east-1",
+				"env":       "production",
+			},
+			Lines: []string{
+				`{"counter":100,"latency":1}`,
+				`{"counter":130,"latency":2}`,
+				`{"counter":10,"latency":3}`,
+				`{"counter":30,"latency":4}`,
+			},
+		})
+		time.Sleep(3 * time.Second)
+	})
+}
+
+func TestRangeMetricCompatibilityMatrix(t *testing.T) {
+	ensureRangeMetricCompatData(t)
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	start := now.Add(-15 * time.Minute).Format(time.RFC3339Nano)
+	end := now.Add(15 * time.Minute).Format(time.RFC3339Nano)
+
+	tests := []struct {
+		name      string
+		query     string
+		tolerance float64
+	}{
+		{name: "rate", query: `rate({app="api-gateway"}[5m])`, tolerance: 1e-9},
+		{name: "count_over_time", query: `count_over_time({app="api-gateway"}[5m])`, tolerance: 1e-9},
+		{name: "bytes_over_time", query: `bytes_over_time({app="api-gateway"}[5m])`, tolerance: 1e-9},
+		{name: "bytes_rate", query: `bytes_rate({app="api-gateway"}[5m])`, tolerance: 1e-9},
+		{name: "sum_over_time_unwrap", query: `sum_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "avg_over_time_unwrap", query: `avg_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "max_over_time_unwrap", query: `max_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "min_over_time_unwrap", query: `min_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "first_over_time_unwrap", query: `first_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "last_over_time_unwrap", query: `last_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "stddev_over_time_unwrap", query: `stddev_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "stdvar_over_time_unwrap", query: `stdvar_over_time({app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "quantile_over_time_unwrap", query: `quantile_over_time(0.95, {app="api-gateway"} | json | unwrap duration_ms [5m])`, tolerance: 1e-9},
+		{name: "rate_counter_unwrap", query: `rate_counter({app="range-metric-counter"} | json | unwrap counter [5m])`, tolerance: 1e-9},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiResult := queryRangeResult(t, lokiURL, tc.query, start, end, "60")
+			proxyResult := queryRangeResult(t, proxyURL, tc.query, start, end, "60")
+
+			if lokiResult.StatusCode != proxyResult.StatusCode {
+				t.Fatalf("status code mismatch loki=%d proxy=%d query=%s lokiBody=%s proxyBody=%s", lokiResult.StatusCode, proxyResult.StatusCode, tc.query, lokiResult.Body, proxyResult.Body)
+			}
+			if lokiResult.StatusCode != http.StatusOK {
+				t.Fatalf("expected success from both backends for %s, loki=%s proxy=%s", tc.name, lokiResult.Body, proxyResult.Body)
+			}
+			lokiResp := lokiResult.JSON
+			proxyResp := proxyResult.JSON
+
+			lokiData, _ := lokiResp["data"].(map[string]interface{})
+			proxyData, _ := proxyResp["data"].(map[string]interface{})
+			if lokiData["resultType"] != proxyData["resultType"] {
+				t.Fatalf("resultType mismatch loki=%v proxy=%v", lokiData["resultType"], proxyData["resultType"])
+			}
+
+			lokiFlat := flattenMatrixResult(t, lokiData["result"])
+			proxyFlat := flattenMatrixResult(t, proxyData["result"])
+			if len(lokiFlat) != len(proxyFlat) {
+				t.Fatalf("series point count mismatch loki=%d proxy=%d", len(lokiFlat), len(proxyFlat))
+			}
+
+			for key, lokiValue := range lokiFlat {
+				proxyValue, ok := proxyFlat[key]
+				if !ok {
+					t.Fatalf("proxy missing series point %s", key)
+				}
+				if math.Abs(lokiValue-proxyValue) > tc.tolerance {
+					t.Fatalf("value mismatch at %s: loki=%v proxy=%v tolerance=%v", key, lokiValue, proxyValue, tc.tolerance)
+				}
+			}
+		})
+	}
+}
+
+func TestRangeMetricCompatibilityMissingUnwrapErrors(t *testing.T) {
+	ensureRangeMetricCompatData(t)
+	now := time.Now().UTC().Truncate(time.Minute)
+	start := now.Add(-15 * time.Minute).Format(time.RFC3339Nano)
+	end := now.Add(15 * time.Minute).Format(time.RFC3339Nano)
+
+	queries := []string{
+		`rate_counter({app="range-metric-counter"}[5m])`,
+		`first_over_time({app="api-gateway"}[5m])`,
+		`last_over_time({app="api-gateway"}[5m])`,
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			lokiResult := queryRangeResult(t, lokiURL, query, start, end, "60")
+			proxyResult := queryRangeResult(t, proxyURL, query, start, end, "60")
+
+			if lokiResult.StatusCode != proxyResult.StatusCode {
+				t.Fatalf("status code mismatch loki=%d proxy=%d query=%s loki=%s proxy=%s", lokiResult.StatusCode, proxyResult.StatusCode, query, lokiResult.Body, proxyResult.Body)
+			}
+			if proxyResult.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400 for missing unwrap query=%s proxy=%s", query, proxyResult.Body)
+			}
+			if !strings.Contains(strings.ToLower(lokiResult.Body), "without unwrap") {
+				t.Fatalf("expected Loki unwrap error query=%s body=%s", query, lokiResult.Body)
+			}
+			if !strings.Contains(strings.ToLower(proxyResult.Body), "without unwrap") {
+				t.Fatalf("expected proxy unwrap error query=%s body=%s", query, proxyResult.Body)
+			}
+		})
+	}
+}
+
+type rangeQueryResult struct {
+	StatusCode int
+	Body       string
+	JSON       map[string]interface{}
+}
+
+func queryRangeResult(t *testing.T, baseURL, query, start, end, step string) rangeQueryResult {
+	t.Helper()
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", start)
+	params.Set("end", end)
+	params.Set("step", step)
+	resp, err := http.Get(baseURL + "/loki/api/v1/query_range?" + params.Encode())
+	if err != nil {
+		t.Fatalf("query_range request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var payload map[string]interface{}
+	_ = json.Unmarshal(body, &payload)
+	return rangeQueryResult{
+		StatusCode: resp.StatusCode,
+		Body:       string(body),
+		JSON:       payload,
+	}
+}
+
+func flattenMatrixResult(t *testing.T, raw interface{}) map[string]float64 {
+	t.Helper()
+	result, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("expected matrix result array, got %T", raw)
+	}
+
+	flat := make(map[string]float64)
+	for _, item := range result {
+		series, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected series object, got %T", item)
+		}
+		metricMap, _ := series["metric"].(map[string]interface{})
+		metricKey := canonicalMetricKey(metricMap)
+		values, _ := series["values"].([]interface{})
+		for _, value := range values {
+			pair, ok := value.([]interface{})
+			if !ok || len(pair) < 2 {
+				continue
+			}
+			ts := toInt64(pair[0])
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(fmt.Sprintf("%v", pair[1])), 64)
+			if err != nil {
+				t.Fatalf("failed to parse matrix value %v: %v", pair[1], err)
+			}
+			flat[fmt.Sprintf("%s@%d", metricKey, ts)] = parsed
+		}
+	}
+	return flat
+}
+
+func canonicalMetricKey(metric map[string]interface{}) string {
+	if len(metric) == 0 {
+		return "{}"
+	}
+	parts := make([]string, 0, len(metric))
+	for key, value := range metric {
+		parts = append(parts, fmt.Sprintf("%s=%v", key, value))
+	}
+	sort.Strings(parts)
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+func toInt64(value interface{}) int64 {
+	switch v := value.(type) {
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case string:
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return parsed
+		}
+		if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			return parsed.Unix()
+		}
+		parsed, _ := strconv.ParseInt(v, 10, 64)
+		return parsed
+	default:
+		parsed, _ := strconv.ParseInt(fmt.Sprintf("%v", value), 10, 64)
+		return parsed
+	}
+}


### PR DESCRIPTION
## Summary
- add proxy-side range metric compatibility handling for range/metric functions, including manual fallback windows where needed
- align translator mappings for bytes_over_time, bytes_rate, and rate_counter to reduce Loki/VL parser and semantic drift
- improve drilldown stability by preserving service_name summaries and keeping label/field behavior deterministic
- add broad unit/e2e compatibility coverage (matrix tests, missing-unwrap parity checks, parser fuzzing/edge cases)
- update docs and changelog for the new compatibility behavior

## Verification
- go test ./internal/proxy ./internal/translator
- go test -tags=e2e -run "TestRangeMetricCompatibilityMatrix|TestRangeMetricCompatibilityMissingUnwrapErrors|TestLokiTrackScore" ./test/e2e-compat/

Validated locally on compose-based e2e stack only (no ops.sand or infra endpoints used).