### PR TITLE
refactor: remove unused fillDetectedLabels after fastjson migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- refactor: remove unused `fillDetectedLabels` function — dead code after `scanDetectedLabelSummariesStream` migrated to `fillDetectedLabelsFJ` in the fastjson migration (#311)
+
 ## [1.28.1] - 2026-05-03
 
 ### Performance

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -321,37 +321,12 @@ func buildEntryLabelsWithStream(entry map[string]interface{}, stream map[string]
 	return labels
 }
 
-// detectedLabelsBufPool pools map[string]string for fillDetectedLabels callers
+// detectedLabelsBufPool pools map[string]string for detected-label scan callers
 // that iterate the result immediately and discard it within the same loop tick.
 var detectedLabelsBufPool = sync.Pool{
 	New: func() interface{} {
 		return make(map[string]string, 16)
 	},
-}
-
-// fillDetectedLabels fills buf with stream labels for entry. Buf is cleared
-// before filling; callers must not retain the map past the next fillDetectedLabels call on the same buf.
-func fillDetectedLabels(entry map[string]interface{}, buf map[string]string) {
-	for k := range buf {
-		delete(buf, k)
-	}
-	stream := parseStreamLabels(asString(entry["_stream"]))
-	for k, v := range stream {
-		buf[k] = v
-	}
-	for _, key := range serviceNameSourceFields {
-		if _, ok := buf[key]; ok {
-			continue
-		}
-		if value, ok := stringifyEntryValue(entry[key]); ok && strings.TrimSpace(value) != "" {
-			buf[key] = value
-		}
-	}
-	if value, ok := stringifyEntryValue(entry["level"]); ok && strings.TrimSpace(value) != "" {
-		buf["level"] = value
-	}
-	ensureDetectedLevel(buf)
-	ensureSyntheticServiceName(buf)
 }
 
 func shouldExposeStructuredField(key string, streamLabels map[string]string, lt *LabelTranslator) bool {


### PR DESCRIPTION
## Summary

- Removes `fillDetectedLabels` which became unused after the fastjson migration in PR #311 migrated its only caller (`scanDetectedLabelSummariesStream`) to `fillDetectedLabelsFJ`
- Updates pool comment to remove the stale reference
- Unblocks PR #310 lint CI failure: `func fillDetectedLabels is unused`

## Test plan
- [ ] `go build ./internal/proxy/` passes
- [ ] Lint passes (no unused function)