### PR TITLE
fix(ci): exempt dependency-only PRs from changelog gate

### DIFF
--- a/scripts/ci/check_changelog_pr.py
+++ b/scripts/ci/check_changelog_pr.py
@@ -20,6 +20,11 @@ RELEASE_PREFIXES = (
     "revert",
 )
 
+DEPENDENCY_UPDATE_PREFIXES = (
+    "build(deps):",
+    "build(deps-dev):",
+)
+
 IMPACTFUL_PATHS = (
     "cmd/",
     "internal/",
@@ -161,6 +166,26 @@ def should_require_changelog(commits: Iterable[str], files: Iterable[str]) -> bo
     return len(file_list) > 0 and len(non_release) != len(file_list)
 
 
+def is_dependency_only_pr(commits: Iterable[str], files: Iterable[str]) -> bool:
+    """True when every commit is a dependency bump and no app code changed."""
+    commit_list = [c for c in commits if c.strip()]
+    file_list = [f for f in files if f.strip()]
+    if not commit_list or not file_list:
+        return False
+    all_dep_commits = all(
+        any(c.strip().lower().startswith(p) for p in DEPENDENCY_UPDATE_PREFIXES)
+        for c in commit_list
+    )
+    if not all_dep_commits:
+        return False
+    return all(
+        f in IMPACTFUL_FILES
+        or is_non_release_path(f)
+        or f.startswith(".github/")
+        for f in file_list
+    )
+
+
 def is_release_metadata_sync(files: Iterable[str]) -> bool:
     file_list = [f for f in files if f.strip()]
     if not file_list or "CHANGELOG.md" not in file_list:
@@ -184,6 +209,10 @@ def main() -> int:
     head_text = run_git("show", f"{args.head}:CHANGELOG.md")
     base_unreleased = extract_unreleased_section(base_text)
     head_unreleased = extract_unreleased_section(head_text)
+
+    if is_dependency_only_pr(commits, files):
+        print("changelog gate: skipped (dependency-only update)")
+        return 0
 
     if is_release_metadata_sync(files):
         if head_unreleased.strip() == base_unreleased.strip():

--- a/scripts/ci/tests/test_check_changelog_pr.py
+++ b/scripts/ci/tests/test_check_changelog_pr.py
@@ -4,6 +4,7 @@ from scripts.ci.check_changelog_pr import (
     extract_unreleased_section,
     has_genuinely_new_unreleased_entries,
     has_meaningful_changelog_content,
+    is_dependency_only_pr,
     is_release_metadata_sync,
     should_require_changelog,
 )
@@ -97,6 +98,42 @@ class CheckChangelogPRTests(unittest.TestCase):
             "- fix: new fix added in this PR\n"
         )
         self.assertTrue(has_genuinely_new_unreleased_entries(head_unreleased, base_changelog))
+
+    def test_dependency_only_pr_go_modules(self):
+        self.assertTrue(
+            is_dependency_only_pr(
+                ["build(deps): bump github.com/klauspost/compress from 1.18.5 to 1.18.6 in the go-minor group"],
+                ["go.mod", "go.sum"],
+            )
+        )
+
+    def test_dependency_only_pr_github_actions(self):
+        self.assertTrue(
+            is_dependency_only_pr(
+                ["build(deps): bump the actions-minor group with 16 updates"],
+                [".github/workflows/ci.yaml", ".github/workflows/release.yaml"],
+            )
+        )
+
+    def test_dependency_only_pr_rejects_mixed_commits(self):
+        self.assertFalse(
+            is_dependency_only_pr(
+                ["build(deps): bump X", "feat: add new feature"],
+                ["go.mod", "go.sum"],
+            )
+        )
+
+    def test_dependency_only_pr_rejects_app_code(self):
+        self.assertFalse(
+            is_dependency_only_pr(
+                ["build(deps): bump X"],
+                ["go.mod", "go.sum", "internal/proxy/proxy.go"],
+            )
+        )
+
+    def test_dependency_only_pr_rejects_empty(self):
+        self.assertFalse(is_dependency_only_pr([], ["go.mod"]))
+        self.assertFalse(is_dependency_only_pr(["build(deps): bump X"], []))
 
     def test_release_metadata_sync_detection(self):
         self.assertTrue(


### PR DESCRIPTION
## Summary

- Dependabot PRs (`build(deps):` commits) were blocked by the changelog gate because `go.mod` is classified as impactful and `.github/` workflow files fall into an unclassified gap
- Adds `is_dependency_only_pr()` detection: skips the gate when all commits are `build(deps):` prefixed and only dependency/CI files changed
- 5 new unit tests covering Go module bumps, GHA bumps, mixed commits (rejected), app code mixed in (rejected), empty inputs (rejected)

## Test plan

- [x] All 17 unit tests pass (12 existing + 5 new)
- [ ] Verify PR #294 (Go dep bump) passes Changelog PR check after merge
- [ ] Verify PR #295 (GHA bump) passes Changelog PR check after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)