### PR TITLE
perf: migrate scanDetectedLabelSummariesStream to fastjson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- perf: migrate `scanDetectedLabelSummariesStream` in drilldown from `encoding/json` + `map[string]interface{}` to `valyala/fastjson`, eliminating per-entry heap allocation on the detected-labels NDJSON scan path
+
 ## [1.28.0] - 2026-05-03
 
 ### Added

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -1801,16 +1801,18 @@ func scanDetectedLabelSummariesStream(r io.Reader, lt *LabelTranslator) map[stri
 			continue
 		}
 
-		var entry map[string]interface{}
-		if err := stdjson.Unmarshal(line, &entry); err != nil {
+		fjParser := vlFJParserPool.Get()
+		fjVal, err := fjParser.ParseBytes(line)
+		if err != nil {
+			vlFJParserPool.Put(fjParser)
 			continue
 		}
 
-		fillDetectedLabels(entry, labelBuf)
-		labels := labelBuf
-		delete(labels, "detected_level")
+		fillDetectedLabelsFJ(fjVal, labelBuf)
+		vlFJParserPool.Put(fjParser)
+		delete(labelBuf, "detected_level")
 
-		for key, value := range labels {
+		for key, value := range labelBuf {
 			lokiLabel := lt.ToLoki(key)
 			if lokiLabel == "" {
 				continue


### PR DESCRIPTION
## Summary

- Replaces `stdjson.Unmarshal` + `map[string]interface{}` per-entry in `scanDetectedLabelSummariesStream` with pooled `valyala/fastjson`, matching the pattern already used in `detectFieldsFromBody`
- Eliminates per-entry heap allocation on the detected-labels NDJSON scan path
- Measured at ~2.8% cumulative CPU in production pprof profiles

## Test plan

- [ ] `go test ./internal/proxy/... -run TestDetect` passes
- [ ] `go build ./...` succeeds
- [ ] CI green