### PR TITLE
fix: remove streamNoExtraFields cache and align metric grouping with translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: remove per-request `streamNoExtraFields` reconstruction cache that could silently suppress log field extraction for later entries in a stream when an earlier entry was a no-op (e.g. plain-text entry followed by a JSON entry with extracted fields)
+- fix: align `addStatsByStreamClause` to group by `(_stream, level)` instead of `(_stream)` alone, matching the translator's existing assumption and preserving level-split stream identity for bare metric queries
+
 ## [1.28.2] - 2026-05-04
 
 ### Changed

--- a/internal/proxy/metric_agg.go
+++ b/internal/proxy/metric_agg.go
@@ -201,7 +201,7 @@ func addStatsByStreamClause(logsqlQuery string) string {
 		return logsqlQuery
 	}
 	statsStart := idx + len("| stats ")
-	return logsqlQuery[:statsStart] + "by (_stream) " + logsqlQuery[statsStart:]
+	return logsqlQuery[:statsStart] + "by (_stream, level) " + logsqlQuery[statsStart:]
 }
 
 func (p *Proxy) handleInstantMetricPostAggregation(w http.ResponseWriter, r *http.Request, start time.Time, originalQuery string, postAgg instantMetricPostAgg) {

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -85,14 +85,14 @@ func TestProxyHelpers_CanonicalReadCacheKey_NormalizesDetectedLimitsAndDefaults(
 
 func TestProxyHelpers_AddStatsByStreamClause_PreservesStreamIdentity(t *testing.T) {
 	got := addStatsByStreamClause(`app:=api-gateway | stats count()`)
-	if got != `app:=api-gateway | stats by (_stream) count()` {
+	if got != `app:=api-gateway | stats by (_stream, level) count()` {
 		t.Fatalf("unexpected stats identity clause: %q", got)
 	}
 }
 
 func TestProxyHelpers_PreserveMetricStreamIdentity_UsesStreamForBareMetrics(t *testing.T) {
 	got := preserveMetricStreamIdentity(`rate({app="api-gateway"} |= "GET"[5m])`, `app:=api-gateway ~"GET" | stats rate()`, nil)
-	if got != `app:=api-gateway ~"GET" | stats by (_stream) rate()` {
+	if got != `app:=api-gateway ~"GET" | stats by (_stream, level) rate()` {
 		t.Fatalf("unexpected preserved metric query: %q", got)
 	}
 }

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -780,7 +780,6 @@ func (p *Proxy) vlLogsToLokiWindowEntriesStream(r io.Reader, originalQuery strin
 	skipLogLineReconstruction := hasTextExtractionParser(originalQuery)
 	classifyAsParsed := hasParserStage(originalQuery, "json") || hasParserStage(originalQuery, "logfmt")
 	needsClassification := categorizedLabels && emitStructuredMetadata
-	streamNoExtraFields := make(map[string]bool, 8)
 
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), windowEntryScannerLineBytes)
@@ -820,7 +819,7 @@ func (p *Proxy) vlLogsToLokiWindowEntriesStream(r io.Reader, originalQuery strin
 
 		desc := p.logQueryStreamDescriptor(rawStream, level, streamLabelCache, streamDescriptorCache)
 
-		needsObject := needsClassification || (!skipLogLineReconstruction && !streamNoExtraFields[desc.key])
+		needsObject := needsClassification || !skipLogLineReconstruction
 		var fjObj *fj.Object
 		if needsObject {
 			obj, fjErr := fjVal.Object()
@@ -831,12 +830,8 @@ func (p *Proxy) vlLogsToLokiWindowEntriesStream(r io.Reader, originalQuery strin
 			fjObj = obj
 		}
 
-		if !skipLogLineReconstruction && !streamNoExtraFields[desc.key] {
-			origMsg := msg
+		if !skipLogLineReconstruction {
 			msg = reconstructLogLineWithFlagFJ(msg, fjObj, desc.rawLabels, false)
-			if msg == origMsg {
-				streamNoExtraFields[desc.key] = true
-			}
 		}
 
 		var sm, parsed map[string]string

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -445,11 +445,6 @@ func (p *Proxy) vlReaderToLokiStreams(r io.Reader, originalQuery, step string, c
 	classifyAsParsed := hasParserStage(originalQuery, "json") || hasParserStage(originalQuery, "logfmt")
 	skipLogLineReconstruction := hasTextExtractionParser(originalQuery)
 	needsClassification := emitStructuredMetadata || categorizedLabels
-	// Per-request adaptive skip: tracks which streams have produced only entries
-	// with no extra non-label fields. When true, Object()+reconstruction can be
-	// skipped entirely for entries from that stream. Resets to unknown (absent)
-	// on first encounter; set to true after the first no-op reconstruction.
-	streamNoExtraFields := make(map[string]bool, 8)
 
 	var (
 		miner        *patternMiner
@@ -512,9 +507,8 @@ func (p *Proxy) vlReaderToLokiStreams(r io.Reader, originalQuery, step string, c
 		// already-parsed stream labels instead of re-parsing _stream itself.
 		desc := p.logQueryStreamDescriptor(rawStream, level, streamLabelCache, streamDescriptorCache)
 
-		// Object() is only needed for reconstruction (when !skipLogLineReconstruction
-		// and we haven't proven this stream has no extra fields) or for classification.
-		needsObject := needsClassification || (!skipLogLineReconstruction && !streamNoExtraFields[desc.key])
+		// Object() is needed for reconstruction or classification.
+		needsObject := needsClassification || !skipLogLineReconstruction
 		var fjObj *fj.Object
 		if needsObject {
 			obj, fjErr := fjVal.Object()
@@ -525,14 +519,8 @@ func (p *Proxy) vlReaderToLokiStreams(r io.Reader, originalQuery, step string, c
 			fjObj = obj
 		}
 
-		if !skipLogLineReconstruction && !streamNoExtraFields[desc.key] {
-			origMsg := msg
+		if !skipLogLineReconstruction {
 			msg = reconstructLogLineWithFlagFJ(msg, fjObj, desc.rawLabels, false)
-			if msg == origMsg {
-				// Reconstruction was a no-op — this stream has no extra fields.
-				// Skip Object()+reconstruction for all subsequent entries of this stream.
-				streamNoExtraFields[desc.key] = true
-			}
 		}
 
 		// classifyEntryMetadataFieldsFJ returns smBuf/pfBuf directly (no copy).


### PR DESCRIPTION
## Summary

- **Reconstruction cache bug**: `streamNoExtraFields` was set after a single no-op reconstruction and then permanently skipped Object()+reconstruction for all later entries of the same stream. If a stream mixed plain-text entries with JSON entries that had extracted fields, the extracted fields in the JSON entries would be silently lost. Fixed by removing the cache — reconstruction always runs; the cost is bounded by the fastjson path's key-only pre-scan fast-return for no-extra-field entries.

- **Metric grouping inconsistency**: `addStatsByStreamClause` grouped by `(_stream)` only, while `translator.defaultRateInnerGrouping()` documents `(_stream, level)` as the correct grouping to keep level-split streams distinct when level is not encoded into VL's `_stream` field. Fixed by aligning both to `(_stream, level)`.

## Deferred

- **Issue 1** (RouteBoth time-range partitioning + dedup): requires architectural redesign — separate PR
- **Issue 2** (MergeNDJSON backward ordering): depends on Issue 1 fix — separate PR  
- **Issue 4** (non-parser rate() sliding window): requires rewriting several integration tests and performance analysis before changing — separate PR

## Test plan

- [ ] All 1551 unit tests pass
- [ ] `TestContract_*` matrix format tests unaffected
- [ ] Stream identity preserved in metric queries (level-split streams remain distinct)