### PR TITLE
ci: replace broken semgrep/semgrep-action@v1 with semgrep CLI

### DIFF
--- a/.github/workflows/security-heavy.yaml
+++ b/.github/workflows/security-heavy.yaml
@@ -66,18 +66,31 @@ jobs:
   semgrep:
     name: Heavy / semgrep
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
-      - uses: semgrep/semgrep-action@v1
+      - name: Semgrep scan
+        run: |
+          pip install semgrep==1.161.0
+          semgrep scan \
+            --config p/default \
+            --config p/dockerfile \
+            --config p/github-actions \
+            --config p/golang \
+            --config p/owasp-top-ten \
+            --config p/secrets \
+            --sarif \
+            --output semgrep.sarif \
+            --error
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
         with:
-          config: >-
-            p/default
-            p/dockerfile
-            p/github-actions
-            p/golang
-            p/owasp-top-ten
-            p/secrets
+          sarif_file: semgrep.sarif
 
   fuzz:
     name: Heavy / fuzz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ci: Trivy updated from `0.69.3` to `0.70.0` (`security-pr.yaml` docker image tag, `security-heavy.yaml` trivy-action pinned to `ed142fd` / `v0.36.0`).
+- ci: replace `semgrep/semgrep-action@v1` (broken — uses removed `returntocorp/semgrep-agent:v1` Docker image) with `pip install semgrep==1.161.0` + `semgrep scan` CLI in `security-heavy.yaml`; adds SARIF upload step.
 
 ## [1.22.2] - 2026-04-29
 


### PR DESCRIPTION
## Summary

`semgrep/semgrep-action@v1` (and every tagged version of that action) hard-codes `docker://returntocorp/semgrep-agent:v1` in its `action.yml`. That Docker image no longer exists, causing:

```
Error: Unable to resolve action `returntocorp/semgrep@v1`, unable to find version `v1`
```

Replace with direct CLI invocation — same 6 rulesets, pinned version, SARIF upload added.

## Test plan

- [ ] `security-heavy.yaml` semgrep job runs without action-resolution error
- [ ] Semgrep scans with `p/default`, `p/dockerfile`, `p/github-actions`, `p/golang`, `p/owasp-top-ten`, `p/secrets`
- [ ] SARIF results uploaded to GitHub Security tab