### PR TITLE
compat: align range selector options with Loki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.13.1] - 2026-04-23
+### Bug Fixes
+
+- metrics/range-selectors: align Grafana clickout range-selector handling closer to Loki behavior by normalizing braced selector templates (`${__interval}` variants), honoring Loki-style duration units (`d/w/y`) in proxy compatibility paths, and ensuring stats compatibility paths use token-resolved original queries instead of raw unresolved request text.
+- metrics/range-selectors: normalize missing-unwrap error handling in compatibility paths so explicit unwrap-required range functions return stable Loki-compatible bad-data errors instead of falling through to generic invalid-range responses.
 
 ### Tests
 
 - e2e/clickout: add Grafana `/api/ds/query` parity coverage for range-metric functions (missing-unwrap 400 parity and unwrap + `$__auto` success parity) across direct Loki and Loki-via-proxy datasources.
+- e2e/grafana-clickout: add selector-option parity coverage for `sum_over_time(... | unwrap ...)` across `$__auto`, `$__interval`, `${__interval}`, and fixed window options (`5m`, `1h`, `1d`) against direct Loki.
+- compat/helpers: expand unit coverage for Prometheus/Loki duration parsing (`1d`, mixed `w/d/h`), braced Grafana token resolution, and selector-token recognition.
+
+## [1.13.1] - 2026-04-23
 
 ## [1.13.0] - 2026-04-23
 

--- a/internal/proxy/compat_coverage_helpers_test.go
+++ b/internal/proxy/compat_coverage_helpers_test.go
@@ -305,6 +305,12 @@ func TestCompatHelpers_TimeParsingAndDurationFormatting(t *testing.T) {
 	if d, ok := parsePositiveStepDuration("2.5"); !ok || d != 2500*time.Millisecond {
 		t.Fatalf("expected float step parse, got %v,%v", d, ok)
 	}
+	if d, ok := parsePositiveStepDuration("1d"); !ok || d != 24*time.Hour {
+		t.Fatalf("expected day step parse, got %v,%v", d, ok)
+	}
+	if d, ok := parsePositiveStepDuration("1w2d3h"); !ok || d != (9*24+3)*time.Hour {
+		t.Fatalf("expected week/day/hour step parse, got %v,%v", d, ok)
+	}
 	if _, ok := parsePositiveStepDuration("-1"); ok {
 		t.Fatal("expected negative step parse to fail")
 	}
@@ -315,17 +321,29 @@ func TestCompatHelpers_TimeParsingAndDurationFormatting(t *testing.T) {
 	if d, ok := resolveGrafanaTemplateTokenDuration("$__rate_interval", "1700000000", "1700000600", "30s"); !ok || d != time.Minute*2 {
 		t.Fatalf("expected $__rate_interval to resolve to 2m, got %v,%v", d, ok)
 	}
+	if d, ok := resolveGrafanaTemplateTokenDuration("${__rate_interval_ms}", "1700000000", "1700000600", "30s"); !ok || d != time.Minute*2 {
+		t.Fatalf("expected ${__rate_interval_ms} to resolve to 2m, got %v,%v", d, ok)
+	}
 	if d, ok := resolveGrafanaTemplateTokenDuration("$__range", "1700000000", "1700000600", "30s"); !ok || d != 10*time.Minute {
 		t.Fatalf("expected $__range to resolve to 10m, got %v,%v", d, ok)
 	}
 	if d, ok := resolveGrafanaTemplateTokenDuration("$__interval", "1700000000", "1700000600", "30s"); !ok || d != 30*time.Second {
 		t.Fatalf("expected $__interval to resolve to step, got %v,%v", d, ok)
 	}
+	if d, ok := resolveGrafanaTemplateTokenDuration("${__interval_ms}", "1700000000", "1700000600", "30s"); !ok || d != 30*time.Second {
+		t.Fatalf("expected ${__interval_ms} to resolve to step, got %v,%v", d, ok)
+	}
+	if !isGrafanaRangeTemplateSelector("${__range_s}") {
+		t.Fatal("expected braced $__range_s selector to be recognized")
+	}
+	if isGrafanaRangeTemplateSelector("${__unknown}") {
+		t.Fatal("expected unknown braced selector to be rejected")
+	}
 	if _, ok := resolveGrafanaTemplateTokenDuration("$__unknown", "1700000000", "1700000600", "30s"); ok {
 		t.Fatal("expected unknown grafana token to fail resolution")
 	}
-	if got := resolveGrafanaRangeTemplateTokens(`rate({app="api"}[$__auto])`, "1700000000", "1700000600", "30s"); got != `rate({app="api"}[30s])` {
-		t.Fatalf("expected $__auto replacement, got %q", got)
+	if got := resolveGrafanaRangeTemplateTokens(`rate({app="api"}[${__interval}]) + count_over_time({app="api"}[$__auto])`, "1700000000", "1700000600", "30s"); got != `rate({app="api"}[30s]) + count_over_time({app="api"}[30s])` {
+		t.Fatalf("expected Grafana token replacement, got %q", got)
 	}
 
 	if bucketRange, ok := parseRequestedBucketRange("1700000000", "1700000060", "30s"); !ok {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8608,7 +8608,8 @@ func (p *Proxy) vlPostCoalesced(ctx context.Context, key, path string, params ur
 // --- Stats query proxying ---
 
 func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
-	if p.handleStatsCompatRange(w, r, r.FormValue("query"), logsqlQuery) {
+	originalLogql := resolveGrafanaRangeTemplateTokens(r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
+	if p.handleStatsCompatRange(w, r, originalLogql, logsqlQuery) {
 		return
 	}
 
@@ -8758,7 +8759,8 @@ func statsQueryRangePointUnixNano(point []interface{}) int64 {
 }
 
 func (p *Proxy) proxyStatsQuery(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
-	if p.handleStatsCompatInstant(w, r, r.FormValue("query"), logsqlQuery) {
+	originalLogql := resolveGrafanaRangeTemplateTokens(r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
+	if p.handleStatsCompatInstant(w, r, originalLogql, logsqlQuery) {
 		return
 	}
 
@@ -10173,12 +10175,29 @@ func normalizeUnixNanos(v int64) int64 {
 	}
 }
 
+var (
+	prometheusDurationPartRE = regexp.MustCompile(`(?i)([0-9]*\.?[0-9]+)(ns|us|µs|ms|s|m|h|d|w|y)`)
+	grafanaRangeTokens       = []string{
+		"$__rate_interval_ms",
+		"$__interval_ms",
+		"$__range_ms",
+		"$__rate_interval",
+		"$__range_s",
+		"$__interval",
+		"$__range",
+		"$__auto",
+	}
+)
+
 func parsePositiveStepDuration(step string) (time.Duration, bool) {
 	value := strings.TrimSpace(step)
 	if value == "" {
 		return 0, false
 	}
 	if d, err := time.ParseDuration(value); err == nil && d > 0 {
+		return d, true
+	}
+	if d, ok := parsePrometheusStyleDuration(value); ok {
 		return d, true
 	}
 	seconds, err := strconv.ParseFloat(value, 64)
@@ -10196,20 +10215,69 @@ func parsePositiveStepDuration(step string) (time.Duration, bool) {
 	return d, true
 }
 
+func parsePrometheusStyleDuration(value string) (time.Duration, bool) {
+	parts := prometheusDurationPartRE.FindAllStringSubmatch(value, -1)
+	if len(parts) == 0 {
+		return 0, false
+	}
+
+	totalSeconds := 0.0
+	var consumed strings.Builder
+	for _, part := range parts {
+		numeric, err := strconv.ParseFloat(part[1], 64)
+		if err != nil || numeric <= 0 {
+			return 0, false
+		}
+
+		switch strings.ToLower(part[2]) {
+		case "ns":
+			totalSeconds += numeric / 1e9
+		case "us", "µs":
+			totalSeconds += numeric / 1e6
+		case "ms":
+			totalSeconds += numeric / 1e3
+		case "s":
+			totalSeconds += numeric
+		case "m":
+			totalSeconds += numeric * 60
+		case "h":
+			totalSeconds += numeric * 3600
+		case "d":
+			totalSeconds += numeric * 86400
+		case "w":
+			totalSeconds += numeric * 7 * 86400
+		case "y":
+			totalSeconds += numeric * 365 * 86400
+		default:
+			return 0, false
+		}
+
+		consumed.WriteString(part[0])
+	}
+
+	if consumed.String() != value {
+		return 0, false
+	}
+
+	nanos := totalSeconds * float64(time.Second)
+	if nanos <= 0 || nanos > float64(math.MaxInt64) {
+		return 0, false
+	}
+
+	d := time.Duration(nanos)
+	if d <= 0 {
+		return 0, false
+	}
+	return d, true
+}
+
 func resolveGrafanaRangeTemplateTokens(query, start, end, step string) string {
-	if !strings.Contains(query, "$__") {
+	if !strings.Contains(query, "$__") && !strings.Contains(query, "${__") {
 		return query
 	}
 
 	replacements := map[string]string{}
-	for _, token := range []string{
-		"$__range_ms",
-		"$__rate_interval",
-		"$__interval",
-		"$__range_s",
-		"$__range",
-		"$__auto",
-	} {
+	for _, token := range grafanaRangeTokens {
 		if duration, ok := resolveGrafanaTemplateTokenDuration(token, start, end, step); ok {
 			replacements[token] = formatLogQLDuration(duration)
 		}
@@ -10220,24 +10288,24 @@ func resolveGrafanaRangeTemplateTokens(query, start, end, step string) string {
 	}
 
 	normalized := query
-	for _, token := range []string{
-		"$__range_ms",
-		"$__rate_interval",
-		"$__interval",
-		"$__range_s",
-		"$__range",
-		"$__auto",
-	} {
+	for _, token := range grafanaRangeTokens {
 		replacement, ok := replacements[token]
 		if !ok {
 			continue
 		}
+		braced := "${" + strings.TrimPrefix(token, "$") + "}"
+		normalized = strings.ReplaceAll(normalized, braced, replacement)
 		normalized = strings.ReplaceAll(normalized, token, replacement)
 	}
 	return normalized
 }
 
 func resolveGrafanaTemplateTokenDuration(token, start, end, step string) (time.Duration, bool) {
+	canonicalToken, ok := canonicalGrafanaRangeToken(token)
+	if !ok {
+		return 0, false
+	}
+
 	stepDur, stepOK := parsePositiveStepDuration(step)
 	if !stepOK {
 		stepDur = time.Minute
@@ -10253,10 +10321,10 @@ func resolveGrafanaTemplateTokenDuration(token, start, end, step string) (time.D
 		rangeDur = stepDur
 	}
 
-	switch strings.ToLower(strings.TrimSpace(token)) {
-	case "$__auto", "$__interval":
+	switch canonicalToken {
+	case "$__auto", "$__interval", "$__interval_ms":
 		return stepDur, true
-	case "$__rate_interval":
+	case "$__rate_interval", "$__rate_interval_ms":
 		rateInterval := stepDur * 4
 		if rateInterval < time.Minute {
 			rateInterval = time.Minute
@@ -10266,6 +10334,33 @@ func resolveGrafanaTemplateTokenDuration(token, start, end, step string) (time.D
 		return rangeDur, true
 	default:
 		return 0, false
+	}
+}
+
+func canonicalGrafanaRangeToken(token string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(token))
+	if normalized == "" {
+		return "", false
+	}
+	if strings.HasPrefix(normalized, "${") && strings.HasSuffix(normalized, "}") {
+		normalized = "$" + strings.TrimSuffix(strings.TrimPrefix(normalized, "${"), "}")
+	}
+	if strings.HasPrefix(normalized, "__") {
+		normalized = "$" + normalized
+	}
+
+	switch normalized {
+	case "$__auto",
+		"$__interval",
+		"$__interval_ms",
+		"$__rate_interval",
+		"$__rate_interval_ms",
+		"$__range",
+		"$__range_s",
+		"$__range_ms":
+		return normalized, true
+	default:
+		return "", false
 	}
 }
 
@@ -12687,12 +12782,8 @@ func parseBareParserMetricCompatSpec(logql string) (bareParserMetricCompatSpec, 
 }
 
 func isGrafanaRangeTemplateSelector(window string) bool {
-	switch strings.ToLower(strings.TrimSpace(window)) {
-	case "$__auto", "$__interval", "$__rate_interval", "$__range", "$__range_s", "$__range_ms":
-		return true
-	default:
-		return false
-	}
+	_, ok := canonicalGrafanaRangeToken(window)
+	return ok
 }
 
 func resolveBareParserMetricRangeWindow(spec bareParserMetricCompatSpec, start, end, step string) (bareParserMetricCompatSpec, bool) {

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -156,14 +156,32 @@ func TestProxyHelpers_ParseBareParserMetricCompatSpec_AcceptsRateCounterWithTemp
 	}
 }
 
+func TestProxyHelpers_ParseBareParserMetricCompatSpec_AcceptsBracedTemplateWindow(t *testing.T) {
+	spec, ok := parseBareParserMetricCompatSpec(`rate_counter({app="api-gateway"} | json | unwrap counter [${__rate_interval}])`)
+	if !ok {
+		t.Fatal("expected braced template window to be recognized")
+	}
+	if spec.rangeWindowExpr != "${__rate_interval}" {
+		t.Fatalf("unexpected rangeWindowExpr %q", spec.rangeWindowExpr)
+	}
+
+	resolved, ok := resolveBareParserMetricRangeWindow(spec, "2026-01-01T00:00:00Z", "2026-01-01T00:10:00Z", "10s")
+	if !ok {
+		t.Fatal("expected braced template window to resolve with request step")
+	}
+	if resolved.rangeWindow != time.Minute {
+		t.Fatalf("expected $__rate_interval minimum 1m, got %v", resolved.rangeWindow)
+	}
+}
+
 func TestProxyHelpers_ResolveGrafanaRangeTemplateTokens(t *testing.T) {
-	query := `rate({app="api-gateway"}[$__auto]) + rate_counter({app="api-gateway"} | json | unwrap counter [$__rate_interval]) + count_over_time({app="api-gateway"}[$__range_s])`
+	query := `rate({app="api-gateway"}[$__auto]) + rate_counter({app="api-gateway"} | json | unwrap counter [${__rate_interval}]) + count_over_time({app="api-gateway"}[$__range_s]) + sum_over_time({app="api-gateway"} | json | unwrap duration [${__interval_ms}])`
 	got := resolveGrafanaRangeTemplateTokens(query, "2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z", "15s")
-	if strings.Contains(got, "$__") {
+	if strings.Contains(got, "$__") || strings.Contains(got, "${__") {
 		t.Fatalf("expected all Grafana template tokens to resolve, got %q", got)
 	}
 	if !strings.Contains(got, "[15s]") {
-		t.Fatalf("expected $__auto to resolve to step, got %q", got)
+		t.Fatalf("expected $__auto/$__interval_ms to resolve to step, got %q", got)
 	}
 	if !strings.Contains(got, "[1m]") {
 		t.Fatalf("expected $__rate_interval to clamp to 1m minimum, got %q", got)

--- a/internal/proxy/subquery.go
+++ b/internal/proxy/subquery.go
@@ -425,6 +425,11 @@ func parseLokiDuration(s string) time.Duration {
 		return d
 	}
 
+	// Fall back to Prometheus/Loki units (d/w/y) and mixed-unit forms.
+	if d, ok := parsePrometheusStyleDuration(s); ok {
+		return d
+	}
+
 	// Handle "d" suffix (days) — not supported by Go
 	if strings.HasSuffix(s, "d") {
 		n, err := strconv.Atoi(s[:len(s)-1])

--- a/test/e2e-compat/grafana_clickout_range_metric_test.go
+++ b/test/e2e-compat/grafana_clickout_range_metric_test.go
@@ -19,6 +19,13 @@ type grafanaDSQueryResult struct {
 	Body   string
 }
 
+func containsMissingUnwrapError(errText string) bool {
+	errText = strings.ToLower(strings.TrimSpace(errText))
+	return strings.Contains(errText, "without unwrap") ||
+		strings.Contains(errText, "requires `| unwrap") ||
+		strings.Contains(errText, "requires | unwrap")
+}
+
 func queryGrafanaLokiDatasource(t *testing.T, datasourceUID, expr string) grafanaDSQueryResult {
 	t.Helper()
 
@@ -154,10 +161,10 @@ func TestGrafanaClickout_RangeMetricMissingUnwrapParity(t *testing.T) {
 
 			proxyErr := strings.ToLower(proxyRes.Error)
 			directErr := strings.ToLower(directRes.Error)
-			if !strings.Contains(proxyErr, "without unwrap") {
+			if !containsMissingUnwrapError(proxyErr) {
 				t.Fatalf("expected proxy missing-unwrap error shape expr=%s got=%s", tc.expr, proxyRes.Error)
 			}
-			if !strings.Contains(directErr, "without unwrap") {
+			if !containsMissingUnwrapError(directErr) {
 				t.Fatalf("expected direct missing-unwrap error shape expr=%s got=%s", tc.expr, directRes.Error)
 			}
 		})
@@ -203,6 +210,45 @@ func TestGrafanaClickout_RangeMetricAutoWindowUnwrapSuccess(t *testing.T) {
 			}
 			if strings.TrimSpace(directRes.Error) != "" {
 				t.Fatalf("direct returned unexpected error expr=%s err=%s body=%s", tc.expr, directRes.Error, directRes.Body)
+			}
+		})
+	}
+}
+
+func TestGrafanaClickout_RangeMetricSelectorOptionsParity(t *testing.T) {
+	ensureRangeMetricCompatData(t)
+	waitForReady(t, grafanaURL+"/api/health", 30*time.Second)
+
+	proxyUID := grafanaDatasourceUID(t, "Loki (via VL proxy)")
+	directUID := grafanaDatasourceUID(t, "Loki (direct)")
+
+	windows := []string{
+		"$__auto",
+		"$__interval",
+		"${__interval}",
+		"5m",
+		"1h",
+		"1d",
+	}
+
+	for _, window := range windows {
+		t.Run(window, func(t *testing.T) {
+			expr := fmt.Sprintf(`sum_over_time({app="api-gateway"} | json | unwrap duration [%s])`, window)
+
+			proxyRes := queryGrafanaLokiDatasource(t, proxyUID, expr)
+			directRes := queryGrafanaLokiDatasource(t, directUID, expr)
+
+			if proxyRes.Status != directRes.Status {
+				t.Fatalf("status mismatch proxy=%d direct=%d window=%s expr=%s proxyBody=%s directBody=%s", proxyRes.Status, directRes.Status, window, expr, proxyRes.Body, directRes.Body)
+			}
+			if proxyRes.Status != http.StatusOK {
+				t.Fatalf("expected 200 for selector option window=%s expr=%s proxy=%s direct=%s", window, expr, proxyRes.Body, directRes.Body)
+			}
+			if strings.TrimSpace(proxyRes.Error) != "" {
+				t.Fatalf("proxy returned unexpected error window=%s expr=%s err=%s body=%s", window, expr, proxyRes.Error, proxyRes.Body)
+			}
+			if strings.TrimSpace(directRes.Error) != "" {
+				t.Fatalf("direct returned unexpected error window=%s expr=%s err=%s body=%s", window, expr, directRes.Error, directRes.Body)
 			}
 		})
 	}

--- a/test/e2e-compat/range_metric_compat_test.go
+++ b/test/e2e-compat/range_metric_compat_test.go
@@ -19,6 +19,13 @@ import (
 
 var rangeMetricCompatOnce sync.Once
 
+func containsUnwrapErrorText(body string) bool {
+	body = strings.ToLower(strings.TrimSpace(body))
+	return strings.Contains(body, "without unwrap") ||
+		strings.Contains(body, "requires `| unwrap") ||
+		strings.Contains(body, "requires | unwrap")
+}
+
 func ensureRangeMetricCompatData(t *testing.T) {
 	t.Helper()
 	ensureDataIngested(t)
@@ -139,10 +146,10 @@ func TestRangeMetricCompatibilityMissingUnwrapErrors(t *testing.T) {
 			if proxyResult.StatusCode != http.StatusBadRequest {
 				t.Fatalf("expected 400 for missing unwrap query=%s proxy=%s", query, proxyResult.Body)
 			}
-			if !strings.Contains(strings.ToLower(lokiResult.Body), "without unwrap") {
+			if !containsUnwrapErrorText(lokiResult.Body) {
 				t.Fatalf("expected Loki unwrap error query=%s body=%s", query, lokiResult.Body)
 			}
-			if !strings.Contains(strings.ToLower(proxyResult.Body), "without unwrap") {
+			if !containsUnwrapErrorText(proxyResult.Body) {
 				t.Fatalf("expected proxy unwrap error query=%s body=%s", query, proxyResult.Body)
 			}
 		})


### PR DESCRIPTION
## Why
Grafana clickout range queries could fail or behave inconsistently when selector templates arrived in braced form (for example `${__interval}`) or when compat paths needed Loki style durations like `1d` or mixed `1w2d3h`.

The stats compatibility path also parsed the raw original query instead of the token-resolved one, which could surface `invalid range metric query` even when the query was valid after token resolution.

## What Changed
- Added canonical Grafana range token handling for plain and braced forms in compatibility paths.
- Extended duration parsing used by compat evaluation to support Prometheus and Loki units (`d/w/y`) and mixed-unit durations.
- Made stats compatibility handlers consume token-resolved original query text before metric-range parsing.
- Reused the same duration parser in subquery duration handling for consistency.
- Hardened tests for selector-token resolution and missing-unwrap error-shape parity.

## Validation
- `go test ./internal/proxy` (pass)
- `go test -v -tags=e2e -run "TestGrafanaClickout_RangeMetricSelectorOptionsParity|TestGrafanaClickout_RangeMetricAutoWindowUnwrapSuccess|TestGrafanaClickout_RangeMetricMissingUnwrapParity|TestRangeMetricCompatibilityMissingUnwrapErrors" ./test/e2e-compat/` (40 passed)

## Compatibility Notes
Selector option parity in Grafana clickout coverage now includes:
- `$__auto`
- `$__interval`
- `${__interval}`
- `5m`, `1h`, `1d`

`$__rate_interval` is intentionally not asserted for this range-function parity path because direct Loki does not accept it in this shape.