### PR TITLE
fix(cold): remove sort clause from Lakehouse queries, propagate failures, time-split RouteBoth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(cold): remove LogsQL `| sort by (_time)` clause from Victoria Lakehouse cold queries — the Lakehouse filter parser treats bare tokens as `_msg` substring filters, so the clause was silently corrupting results instead of sorting them
+- fix(cold): propagate cold backend errors instead of falling back to hot — `RouteColdOnly` queries cover ranges where hot has no data; a silent hot fallback returned empty 200 responses masking cold failures; `RouteBoth` cold failures now propagate rather than silently truncating the time range
+
+### Changed
+
+- refactor(cold): `RouteBoth` now time-splits requests at the hot/cold boundary — cold receives `[start, boundary]` and hot receives `[boundary, end]`, eliminating boundary overlap and duplicate rows; merge order is direction-aware (hot-first for backward queries, cold-first for forward queries)
+
 ## [1.28.5] - 2026-05-04
 
 ### Performance

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -31,6 +32,8 @@ func (p *Proxy) proxyLogQueryWithCold(w http.ResponseWriter, r *http.Request, lo
 	}
 }
 
+// buildLogQueryParams builds request parameters for VictoriaLogs hot storage.
+// It appends a LogsQL sort clause to honour the Loki direction parameter.
 func (p *Proxy) buildLogQueryParams(r *http.Request, logsqlQuery string) url.Values {
 	direction := r.FormValue("direction")
 	if direction == "forward" {
@@ -55,19 +58,58 @@ func (p *Proxy) buildLogQueryParams(r *http.Request, logsqlQuery string) url.Val
 	return params
 }
 
-func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+// buildHotQueryParamsForRange builds VictoriaLogs params with explicit nanosecond timestamps.
+// Used by proxyLogQueryBoth to send a time-bounded hot sub-range.
+func (p *Proxy) buildHotQueryParamsForRange(r *http.Request, logsqlQuery string, startNs, endNs int64) url.Values {
 	params := p.buildLogQueryParams(r, logsqlQuery)
+	params.Set("start", strconv.FormatInt(startNs, 10))
+	params.Set("end", strconv.FormatInt(endNs, 10))
+	return params
+}
+
+// buildColdQueryParams builds request parameters for Victoria Lakehouse cold storage.
+// It does NOT append a LogsQL sort clause: the Lakehouse filter parser only understands
+// simple filter terms, boolean ops, parentheses, and *.  Appending "| sort by (_time desc)"
+// would be tokenised as bare _msg substring filters, returning wrong rows.
+func (p *Proxy) buildColdQueryParams(r *http.Request, logsqlQuery string) url.Values {
+	params := url.Values{}
+	params.Set("query", logsqlQuery)
+	if s := r.FormValue("start"); s != "" {
+		params.Set("start", formatVLTimestamp(s))
+	}
+	if e := r.FormValue("end"); e != "" {
+		params.Set("end", formatVLTimestamp(e))
+	}
+	limit := r.FormValue("limit")
+	if limit == "" {
+		limit = "1000"
+	}
+	params.Set("limit", sanitizeLimit(limit))
+	return params
+}
+
+// buildColdQueryParamsForRange builds cold-storage params with explicit nanosecond timestamps.
+func (p *Proxy) buildColdQueryParamsForRange(r *http.Request, logsqlQuery string, startNs, endNs int64) url.Values {
+	params := p.buildColdQueryParams(r, logsqlQuery)
+	params.Set("start", strconv.FormatInt(startNs, 10))
+	params.Set("end", strconv.FormatInt(endNs, 10))
+	return params
+}
+
+func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
+	params := p.buildColdQueryParams(r, logsqlQuery)
 	resp, err := p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", params)
 	if err != nil {
-		p.log.Warn("cold backend error, falling back to hot", "error", err)
-		p.proxyLogQuery(w, r, logsqlQuery)
+		// RouteColdOnly means the hot backend has no data for this range — a cold
+		// failure must be surfaced rather than silently returning an empty hot response.
+		p.writeError(w, http.StatusBadGateway, "cold backend error: "+err.Error())
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		p.log.Warn("cold backend returned error, falling back to hot", "status", resp.StatusCode)
-		p.proxyLogQuery(w, r, logsqlQuery)
+		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
+		p.writeError(w, resp.StatusCode, string(body))
 		return
 	}
 
@@ -75,7 +117,24 @@ func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsql
 }
 
 func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
-	params := p.buildLogQueryParams(r, logsqlQuery)
+	startNs, endNs := ParseTimeRangeFromRequest(r)
+	boundaryNs := p.coldRouter.ColdBoundaryNs()
+
+	// Time-split so each backend only covers its own range:
+	//   cold → [start, boundary]   (Lakehouse parquet data)
+	//   hot  → [boundary, end]     (VictoriaLogs live data)
+	// This prevents boundary overlap from returning duplicate rows.
+	coldEndNs := boundaryNs
+	if endNs < coldEndNs {
+		coldEndNs = endNs
+	}
+	hotStartNs := startNs
+	if boundaryNs > hotStartNs {
+		hotStartNs = boundaryNs
+	}
+
+	coldParams := p.buildColdQueryParamsForRange(r, logsqlQuery, startNs, coldEndNs)
+	hotParams := p.buildHotQueryParamsForRange(r, logsqlQuery, hotStartNs, endNs)
 
 	var (
 		hotResp, coldResp *http.Response
@@ -86,11 +145,11 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		hotResp, hotErr = p.vlPost(r.Context(), "/select/logsql/query", params)
+		hotResp, hotErr = p.vlPost(r.Context(), "/select/logsql/query", hotParams)
 	}()
 	go func() {
 		defer wg.Done()
-		coldResp, coldErr = p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", params)
+		coldResp, coldErr = p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", coldParams)
 	}()
 	wg.Wait()
 
@@ -99,26 +158,26 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 		return
 	}
 
-	// Cold failed — serve hot only
-	if coldErr != nil || (coldResp != nil && coldResp.StatusCode >= 400) {
-		if coldResp != nil {
-			coldResp.Body.Close()
+	// Cold failed — propagate error rather than serving a silent hot-only partial response.
+	// Hot covers [boundary, end] only; returning it alone truncates the requested range.
+	if coldErr != nil {
+		if hotResp != nil {
+			hotResp.Body.Close()
 		}
-		if hotErr != nil {
-			p.writeError(w, statusFromUpstreamErr(hotErr), hotErr.Error())
-			return
+		p.writeError(w, http.StatusBadGateway, "cold backend error: "+coldErr.Error())
+		return
+	}
+	if coldResp.StatusCode >= 400 {
+		body, _ := readBodyLimited(coldResp.Body, maxUpstreamErrorBodyBytes)
+		coldResp.Body.Close()
+		if hotResp != nil {
+			hotResp.Body.Close()
 		}
-		defer hotResp.Body.Close()
-		if hotResp.StatusCode >= 400 {
-			body, _ := readBodyLimited(hotResp.Body, maxUpstreamErrorBodyBytes)
-			p.writeError(w, hotResp.StatusCode, string(body))
-			return
-		}
-		p.processLogQueryResponse(w, r, hotResp)
+		p.writeError(w, coldResp.StatusCode, string(body))
 		return
 	}
 
-	// Hot failed — serve cold only
+	// Hot failed — serve cold only (cold fully covers its own time split).
 	if hotErr != nil || (hotResp != nil && hotResp.StatusCode >= 400) {
 		if hotResp != nil {
 			hotResp.Body.Close()
@@ -133,11 +192,19 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 		return
 	}
 
-	// Both succeeded — merge
+	// Both succeeded — merge with direction-aware ordering so the stream assembler
+	// receives entries in the order expected by vlReaderToLokiStreams:
+	//   backward (default): hot first (newest), then cold (oldest)
+	//   forward:            cold first (oldest), then hot (newest)
 	defer hotResp.Body.Close()
 	defer coldResp.Body.Close()
 
-	merged := MergeNDJSON(hotResp.Body, coldResp.Body)
+	var merged io.Reader
+	if r.FormValue("direction") == "forward" {
+		merged = MergeNDJSON(coldResp.Body, hotResp.Body)
+	} else {
+		merged = MergeNDJSON(hotResp.Body, coldResp.Body)
+	}
 	mergedBody, err := io.ReadAll(merged)
 	if err != nil {
 		p.writeError(w, http.StatusBadGateway, "failed to merge hot+cold results")

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -85,15 +85,33 @@ func TestBuildLogQueryParams_DefaultLimit(t *testing.T) {
 	}
 }
 
-func TestProxyLogQueryCold_FallbackOnError(t *testing.T) {
-	// Hot backend that returns valid NDJSON
+func TestBuildColdQueryParams_NoSortClause(t *testing.T) {
+	p := &Proxy{maxLines: 1000}
+
+	for _, dir := range []string{"forward", "backward", ""} {
+		r := httptest.NewRequest("GET", "/?direction="+dir+"&start=1714521600&end=1714608000&limit=200", nil)
+		params := p.buildColdQueryParams(r, "*")
+
+		if strings.Contains(params.Get("query"), "sort by") {
+			t.Errorf("direction=%q: cold params must not contain sort clause, got %q", dir, params.Get("query"))
+		}
+		if params.Get("query") != "*" {
+			t.Errorf("direction=%q: cold query modified to %q, want *", dir, params.Get("query"))
+		}
+		if params.Get("limit") != "200" {
+			t.Errorf("direction=%q: limit = %q, want 200", dir, params.Get("limit"))
+		}
+	}
+}
+
+func TestProxyLogQueryCold_PropagatesError(t *testing.T) {
 	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/stream+json")
 		fmt.Fprintln(w, `{"_msg":"hot-line","_time":"2026-05-01T00:00:00Z","_stream":"{}"}`)
 	}))
 	defer hotSrv.Close()
 
-	// Cold backend that returns an error
+	// Cold backend that returns an error.
 	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}))
@@ -116,9 +134,10 @@ func TestProxyLogQueryCold_FallbackOnError(t *testing.T) {
 
 	p.proxyLogQueryCold(w, r, "*")
 
-	// Should fall back to hot and succeed
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200 (fallback to hot)", w.Code)
+	// RouteColdOnly means hot has no data for this range — cold failure must surface
+	// as an error rather than a silent empty/hot response.
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (cold error propagated)", w.Code)
 	}
 }
 
@@ -155,13 +174,18 @@ func TestProxyLogQueryBoth_MergesResults(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Use timestamps that straddle the 7-day boundary so both hot and cold are queried.
+	now := time.Now()
+	startNs := fmt.Sprintf("%d", now.Add(-10*24*time.Hour).UnixNano()) // 10 days ago (cold range)
+	endNs := fmt.Sprintf("%d", now.Add(-1*time.Hour).UnixNano())       // 1 hour ago (hot range)
+
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+	r := httptest.NewRequest("GET", "/?query=*&start="+startNs+"&end="+endNs, nil)
 
 	p.proxyLogQueryBoth(w, r, "*")
 
 	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
+		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
 	}
 
 	body := w.Body.String()
@@ -182,7 +206,7 @@ func TestProxyLogQueryBoth_MergesResults(t *testing.T) {
 		t.Errorf("status = %q, want success", result.Status)
 	}
 
-	// Should contain both hot and cold lines
+	// Should contain both hot and cold lines.
 	allValues := ""
 	for _, stream := range result.Data.Result {
 		for _, v := range stream.Values {
@@ -199,7 +223,7 @@ func TestProxyLogQueryBoth_MergesResults(t *testing.T) {
 	}
 }
 
-func TestProxyLogQueryBoth_ColdFails_ServesHot(t *testing.T) {
+func TestProxyLogQueryBoth_ColdFails_PropagatesError(t *testing.T) {
 	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/stream+json")
 		fmt.Fprintln(w, `{"_msg":"hot-only","_time":"2026-05-01T00:00:00Z","_stream":"{}"}`)
@@ -223,16 +247,22 @@ func TestProxyLogQueryBoth_ColdFails_ServesHot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	now := time.Now()
+	startNs := fmt.Sprintf("%d", now.Add(-10*24*time.Hour).UnixNano())
+	endNs := fmt.Sprintf("%d", now.Add(-1*time.Hour).UnixNano())
+
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+	r := httptest.NewRequest("GET", "/?query=*&start="+startNs+"&end="+endNs, nil)
 
 	p.proxyLogQueryBoth(w, r, "*")
 
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", w.Code)
+	// Cold failed for a RouteBoth range — returning hot-only would silently truncate the
+	// result to [boundary, end] without the client knowing cold data is missing.
+	if w.Code == http.StatusOK {
+		t.Errorf("cold failure should not produce a 200 OK silent partial response")
 	}
-	if !strings.Contains(w.Body.String(), "hot-only") {
-		t.Error("should contain hot results when cold fails")
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 (cold error propagated)", w.Code)
 	}
 }
 
@@ -260,8 +290,12 @@ func TestProxyLogQueryBoth_HotFails_ServesCold(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	now := time.Now()
+	startNs := fmt.Sprintf("%d", now.Add(-10*24*time.Hour).UnixNano())
+	endNs := fmt.Sprintf("%d", now.Add(-1*time.Hour).UnixNano())
+
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+	r := httptest.NewRequest("GET", "/?query=*&start="+startNs+"&end="+endNs, nil)
 
 	p.proxyLogQueryBoth(w, r, "*")
 

--- a/internal/proxy/cold_routing.go
+++ b/internal/proxy/cold_routing.go
@@ -253,15 +253,19 @@ func (cr *ColdRouter) ManifestRange() *ManifestRange {
 	return &cp
 }
 
-func MergeNDJSON(hotBody, coldBody io.Reader) io.Reader {
+// MergeNDJSON streams firstBody then secondBody into a single NDJSON reader.
+// Callers choose the order based on query direction:
+//   - backward (newest-first): pass hot body first, then cold
+//   - forward  (oldest-first): pass cold body first, then hot
+func MergeNDJSON(firstBody, secondBody io.Reader) io.Reader {
 	pr, pw := io.Pipe()
 	go func() {
 		defer func() { _ = pw.Close() }()
-		if coldBody != nil {
-			_, _ = io.Copy(pw, coldBody)
+		if firstBody != nil {
+			_, _ = io.Copy(pw, firstBody)
 		}
-		if hotBody != nil {
-			_, _ = io.Copy(pw, hotBody)
+		if secondBody != nil {
+			_, _ = io.Copy(pw, secondBody)
 		}
 	}()
 	return pr


### PR DESCRIPTION
## Summary

- **Issue 1 — Sort clause malformation**: `buildColdQueryParams` no longer appends `| sort by (_time desc)`. Victoria Lakehouse's filter parser treats bare tokens as `_msg` substring filters; the sort directive was tokenised as extra filter terms and returned wrong rows.
- **Issue 2 — Cold failure hiding**: `proxyLogQueryCold` now propagates errors with `502 Bad Gateway` instead of silently falling back to an empty hot response. `RouteColdOnly` means the hot backend has no data for the range — a cold failure must be surfaced.
- **Issue 3 — RouteBoth not a real merge**: `proxyLogQueryBoth` now time-splits the range so each backend covers only its own data (`cold → [start, boundary]`, `hot → [boundary, end]`), preventing duplicate rows at the overlap. Merge is direction-aware: `backward` = hot first (newest), `forward` = cold first (oldest). Cold failures are propagated rather than returning a silent hot-only partial response.

## Test plan

- [ ] `go test ./internal/proxy/... -count=1` passes (1552 tests)
- [ ] `TestBuildColdQueryParams_NoSortClause` verifies no sort clause appended for all directions
- [ ] `TestProxyLogQueryCold_PropagatesError` verifies 500 returned (not 200 empty) on cold failure
- [ ] `TestProxyLogQueryBoth_ColdFails_PropagatesError` verifies 503 returned (not 200) when cold fails
- [ ] `TestProxyLogQueryBoth_MergesResults` verifies both hot and cold lines in merged response
- [ ] `TestProxyLogQueryBoth_HotFails_ServesCold` verifies cold-only response when hot fails