### PR TITLE
ci: update Trivy from 0.69.3 to 0.70.0

### DIFF
--- a/.github/workflows/security-heavy.yaml
+++ b/.github/workflows/security-heavy.yaml
@@ -31,7 +31,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=security-heavy-proxy
 
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.PROXY_IMAGE }}
           exit-code: "1"

--- a/.github/workflows/security-pr.yaml
+++ b/.github/workflows/security-pr.yaml
@@ -74,7 +74,7 @@ jobs:
           docker run --rm \
             -v "$PWD:/repo" \
             -w /repo \
-            aquasec/trivy:0.69.3 \
+            aquasec/trivy:0.70.0 \
             fs . \
             --ignorefile .trivyignore.yaml \
             --scanners vuln,misconfig,secret \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- ci: Trivy updated from `0.69.3` to `0.70.0` (`security-pr.yaml` docker image tag, `security-heavy.yaml` trivy-action pinned to `ed142fd` / `v0.36.0`).
+
 ## [1.22.2] - 2026-04-29
 
 ### Changed


### PR DESCRIPTION
## Summary

- `security-pr.yaml`: bump `aquasec/trivy` docker image tag `0.69.3` → `0.70.0`
- `security-heavy.yaml`: pin `trivy-action` to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (`v0.36.0`), which bundles Trivy 0.70.0

## Test plan

- [ ] `security-pr.yaml` Trivy filesystem scan runs with 0.70.0 image
- [ ] `security-heavy.yaml` Trivy image scan uses trivy-action v0.36.0 (SHA-pinned)
- [ ] CI passes