### PR TITLE
test(e2e): harden Grafana clickout range-metric unwrap coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- e2e/clickout: add Grafana `/api/ds/query` parity coverage for range-metric functions (missing-unwrap 400 parity and unwrap + `$__auto` success parity) across direct Loki and Loki-via-proxy datasources.
+
 ## [1.13.0] - 2026-04-23
 
 ### Bug Fixes

--- a/test/e2e-compat/grafana_clickout_range_metric_test.go
+++ b/test/e2e-compat/grafana_clickout_range_metric_test.go
@@ -1,0 +1,209 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type grafanaDSQueryResult struct {
+	Status int
+	Error  string
+	Body   string
+}
+
+func queryGrafanaLokiDatasource(t *testing.T, datasourceUID, expr string) grafanaDSQueryResult {
+	t.Helper()
+
+	payload := map[string]interface{}{
+		"from": "now-6h",
+		"to":   "now",
+		"queries": []map[string]interface{}{
+			{
+				"refId":      "A",
+				"datasource": map[string]interface{}{"type": "loki", "uid": datasourceUID},
+				"expr":       expr,
+				"queryType":  "range",
+				"editorMode": "code",
+				"maxLines":   1000,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal grafana ds query payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, grafanaURL+"/api/ds/query", bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("build grafana ds query request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("execute grafana ds query request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read grafana ds query response: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode grafana ds query response: %v body=%s", err, string(body))
+	}
+
+	resultsRaw, ok := decoded["results"]
+	if !ok {
+		t.Fatalf("grafana ds query missing results: %v", decoded)
+	}
+	results, ok := resultsRaw.(map[string]interface{})
+	if !ok {
+		t.Fatalf("grafana ds query results not an object: %T", resultsRaw)
+	}
+	queryRaw, ok := results["A"]
+	if !ok {
+		t.Fatalf("grafana ds query missing refId A: %v", results)
+	}
+	query, ok := queryRaw.(map[string]interface{})
+	if !ok {
+		t.Fatalf("grafana ds query A not an object: %T", queryRaw)
+	}
+
+	status := asInt(query["status"])
+	errText := strings.TrimSpace(fmt.Sprintf("%v", query["error"]))
+	if errText == "<nil>" {
+		errText = ""
+	}
+
+	return grafanaDSQueryResult{
+		Status: status,
+		Error:  errText,
+		Body:   string(body),
+	}
+}
+
+func asInt(value interface{}) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		i, _ := v.Int64()
+		return int(i)
+	case string:
+		if v == "" {
+			return 0
+		}
+		var i int
+		_, _ = fmt.Sscanf(v, "%d", &i)
+		return i
+	default:
+		return 0
+	}
+}
+
+func TestGrafanaClickout_RangeMetricMissingUnwrapParity(t *testing.T) {
+	ensureRangeMetricCompatData(t)
+	waitForReady(t, grafanaURL+"/api/health", 30*time.Second)
+
+	proxyUID := grafanaDatasourceUID(t, "Loki (via VL proxy)")
+	directUID := grafanaDatasourceUID(t, "Loki (direct)")
+
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "sum_over_time", expr: `sum_over_time({app="api-gateway"}[$__auto])`},
+		{name: "avg_over_time", expr: `avg_over_time({app="api-gateway"}[$__auto])`},
+		{name: "max_over_time", expr: `max_over_time({app="api-gateway"}[$__auto])`},
+		{name: "min_over_time", expr: `min_over_time({app="api-gateway"}[$__auto])`},
+		{name: "first_over_time", expr: `first_over_time({app="api-gateway"}[$__auto])`},
+		{name: "last_over_time", expr: `last_over_time({app="api-gateway"}[$__auto])`},
+		{name: "stddev_over_time", expr: `stddev_over_time({app="api-gateway"}[$__auto])`},
+		{name: "stdvar_over_time", expr: `stdvar_over_time({app="api-gateway"}[$__auto])`},
+		{name: "quantile_over_time", expr: `quantile_over_time(0.95, {app="api-gateway"}[$__auto])`},
+		{name: "rate_counter", expr: `rate_counter({app="range-metric-counter"}[$__auto])`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyRes := queryGrafanaLokiDatasource(t, proxyUID, tc.expr)
+			directRes := queryGrafanaLokiDatasource(t, directUID, tc.expr)
+
+			if proxyRes.Status != directRes.Status {
+				t.Fatalf("status mismatch proxy=%d direct=%d expr=%s proxyBody=%s directBody=%s", proxyRes.Status, directRes.Status, tc.expr, proxyRes.Body, directRes.Body)
+			}
+			if proxyRes.Status != http.StatusBadRequest {
+				t.Fatalf("expected 400 for missing unwrap expr=%s proxy=%s direct=%s", tc.expr, proxyRes.Body, directRes.Body)
+			}
+
+			proxyErr := strings.ToLower(proxyRes.Error)
+			directErr := strings.ToLower(directRes.Error)
+			if !strings.Contains(proxyErr, "without unwrap") {
+				t.Fatalf("expected proxy missing-unwrap error shape expr=%s got=%s", tc.expr, proxyRes.Error)
+			}
+			if !strings.Contains(directErr, "without unwrap") {
+				t.Fatalf("expected direct missing-unwrap error shape expr=%s got=%s", tc.expr, directRes.Error)
+			}
+		})
+	}
+}
+
+func TestGrafanaClickout_RangeMetricAutoWindowUnwrapSuccess(t *testing.T) {
+	ensureRangeMetricCompatData(t)
+	waitForReady(t, grafanaURL+"/api/health", 30*time.Second)
+
+	proxyUID := grafanaDatasourceUID(t, "Loki (via VL proxy)")
+	directUID := grafanaDatasourceUID(t, "Loki (direct)")
+
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "sum_over_time_unwrap", expr: `sum_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "avg_over_time_unwrap", expr: `avg_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "max_over_time_unwrap", expr: `max_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "min_over_time_unwrap", expr: `min_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "first_over_time_unwrap", expr: `first_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "last_over_time_unwrap", expr: `last_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "stddev_over_time_unwrap", expr: `stddev_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "stdvar_over_time_unwrap", expr: `stdvar_over_time({app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "quantile_over_time_unwrap", expr: `quantile_over_time(0.95, {app="api-gateway"} | json | unwrap duration [$__auto])`},
+		{name: "rate_counter_unwrap", expr: `rate_counter({app="range-metric-counter"} | json | unwrap counter [$__auto])`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyRes := queryGrafanaLokiDatasource(t, proxyUID, tc.expr)
+			directRes := queryGrafanaLokiDatasource(t, directUID, tc.expr)
+
+			if proxyRes.Status != directRes.Status {
+				t.Fatalf("status mismatch proxy=%d direct=%d expr=%s proxyBody=%s directBody=%s", proxyRes.Status, directRes.Status, tc.expr, proxyRes.Body, directRes.Body)
+			}
+			if proxyRes.Status != http.StatusOK {
+				t.Fatalf("expected 200 for unwrap query expr=%s proxy=%s direct=%s", tc.expr, proxyRes.Body, directRes.Body)
+			}
+			if strings.TrimSpace(proxyRes.Error) != "" {
+				t.Fatalf("proxy returned unexpected error expr=%s err=%s body=%s", tc.expr, proxyRes.Error, proxyRes.Body)
+			}
+			if strings.TrimSpace(directRes.Error) != "" {
+				t.Fatalf("direct returned unexpected error expr=%s err=%s body=%s", tc.expr, directRes.Error, directRes.Body)
+			}
+		})
+	}
+}

--- a/test/e2e-compat/range_metric_compat_test.go
+++ b/test/e2e-compat/range_metric_compat_test.go
@@ -116,6 +116,13 @@ func TestRangeMetricCompatibilityMissingUnwrapErrors(t *testing.T) {
 	end := now.Add(15 * time.Minute).Format(time.RFC3339Nano)
 
 	queries := []string{
+		`sum_over_time({app="api-gateway"}[5m])`,
+		`avg_over_time({app="api-gateway"}[5m])`,
+		`max_over_time({app="api-gateway"}[5m])`,
+		`min_over_time({app="api-gateway"}[5m])`,
+		`stddev_over_time({app="api-gateway"}[5m])`,
+		`stdvar_over_time({app="api-gateway"}[5m])`,
+		`quantile_over_time(0.95, {app="api-gateway"}[5m])`,
 		`rate_counter({app="range-metric-counter"}[5m])`,
 		`first_over_time({app="api-gateway"}[5m])`,
 		`last_over_time({app="api-gateway"}[5m])`,


### PR DESCRIPTION
## Why
Grafana /api/ds/query clickout paths for Loki range-metric functions were not fully covered in e2e parity tests. This left gaps for obvious no-unwrap regressions.

## What changed
- expanded missing-unwrap parity matrix in `test/e2e-compat/range_metric_compat_test.go` to include:
  - sum_over_time, avg_over_time, max_over_time, min_over_time
  - stddev_over_time, stdvar_over_time, quantile_over_time
  - rate_counter, first_over_time, last_over_time
- added new Grafana clickout e2e suite in `test/e2e-compat/grafana_clickout_range_metric_test.go`:
  - validates no-unwrap range funcs fail with 400 on both direct Loki and proxy datasource via `/api/ds/query`
  - validates unwrap + `$__auto` queries succeed (200) on both direct Loki and proxy datasource
  - enforces `without unwrap` error-shape parity guard for the no-unwrap matrix

## Verification
- `go test -v -tags=e2e -run "TestGrafanaClickout_RangeMetric|TestRangeMetricCompatibilityMissingUnwrapErrors" ./test/e2e-compat/` (33 passed)
