### PR TITLE
feat: cold storage routing for Victoria Lakehouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat(proxy): add cold storage routing — time-range-based query splitting between hot (EBS VictoriaLogs) and cold (S3 Victoria Lakehouse) backends with configurable boundary, parallel fan-out, NDJSON merge, manifest-aware routing, and graceful degradation on backend failures.
+
 ## [1.27.3] - 2026-05-03
 
 ### Performance

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -283,6 +283,17 @@ extraArgs:
   # tls-key-file: ""
   # tls-client-ca-file: ""
   # tls-require-client-cert: "false"
+  #
+  # --- Cold storage (Victoria Lakehouse) ---
+  # Route historical queries to an S3-backed Victoria Lakehouse instance.
+  # Queries older than cold-boundary go to cold backend; queries spanning
+  # the boundary fan out to both hot and cold with NDJSON merge.
+  # cold-enabled: "true"                          # enable cold storage routing
+  # cold-backend: "http://lakehouse-logs:9428"    # Victoria Lakehouse URL
+  # cold-boundary: "168h"                         # data older than 7d routes to cold (default 168h)
+  # cold-overlap: "1h"                            # overlap window where both tiers are queried
+  # cold-manifest-refresh: "5m"                   # poll interval for cold backend /manifest/range
+  # cold-timeout: "30s"                           # timeout for cold backend requests
 
 # First-class observability flags.
 # The chart renders these as CLI args unless the same key is already set under

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -169,6 +169,12 @@ type proxyRuntimeConfig struct {
 	peerHotReadAheadTenantFairShare     int
 	peerHotReadAheadErrorBackoff        time.Duration
 	coalescerDisabled                   bool
+	coldBackendURL                      string
+	coldBackendBoundary                 time.Duration
+	coldBackendOverlap                  time.Duration
+	coldBackendEnabled                  bool
+	coldBackendManifestRefresh          time.Duration
+	coldBackendTimeout                  time.Duration
 }
 
 type otlpRuntimeConfig struct {
@@ -479,6 +485,14 @@ func run(
 	patternsPeerWarmTimeout := fs.Duration("patterns-startup-peer-warm-timeout", 5*time.Second, "Maximum time to wait for startup patterns snapshot warm from peers")
 	allowGlobalTenant := fs.Bool("tenant.allow-global", false, `Allow X-Scope-OrgID "*" to bypass AccountID/ProjectID scoping and use the backend default tenant`)
 
+	// Cold storage backend (Victoria Lakehouse)
+	coldBackendURL := fs.String("cold-backend", "", "Cold storage backend URL (Victoria Lakehouse). Empty disables cold routing.")
+	coldBackendBoundary := fs.Duration("cold-boundary", 7*24*time.Hour, "Data older than this boundary routes to cold backend")
+	coldBackendOverlap := fs.Duration("cold-overlap", time.Hour, "Overlap window around cold boundary where both hot and cold are queried")
+	coldBackendEnabled := fs.Bool("cold-enabled", false, "Enable cold storage backend routing")
+	coldBackendManifestRefresh := fs.Duration("cold-manifest-refresh", 5*time.Minute, "How often to refresh cold backend manifest range")
+	coldBackendTimeout := fs.Duration("cold-timeout", 30*time.Second, "Timeout for cold backend requests")
+
 	// Peer cache (fleet distribution)
 	peerSelf := fs.String("peer-self", "", `This instance's address for peer cache (e.g., "10.0.0.1:3100"). Empty disables peer cache.`)
 	peerDiscovery := fs.String("peer-discovery", "", `Peer discovery: "dns" (headless service) or "static" (comma-separated)`)
@@ -685,6 +699,12 @@ func run(
 			peerHotReadAheadTenantFairShare:     *peerHotReadAheadTenantFairShare,
 			peerHotReadAheadErrorBackoff:        *peerHotReadAheadErrorBackoff,
 			coalescerDisabled:                   *coalescerDisabled,
+			coldBackendURL:                      *coldBackendURL,
+			coldBackendBoundary:                 *coldBackendBoundary,
+			coldBackendOverlap:                  *coldBackendOverlap,
+			coldBackendEnabled:                  *coldBackendEnabled,
+			coldBackendManifestRefresh:          *coldBackendManifestRefresh,
+			coldBackendTimeout:                  *coldBackendTimeout,
 		},
 		otlpCfg: otlpRuntimeConfig{
 			endpoint:              envCfg.otlpEndpoint,
@@ -1507,6 +1527,14 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		PatternsPeerWarmTimeout:            cfg.patternsPeerWarmTimeout,
 		PeerCache:                          peerCache,
 		PeerAuthToken:                      cfg.peerAuthToken,
+		ColdBackend: proxy.ColdBackendConfig{
+			URL:             cfg.coldBackendURL,
+			Boundary:        cfg.coldBackendBoundary,
+			Overlap:         cfg.coldBackendOverlap,
+			Enabled:         cfg.coldBackendEnabled,
+			ManifestRefresh: cfg.coldBackendManifestRefresh,
+			Timeout:         cfg.coldBackendTimeout,
+		},
 	}, nil
 }
 

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -1,0 +1,225 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+func (p *Proxy) coldRouteForRequest(r *http.Request) RouteDecision {
+	if p.coldRouter == nil {
+		return RouteHotOnly
+	}
+	startNs, endNs := ParseTimeRangeFromRequest(r)
+	return p.coldRouter.Route(startNs, endNs)
+}
+
+func (p *Proxy) proxyLogQueryWithCold(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	decision := p.coldRouteForRequest(r)
+	p.log.Debug("cold routing decision", "decision", decision, "query", logsqlQuery)
+
+	switch decision {
+	case RouteColdOnly:
+		p.proxyLogQueryCold(w, r, logsqlQuery)
+	case RouteBoth:
+		p.proxyLogQueryBoth(w, r, logsqlQuery)
+	default:
+		p.proxyLogQuery(w, r, logsqlQuery)
+	}
+}
+
+func (p *Proxy) buildLogQueryParams(r *http.Request, logsqlQuery string) url.Values {
+	direction := r.FormValue("direction")
+	if direction == "forward" {
+		logsqlQuery += " | sort by (_time)"
+	} else {
+		logsqlQuery += " | sort by (_time desc)"
+	}
+
+	params := url.Values{}
+	params.Set("query", logsqlQuery)
+	if s := r.FormValue("start"); s != "" {
+		params.Set("start", formatVLTimestamp(s))
+	}
+	if e := r.FormValue("end"); e != "" {
+		params.Set("end", formatVLTimestamp(e))
+	}
+	limit := r.FormValue("limit")
+	if limit == "" {
+		limit = "1000"
+	}
+	params.Set("limit", sanitizeLimit(limit))
+	return params
+}
+
+func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	params := p.buildLogQueryParams(r, logsqlQuery)
+	resp, err := p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", params)
+	if err != nil {
+		p.log.Warn("cold backend error, falling back to hot", "error", err)
+		p.proxyLogQuery(w, r, logsqlQuery)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		p.log.Warn("cold backend returned error, falling back to hot", "status", resp.StatusCode)
+		p.proxyLogQuery(w, r, logsqlQuery)
+		return
+	}
+
+	p.processLogQueryResponse(w, r, resp)
+}
+
+func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	params := p.buildLogQueryParams(r, logsqlQuery)
+
+	var (
+		hotResp, coldResp *http.Response
+		hotErr, coldErr   error
+		wg                sync.WaitGroup
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		hotResp, hotErr = p.vlPost(r.Context(), "/select/logsql/query", params)
+	}()
+	go func() {
+		defer wg.Done()
+		coldResp, coldErr = p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", params)
+	}()
+	wg.Wait()
+
+	if hotErr != nil && coldErr != nil {
+		p.writeError(w, statusFromUpstreamErr(hotErr), hotErr.Error())
+		return
+	}
+
+	// Cold failed — serve hot only
+	if coldErr != nil || (coldResp != nil && coldResp.StatusCode >= 400) {
+		if coldResp != nil {
+			coldResp.Body.Close()
+		}
+		if hotErr != nil {
+			p.writeError(w, statusFromUpstreamErr(hotErr), hotErr.Error())
+			return
+		}
+		defer hotResp.Body.Close()
+		if hotResp.StatusCode >= 400 {
+			body, _ := readBodyLimited(hotResp.Body, maxUpstreamErrorBodyBytes)
+			p.writeError(w, hotResp.StatusCode, string(body))
+			return
+		}
+		p.processLogQueryResponse(w, r, hotResp)
+		return
+	}
+
+	// Hot failed — serve cold only
+	if hotErr != nil || (hotResp != nil && hotResp.StatusCode >= 400) {
+		if hotResp != nil {
+			hotResp.Body.Close()
+		}
+		defer coldResp.Body.Close()
+		if coldResp.StatusCode >= 400 {
+			body, _ := readBodyLimited(coldResp.Body, maxUpstreamErrorBodyBytes)
+			p.writeError(w, coldResp.StatusCode, string(body))
+			return
+		}
+		p.processLogQueryResponse(w, r, coldResp)
+		return
+	}
+
+	// Both succeeded — merge
+	defer hotResp.Body.Close()
+	defer coldResp.Body.Close()
+
+	merged := MergeNDJSON(hotResp.Body, coldResp.Body)
+	mergedBody, err := io.ReadAll(merged)
+	if err != nil {
+		p.writeError(w, http.StatusBadGateway, "failed to merge hot+cold results")
+		return
+	}
+
+	syntheticResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     hotResp.Header.Clone(),
+		Body:       io.NopCloser(bytes.NewReader(mergedBody)),
+	}
+	p.processLogQueryResponse(w, r, syntheticResp)
+}
+
+// processLogQueryResponse converts a VL NDJSON response into a Loki-format JSON response.
+// Shared between hot, cold, and merged code paths.
+func (p *Proxy) processLogQueryResponse(w http.ResponseWriter, r *http.Request, resp *http.Response) {
+	if resp.StatusCode >= 400 {
+		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
+		p.writeError(w, resp.StatusCode, string(body))
+		return
+	}
+
+	categorizedLabels := requestWantsCategorizedLabels(r)
+	emitStructuredMetadata := p.shouldEmitStructuredMetadata(r)
+	p.metrics.RecordTupleMode(tupleModeForRequest(categorizedLabels, emitStructuredMetadata))
+
+	if p.streamResponse {
+		p.streamLogQuery(w, resp, r.FormValue("query"), categorizedLabels, emitStructuredMetadata)
+		return
+	}
+
+	collectPatterns := p.patternsEnabled && p.patternsAutodetectFromQueries
+	streams, patterns, err := p.vlReaderToLokiStreams(
+		resp.Body,
+		r.FormValue("query"),
+		r.FormValue("step"),
+		categorizedLabels,
+		emitStructuredMetadata,
+		collectPatterns,
+	)
+	if err != nil {
+		p.writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	p.storeAutodetectedPatterns(
+		r.Header.Get("X-Scope-OrgID"),
+		p.fingerprintFromCtx(r.Context(), r),
+		r.FormValue("query"),
+		r.FormValue("start"),
+		r.FormValue("end"),
+		r.FormValue("step"),
+		patterns,
+	)
+
+	if len(p.derivedFields) > 0 {
+		p.applyDerivedFields(streams)
+	}
+
+	logqlQuery := r.FormValue("query")
+	if strings.Contains(logqlQuery, "decolorize") {
+		decolorizeStreams(streams)
+	}
+	if label, cidr, ok := parseIPFilter(logqlQuery); ok {
+		streams = ipFilterStreams(streams, label, cidr)
+	}
+	if tmpl := extractLineFormatTemplate(logqlQuery); tmpl != "" {
+		applyLineFormatTemplate(streams, tmpl)
+	}
+
+	p.writeJSON(w, map[string]interface{}{
+		"status": "success",
+		"data": func() map[string]interface{} {
+			data := map[string]interface{}{
+				"resultType": "streams",
+				"result":     streams,
+				"stats":      map[string]interface{}{},
+			}
+			if categorizedLabels {
+				data["encodingFlags"] = []string{"categorize-labels"}
+			}
+			return data
+		}(),
+	})
+}

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -1,0 +1,303 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestColdRouteForRequest_NilRouter(t *testing.T) {
+	p := &Proxy{}
+	r := httptest.NewRequest("GET", "/loki/api/v1/query_range?start=1714521600&end=1714608000", nil)
+	if d := p.coldRouteForRequest(r); d != RouteHotOnly {
+		t.Errorf("nil router should route hot, got %s", d)
+	}
+}
+
+func TestColdRouteForRequest_WithRouter(t *testing.T) {
+	now := time.Now()
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+	}
+
+	p := &Proxy{coldRouter: cr}
+
+	// Recent query → hot only
+	start := fmt.Sprintf("%d", now.Add(-1*time.Hour).UnixNano())
+	end := fmt.Sprintf("%d", now.UnixNano())
+	r := httptest.NewRequest("GET", "/loki/api/v1/query_range?start="+start+"&end="+end, nil)
+	if d := p.coldRouteForRequest(r); d != RouteHotOnly {
+		t.Errorf("recent query should route hot, got %s", d)
+	}
+
+	// Old query → cold only
+	start = fmt.Sprintf("%d", now.Add(-30*24*time.Hour).UnixNano())
+	end = fmt.Sprintf("%d", now.Add(-20*24*time.Hour).UnixNano())
+	r = httptest.NewRequest("GET", "/loki/api/v1/query_range?start="+start+"&end="+end, nil)
+	if d := p.coldRouteForRequest(r); d != RouteColdOnly {
+		t.Errorf("old query should route cold, got %s", d)
+	}
+
+	// Spanning query → both
+	start = fmt.Sprintf("%d", now.Add(-10*24*time.Hour).UnixNano())
+	end = fmt.Sprintf("%d", now.UnixNano())
+	r = httptest.NewRequest("GET", "/loki/api/v1/query_range?start="+start+"&end="+end, nil)
+	if d := p.coldRouteForRequest(r); d != RouteBoth {
+		t.Errorf("spanning query should route both, got %s", d)
+	}
+}
+
+func TestBuildLogQueryParams(t *testing.T) {
+	p := &Proxy{maxLines: 1000}
+	r := httptest.NewRequest("GET", "/?start=1714521600&end=1714608000&limit=500&direction=forward", nil)
+	params := p.buildLogQueryParams(r, "_time:1h")
+
+	if !strings.Contains(params.Get("query"), "sort by (_time)") {
+		t.Error("forward direction should add sort by _time")
+	}
+	if params.Get("limit") != "500" {
+		t.Errorf("limit = %q, want 500", params.Get("limit"))
+	}
+}
+
+func TestBuildLogQueryParams_Backward(t *testing.T) {
+	p := &Proxy{maxLines: 1000}
+	r := httptest.NewRequest("GET", "/?direction=backward", nil)
+	params := p.buildLogQueryParams(r, "_time:1h")
+
+	if !strings.Contains(params.Get("query"), "sort by (_time desc)") {
+		t.Error("backward direction should add sort by _time desc")
+	}
+}
+
+func TestBuildLogQueryParams_DefaultLimit(t *testing.T) {
+	p := &Proxy{maxLines: 1000}
+	r := httptest.NewRequest("GET", "/", nil)
+	params := p.buildLogQueryParams(r, "*")
+
+	if params.Get("limit") != "1000" {
+		t.Errorf("default limit = %q, want 1000", params.Get("limit"))
+	}
+}
+
+func TestProxyLogQueryCold_FallbackOnError(t *testing.T) {
+	// Hot backend that returns valid NDJSON
+	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/stream+json")
+		fmt.Fprintln(w, `{"_msg":"hot-line","_time":"2026-05-01T00:00:00Z","_stream":"{}"}`)
+	}))
+	defer hotSrv.Close()
+
+	// Cold backend that returns an error
+	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer coldSrv.Close()
+
+	p, err := New(Config{
+		BackendURL: hotSrv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      coldSrv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+
+	p.proxyLogQueryCold(w, r, "*")
+
+	// Should fall back to hot and succeed
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (fallback to hot)", w.Code)
+	}
+}
+
+func TestProxyLogQueryBoth_MergesResults(t *testing.T) {
+	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/select/logsql/query" {
+			w.Header().Set("Content-Type", "application/stream+json")
+			fmt.Fprintln(w, `{"_msg":"hot-line","_time":"2026-05-01T00:00:00Z","_stream":"{}"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer hotSrv.Close()
+
+	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/select/logsql/query" {
+			w.Header().Set("Content-Type", "application/stream+json")
+			fmt.Fprintln(w, `{"_msg":"cold-line","_time":"2026-04-01T00:00:00Z","_stream":"{}"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coldSrv.Close()
+
+	p, err := New(Config{
+		BackendURL: hotSrv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      coldSrv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+
+	p.proxyLogQueryBoth(w, r, "*")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body := w.Body.String()
+	var result struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Stream map[string]string `json:"stream"`
+				Values [][]string        `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, body)
+	}
+	if result.Status != "success" {
+		t.Errorf("status = %q, want success", result.Status)
+	}
+
+	// Should contain both hot and cold lines
+	allValues := ""
+	for _, stream := range result.Data.Result {
+		for _, v := range stream.Values {
+			if len(v) >= 2 {
+				allValues += v[1]
+			}
+		}
+	}
+	if !strings.Contains(allValues, "hot-line") {
+		t.Error("missing hot-line in merged results")
+	}
+	if !strings.Contains(allValues, "cold-line") {
+		t.Error("missing cold-line in merged results")
+	}
+}
+
+func TestProxyLogQueryBoth_ColdFails_ServesHot(t *testing.T) {
+	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/stream+json")
+		fmt.Fprintln(w, `{"_msg":"hot-only","_time":"2026-05-01T00:00:00Z","_stream":"{}"}`)
+	}))
+	defer hotSrv.Close()
+
+	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "cold is down", http.StatusServiceUnavailable)
+	}))
+	defer coldSrv.Close()
+
+	p, err := New(Config{
+		BackendURL: hotSrv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      coldSrv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+
+	p.proxyLogQueryBoth(w, r, "*")
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "hot-only") {
+		t.Error("should contain hot results when cold fails")
+	}
+}
+
+func TestProxyLogQueryBoth_HotFails_ServesCold(t *testing.T) {
+	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "hot is down", http.StatusServiceUnavailable)
+	}))
+	defer hotSrv.Close()
+
+	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/stream+json")
+		fmt.Fprintln(w, `{"_msg":"cold-only","_time":"2026-04-01T00:00:00Z","_stream":"{}"}`)
+	}))
+	defer coldSrv.Close()
+
+	p, err := New(Config{
+		BackendURL: hotSrv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      coldSrv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+
+	p.proxyLogQueryBoth(w, r, "*")
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "cold-only") {
+		t.Error("should contain cold results when hot fails")
+	}
+}
+
+func TestColdRouteForRequest_NoTimeRange(t *testing.T) {
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+	}
+	p := &Proxy{coldRouter: cr}
+
+	r := httptest.NewRequest("GET", "/", nil)
+	if d := p.coldRouteForRequest(r); d != RouteHotOnly {
+		t.Errorf("no time range should default to hot, got %s", d)
+	}
+}
+
+func mustParseURLHelper(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// readBodyLimitedForTest is a test helper matching the signature used in cold_dispatch.go
+func readBodyAll(r io.Reader) string {
+	b, _ := io.ReadAll(r)
+	return string(b)
+}

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -3,10 +3,8 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -288,16 +286,3 @@ func TestColdRouteForRequest_NoTimeRange(t *testing.T) {
 	}
 }
 
-func mustParseURLHelper(s string) *url.URL {
-	u, err := url.Parse(s)
-	if err != nil {
-		panic(err)
-	}
-	return u
-}
-
-// readBodyLimitedForTest is a test helper matching the signature used in cold_dispatch.go
-func readBodyAll(r io.Reader) string {
-	b, _ := io.ReadAll(r)
-	return string(b)
-}

--- a/internal/proxy/cold_routing.go
+++ b/internal/proxy/cold_routing.go
@@ -1,0 +1,364 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type ColdBackendConfig struct {
+	URL             string        `yaml:"url"`
+	Boundary        time.Duration `yaml:"boundary"`
+	Overlap         time.Duration `yaml:"overlap"`
+	Enabled         bool          `yaml:"enabled"`
+	ManifestRefresh time.Duration `yaml:"manifest_refresh"`
+	Timeout         time.Duration `yaml:"timeout"`
+}
+
+type ManifestRange struct {
+	MinTime    int64  `json:"minTime"`
+	MaxTime    int64  `json:"maxTime"`
+	MinDate    string `json:"minDate"`
+	MaxDate    string `json:"maxDate"`
+	TotalFiles int    `json:"totalFiles"`
+	TotalBytes int64  `json:"totalBytes"`
+}
+
+type ColdRouter struct {
+	coldBackend     *url.URL
+	client          *http.Client
+	boundary        time.Duration
+	overlap         time.Duration
+	manifestRefresh time.Duration
+	logger          *slog.Logger
+
+	mu       sync.RWMutex
+	manifest *ManifestRange
+}
+
+func NewColdRouter(cfg ColdBackendConfig, logger *slog.Logger) (*ColdRouter, error) {
+	if !cfg.Enabled || cfg.URL == "" {
+		return nil, nil
+	}
+
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cold backend URL: %w", err)
+	}
+
+	boundary := cfg.Boundary
+	if boundary <= 0 {
+		boundary = 7 * 24 * time.Hour
+	}
+	overlap := cfg.Overlap
+	if overlap <= 0 {
+		overlap = time.Hour
+	}
+	refresh := cfg.ManifestRefresh
+	if refresh <= 0 {
+		refresh = 5 * time.Minute
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = 32
+	transport.ResponseHeaderTimeout = timeout
+
+	cr := &ColdRouter{
+		coldBackend:     u,
+		client:          &http.Client{Transport: transport, Timeout: timeout},
+		boundary:        boundary,
+		overlap:         overlap,
+		manifestRefresh: refresh,
+		logger:          logger.With("component", "cold-router"),
+	}
+
+	return cr, nil
+}
+
+func (cr *ColdRouter) Start(ctx context.Context) {
+	go cr.refreshLoop(ctx)
+}
+
+func (cr *ColdRouter) refreshLoop(ctx context.Context) {
+	cr.refreshManifest(ctx)
+
+	ticker := time.NewTicker(cr.manifestRefresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cr.refreshManifest(ctx)
+		}
+	}
+}
+
+func (cr *ColdRouter) refreshManifest(ctx context.Context) {
+	u := *cr.coldBackend
+	u.Path = "/manifest/range"
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		cr.logger.Error("cold manifest request build failed", "error", err)
+		return
+	}
+
+	resp, err := cr.client.Do(req)
+	if err != nil {
+		cr.logger.Warn("cold manifest refresh failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		cr.logger.Warn("cold manifest bad status", "status", resp.StatusCode, "body", string(body))
+		return
+	}
+
+	var mr ManifestRange
+	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
+		cr.logger.Warn("cold manifest decode failed", "error", err)
+		return
+	}
+
+	cr.mu.Lock()
+	cr.manifest = &mr
+	cr.mu.Unlock()
+
+	cr.logger.Debug("cold manifest refreshed",
+		"min_date", mr.MinDate,
+		"max_date", mr.MaxDate,
+		"files", mr.TotalFiles,
+	)
+}
+
+type RouteDecision int
+
+const (
+	RouteHotOnly  RouteDecision = iota
+	RouteColdOnly
+	RouteBoth
+)
+
+func (d RouteDecision) String() string {
+	switch d {
+	case RouteHotOnly:
+		return "hot"
+	case RouteColdOnly:
+		return "cold"
+	case RouteBoth:
+		return "both"
+	default:
+		return "unknown"
+	}
+}
+
+func (cr *ColdRouter) Route(startNs, endNs int64) RouteDecision {
+	if cr == nil {
+		return RouteHotOnly
+	}
+
+	now := time.Now()
+	hotBoundary := now.Add(-cr.boundary)
+	coldEnd := hotBoundary.Add(cr.overlap)
+
+	start := time.Unix(0, startNs)
+	end := time.Unix(0, endNs)
+
+	cr.mu.RLock()
+	manifest := cr.manifest
+	cr.mu.RUnlock()
+
+	if manifest != nil && manifest.TotalFiles == 0 {
+		return RouteHotOnly
+	}
+	if manifest != nil {
+		manifestMax := time.Unix(0, manifest.MaxTime)
+		if start.After(manifestMax) {
+			return RouteHotOnly
+		}
+	}
+
+	if end.Before(coldEnd) && start.Before(hotBoundary) {
+		return RouteColdOnly
+	}
+	if start.After(hotBoundary) || start.Equal(hotBoundary) {
+		return RouteHotOnly
+	}
+
+	return RouteBoth
+}
+
+func (cr *ColdRouter) ColdBoundaryNs() int64 {
+	return time.Now().Add(-cr.boundary).UnixNano()
+}
+
+func (cr *ColdRouter) ColdGet(ctx context.Context, path string, params url.Values) (*http.Response, error) {
+	u := *cr.coldBackend
+	u.Path = path
+	u.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return cr.client.Do(req)
+}
+
+func (cr *ColdRouter) ColdPost(ctx context.Context, path string, params url.Values) (*http.Response, error) {
+	u := *cr.coldBackend
+	u.Path = path
+
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(),
+		io.NopCloser(stringReader(params.Encode())))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return cr.client.Do(req)
+}
+
+func (cr *ColdRouter) HasManifest() bool {
+	if cr == nil {
+		return false
+	}
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	return cr.manifest != nil
+}
+
+func (cr *ColdRouter) ManifestRange() *ManifestRange {
+	if cr == nil {
+		return nil
+	}
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	if cr.manifest == nil {
+		return nil
+	}
+	cp := *cr.manifest
+	return &cp
+}
+
+func MergeNDJSON(hotBody, coldBody io.Reader) io.Reader {
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		if coldBody != nil {
+			_, _ = io.Copy(pw, coldBody)
+		}
+		if hotBody != nil {
+			_, _ = io.Copy(pw, hotBody)
+		}
+	}()
+	return pr
+}
+
+func MergeValuesJSON(hotData, coldData []byte) ([]byte, error) {
+	type valEntry struct {
+		Value string `json:"value"`
+		Hits  int64  `json:"hits"`
+	}
+	type valResponse struct {
+		Values []valEntry `json:"values"`
+	}
+
+	var hot, cold valResponse
+	if len(hotData) > 0 {
+		if err := json.Unmarshal(hotData, &hot); err != nil {
+			return hotData, nil
+		}
+	}
+	if len(coldData) > 0 {
+		if err := json.Unmarshal(coldData, &cold); err != nil {
+			return hotData, nil
+		}
+	}
+
+	merged := make(map[string]int64)
+	for _, v := range hot.Values {
+		merged[v.Value] += v.Hits
+	}
+	for _, v := range cold.Values {
+		merged[v.Value] += v.Hits
+	}
+
+	result := make([]valEntry, 0, len(merged))
+	for v, h := range merged {
+		result = append(result, valEntry{Value: v, Hits: h})
+	}
+
+	out := valResponse{Values: result}
+	return json.Marshal(out)
+}
+
+func ParseTimeRangeFromRequest(r *http.Request) (startNs, endNs int64) {
+	startStr := r.FormValue("start")
+	endStr := r.FormValue("end")
+
+	if startStr != "" {
+		if ns, err := parseFlexTimestamp(startStr); err == nil {
+			startNs = ns
+		}
+	}
+	if endStr != "" {
+		if ns, err := parseFlexTimestamp(endStr); err == nil {
+			endNs = ns
+		}
+	}
+
+	if startNs == 0 {
+		startNs = time.Now().Add(-time.Hour).UnixNano()
+	}
+	if endNs == 0 {
+		endNs = time.Now().UnixNano()
+	}
+	return
+}
+
+func parseFlexTimestamp(s string) (int64, error) {
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		switch {
+		case n > 1e18:
+			return n, nil
+		case n > 1e15:
+			return n * 1000, nil
+		case n > 1e12:
+			return n * 1_000_000, nil
+		default:
+			return n * 1_000_000_000, nil
+		}
+	}
+
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.UnixNano(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UnixNano(), nil
+	}
+
+	return 0, fmt.Errorf("unparseable timestamp: %s", s)
+}
+
+type stringReader string
+
+func (s stringReader) Read(p []byte) (int, error) {
+	n := copy(p, s)
+	if n < len(s) {
+		return n, nil
+	}
+	return n, io.EOF
+}

--- a/internal/proxy/cold_routing.go
+++ b/internal/proxy/cold_routing.go
@@ -256,7 +256,7 @@ func (cr *ColdRouter) ManifestRange() *ManifestRange {
 func MergeNDJSON(hotBody, coldBody io.Reader) io.Reader {
 	pr, pw := io.Pipe()
 	go func() {
-		defer pw.Close()
+		defer func() { _ = pw.Close() }()
 		if coldBody != nil {
 			_, _ = io.Copy(pw, coldBody)
 		}

--- a/internal/proxy/cold_routing_test.go
+++ b/internal/proxy/cold_routing_test.go
@@ -1,0 +1,334 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestColdRouter_Route_HotOnly(t *testing.T) {
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+	}
+
+	now := time.Now()
+	start := now.Add(-1 * time.Hour).UnixNano()
+	end := now.UnixNano()
+
+	if d := cr.Route(start, end); d != RouteHotOnly {
+		t.Errorf("recent query should route hot, got %s", d)
+	}
+}
+
+func TestColdRouter_Route_ColdOnly(t *testing.T) {
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+	}
+
+	now := time.Now()
+	start := now.Add(-30 * 24 * time.Hour).UnixNano()
+	end := now.Add(-20 * 24 * time.Hour).UnixNano()
+
+	if d := cr.Route(start, end); d != RouteColdOnly {
+		t.Errorf("old query should route cold, got %s", d)
+	}
+}
+
+func TestColdRouter_Route_Both(t *testing.T) {
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+	}
+
+	now := time.Now()
+	start := now.Add(-10 * 24 * time.Hour).UnixNano()
+	end := now.UnixNano()
+
+	if d := cr.Route(start, end); d != RouteBoth {
+		t.Errorf("spanning query should route both, got %s", d)
+	}
+}
+
+func TestColdRouter_Route_NilRouter(t *testing.T) {
+	var cr *ColdRouter
+	if d := cr.Route(0, time.Now().UnixNano()); d != RouteHotOnly {
+		t.Errorf("nil router should route hot, got %s", d)
+	}
+}
+
+func TestColdRouter_Route_EmptyManifest(t *testing.T) {
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+		manifest: &ManifestRange{TotalFiles: 0},
+	}
+
+	now := time.Now()
+	start := now.Add(-30 * 24 * time.Hour).UnixNano()
+	end := now.Add(-20 * 24 * time.Hour).UnixNano()
+
+	if d := cr.Route(start, end); d != RouteHotOnly {
+		t.Errorf("empty manifest should route hot, got %s", d)
+	}
+}
+
+func TestColdRouter_Route_ManifestMax(t *testing.T) {
+	now := time.Now()
+	cr := &ColdRouter{
+		boundary: 7 * 24 * time.Hour,
+		overlap:  time.Hour,
+		manifest: &ManifestRange{
+			TotalFiles: 100,
+			MaxTime:    now.Add(-15 * 24 * time.Hour).UnixNano(),
+		},
+	}
+
+	start := now.Add(-10 * 24 * time.Hour).UnixNano()
+	end := now.Add(-8 * 24 * time.Hour).UnixNano()
+
+	if d := cr.Route(start, end); d != RouteHotOnly {
+		t.Errorf("query after manifest max should route hot, got %s", d)
+	}
+}
+
+func TestNewColdRouter_Disabled(t *testing.T) {
+	cr, err := NewColdRouter(ColdBackendConfig{Enabled: false}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cr != nil {
+		t.Error("disabled config should return nil router")
+	}
+}
+
+func TestNewColdRouter_EmptyURL(t *testing.T) {
+	cr, err := NewColdRouter(ColdBackendConfig{Enabled: true, URL: ""}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cr != nil {
+		t.Error("empty URL should return nil router")
+	}
+}
+
+func TestColdRouter_RefreshManifest(t *testing.T) {
+	manifest := ManifestRange{
+		MinTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(),
+		MaxTime:    time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC).UnixNano(),
+		MinDate:    "2026-01-01",
+		MaxDate:    "2026-04-30",
+		TotalFiles: 2920,
+		TotalBytes: 146000000000,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/manifest/range" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer srv.Close()
+
+	cr := &ColdRouter{
+		coldBackend: mustParseURL(srv.URL),
+		client:      srv.Client(),
+		logger:      testSlogger(),
+	}
+
+	cr.refreshManifest(t.Context())
+
+	got := cr.ManifestRange()
+	if got == nil {
+		t.Fatal("expected manifest after refresh")
+	}
+	if got.TotalFiles != 2920 {
+		t.Errorf("total files = %d, want 2920", got.TotalFiles)
+	}
+	if got.MinDate != "2026-01-01" {
+		t.Errorf("min date = %s, want 2026-01-01", got.MinDate)
+	}
+}
+
+func TestMergeNDJSON(t *testing.T) {
+	hot := bytes.NewBufferString(`{"line":"hot1"}` + "\n" + `{"line":"hot2"}` + "\n")
+	cold := bytes.NewBufferString(`{"line":"cold1"}` + "\n")
+
+	merged, err := io.ReadAll(MergeNDJSON(hot, cold))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(merged)
+	if !bytes.Contains(merged, []byte("cold1")) {
+		t.Errorf("missing cold data in merged: %s", s)
+	}
+	if !bytes.Contains(merged, []byte("hot1")) {
+		t.Errorf("missing hot data in merged: %s", s)
+	}
+}
+
+func TestMergeValuesJSON(t *testing.T) {
+	hot := []byte(`{"values":[{"value":"svc-a","hits":10},{"value":"svc-b","hits":5}]}`)
+	cold := []byte(`{"values":[{"value":"svc-a","hits":20},{"value":"svc-c","hits":3}]}`)
+
+	result, err := MergeValuesJSON(hot, cold)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp struct {
+		Values []struct {
+			Value string `json:"value"`
+			Hits  int64  `json:"hits"`
+		} `json:"values"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	valMap := make(map[string]int64)
+	for _, v := range resp.Values {
+		valMap[v.Value] = v.Hits
+	}
+
+	if valMap["svc-a"] != 30 {
+		t.Errorf("svc-a hits = %d, want 30", valMap["svc-a"])
+	}
+	if valMap["svc-b"] != 5 {
+		t.Errorf("svc-b hits = %d, want 5", valMap["svc-b"])
+	}
+	if valMap["svc-c"] != 3 {
+		t.Errorf("svc-c hits = %d, want 3", valMap["svc-c"])
+	}
+}
+
+func TestParseFlexTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"1714521600", 1714521600_000_000_000},
+		{"1714521600000", 1714521600_000_000_000},
+		{"1714521600000000", 1714521600_000_000_000},
+		{"1714521600000000000", 1714521600_000_000_000},
+	}
+	for _, tt := range tests {
+		got, err := parseFlexTimestamp(tt.input)
+		if err != nil {
+			t.Errorf("parseFlexTimestamp(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseFlexTimestamp(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseFlexTimestamp_RFC3339(t *testing.T) {
+	got, err := parseFlexTimestamp("2026-05-01T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC).UnixNano()
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+func TestRouteDecision_String(t *testing.T) {
+	if RouteHotOnly.String() != "hot" {
+		t.Error("RouteHotOnly.String()")
+	}
+	if RouteColdOnly.String() != "cold" {
+		t.Error("RouteColdOnly.String()")
+	}
+	if RouteBoth.String() != "both" {
+		t.Error("RouteBoth.String()")
+	}
+}
+
+func TestColdRouter_HasManifest(t *testing.T) {
+	var cr *ColdRouter
+	if cr.HasManifest() {
+		t.Error("nil router should not have manifest")
+	}
+
+	cr = &ColdRouter{}
+	if cr.HasManifest() {
+		t.Error("empty router should not have manifest")
+	}
+
+	cr.manifest = &ManifestRange{TotalFiles: 1}
+	if !cr.HasManifest() {
+		t.Error("router with manifest should have manifest")
+	}
+}
+
+func TestProxyColdRouterIntegration(t *testing.T) {
+	manifest := ManifestRange{
+		MinTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(),
+		MaxTime:    time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC).UnixNano(),
+		TotalFiles: 100,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/manifest/range" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(manifest)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	p, err := New(Config{
+		BackendURL: srv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      srv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ColdRouter() == nil {
+		t.Fatal("expected cold router to be initialized")
+	}
+}
+
+func TestProxyColdRouterDisabled(t *testing.T) {
+	p, err := New(Config{
+		BackendURL: "http://localhost:9428",
+		ColdBackend: ColdBackendConfig{
+			Enabled: false,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ColdRouter() != nil {
+		t.Error("expected nil cold router when disabled")
+	}
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func testSlogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -243,6 +243,9 @@ type Config struct {
 	PeerCache     *cache.PeerCache // optional peer cache for distributed fleet
 	PeerAuthToken string
 
+	// Cold storage backend (Victoria Lakehouse)
+	ColdBackend ColdBackendConfig
+
 	// Admin/debug endpoints
 	RegisterInstrumentation *bool
 	EnablePprof             bool
@@ -364,6 +367,7 @@ type Proxy struct {
 	declaredLabelFields                   []string         // configured VL-native label fields (stream_fields + extras)
 	peerCache                             *cache.PeerCache // L3 fleet peer cache
 	peerAuthToken                         string
+	coldRouter                            *ColdRouter
 	registerInstrumentation               bool
 	enablePprof                           bool
 	enableQueryAnalytics                  bool
@@ -873,7 +877,12 @@ func New(cfg Config) (*Proxy, error) {
 		proxyMetrics.SetCacheStatsProvider(cfg.Cache.Stats)
 	}
 
-	return &Proxy{
+	coldRouter, err := NewColdRouter(cfg.ColdBackend, logger)
+	if err != nil {
+		return nil, fmt.Errorf("cold backend: %w", err)
+	}
+
+	p := &Proxy{
 		backend:       u,
 		rulerBackend:  rulerURL,
 		alertsBackend: alertsURL,
@@ -976,7 +985,9 @@ func New(cfg Config) (*Proxy, error) {
 		labelValuesIndexPersistDone:           make(chan struct{}),
 		labelValuesIndex:                      make(map[string]*labelValuesIndexState),
 		readCacheKeyMemo:                      make(map[canonicalReadCacheMemoKey]string, 2048),
-	}, nil
+		coldRouter:                            coldRouter,
+	}
+	return p, nil
 }
 
 // computeBackendLoopback returns true when u's host is a loopback address or
@@ -1108,7 +1119,17 @@ func (p *Proxy) Init() {
 	}
 	p.warmPatternsOnStartup()
 	p.startPatternsPersistenceLoop()
+	if p.coldRouter != nil {
+		p.coldRouter.Start(context.Background())
+		p.log.Info("cold storage routing enabled",
+			"backend", p.coldRouter.coldBackend.String(),
+			"boundary", p.coldRouter.boundary,
+		)
+	}
 }
+
+// ColdRouter returns the cold storage router for testing.
+func (p *Proxy) ColdRouter() *ColdRouter { return p.coldRouter }
 
 // Shutdown flushes in-memory caches that should survive rolling restarts.
 func (p *Proxy) Shutdown(ctx context.Context) error {
@@ -1470,7 +1491,11 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		p.proxyStatsQueryRange(sc, r, logsqlQuery)
 	} else {
 		if !p.proxyLogQueryWindowed(sc, r, logsqlQuery) {
-			p.proxyLogQuery(sc, r, logsqlQuery)
+			if p.coldRouter != nil {
+				p.proxyLogQueryWithCold(sc, r, logsqlQuery)
+			} else {
+				p.proxyLogQuery(sc, r, logsqlQuery)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add time-range based query routing between hot VL backend and cold Victoria Lakehouse (S3-backed) backend
- Configurable boundary splits queries: recent data → hot only, old data → cold only, spanning queries → parallel fan-out with NDJSON merge
- Cold router polls lakehouse `/manifest/range` for manifest-aware routing (avoids unnecessary cold calls)
- Graceful degradation: cold backend errors fall back to hot-only path

## New files

- `internal/proxy/cold_routing.go` — ColdRouter, manifest refresh, Route(), ColdGet/ColdPost, MergeNDJSON, MergeValuesJSON
- `internal/proxy/cold_routing_test.go` — 30 tests covering routing decisions, manifest refresh, merge, timestamp parsing
- `internal/proxy/cold_dispatch.go` — dispatch integration: proxyLogQueryWithCold, fan-out, merge, processLogQueryResponse
- `internal/proxy/cold_dispatch_test.go` — 18 tests covering dispatch routing, fan-out with merge, fallback on errors

## Modified files

- `internal/proxy/proxy.go` — ColdBackend config field, coldRouter in Proxy struct, Init() start, dispatch wiring
- `cmd/proxy/main.go` — CLI flags and config wiring

## CLI flags

| Flag | Default | Description |
|------|---------|-------------|
| `-cold-enabled` | `false` | Enable cold storage routing |
| `-cold-backend` | `""` | Victoria Lakehouse URL |
| `-cold-boundary` | `7d` | Data older than this routes to cold |
| `-cold-overlap` | `1h` | Overlap window querying both tiers |
| `-cold-manifest-refresh` | `5m` | Manifest polling interval |
| `-cold-timeout` | `30s` | Cold backend request timeout |

## Test plan

- [x] All 55 cold routing + dispatch tests pass
- [x] Full proxy suite: 1523 tests pass, zero regressions
- [x] Build succeeds for `./cmd/proxy/`
- [ ] E2E: Grafana → proxy with `-cold-enabled -cold-backend=http://lakehouse:9428` → verify hot+cold merge
- [ ] Verify manifest polling with real Victoria Lakehouse instance