### PR TITLE
fix: add Unreleased changelog for PR #252 and fix stale-branch gate bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(detected_fields): infer `int`/`float` types for logfmt string values so Grafana's unwrap field selector correctly lists numeric fields.
+- fix(detected_fields): strip bare `| unwrap` (without field name) from field detection queries, preventing VictoriaLogs parse errors when Grafana sends an incomplete query to the `detected_fields` endpoint.
+- fix(compat): `| json | status >= 400` no longer incorrectly rejected as a binary op on a log query by the LogQL syntax validator.
+
 ## [1.16.0] - 2026-04-25
 
 ### Added

--- a/scripts/ci/check_changelog_pr.py
+++ b/scripts/ci/check_changelog_pr.py
@@ -81,6 +81,24 @@ def extract_unreleased_section(text: str) -> str:
     return match.group("body").strip()
 
 
+def extract_bullet_points(text: str) -> set[str]:
+    """Return every bullet-point line from a changelog block (normalised)."""
+    return {line.strip() for line in text.splitlines() if line.strip().startswith("- ")}
+
+
+def has_genuinely_new_unreleased_entries(head_unreleased: str, base_full_changelog: str) -> bool:
+    """True only if [Unreleased] on HEAD has bullets absent from every section of BASE.
+
+    Guards against stale feature branches whose [Unreleased] section still
+    carries entries that were already released on main (e.g. moved to [1.15.0]).
+    Comparing file-states at base vs head would pass in that case because the
+    files differ, even though no new entry was added in this PR.
+    """
+    base_all_bullets = extract_bullet_points(base_full_changelog)
+    head_new_bullets = extract_bullet_points(head_unreleased) - base_all_bullets
+    return bool(head_new_bullets)
+
+
 def has_meaningful_changelog_content(section: str) -> bool:
     if not section.strip():
         return False
@@ -195,9 +213,10 @@ def main() -> int:
         )
         return 1
 
-    if head_unreleased.strip() == base_unreleased.strip():
+    if not has_genuinely_new_unreleased_entries(head_unreleased, base_text):
         print(
-            "changelog gate: Unreleased section was not updated in this PR",
+            "changelog gate: Unreleased section must contain entries not already present in a released version "
+            "(stale feature branch entries carried over from before a release do not count)",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/tests/test_check_changelog_pr.py
+++ b/scripts/ci/tests/test_check_changelog_pr.py
@@ -2,6 +2,7 @@ import unittest
 
 from scripts.ci.check_changelog_pr import (
     extract_unreleased_section,
+    has_genuinely_new_unreleased_entries,
     has_meaningful_changelog_content,
     is_release_metadata_sync,
     should_require_changelog,
@@ -63,6 +64,39 @@ class CheckChangelogPRTests(unittest.TestCase):
                 ],
             )
         )
+
+    def test_has_genuinely_new_unreleased_entries_detects_new(self):
+        base_changelog = "## [1.0.0]\n\n- fix: old bug\n"
+        head_unreleased = "- fix: brand new fix\n"
+        self.assertTrue(has_genuinely_new_unreleased_entries(head_unreleased, base_changelog))
+
+    def test_has_genuinely_new_unreleased_entries_rejects_stale_branch(self):
+        # Simulates a feature branch that still has entries from before the last release.
+        # Those same bullets now appear in [1.15.0] on main — must NOT count as new.
+        base_changelog = (
+            "## [Unreleased]\n\n"
+            "## [1.15.0] - 2026-04-25\n\n"
+            "- feat(otel): hierarchical OTel detection\n"
+            "- fix(otel): service_name suppression\n"
+        )
+        head_unreleased = (
+            "### Added\n\n"
+            "- feat(otel): hierarchical OTel detection\n"
+            "- fix(otel): service_name suppression\n"
+        )
+        self.assertFalse(has_genuinely_new_unreleased_entries(head_unreleased, base_changelog))
+
+    def test_has_genuinely_new_unreleased_entries_mixed(self):
+        # One stale entry + one genuinely new one → should pass.
+        base_changelog = (
+            "## [1.15.0] - 2026-04-25\n\n"
+            "- feat(otel): old feature\n"
+        )
+        head_unreleased = (
+            "- feat(otel): old feature\n"
+            "- fix: new fix added in this PR\n"
+        )
+        self.assertTrue(has_genuinely_new_unreleased_entries(head_unreleased, base_changelog))
 
     def test_release_metadata_sync_detection(self):
         self.assertTrue(


### PR DESCRIPTION
## Summary

- Add `[Unreleased]` changelog entries for the `detected_fields` fixes landed in PR #252 (int/float type inference, bare `| unwrap` stripping, label-filter false-positive fix) — unblocks the stalled auto-release
- Fix `check_changelog_pr.py` stale-branch false-positive: the gate was passing when a feature branch carried old `[Unreleased]` entries that had already been moved to a released section on main; those entries made the file differ from base, satisfying the gate even though no new entries were added for the current PR

## Root cause of the bypass

`head_unreleased != base_unreleased` passed because:
- `base` (main after v1.16.0 release) had empty `[Unreleased]`
- `head` (feature branch) still had OTel entries from before v1.15.0 in `[Unreleased]`

The new `has_genuinely_new_unreleased_entries()` check compares head's `[Unreleased]` bullets against **all** bullets in the base CHANGELOG (including released sections). Stale carry-over entries are no longer accepted.

## Test plan

- [ ] `python3 -m unittest scripts.ci.tests.test_check_changelog_pr -v` — 12 tests pass (3 new: detects new, rejects stale, accepts mixed)
- [ ] Changelog gate GREEN on this PR
- [ ] Auto-release triggers and creates a new patch release after merge