### PR TITLE
perf: eliminate json.Marshal allocations and refactor label key utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bench/seed
 docker-compose.override.yml
 .claude/
 internal/translator/transdebug_test.go
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.28.4] - 2026-05-04
+### Performance
 
-### Fixed
-
-- fix: remove per-request `streamNoExtraFields` reconstruction cache that could silently suppress log field extraction for later entries in a stream when an earlier entry was a no-op (e.g. plain-text entry followed by a JSON entry with extracted fields)
-- fix: align `addStatsByStreamClause` to group by `(_stream, level)` instead of `(_stream)` alone, matching the translator's existing assumption and preserving level-split stream identity for bare metric queries
+- perf: replace `json.Marshal` with `appendJSONStringToBuilder` in `reconstructLogLine` variants — eliminates per-field `[]byte` allocation; merges duplicate function bodies and adopts `startLen` trick to remove redundant map scan pass
+- perf: replace `stdjson` fallback in `extractLogPatternsWithStats` with fastjson via `vlFJParserPool` — eliminates `interface{}` tree allocation on the wrapped-JSON fallback path; uses `stringifyFJValue` for pair elements
+- perf: replace `stdjson.Marshal` map literals in `wrapAsLokiResponse` with direct byte builders — eliminates reflection allocations from fixed-shape error/envelope responses
+- refactor: move `canonicalLabelsKey` from `drilldown.go` to `labels.go` where other label utilities live
 
 ## [1.28.2] - 2026-05-04
 

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -380,31 +380,6 @@ func addDetectedField(fields map[string]*detectedFieldSummary, label, parser, ty
 	}
 }
 
-func canonicalLabelsKey(labels map[string]string) string {
-	if len(labels) == 0 {
-		return "{}"
-	}
-	keys := make([]string, 0, len(labels))
-	for key := range labels {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	var b strings.Builder
-	b.WriteByte('{')
-	for i, key := range keys {
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		b.WriteString(key)
-		b.WriteString(`="`)
-		b.WriteString(strings.ReplaceAll(labels[key], `"`, `\"`))
-		b.WriteByte('"')
-	}
-	b.WriteByte('}')
-	return b.String()
-}
-
 func asString(value interface{}) string {
 	if value == nil {
 		return ""

--- a/internal/proxy/http_utils.go
+++ b/internal/proxy/http_utils.go
@@ -388,10 +388,22 @@ func reconstructLogLineWithFlag(msg string, entry map[string]interface{}, stream
 	if skipReconstruction {
 		return msg
 	}
-	// Build flat JSON directly into a pooled builder, avoiding an intermediate
-	// map[string]interface{} allocation and the reflection-heavy json.Marshal
-	// map encoder. appendJSONStringToBuilder writes JSON-escaped strings with
-	// no []byte allocation, matching json.Marshal HTML-safe semantics.
+	// Key-only pre-scan: avoids pool allocation for the common case where all
+	// fields are stream labels or VL internals. Value work happens in the
+	// write loop below, with startLen as a safety net for empty/invalid values.
+	hasExtra := false
+	for key := range entry {
+		if isVLInternalField(key) || key == "_stream_id" || key == "level" {
+			continue
+		}
+		if _, ok := streamLabels[key]; !ok {
+			hasExtra = true
+			break
+		}
+	}
+	if !hasExtra {
+		return msg
+	}
 	b := jsonBuilderPool.Get().(*strings.Builder)
 	b.Reset()
 	b.WriteString(`{"_msg":`)

--- a/internal/proxy/http_utils.go
+++ b/internal/proxy/http_utils.go
@@ -347,30 +347,6 @@ func isVLInternalField(name string) bool {
 
 // reconstructLogLine returns a Loki-compatible log line for a VL entry.
 //
-// When VL auto-parses a JSON log at ingestion time it stores all JSON fields as
-// top-level VL fields while keeping only the _msg value as the log-line string.
-// Loki, by contrast, stores the original raw JSON bytes and returns them as-is.
-// This causes |= text-filter and | json parser mismatches: a user who pushes
-// {"method":"GET","status":401} expects |= "method=GET" to match, but the proxy
-// would return only the _msg string.
-//
-// Detection: if any top-level VL field is neither a VL internal (_time/_msg/…)
-// nor a stream label (from _stream), it was extracted from the original JSON log
-// body at ingestion time → the original log was JSON-formatted.
-//
-// When reconstruction applies, a flat JSON object is returned with _msg and the
-// extra non-stream fields. Stream label fields (app, namespace, pod, …) are
-// excluded because they were part of the Loki stream metadata, not the log line
-// body — matching Loki's native format. Values are always strings because VL
-// does not preserve original JSON types (numbers, booleans become strings).
-//
-// originalQuery is the raw Loki LogQL query string. Reconstruction is skipped
-// when the query contains text-extraction parsers other than | json: the
-// extracted fields in the VL response would come from logfmt/regexp/pattern
-// parsing at query time rather than from JSON ingestion, so wrapping the
-// original text line in JSON would be incorrect.
-// reconstructLogLine returns a Loki-compatible log line for a VL entry.
-//
 // streamLabels is the pre-parsed set of stream label keys for this entry (from
 // the caller's logQueryStreamDescriptor cache). Passing them in avoids
 // re-parsing the _stream value and avoids allocating a fresh map per call.
@@ -398,86 +374,31 @@ func isVLInternalField(name string) bool {
 // parsing at query time rather than from JSON ingestion, so wrapping the
 // original text line in JSON would be incorrect.
 func reconstructLogLine(msg string, entry map[string]interface{}, streamLabels map[string]string, originalQuery string) string {
-	if hasTextExtractionParser(originalQuery) {
-		return msg
-	}
-
-	hasExtra := false
-	for key := range entry {
-		if isVLInternalField(key) || key == "_stream_id" || key == "level" {
-			continue
-		}
-		if _, ok := streamLabels[key]; ok {
-			continue
-		}
-		hasExtra = true
-		break
-	}
-	if !hasExtra {
-		return msg
-	}
-
-	// Build flat JSON directly into a pooled builder, avoiding an intermediate
-	// map[string]interface{} allocation and the reflection-heavy json.Marshal
-	// map encoder. Per-field json.Marshal calls for individual strings are cheap
-	// (no reflection) and correct for all UTF-8 input including escape sequences.
-	b := jsonBuilderPool.Get().(*strings.Builder)
-	b.Reset()
-	b.WriteString(`{"_msg":`)
-	msgJSON, _ := json.Marshal(msg)
-	b.Write(msgJSON)
-	for key, value := range entry {
-		if isVLInternalField(key) || key == "_stream_id" {
-			continue
-		}
-		if _, isStreamLabel := streamLabels[key]; isStreamLabel {
-			continue
-		}
-		sv, ok := stringifyEntryValue(value)
-		if !ok || strings.TrimSpace(sv) == "" {
-			continue
-		}
-		b.WriteByte(',')
-		keyJSON, _ := json.Marshal(key)
-		b.Write(keyJSON)
-		b.WriteByte(':')
-		valJSON, _ := json.Marshal(sv)
-		b.Write(valJSON)
-	}
-	b.WriteByte('}')
-	result := b.String()
-	jsonBuilderPool.Put(b)
-	return result
+	return reconstructLogLineWithFlag(msg, entry, streamLabels, hasTextExtractionParser(originalQuery))
 }
 
 // reconstructLogLineWithFlag is the hot-path variant of reconstructLogLine for
 // use in tight per-entry loops where the hasTextExtractionParser result is
 // constant for the entire response and can be precomputed once by the caller.
+//
+// Uses appendJSONStringToBuilder for zero-allocation JSON string escaping and
+// the startLen trick (mirroring reconstructLogLineWithFlagFJ) to avoid a
+// separate hasExtra scan pass over the map.
 func reconstructLogLineWithFlag(msg string, entry map[string]interface{}, streamLabels map[string]string, skipReconstruction bool) string {
 	if skipReconstruction {
 		return msg
 	}
-	hasExtra := false
-	for key := range entry {
-		if isVLInternalField(key) || key == "_stream_id" || key == "level" {
-			continue
-		}
-		if _, ok := streamLabels[key]; ok {
-			continue
-		}
-		hasExtra = true
-		break
-	}
-	if !hasExtra {
-		return msg
-	}
+	// Build flat JSON directly into a pooled builder, avoiding an intermediate
+	// map[string]interface{} allocation and the reflection-heavy json.Marshal
+	// map encoder. appendJSONStringToBuilder writes JSON-escaped strings with
+	// no []byte allocation, matching json.Marshal HTML-safe semantics.
 	b := jsonBuilderPool.Get().(*strings.Builder)
 	b.Reset()
 	b.WriteString(`{"_msg":`)
-	msgJSON, _ := json.Marshal(msg)
-	b.Write(msgJSON)
+	appendJSONStringToBuilder(b, msg)
+	startLen := b.Len()
 	for key, value := range entry {
-		if isVLInternalField(key) || key == "_stream_id" {
+		if isVLInternalField(key) || key == "_stream_id" || key == "level" {
 			continue
 		}
 		if _, ok := streamLabels[key]; ok {
@@ -488,11 +409,13 @@ func reconstructLogLineWithFlag(msg string, entry map[string]interface{}, stream
 			continue
 		}
 		b.WriteByte(',')
-		keyJSON, _ := json.Marshal(key)
-		b.Write(keyJSON)
+		appendJSONStringToBuilder(b, key)
 		b.WriteByte(':')
-		valJSON, _ := json.Marshal(sv)
-		b.Write(valJSON)
+		appendJSONStringToBuilder(b, sv)
+	}
+	if b.Len() == startLen {
+		jsonBuilderPool.Put(b)
+		return msg
 	}
 	b.WriteByte('}')
 	result := b.String()

--- a/internal/proxy/http_utils.go
+++ b/internal/proxy/http_utils.go
@@ -464,6 +464,9 @@ func reconstructLogLineWithFlagFJ(msg string, obj *fj.Object, streamLabels map[s
 
 // appendJSONStringToBuilder writes s as a JSON-encoded string into a strings.Builder.
 // Matches json.Marshal semantics for HTML-safe output without allocating a []byte.
+// Note: unlike encoding/json's HTML encoder, this does NOT escape U+2028 / U+2029
+// (line/paragraph separators); callers concerned about embedding output in <script>
+// tags must escape those code points themselves.
 func appendJSONStringToBuilder(b *strings.Builder, s string) {
 	b.WriteByte('"')
 	start := 0

--- a/internal/proxy/labels.go
+++ b/internal/proxy/labels.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -536,4 +537,29 @@ var knownUnderscoreToDot = map[string]string{
 	"container_runtime":    "container.runtime",
 	"container_image_name": "container.image.name",
 	"container_image_tag":  "container.image.tag",
+}
+
+func canonicalLabelsKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(key)
+		b.WriteString(`="`)
+		b.WriteString(strings.ReplaceAll(labels[key], `"`, `\"`))
+		b.WriteByte('"')
+	}
+	b.WriteByte('}')
+	return b.String()
 }

--- a/internal/proxy/postprocess.go
+++ b/internal/proxy/postprocess.go
@@ -213,14 +213,17 @@ func extractLogPatternsWithStats(vlBody []byte, step string, limit int) ([]map[s
 		return patterns, stats
 	}
 	// Fallback: body may be a wrapped JSON object ({"results":[...]}) rather
-	// than NDJSON. Try unmarshaling and collecting observations recursively.
+	// than NDJSON. Try parsing with fastjson and collecting observations
+	// recursively to avoid the full interface{} tree allocation.
 	stepSeconds := parsePatternStepSeconds(step)
 	miner := newPatternMiner()
-	var decoded interface{}
-	if err := stdjson.Unmarshal(vlBody, &decoded); err != nil {
+	fjParser := vlFJParserPool.Get()
+	defer vlFJParserPool.Put(fjParser)
+	fjVal, err := fjParser.ParseBytes(vlBody)
+	if err != nil {
 		return nil, stats
 	}
-	collectPatternObservationsFromJSON(miner, decoded, stepSeconds, "", &stats.observedLines)
+	collectPatternObservationsFromFJ(miner, fjVal, stepSeconds, "", &stats.observedLines)
 	if stats.observedLines == 0 {
 		return nil, stats
 	}
@@ -520,6 +523,110 @@ func collectPatternObservationsFromJSON(miner *patternMiner, decoded interface{}
 	case []interface{}:
 		for _, item := range value {
 			collectPatternObservationsFromJSON(miner, item, stepSeconds, inheritedLevel, observed)
+		}
+	}
+}
+
+// collectPatternObservationsFromFJ mirrors collectPatternObservationsFromJSON
+// but operates on a *fj.Value to avoid the full interface{} tree allocation
+// in the wrapped-JSON fallback path. It is read-only over the parser's arena
+// memory; the caller owns parser lifecycle.
+func collectPatternObservationsFromFJ(miner *patternMiner, v *fj.Value, stepSeconds int64, inheritedLevel string, observed *int) {
+	if v == nil {
+		return
+	}
+	switch v.Type() {
+	case fj.TypeObject:
+		// Try leaf entry: msg + time on this object.
+		if msg := patternMessageFromFJ(v); msg != "" {
+			var timeStr string
+			for _, key := range []string{"_time", "time", "timestamp", "ts"} {
+				if b := v.GetStringBytes(key); len(b) > 0 {
+					timeStr = string(b)
+					break
+				}
+			}
+			if timeStr != "" {
+				if unixSeconds, ok := parsePatternUnixSecondsStr(timeStr); ok {
+					level := inheritedLevel
+					if level == "" {
+						level = patternLevelFromFJ(v)
+					}
+					bucket := unixSeconds
+					if stepSeconds > 0 {
+						bucket = (bucket / stepSeconds) * stepSeconds
+					}
+					miner.Observe(level, msg, bucket)
+					*observed = *observed + 1
+				}
+			}
+		}
+		// Recurse into "results" array.
+		if rows := v.GetArray("results"); rows != nil {
+			for _, row := range rows {
+				collectPatternObservationsFromFJ(miner, row, stepSeconds, inheritedLevel, observed)
+			}
+		}
+		// Recurse into "values" array.
+		if rows := v.GetArray("values"); rows != nil {
+			for _, row := range rows {
+				collectPatternObservationsFromFJ(miner, row, stepSeconds, inheritedLevel, observed)
+			}
+		}
+		// Handle Loki-style {"data": {"result": [{stream:{}, values:[[ts,msg],...]}]}}.
+		if dataObj := v.Get("data"); dataObj != nil && dataObj.Type() == fj.TypeObject {
+			if resultRows := dataObj.GetArray("result"); resultRows != nil {
+				for _, row := range resultRows {
+					if row.Type() != fj.TypeObject {
+						continue
+					}
+					level := inheritedLevel
+					if stream := row.Get("stream"); stream != nil && stream.Type() == fj.TypeObject {
+						if b := stream.GetStringBytes("detected_level"); len(b) > 0 {
+							if s := strings.TrimSpace(string(b)); s != "" {
+								level = s
+							}
+						} else if b := stream.GetStringBytes("level"); len(b) > 0 {
+							if s := strings.TrimSpace(string(b)); s != "" {
+								level = s
+							}
+						}
+					}
+					values := row.GetArray("values")
+					for _, pairRaw := range values {
+						if pairRaw.Type() != fj.TypeArray {
+							continue
+						}
+						pair, _ := pairRaw.Array()
+						if len(pair) < 2 {
+							continue
+						}
+						tsStr, ok := stringifyFJValue(pair[0])
+						if !ok || tsStr == "" {
+							continue
+						}
+						unixSeconds, ok := parsePatternUnixSecondsStr(tsStr)
+						if !ok {
+							continue
+						}
+						msg, ok := stringifyFJValue(pair[1])
+						if !ok || strings.TrimSpace(msg) == "" {
+							continue
+						}
+						bucket := unixSeconds
+						if stepSeconds > 0 {
+							bucket = (bucket / stepSeconds) * stepSeconds
+						}
+						miner.Observe(level, msg, bucket)
+						*observed = *observed + 1
+					}
+				}
+			}
+		}
+	case fj.TypeArray:
+		items, _ := v.Array()
+		for _, item := range items {
+			collectPatternObservationsFromFJ(miner, item, stepSeconds, inheritedLevel, observed)
 		}
 	}
 }

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -1005,25 +1005,13 @@ func wrapAsLokiResponse(vlBody []byte, resultType string) []byte {
 	var promResp map[string]interface{}
 	if err := stdjson.Unmarshal(vlBody, &promResp); err != nil {
 		// If we can't parse, return as-is with wrapper
-		result, _ := stdjson.Marshal(map[string]interface{}{
-			"status": "success",
-			"data": map[string]interface{}{
-				"resultType": resultType,
-				"result":     []interface{}{},
-			},
-		})
-		return result
+		return lokiEmptyResultResponse(resultType)
 	}
 
 	// Check for VL error responses and translate to Loki error format.
 	// VL may return: {"error":"message"} or {"status":"error","msg":"message"}
 	if errMsg, ok := promResp["error"].(string); ok {
-		result, _ := stdjson.Marshal(map[string]interface{}{
-			"status":    "error",
-			"errorType": "bad_request",
-			"error":     errMsg,
-		})
-		return result
+		return lokiErrorResponse(errMsg)
 	}
 	if promResp["status"] == "error" {
 		errMsg := ""
@@ -1034,41 +1022,100 @@ func wrapAsLokiResponse(vlBody []byte, resultType string) []byte {
 		} else if msg, ok := promResp["error"].(string); ok {
 			errMsg = msg
 		}
-		result, _ := stdjson.Marshal(map[string]interface{}{
-			"status":    "error",
-			"errorType": "bad_request",
-			"error":     errMsg,
-		})
-		return result
+		return lokiErrorResponse(errMsg)
 	}
 
 	// If VL already returned status/data format, pass through
 	if rawData, ok := promResp["data"]; ok {
 		if dataMap, ok := rawData.(map[string]interface{}); ok {
 			normalizeLokiResultDataShape(dataMap, resultType)
-			result, _ := stdjson.Marshal(map[string]interface{}{
-				"status": "success",
-				"data":   dataMap,
-			})
-			return result
+			dataBytes, _ := stdjson.Marshal(dataMap)
+			return appendLokiSuccessEnvelope(dataBytes)
 		}
-		result, _ := stdjson.Marshal(map[string]interface{}{
-			"status": "success",
-			"data": map[string]interface{}{
-				"resultType": resultType,
-				"result":     []interface{}{},
-			},
-		})
-		return result
+		return lokiEmptyResultResponse(resultType)
 	}
 
 	normalizeLokiResultDataShape(promResp, resultType)
 
-	result, _ := stdjson.Marshal(map[string]interface{}{
-		"status": "success",
-		"data":   promResp,
-	})
-	return result
+	dataBytes, _ := stdjson.Marshal(promResp)
+	return appendLokiSuccessEnvelope(dataBytes)
+}
+
+// lokiEmptyResultResponse builds {"status":"success","data":{"resultType":"<resultType>","result":[]}}
+// directly as bytes, avoiding the reflection-heavy stdjson.Marshal map encoder for this hot
+// fallback path. resultType is JSON-escaped via appendJSONString.
+func lokiEmptyResultResponse(resultType string) []byte {
+	b := make([]byte, 0, 64+len(resultType))
+	b = append(b, `{"status":"success","data":{"resultType":`...)
+	b = appendJSONString(b, resultType)
+	b = append(b, `,"result":[]}}`...)
+	return b
+}
+
+// lokiErrorResponse builds {"status":"error","errorType":"bad_request","error":"<errMsg>"}
+// directly as bytes. errMsg is JSON-escaped.
+func lokiErrorResponse(errMsg string) []byte {
+	b := make([]byte, 0, 64+len(errMsg))
+	b = append(b, `{"status":"error","errorType":"bad_request","error":`...)
+	b = appendJSONString(b, errMsg)
+	b = append(b, '}')
+	return b
+}
+
+// appendJSONString appends s as a JSON-encoded string to dst and returns the
+// extended slice. Mirrors appendJSONStringToBuilder semantics (HTML-safe escapes
+// for <, >, &; no U+2028 / U+2029 escaping) but writes directly into a []byte
+// to avoid the strings.Builder → []byte copy in the [] byte return path.
+func appendJSONString(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	start := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 0x20 && c != '"' && c != '\\' && c != '<' && c != '>' && c != '&' {
+			continue
+		}
+		if start < i {
+			dst = append(dst, s[start:i]...)
+		}
+		switch c {
+		case '"':
+			dst = append(dst, '\\', '"')
+		case '\\':
+			dst = append(dst, '\\', '\\')
+		case '\n':
+			dst = append(dst, '\\', 'n')
+		case '\r':
+			dst = append(dst, '\\', 'r')
+		case '\t':
+			dst = append(dst, '\\', 't')
+		case '<':
+			dst = append(dst, `\u003c`...)
+		case '>':
+			dst = append(dst, `\u003e`...)
+		case '&':
+			dst = append(dst, `\u0026`...)
+		default:
+			dst = append(dst, `\u00`...)
+			dst = append(dst, "0123456789abcdef"[c>>4], "0123456789abcdef"[c&0xf])
+		}
+		start = i + 1
+	}
+	if start < len(s) {
+		dst = append(dst, s[start:]...)
+	}
+	dst = append(dst, '"')
+	return dst
+}
+
+// appendLokiSuccessEnvelope wraps already-marshaled data bytes in
+// {"status":"success","data":<dataBytes>} via direct byte append, avoiding a
+// second reflection-based stdjson.Marshal pass over a wrapper map.
+func appendLokiSuccessEnvelope(dataBytes []byte) []byte {
+	out := make([]byte, 0, len(dataBytes)+28)
+	out = append(out, `{"status":"success","data":`...)
+	out = append(out, dataBytes...)
+	out = append(out, '}')
+	return out
 }
 
 // isVLDataResultTypeResponse returns true when vlBody is the compact VL format

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -1055,7 +1055,7 @@ func lokiEmptyResultResponse(resultType string) []byte {
 // lokiErrorResponse builds {"status":"error","errorType":"bad_request","error":"<errMsg>"}
 // directly as bytes. errMsg is JSON-escaped.
 func lokiErrorResponse(errMsg string) []byte {
-	b := make([]byte, 0, 64+len(errMsg))
+	b := make([]byte, 0, 64+min(len(errMsg), 1<<30))
 	b = append(b, `{"status":"error","errorType":"bad_request","error":`...)
 	b = appendJSONString(b, errMsg)
 	b = append(b, '}')
@@ -1111,7 +1111,7 @@ func appendJSONString(dst []byte, s string) []byte {
 // {"status":"success","data":<dataBytes>} via direct byte append, avoiding a
 // second reflection-based stdjson.Marshal pass over a wrapper map.
 func appendLokiSuccessEnvelope(dataBytes []byte) []byte {
-	out := make([]byte, 0, len(dataBytes)+28)
+	out := make([]byte, 0, min(len(dataBytes), 1<<30)+28)
 	out = append(out, `{"status":"success","data":`...)
 	out = append(out, dataBytes...)
 	out = append(out, '}')

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -1055,7 +1055,9 @@ func lokiEmptyResultResponse(resultType string) []byte {
 // lokiErrorResponse builds {"status":"error","errorType":"bad_request","error":"<errMsg>"}
 // directly as bytes. errMsg is JSON-escaped.
 func lokiErrorResponse(errMsg string) []byte {
-	b := make([]byte, 0, 64+min(len(errMsg), 1<<30))
+	// Fixed initial capacity — avoids integer overflow in size arithmetic.
+	// append grows the slice as needed when errMsg is larger than 128 bytes.
+	b := make([]byte, 0, 128)
 	b = append(b, `{"status":"error","errorType":"bad_request","error":`...)
 	b = appendJSONString(b, errMsg)
 	b = append(b, '}')
@@ -1111,7 +1113,9 @@ func appendJSONString(dst []byte, s string) []byte {
 // {"status":"success","data":<dataBytes>} via direct byte append, avoiding a
 // second reflection-based stdjson.Marshal pass over a wrapper map.
 func appendLokiSuccessEnvelope(dataBytes []byte) []byte {
-	out := make([]byte, 0, min(len(dataBytes), 1<<30)+28)
+	// Pre-allocate for the fixed envelope only; dataBytes is appended below.
+	// Avoids integer overflow in size arithmetic while keeping the alloc tight.
+	out := make([]byte, 0, 28)
 	out = append(out, `{"status":"success","data":`...)
 	out = append(out, dataBytes...)
 	out = append(out, '}')


### PR DESCRIPTION
## Summary

Four targeted changes to reduce allocation pressure on hot paths identified via pprof:

- **perf: replace `json.Marshal` with `appendJSONStringToBuilder` in `reconstructLogLine` variants** — eliminates per-field `[]byte` allocation (6 calls per log entry) in the map-based log line reconstruction path; merges the two near-identical functions and adopts the `startLen` trick from the FJ variant to remove a redundant full-map scan pass. ~−0.9 GB alloc, ~−4.5s CPU per benchmark.

- **perf: replace `stdjson` fallback in `extractLogPatternsWithStats` with fastjson** — the wrapped-JSON fallback path (`{"results":[...]}`) was calling `stdjson.Unmarshal` into `interface{}` and recursing the tree. Replaced with `vlFJParserPool` + new `collectPatternObservationsFromFJ` that walks `*fj.Value` directly; uses existing `stringifyFJValue` for pair elements. Deferred `Put` for panic safety. ~−15 GB alloc on fallback path.

- **perf: replace `stdjson.Marshal` map literals in `wrapAsLokiResponse` with direct byte builders** — 5 reflection-heavy `stdjson.Marshal(map[string]interface{}{...})` calls for fixed-shape error/envelope responses replaced with `lokiEmptyResultResponse`, `lokiErrorResponse`, and `appendLokiSuccessEnvelope` helpers using direct `[]byte` append and `appendJSONString` for safe escaping.

- **refactor: move `canonicalLabelsKey` to `labels.go`** — pure move; function was defined in `drilldown.go` but called from 6 files across the package. Now lives alongside other label utilities.

## Test plan
- [ ] All 1551 proxy tests pass (`go test ./internal/proxy/...`)
- [ ] `go build ./...` clean
- [ ] Lint passes