### PR TITLE
feat: LogQL syntax validation and exhaustive pipeline parity tests

### DIFF
--- a/internal/proxy/loki_errors_test.go
+++ b/internal/proxy/loki_errors_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -47,30 +48,21 @@ func TestLokiError_ResponseFormat(t *testing.T) {
 	c := cache.New(60*time.Second, 10000)
 	p, _ := New(Config{BackendURL: vlBackend.URL, Cache: c, LogLevel: "error"})
 
-	// Send a request with a query that has an unmatched brace — triggers bad_data error
+	// Send a request with a query that has an unmatched brace — triggers parse error
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", `/loki/api/v1/query_range?query={unclosed&start=1&end=2&step=1`, nil)
 	mux := http.NewServeMux()
 	p.RegisterRoutes(mux)
 	mux.ServeHTTP(w, r)
 
-	var resp struct {
-		Status    string `json:"status"`
-		ErrorType string `json:"errorType"`
-		Error     string `json:"error"`
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse error response: %v\nbody: %s", err, w.Body.String())
-	}
-
-	if resp.Status != "error" {
-		t.Errorf("expected status=error, got %q", resp.Status)
-	}
-	if resp.ErrorType != "bad_data" {
-		t.Errorf("expected errorType=bad_data, got %q", resp.ErrorType)
-	}
-	if resp.Error == "" {
-		t.Error("error message should not be empty")
+	body := w.Body.String()
+	// Loki returns plain text "parse error ..." for syntax errors.
+	// Accept either plain text parse error or JSON error response.
+	if !strings.Contains(body, "parse error") && !strings.Contains(body, "bad_data") {
+		t.Errorf("expected parse error or bad_data in response, got %q", body)
 	}
 }
 
@@ -110,11 +102,17 @@ func TestLokiError_BadQuery_ReturnsBadData(t *testing.T) {
 	p.RegisterRoutes(mux)
 	mux.ServeHTTP(w, r)
 
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bad query should return 400, got %d", w.Code)
+	}
+	body := w.Body.String()
+	// Loki returns plain text parse errors for syntax issues.
+	// Accept either plain text "parse error" or JSON errorType=bad_data.
 	var resp struct {
 		ErrorType string `json:"errorType"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.ErrorType != "bad_data" {
-		t.Errorf("bad query should return errorType=bad_data, got %q", resp.ErrorType)
+	if resp.ErrorType != "bad_data" && !strings.Contains(body, "parse error") {
+		t.Errorf("bad query should return errorType=bad_data or parse error, got %q", body)
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12010,7 +12010,7 @@ func (p *Proxy) validateQuery(w http.ResponseWriter, query string, endpoint stri
 	if err := validateLogQLSyntax(query); err != "" {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, err)
+		_, _ = fmt.Fprint(w, err)
 		p.metrics.RecordRequest(endpoint, http.StatusBadRequest, 0)
 		return "", false
 	}
@@ -12084,16 +12084,38 @@ var emptyValueRe = regexp.MustCompile(`[=!~]=?\s*[,}]`)
 
 // binaryOpOnLogRe matches a binary operator followed by a number at the end
 // of a pipeline expression (not inside a metric function).
-// Excludes field filter comparisons like "| json | status>=400" where the
-// operator is preceded by an identifier (field name).
 var binaryOpOnLogRe = regexp.MustCompile(`(?:^|\s)\s*(==|!=|<=|>=|<|>|\+|-|\*|/|%|\^)\s*\d+\s*$`)
 
+// labelFilterRe matches a standalone label filter stage: identifier <op> number.
+var labelFilterRe = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:==|!=|<=|>=|<|>)\s*\d+(\.\d+)?\s*$`)
+
+// logParserKeywords is the set of LogQL parser stage keywords that cannot be field names
+// in a label filter comparison (e.g. "| json == 2" is invalid; "| status >= 400" is valid).
+var logParserKeywords = map[string]bool{
+	"json": true, "logfmt": true, "unpack": true, "regexp": true,
+	"pattern": true, "decolorize": true,
+}
+
 func isBinaryOpOnLogQuery(rest string) bool {
-	// If rest is empty or starts with nothing after pipeline, no binary op
 	if rest == "" {
 		return false
 	}
-	return binaryOpOnLogRe.MatchString(rest)
+	if !binaryOpOnLogRe.MatchString(rest) {
+		return false
+	}
+	// If the last pipe-separated segment is a label filter (field op number) where
+	// the field is not a parser keyword, it's a valid stage — e.g. "| json | status >= 400".
+	lastPipe := strings.LastIndex(rest, "|")
+	lastSeg := strings.TrimSpace(rest)
+	if lastPipe >= 0 {
+		lastSeg = strings.TrimSpace(rest[lastPipe+1:])
+	}
+	if m := labelFilterRe.FindStringSubmatch(lastSeg); m != nil {
+		if !logParserKeywords[m[1]] {
+			return false
+		}
+	}
+	return true
 }
 
 func extractBinaryOp(rest string) string {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12084,7 +12084,9 @@ var emptyValueRe = regexp.MustCompile(`[=!~]=?\s*[,}]`)
 
 // binaryOpOnLogRe matches a binary operator followed by a number at the end
 // of a pipeline expression (not inside a metric function).
-var binaryOpOnLogRe = regexp.MustCompile(`(?:^|\|[^|]*?)\s*(==|!=|<=|>=|<|>|\+|-|\*|/|%|\^)\s*\d+\s*$`)
+// Excludes field filter comparisons like "| json | status>=400" where the
+// operator is preceded by an identifier (field name).
+var binaryOpOnLogRe = regexp.MustCompile(`(?:^|\s)\s*(==|!=|<=|>=|<|>|\+|-|\*|/|%|\^)\s*\d+\s*$`)
 
 func isBinaryOpOnLogQuery(rest string) bool {
 	// If rest is empty or starts with nothing after pipeline, no binary op

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12007,7 +12007,99 @@ func (p *Proxy) validateQuery(w http.ResponseWriter, query string, endpoint stri
 		p.metrics.RecordRequest(endpoint, http.StatusBadRequest, 0)
 		return "", false
 	}
+	if err := validateLogQLSyntax(query); err != "" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, err)
+		p.metrics.RecordRequest(endpoint, http.StatusBadRequest, 0)
+		return "", false
+	}
 	return query, true
+}
+
+// validateLogQLSyntax performs lightweight LogQL syntax validation to catch
+// queries that Loki would reject with a parse error. Returns the error message
+// (matching Loki's format) or empty string if valid.
+//
+// This catches:
+// - Empty queries
+// - Queries without a stream selector (e.g., "| json")
+// - Malformed stream selectors (e.g., "{app=}")
+// - Binary operations on log/pipeline expressions (e.g., "{app=...} == 2")
+func validateLogQLSyntax(query string) string {
+	query = strings.TrimSpace(query)
+
+	// Empty query
+	if query == "" {
+		return "parse error : syntax error: unexpected $end"
+	}
+
+	// No stream selector — starts with pipeline
+	if strings.HasPrefix(query, "|") {
+		return "parse error at line 1, col 1: syntax error: unexpected |"
+	}
+
+	// Malformed selector: unclosed or empty values
+	if strings.HasPrefix(query, "{") {
+		braceDepth := 0
+		selectorEnd := -1
+		for i, ch := range query {
+			if ch == '{' {
+				braceDepth++
+			} else if ch == '}' {
+				braceDepth--
+				if braceDepth == 0 {
+					selectorEnd = i
+					break
+				}
+			}
+		}
+		if selectorEnd < 0 {
+			return "parse error at line 1, col 1: syntax error: unexpected end of input"
+		}
+		selector := query[:selectorEnd+1]
+		// Check for empty values like {app=} or {app= }
+		if emptyValueRe.MatchString(selector) {
+			return "parse error at line 1, col " + strconv.Itoa(strings.Index(selector, "=}")+2) + ": syntax error: unexpected }, expecting STRING"
+		}
+
+		// Check for binary operations on log queries
+		// Pattern: {selector} [| pipeline...] <binary_op> <number>
+		// This is invalid unless wrapped in a metric function
+		rest := strings.TrimSpace(query[selectorEnd+1:])
+		if isBinaryOpOnLogQuery(rest) {
+			op := extractBinaryOp(rest)
+			exprType := "*syntax.MatchersExpr"
+			if strings.Contains(rest, "|") {
+				exprType = "*syntax.PipelineExpr"
+			}
+			return "parse error : unexpected type for left leg of binary operation (" + op + "): " + exprType
+		}
+	}
+
+	return ""
+}
+
+var emptyValueRe = regexp.MustCompile(`[=!~]=?\s*[,}]`)
+
+// binaryOpOnLogRe matches a binary operator followed by a number at the end
+// of a pipeline expression (not inside a metric function).
+var binaryOpOnLogRe = regexp.MustCompile(`(?:^|\|[^|]*?)\s*(==|!=|<=|>=|<|>|\+|-|\*|/|%|\^)\s*\d+\s*$`)
+
+func isBinaryOpOnLogQuery(rest string) bool {
+	// If rest is empty or starts with nothing after pipeline, no binary op
+	if rest == "" {
+		return false
+	}
+	return binaryOpOnLogRe.MatchString(rest)
+}
+
+func extractBinaryOp(rest string) string {
+	m := binaryOpOnLogRe.FindStringSubmatch(rest)
+	if len(m) >= 2 {
+		return m[1]
+	}
+	return "?"
 }
 
 // sanitizeLimit caps and validates the limit parameter.

--- a/test/e2e-compat/logql_exhaustive_test.go
+++ b/test/e2e-compat/logql_exhaustive_test.go
@@ -125,63 +125,105 @@ func TestLogQL_Exhaustive_QueryParity(t *testing.T) {
 		{"logfmt_parser", `{app="payment-service",env="production"} | logfmt`, "parser"},
 		{"unpack_parser", `{app="api-gateway",env="production"} | unpack`, "parser"},
 		{"decolorize", `{app="api-gateway",env="production"} | decolorize`, "parser"},
+		{"regexp_parser", `{app="api-gateway",env="production"} | regexp "\"method\":\"(?P<http_method>[A-Z]+)\""`, "parser"},
+		{"pattern_parser", `{app="api-gateway",env="production"} | json | line_format "{{.method}} {{.path}} {{.status}}" | pattern "<method> <path> <code>"`, "parser"},
 
 		// ── Field filters (after parser) ──
 		{"json_field_eq", `{app="api-gateway",env="production"} | json | method="GET"`, "field_filter"},
 		{"json_field_ne", `{app="api-gateway",env="production"} | json | method!="DELETE"`, "field_filter"},
 		{"json_field_regex", `{app="api-gateway",env="production"} | json | path=~"/api/.*"`, "field_filter"},
+		{"json_field_not_regex", `{app="api-gateway",env="production"} | json | path!~"/health.*"`, "field_filter"},
 		{"json_field_gt", `{app="api-gateway",env="production"} | json | status>=400`, "field_filter"},
 		{"json_field_lt", `{app="api-gateway",env="production"} | json | duration_ms<100`, "field_filter"},
+		{"logfmt_field_eq", `{app="payment-service",env="production"} | logfmt | level="error"`, "field_filter"},
+		{"detected_level_filter", `{app="api-gateway",env="production"} | detected_level="error"`, "field_filter"},
 
 		// ── Format stages ──
 		{"line_format", `{app="api-gateway",env="production"} | json | line_format "{{.method}} {{.path}}"`, "format"},
+		{"line_format_with_newline", `{app="api-gateway",env="production"} | json | line_format "method={{.method}}\npath={{.path}}"`, "format"},
 		{"label_format", `{app="api-gateway",env="production"} | json | label_format method_up="{{.method}}"`, "format"},
+		{"label_format_multiple", `{app="api-gateway",env="production"} | json | label_format m="{{.method}}", s="{{.status}}"`, "format"},
 
 		// ── Drop / Keep ──
-		{"drop_labels", `{app="api-gateway",env="production"} | json | drop trace_id`, "drop_keep"},
-		{"keep_labels", `{app="api-gateway",env="production"} | json | keep method, status`, "drop_keep"},
+		{"drop_single", `{app="api-gateway",env="production"} | json | drop trace_id`, "drop_keep"},
+		{"drop_multiple", `{app="api-gateway",env="production"} | json | drop trace_id, user_id`, "drop_keep"},
+		{"keep_single", `{app="api-gateway",env="production"} | json | keep method`, "drop_keep"},
+		{"keep_multiple", `{app="api-gateway",env="production"} | json | keep method, status`, "drop_keep"},
 		{"drop_error", `{app="api-gateway",env="production"} | json | drop __error__, __error_details__`, "drop_keep"},
 
-		// ── Multi-stage ──
+		// ── Multi-stage pipelines ──
 		{"json_filter_format", `{app="api-gateway",env="production"} | json | method="GET" | line_format "{{.status}}"`, "multi_stage"},
 		{"logfmt_filter", `{app="payment-service",env="production"} | logfmt | level="error"`, "multi_stage"},
 		{"json_drop_format", `{app="api-gateway",env="production"} | json | drop trace_id | line_format "{{.method}}"`, "multi_stage"},
 		{"chained_line_filters", `{app="api-gateway",env="production"} |= "api" |~ "GET|POST" != "health"`, "multi_stage"},
+		{"json_keep_format", `{app="api-gateway",env="production"} | json | keep method, status | line_format "{{.method}} {{.status}}"`, "multi_stage"},
+		{"line_filter_then_json", `{app="api-gateway",env="production"} |= "GET" | json`, "multi_stage"},
+		{"json_two_field_filters", `{app="api-gateway",env="production"} | json | method="GET" | path=~"/api/.*"`, "multi_stage"},
+		{"decolorize_then_json", `{app="api-gateway",env="production"} | decolorize | json`, "multi_stage"},
 
-		// ── Metric queries ──
-		{"count_over_time", `count_over_time({app="api-gateway",env="production"}[5m])`, "metric"},
-		{"rate", `rate({app="api-gateway",env="production"}[5m])`, "metric"},
-		{"bytes_over_time", `bytes_over_time({app="api-gateway",env="production"}[5m])`, "metric"},
-		{"bytes_rate", `bytes_rate({app="api-gateway",env="production"}[5m])`, "metric"},
+		// ── Metric queries (range aggregations) ──
+		{"count_over_time", `count_over_time({app="api-gateway",env="production"}[5m])`, "metric_range"},
+		{"rate", `rate({app="api-gateway",env="production"}[5m])`, "metric_range"},
+		{"bytes_over_time", `bytes_over_time({app="api-gateway",env="production"}[5m])`, "metric_range"},
+		{"bytes_rate", `bytes_rate({app="api-gateway",env="production"}[5m])`, "metric_range"},
+		{"rate_with_line_filter", `rate({app="api-gateway",env="production"} |= "GET"[5m])`, "metric_range"},
+		{"rate_with_json_filter", `rate({app="api-gateway",env="production"} | json | method="GET"[5m])`, "metric_range"},
+		{"count_with_logfmt", `count_over_time({app="payment-service",env="production"} | logfmt | level="error"[5m])`, "metric_range"},
+
+		// ── Metric aggregations ──
 		{"sum_by", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "metric_agg"},
 		{"sum_rate_by", `sum by (app) (rate({env="production"}[5m]))`, "metric_agg"},
-		{"rate_with_filter", `rate({app="api-gateway",env="production"} |= "GET"[5m])`, "metric"},
+		{"avg_by", `avg by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "metric_agg"},
+		{"max_by", `max by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "metric_agg"},
+		{"min_by", `min by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "metric_agg"},
+		{"count_agg", `count(count_over_time({env="production"}[5m]))`, "metric_agg"},
 		{"topk", `topk(3, sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
 		{"bottomk", `bottomk(3, sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
 		{"sort_metric", `sort(sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
 		{"sort_desc_metric", `sort_desc(sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
 
 		// ── Unwrap metrics ──
-		{"sum_over_time_unwrap", `sum_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
-		{"avg_over_time_unwrap", `avg_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
-		{"max_over_time_unwrap", `max_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
-		{"min_over_time_unwrap", `min_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
+		{"sum_over_time_unwrap", `sum_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"avg_over_time_unwrap", `avg_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"max_over_time_unwrap", `max_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"min_over_time_unwrap", `min_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"first_over_time_unwrap", `first_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"last_over_time_unwrap", `last_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"stddev_over_time_unwrap", `stddev_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"stdvar_over_time_unwrap", `stdvar_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
+		{"quantile_over_time_unwrap", `quantile_over_time(0.99, {app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap"},
 
 		// ── Comparison operators on metrics ──
 		{"metric_gt_zero", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) > 0`, "metric_compare"},
+		{"metric_lt", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) < 1000`, "metric_compare"},
+		{"metric_eq", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) == 0`, "metric_compare"},
+		{"metric_ne", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) != 0`, "metric_compare"},
 		{"metric_bool_gt", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) > bool 0`, "metric_compare"},
 		{"metric_scalar_mul", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) * 100`, "metric_compare"},
+		{"metric_scalar_div", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) / 60`, "metric_compare"},
+		{"metric_scalar_add", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) + 1`, "metric_compare"},
 
 		// ── Vector operations ──
 		{"vector_or", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) or sum by (level) (count_over_time({app="api-gateway",env="production",level="debug"}[5m]))`, "vector_op"},
 		{"vector_and", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) and sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "vector_op"},
 		{"vector_unless", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) unless sum by (level) (count_over_time({app="api-gateway",env="production",level="debug"}[5m]))`, "vector_op"},
+		{"vector_div", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) / sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "vector_op"},
+
+		// ── Grouping modifiers ──
+		{"on_grouping", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) / on(level) sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "grouping"},
+		{"without_grouping", `sum without (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "grouping"},
 
 		// ── Absent ──
 		{"absent_over_time", `absent_over_time({app="nonexistent_service_xyz"}[5m])`, "absent"},
 
 		// ── Empty results (valid but no data) ──
 		{"impossible_filter", `{app="api-gateway",env="production"} |= "IMPOSSIBLE_STRING_NEVER_EXISTS"`, "empty"},
+		{"nonexistent_app", `{app="this_app_does_not_exist",env="production"}`, "empty"},
+
+		// ── Instant queries via query_range ──
+		{"simple_selector_only", `{app="api-gateway",env="production",level="error"}`, "basic"},
+		{"wildcard_regex", `{app=~".+",env="production"}`, "basic"},
+		{"multiple_not_equal", `{app!="nginx-ingress",env="production",level!="debug"}`, "basic"},
 	}
 
 	score := &exhaustiveScore{}

--- a/test/e2e-compat/logql_exhaustive_test.go
+++ b/test/e2e-compat/logql_exhaustive_test.go
@@ -1,0 +1,300 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestLogQL_Exhaustive_ErrorParity walks through ALL LogQL expression types
+// and verifies the proxy returns the same error codes and messages as Loki.
+// This is the "test machine" that systematically discovers parity gaps.
+func TestLogQL_Exhaustive_ErrorParity(t *testing.T) {
+	ensureDataIngested(t)
+
+	cases := []struct {
+		name     string
+		query    string
+		category string
+	}{
+		// ── Binary operations on log queries (must error) ──
+		{"binary_eq_on_matchers", `{level="info"} == 2`, "binary_on_log"},
+		{"binary_ne_on_matchers", `{level="info"} != 2`, "binary_on_log"},
+		{"binary_lt_on_matchers", `{level="info"} < 2`, "binary_on_log"},
+		{"binary_le_on_matchers", `{level="info"} <= 2`, "binary_on_log"},
+		{"binary_gt_on_matchers", `{level="info"} > 2`, "binary_on_log"},
+		{"binary_ge_on_matchers", `{level="info"} >= 2`, "binary_on_log"},
+		{"binary_eq_on_pipeline", `{app="api-gateway"} | json == 2`, "binary_on_log"},
+		{"binary_le_on_pipeline", `{app="api-gateway"} | json <= 2`, "binary_on_log"},
+		{"binary_add_on_log", `{level="info"} + 1`, "binary_on_log"},
+		{"binary_sub_on_log", `{level="info"} - 1`, "binary_on_log"},
+		{"binary_mul_on_log", `{level="info"} * 2`, "binary_on_log"},
+		{"binary_div_on_log", `{level="info"} / 2`, "binary_on_log"},
+		{"binary_mod_on_log", `{level="info"} % 2`, "binary_on_log"},
+		{"binary_pow_on_log", `{level="info"} ^ 2`, "binary_on_log"},
+
+		// ── Malformed selectors ──
+		{"empty_value_selector", `{app=}`, "malformed"},
+		{"unclosed_brace", `{app="api-gateway"`, "malformed"},
+		{"no_selector", `| json`, "malformed"},
+		{"empty_query", ``, "malformed"},
+
+		// ── Invalid regex ──
+		{"invalid_regex_match", `{app=~"[invalid"}`, "invalid_regex"},
+		{"invalid_regex_not_match", `{app!~"(unclosed"}`, "invalid_regex"},
+
+		// ── Metric without range ──
+		{"rate_no_range", `rate({app="api-gateway"})`, "metric_no_range"},
+		{"count_no_range", `count_over_time({app="api-gateway"})`, "metric_no_range"},
+		{"bytes_no_range", `bytes_over_time({app="api-gateway"})`, "metric_no_range"},
+
+		// ── Metric on log query (no aggregation function) ──
+		{"sum_on_log", `sum({app="api-gateway"})`, "metric_on_log"},
+		{"avg_on_log", `avg({app="api-gateway"})`, "metric_on_log"},
+		{"topk_on_log", `topk(5, {app="api-gateway"})`, "metric_on_log"},
+		{"sort_on_log", `sort({app="api-gateway"})`, "metric_on_log"},
+		{"sort_desc_on_log", `sort_desc({app="api-gateway"})`, "metric_on_log"},
+
+		// ── Unwrap without parser ──
+		{"unwrap_no_parser", `sum_over_time({app="api-gateway"} | unwrap duration_ms [5m])`, "unwrap"},
+
+		// ── Invalid pipeline stages ──
+		{"double_parser", `{app="api-gateway"} | json | json`, "pipeline"},
+		{"line_format_no_template", `{app="api-gateway"} | line_format`, "pipeline"},
+	}
+
+	score := &exhaustiveScore{}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiCode, lokiBody := exhaustiveQuery(t, lokiURL, tc.query)
+			proxyCode, proxyBody := exhaustiveQuery(t, proxyURL, tc.query)
+
+			lokiIsError := lokiCode >= 400
+			proxyIsError := proxyCode >= 400
+
+			if lokiIsError == proxyIsError {
+				score.pass(tc.category, tc.name)
+			} else if lokiIsError && !proxyIsError {
+				score.fail(tc.category, tc.name,
+					fmt.Sprintf("Loki=%d Proxy=%d | Loki error: %s", lokiCode, proxyCode, exhaustiveTruncate(lokiBody, 120)))
+				t.Errorf("SILENT FAIL: Loki returns %d but proxy returns %d for %q\n  Loki: %s",
+					lokiCode, proxyCode, tc.query, exhaustiveTruncate(lokiBody, 150))
+			} else {
+				score.fail(tc.category, tc.name,
+					fmt.Sprintf("Proxy=%d Loki=%d | Proxy error: %s", proxyCode, lokiCode, exhaustiveTruncate(proxyBody, 120)))
+				t.Errorf("EXTRA ERROR: Proxy returns %d but Loki returns %d for %q\n  Proxy: %s",
+					proxyCode, lokiCode, tc.query, exhaustiveTruncate(proxyBody, 150))
+			}
+		})
+	}
+
+	score.report(t)
+}
+
+// TestLogQL_Exhaustive_QueryParity walks through ALL valid LogQL pipeline
+// operations and verifies both Loki and proxy return success.
+func TestLogQL_Exhaustive_QueryParity(t *testing.T) {
+	ensureDataIngested(t)
+
+	cases := []struct {
+		name     string
+		query    string
+		category string
+	}{
+		// ── Selectors ──
+		{"exact_match", `{app="api-gateway",env="production"}`, "selector"},
+		{"regex_match", `{app=~"api-.*",env="production"}`, "selector"},
+		{"not_equal", `{app!="payment-service",env="production"}`, "selector"},
+		{"regex_not_match", `{app!~"nginx.*",env="production"}`, "selector"},
+
+		// ── Line filters ──
+		{"line_contains", `{app="api-gateway",env="production"} |= "GET"`, "line_filter"},
+		{"line_not_contains", `{app="api-gateway",env="production"} != "health"`, "line_filter"},
+		{"line_regex", `{app="api-gateway",env="production"} |~ "GET|POST"`, "line_filter"},
+		{"line_not_regex", `{app="api-gateway",env="production"} !~ "health|ready"`, "line_filter"},
+
+		// ── Parsers ──
+		{"json_parser", `{app="api-gateway",env="production"} | json`, "parser"},
+		{"logfmt_parser", `{app="payment-service",env="production"} | logfmt`, "parser"},
+		{"unpack_parser", `{app="api-gateway",env="production"} | unpack`, "parser"},
+		{"decolorize", `{app="api-gateway",env="production"} | decolorize`, "parser"},
+
+		// ── Field filters (after parser) ──
+		{"json_field_eq", `{app="api-gateway",env="production"} | json | method="GET"`, "field_filter"},
+		{"json_field_ne", `{app="api-gateway",env="production"} | json | method!="DELETE"`, "field_filter"},
+		{"json_field_regex", `{app="api-gateway",env="production"} | json | path=~"/api/.*"`, "field_filter"},
+		{"json_field_gt", `{app="api-gateway",env="production"} | json | status>=400`, "field_filter"},
+		{"json_field_lt", `{app="api-gateway",env="production"} | json | duration_ms<100`, "field_filter"},
+
+		// ── Format stages ──
+		{"line_format", `{app="api-gateway",env="production"} | json | line_format "{{.method}} {{.path}}"`, "format"},
+		{"label_format", `{app="api-gateway",env="production"} | json | label_format method_up="{{.method}}"`, "format"},
+
+		// ── Drop / Keep ──
+		{"drop_labels", `{app="api-gateway",env="production"} | json | drop trace_id`, "drop_keep"},
+		{"keep_labels", `{app="api-gateway",env="production"} | json | keep method, status`, "drop_keep"},
+		{"drop_error", `{app="api-gateway",env="production"} | json | drop __error__, __error_details__`, "drop_keep"},
+
+		// ── Multi-stage ──
+		{"json_filter_format", `{app="api-gateway",env="production"} | json | method="GET" | line_format "{{.status}}"`, "multi_stage"},
+		{"logfmt_filter", `{app="payment-service",env="production"} | logfmt | level="error"`, "multi_stage"},
+		{"json_drop_format", `{app="api-gateway",env="production"} | json | drop trace_id | line_format "{{.method}}"`, "multi_stage"},
+		{"chained_line_filters", `{app="api-gateway",env="production"} |= "api" |~ "GET|POST" != "health"`, "multi_stage"},
+
+		// ── Metric queries ──
+		{"count_over_time", `count_over_time({app="api-gateway",env="production"}[5m])`, "metric"},
+		{"rate", `rate({app="api-gateway",env="production"}[5m])`, "metric"},
+		{"bytes_over_time", `bytes_over_time({app="api-gateway",env="production"}[5m])`, "metric"},
+		{"bytes_rate", `bytes_rate({app="api-gateway",env="production"}[5m])`, "metric"},
+		{"sum_by", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "metric_agg"},
+		{"sum_rate_by", `sum by (app) (rate({env="production"}[5m]))`, "metric_agg"},
+		{"rate_with_filter", `rate({app="api-gateway",env="production"} |= "GET"[5m])`, "metric"},
+		{"topk", `topk(3, sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
+		{"bottomk", `bottomk(3, sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
+		{"sort_metric", `sort(sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
+		{"sort_desc_metric", `sort_desc(sum by (app) (count_over_time({env="production"}[5m])))`, "metric_agg"},
+
+		// ── Unwrap metrics ──
+		{"sum_over_time_unwrap", `sum_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
+		{"avg_over_time_unwrap", `avg_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
+		{"max_over_time_unwrap", `max_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
+		{"min_over_time_unwrap", `min_over_time({app="api-gateway",env="production"} | json | unwrap duration_ms [5m])`, "unwrap_metric"},
+
+		// ── Comparison operators on metrics ──
+		{"metric_gt_zero", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) > 0`, "metric_compare"},
+		{"metric_bool_gt", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) > bool 0`, "metric_compare"},
+		{"metric_scalar_mul", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) * 100`, "metric_compare"},
+
+		// ── Vector operations ──
+		{"vector_or", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) or sum by (level) (count_over_time({app="api-gateway",env="production",level="debug"}[5m]))`, "vector_op"},
+		{"vector_and", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) and sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`, "vector_op"},
+		{"vector_unless", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m])) unless sum by (level) (count_over_time({app="api-gateway",env="production",level="debug"}[5m]))`, "vector_op"},
+
+		// ── Absent ──
+		{"absent_over_time", `absent_over_time({app="nonexistent_service_xyz"}[5m])`, "absent"},
+
+		// ── Empty results (valid but no data) ──
+		{"impossible_filter", `{app="api-gateway",env="production"} |= "IMPOSSIBLE_STRING_NEVER_EXISTS"`, "empty"},
+	}
+
+	score := &exhaustiveScore{}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiCode, _ := exhaustiveQuery(t, lokiURL, tc.query)
+			proxyCode, proxyBody := exhaustiveQuery(t, proxyURL, tc.query)
+
+			lokiOK := lokiCode == 200
+			proxyOK := proxyCode == 200
+
+			if lokiOK && proxyOK {
+				score.pass(tc.category, tc.name)
+			} else if lokiOK && !proxyOK {
+				score.fail(tc.category, tc.name,
+					fmt.Sprintf("Loki=200 Proxy=%d: %s", proxyCode, exhaustiveTruncate(proxyBody, 120)))
+				t.Errorf("Loki succeeds but proxy fails (%d) for %q: %s",
+					proxyCode, tc.query, exhaustiveTruncate(proxyBody, 150))
+			} else if !lokiOK && proxyOK {
+				score.fail(tc.category, tc.name,
+					fmt.Sprintf("Loki=%d Proxy=200: proxy should also error", lokiCode))
+				t.Errorf("Loki fails (%d) but proxy succeeds for %q", lokiCode, tc.query)
+			} else {
+				// Both error — check if codes match
+				if lokiCode != proxyCode {
+					score.fail(tc.category, tc.name,
+						fmt.Sprintf("error code mismatch: Loki=%d Proxy=%d", lokiCode, proxyCode))
+				} else {
+					score.pass(tc.category, tc.name)
+				}
+			}
+		})
+	}
+
+	score.report(t)
+}
+
+// ─── HELPERS ────────────────────────────────────────────────────────────────
+
+type exhaustiveScore struct {
+	total    int
+	passed   int
+	failed   int
+	failures []string
+}
+
+func (s *exhaustiveScore) pass(category, name string) {
+	s.total++
+	s.passed++
+}
+
+func (s *exhaustiveScore) fail(category, name, detail string) {
+	s.total++
+	s.failed++
+	s.failures = append(s.failures, fmt.Sprintf("[%s] %s: %s", category, name, detail))
+}
+
+func (s *exhaustiveScore) report(t *testing.T) {
+	t.Helper()
+	pct := 0
+	if s.total > 0 {
+		pct = 100 * s.passed / s.total
+	}
+	t.Logf("\n╔═══════════════════════════════════════════╗")
+	t.Logf("║  LogQL Exhaustive Parity Score            ║")
+	t.Logf("╠═══════════════════════════════════════════╣")
+	t.Logf("║  Passed: %3d / %3d (%3d%%)                 ║", s.passed, s.total, pct)
+	t.Logf("║  Failed: %3d                              ║", s.failed)
+	t.Logf("╚═══════════════════════════════════════════╝")
+	if len(s.failures) > 0 {
+		t.Logf("\nFailures:")
+		for _, f := range s.failures {
+			t.Logf("  %s", f)
+		}
+	}
+	if s.failed > 0 {
+		t.Errorf("LogQL parity: %d/%d (%d%%) — %d failures", s.passed, s.total, pct, s.failed)
+	}
+}
+
+func exhaustiveQuery(t *testing.T, baseURL, query string) (int, string) {
+	t.Helper()
+	now := time.Now()
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-2*time.Hour).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("limit", "10")
+	params.Set("step", "60")
+
+	resp, err := http.Get(baseURL + "/loki/api/v1/query_range?" + params.Encode())
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+func exhaustiveParseStatus(body string) string {
+	var result map[string]interface{}
+	if json.Unmarshal([]byte(body), &result) == nil {
+		if s, ok := result["status"].(string); ok {
+			return s
+		}
+	}
+	return "unknown"
+}
+
+func exhaustiveTruncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/test/e2e-compat/loki-local-config.yaml
+++ b/test/e2e-compat/loki-local-config.yaml
@@ -31,6 +31,7 @@ limits_config:
   ingestion_rate_mb: 50000
   ingestion_burst_size_mb: 50000
   max_global_streams_per_user: 0
+  max_query_series: 5000
   volume_enabled: true
 
 query_range:

--- a/test/e2e-compat/pipeline_parity_test.go
+++ b/test/e2e-compat/pipeline_parity_test.go
@@ -1,0 +1,297 @@
+//go:build e2e
+
+package e2e_compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPipeline_ErrorPropagation verifies that the proxy returns the same
+// errors as Loki for invalid LogQL queries, rather than silently succeeding.
+func TestPipeline_ErrorPropagation(t *testing.T) {
+	ensureDataIngested(t)
+
+	invalidQueries := []struct {
+		name  string
+		query string
+	}{
+		{"binary_op_on_pipeline", `{cluster="us-east-1"} | json <= 2`},
+		{"missing_range_for_rate", `rate({app="api-gateway"})`},
+		{"malformed_selector", `{app=}`},
+		{"invalid_regex", `{app=~"[invalid"}`},
+		{"metric_on_log_query", `sum({app="api-gateway"})`},
+	}
+
+	for _, tc := range invalidQueries {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiStatus, lokiBody := pipelineQueryRaw(t, lokiURL, tc.query)
+			proxyStatus, proxyBody := pipelineQueryRaw(t, proxyURL, tc.query)
+
+			// Both should return error (4xx status or error in body)
+			lokiIsError := lokiStatus >= 400 || strings.Contains(lokiBody, "error")
+			proxyIsError := proxyStatus >= 400 || strings.Contains(proxyBody, "error")
+
+			if lokiIsError && !proxyIsError {
+				t.Errorf("Loki returns error (status=%d) but proxy succeeds (status=%d) for query %q\nLoki: %s\nProxy: %s",
+					lokiStatus, proxyStatus, tc.query, pipelineTruncate(lokiBody, 200), pipelineTruncate(proxyBody, 200))
+			}
+		})
+	}
+}
+
+// TestPipeline_ParserStages tests every parser stage for Loki vs proxy parity.
+func TestPipeline_ParserStages(t *testing.T) {
+	ensureDataIngested(t)
+
+	parserTests := []struct {
+		name  string
+		query string
+	}{
+		// JSON parser
+		{"json_basic", `{app="api-gateway",env="production"} | json`},
+		{"json_with_field_filter", `{app="api-gateway",env="production"} | json | method="GET"`},
+		{"json_with_numeric_filter", `{app="api-gateway",env="production"} | json | status>=400`},
+		{"json_with_regex_filter", `{app="api-gateway",env="production"} | json | path=~"/api/v1/.*"`},
+
+		// Logfmt parser
+		{"logfmt_basic", `{app="payment-service",env="production"} | logfmt`},
+		{"logfmt_with_field_filter", `{app="payment-service",env="production"} | logfmt | level="error"`},
+
+		// Line format
+		{"line_format_basic", `{app="api-gateway",env="production"} | json | line_format "{{.method}} {{.path}} {{.status}}"`},
+
+		// Label format
+		{"label_format_basic", `{app="api-gateway",env="production"} | json | label_format method_upper="{{.method}}"`},
+
+		// Drop / Keep
+		{"drop_labels", `{app="api-gateway",env="production"} | json | drop trace_id, user_id`},
+		{"keep_labels", `{app="api-gateway",env="production"} | json | keep method, path, status`},
+
+		// Decolorize
+		{"decolorize", `{app="api-gateway",env="production"} | decolorize`},
+
+		// Unpack
+		{"unpack_basic", `{app="api-gateway",env="production"} | unpack`},
+	}
+
+	for _, tc := range parserTests {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiResult := pipelineQueryLoki(t, tc.query)
+			proxyResult := pipelineQueryProxy(t, tc.query)
+
+			lokiOK := pipelineCheckStatus(lokiResult)
+			proxyOK := pipelineCheckStatus(proxyResult)
+
+			if lokiOK != proxyOK {
+				t.Errorf("status mismatch: loki_ok=%v proxy_ok=%v for %q", lokiOK, proxyOK, tc.query)
+				return
+			}
+
+			if !lokiOK {
+				return // both errored, which is fine
+			}
+
+			lokiLines := pipelineCountLogLines(lokiResult)
+			proxyLines := pipelineCountLogLines(proxyResult)
+
+			if lokiLines == 0 && proxyLines == 0 {
+				return // both empty, which is fine
+			}
+
+			// Allow some tolerance for line counts (VL indexing timing)
+			if lokiLines > 0 && proxyLines == 0 {
+				t.Errorf("loki returned %d lines but proxy returned 0 for %q", lokiLines, tc.query)
+			}
+			if proxyLines > 0 && lokiLines == 0 {
+				t.Errorf("proxy returned %d lines but loki returned 0 for %q", proxyLines, tc.query)
+			}
+		})
+	}
+}
+
+// TestPipeline_LineFilters tests all line filter operations.
+func TestPipeline_LineFilters(t *testing.T) {
+	ensureDataIngested(t)
+
+	filterTests := []struct {
+		name  string
+		query string
+	}{
+		// Contains
+		{"contains", `{app="api-gateway",env="production"} |= "GET"`},
+		{"not_contains", `{app="api-gateway",env="production"} != "health"`},
+
+		// Regex
+		{"regex_match", `{app="api-gateway",env="production"} |~ "GET|POST"`},
+		{"regex_not_match", `{app="api-gateway",env="production"} !~ "health|ready|metrics"`},
+
+		// Chained filters
+		{"chained_contains", `{app="api-gateway",env="production"} |= "api" |= "GET"`},
+		{"chained_mixed", `{app="api-gateway",env="production"} |= "api" |~ "GET|POST" != "health"`},
+		{"chained_regex", `{app="api-gateway",env="production"} |~ "status.*[45][0-9][0-9]"`},
+	}
+
+	for _, tc := range filterTests {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiResult := pipelineQueryLoki(t, tc.query)
+			proxyResult := pipelineQueryProxy(t, tc.query)
+
+			lokiOK := pipelineCheckStatus(lokiResult)
+			proxyOK := pipelineCheckStatus(proxyResult)
+
+			if lokiOK != proxyOK {
+				t.Errorf("status mismatch: loki_ok=%v proxy_ok=%v for %q", lokiOK, proxyOK, tc.query)
+				return
+			}
+
+			lokiLines := pipelineCountLogLines(lokiResult)
+			proxyLines := pipelineCountLogLines(proxyResult)
+
+			if lokiLines > 0 && proxyLines == 0 {
+				t.Errorf("loki returned %d lines but proxy returned 0 for %q", lokiLines, tc.query)
+			}
+		})
+	}
+}
+
+// TestPipeline_MultiStage tests multi-stage pipeline combinations.
+func TestPipeline_MultiStage(t *testing.T) {
+	ensureDataIngested(t)
+
+	multiStageTests := []struct {
+		name  string
+		query string
+	}{
+		{"json_then_line_filter", `{app="api-gateway",env="production"} | json | method="GET" |= "users"`},
+		{"json_then_line_format", `{app="api-gateway",env="production"} | json | line_format "{{.method}} {{.path}}"`},
+		{"json_then_label_format", `{app="api-gateway",env="production"} | json | label_format req="{{.method}} {{.path}}"`},
+		{"logfmt_then_line_filter", `{app="payment-service",env="production"} | logfmt | level="error" |= "database"`},
+		{"json_drop_then_format", `{app="api-gateway",env="production"} | json | drop trace_id | line_format "{{.method}} {{.status}}"`},
+		{"json_keep_then_format", `{app="api-gateway",env="production"} | json | keep method, status | line_format "{{.method}} {{.status}}"`},
+		{"parser_then_drop_error", `{app="api-gateway",env="production"} | json | drop __error__, __error_details__`},
+	}
+
+	for _, tc := range multiStageTests {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiResult := pipelineQueryLoki(t, tc.query)
+			proxyResult := pipelineQueryProxy(t, tc.query)
+
+			lokiOK := pipelineCheckStatus(lokiResult)
+			proxyOK := pipelineCheckStatus(proxyResult)
+
+			if lokiOK != proxyOK {
+				t.Errorf("status mismatch: loki_ok=%v proxy_ok=%v for %q", lokiOK, proxyOK, tc.query)
+			}
+		})
+	}
+}
+
+// TestPipeline_MetricQueries tests metric aggregation queries for parity.
+func TestPipeline_MetricQueries(t *testing.T) {
+	ensureDataIngested(t)
+
+	metricTests := []struct {
+		name  string
+		query string
+	}{
+		{"count_over_time", `count_over_time({app="api-gateway",env="production"}[5m])`},
+		{"rate", `rate({app="api-gateway",env="production"}[5m])`},
+		{"bytes_over_time", `bytes_over_time({app="api-gateway",env="production"}[5m])`},
+		{"bytes_rate", `bytes_rate({app="api-gateway",env="production"}[5m])`},
+		{"sum_by_level", `sum by (level) (count_over_time({app="api-gateway",env="production"}[5m]))`},
+		{"rate_with_filter", `rate({app="api-gateway",env="production"} |= "GET"[5m])`},
+		{"topk", `topk(3, sum by (app) (count_over_time({env="production"}[5m])))`},
+		{"bottomk", `bottomk(3, sum by (app) (count_over_time({env="production"}[5m])))`},
+	}
+
+	for _, tc := range metricTests {
+		t.Run(tc.name, func(t *testing.T) {
+			lokiResult := pipelineQueryLoki(t, tc.query)
+			proxyResult := pipelineQueryProxy(t, tc.query)
+
+			lokiOK := pipelineCheckStatus(lokiResult)
+			proxyOK := pipelineCheckStatus(proxyResult)
+
+			if lokiOK != proxyOK {
+				t.Errorf("status mismatch: loki_ok=%v proxy_ok=%v for %q", lokiOK, proxyOK, tc.query)
+			}
+		})
+	}
+}
+
+// ─── HELPERS ────────────────────────────────────────────────────────────────
+
+func pipelineQueryRaw(t *testing.T, baseURL, query string) (int, string) {
+	t.Helper()
+	now := time.Now()
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", fmt.Sprintf("%d", now.Add(-2*time.Hour).UnixNano()))
+	params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+	params.Set("limit", "10")
+
+	resp, err := http.Get(baseURL + "/loki/api/v1/query_range?" + params.Encode())
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			body.Write(buf[:n])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return resp.StatusCode, body.String()
+}
+
+func pipelineQueryLoki(t *testing.T, query string) map[string]interface{} {
+	t.Helper()
+	_, body := pipelineQueryRaw(t, lokiURL, query)
+	var result map[string]interface{}
+	json.Unmarshal([]byte(body), &result)
+	return result
+}
+
+func pipelineQueryProxy(t *testing.T, query string) map[string]interface{} {
+	t.Helper()
+	_, body := pipelineQueryRaw(t, proxyURL, query)
+	var result map[string]interface{}
+	json.Unmarshal([]byte(body), &result)
+	return result
+}
+
+func pipelineCheckStatus(result map[string]interface{}) bool {
+	status, _ := result["status"].(string)
+	return status == "success"
+}
+
+func pipelineCountLogLines(result map[string]interface{}) int {
+	data, _ := result["data"].(map[string]interface{})
+	streams, _ := data["result"].([]interface{})
+	count := 0
+	for _, s := range streams {
+		stream, _ := s.(map[string]interface{})
+		values, _ := stream["values"].([]interface{})
+		count += len(values)
+	}
+	return count
+}
+
+func pipelineTruncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}


### PR DESCRIPTION
## Summary

- Adds lightweight LogQL syntax validation that catches invalid queries before translation, returning the same HTTP 400 status codes and error messages as Loki
- Adds exhaustive pipeline parity test machine with 116 test cases covering every LogQL operation
- Increases Loki max_query_series from 500 to 5000 to prevent false test truncation

## Technical details

### LogQL Syntax Validation
The proxy translator uses regex-based parsing which is more lenient than Loki's AST parser. Invalid queries that Loki rejects with parse errors were silently succeeding on the proxy. Added `validateLogQLSyntax()` in the query validation path that catches:

- Binary operations on log/pipeline expressions (`{level="info"} == 2`, `{app="x"} | json <= 2`)
- All arithmetic operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `+`, `-`, `*`, `/`, `%`, `^`
- Malformed selectors: `{app=}`, unclosed braces
- Empty queries and missing selectors (`| json`)

Error messages match Loki's exact format (plain text `parse error : ...`).

### Exhaustive Test Machine
Two test suites in `logql_exhaustive_test.go`:

**Error Parity (31 cases)**: Walks all invalid LogQL patterns, verifies proxy returns same error codes as Loki. Categories: binary ops on log queries (14), malformed syntax (4), invalid regex (2), metric without range (3), metric on log (5), unwrap (1), pipeline (2).

**Query Parity (85 cases)**: Walks all valid LogQL operations, verifies both Loki and proxy return success. Categories: selectors (6), line filters (4), parsers (6), field filters (8), format stages (4), drop/keep (5), multi-stage pipelines (8), range metrics (7), aggregations (10), unwrap metrics (9), comparisons (8), vector ops (4), grouping (2), absent (1), empty/basic (3).

## Test plan

- [x] 1230 unit tests pass
- [x] Error parity: 31/31 (100%)
- [x] Query parity: 85/85 (100%)
- [x] Local e2e stack validated