### PR TITLE
fix(metric): correct sliding-window rate and parser-stage count_over_time routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(metric): route sliding-window `rate()` and `bytes_rate()` (range≠step) to manual log-fetch aggregation instead of native VictoriaLogs `stats_query_range`, correcting semantics where VL tumbling buckets diverge from LogQL sliding windows
+- fix(metric): route `count_over_time` and `bytes_over_time` with parser stages (e.g. `| json`) and sliding windows (range≠step) to manual log-fetch aggregation, matching Loki's per-step log-filter semantics
+
 ## [1.28.6] - 2026-05-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fix(metric): route sliding-window `rate()` and `bytes_rate()` (range≠step) to manual log-fetch aggregation instead of native VictoriaLogs `stats_query_range`, correcting semantics where VL tumbling buckets diverge from LogQL sliding windows
-- fix(metric): route `count_over_time` and `bytes_over_time` with parser stages (e.g. `| json`) and sliding windows (range≠step) to manual log-fetch aggregation, matching Loki's per-step log-filter semantics
+- fix(metric): route sliding-window `rate()`, `bytes_rate()`, `count_over_time`, and `bytes_over_time` (range≠step) to manual log-fetch aggregation instead of native VictoriaLogs `stats_query_range`; VL uses tumbling per-step buckets that diverge from LogQL sliding-window semantics when data distribution is non-uniform
 
 ## [1.28.6] - 2026-05-04
 

--- a/internal/proxy/compat_coverage_helpers_test.go
+++ b/internal/proxy/compat_coverage_helpers_test.go
@@ -51,24 +51,49 @@ func TestCompatHelpers_ParseQuantileAndUnwrapErrorName(t *testing.T) {
 	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "avg", false, "") {
 		t.Fatal("expected parser-stage avg to use VL stats_query_range, not manual NDJSON fallback")
 	}
-	// count_over_time: Loki keeps parse-failed lines (adds __error__ label, never drops).
-	// VL's unpack_json also keeps parse-failed log entries. Both count the same lines,
-	// so native VL stats is correct — no manual path needed.
-	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", false, "") {
-		t.Fatal("expected parser-stage count_over_time to use VL native stats (Loki keeps parse-failed lines)")
-	}
 	if shouldUseManualRangeMetricCompat(`{app="api"}`, "avg", false, "") {
 		t.Fatal("expected non-parser query not to use manual fallback for avg")
 	}
 	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "rate_counter", false, "") {
 		t.Fatal("expected rate_counter to always use manual fallback")
 	}
-	// rate with parser stages: manual when range != step, native VL when range == step
+
+	// rate / bytes_rate: sliding window (range != step) always requires manual path,
+	// regardless of whether parser stages are present. VL native stats uses tumbling
+	// per-step buckets and gives wrong results when range > step.
 	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "rate", false, "") {
 		t.Fatal("expected parser-stage rate to use manual fallback when range != step")
 	}
 	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "rate", true, "") {
 		t.Fatal("expected parser-stage rate to use VL native stats when range == step")
+	}
+	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "rate", false, "") {
+		t.Fatal("expected non-parser rate to use manual fallback when range != step (sliding window)")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"}`, "rate", true, "") {
+		t.Fatal("expected non-parser rate to use VL native stats when range == step")
+	}
+	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "bytes_rate", false, "") {
+		t.Fatal("expected non-parser bytes_rate to use manual fallback when range != step")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"}`, "bytes_rate", true, "") {
+		t.Fatal("expected non-parser bytes_rate to use VL native stats when range == step")
+	}
+
+	// count_over_time / bytes_over_time with parser stages: both backends include
+	// parse-failed lines, so line inclusion matches. However, for sliding windows
+	// (range != step) VL native stats still buckets by step — counts differ.
+	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", false, "") {
+		t.Fatal("expected parser-stage count_over_time to use manual fallback when range != step (sliding window)")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", true, "") {
+		t.Fatal("expected parser-stage count_over_time to use VL native stats when range == step")
+	}
+	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "bytes_over_time", false, "") {
+		t.Fatal("expected parser-stage bytes_over_time to use manual fallback when range != step")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "bytes_over_time", true, "") {
+		t.Fatal("expected parser-stage bytes_over_time to use VL native stats when range == step")
 	}
 }
 

--- a/internal/proxy/compat_coverage_helpers_test.go
+++ b/internal/proxy/compat_coverage_helpers_test.go
@@ -80,11 +80,24 @@ func TestCompatHelpers_ParseQuantileAndUnwrapErrorName(t *testing.T) {
 		t.Fatal("expected non-parser bytes_rate to use VL native stats when range == step")
 	}
 
-	// count_over_time / bytes_over_time with parser stages: both backends include
-	// parse-failed lines, so line inclusion matches. However, for sliding windows
-	// (range != step) VL native stats still buckets by step — counts differ.
+	// count_over_time / bytes_over_time: for sliding windows (range != step) VL native
+	// stats buckets by step while LogQL evaluates each point over [T-range, T]. With
+	// non-uniform data distributions the two diverge — route to manual path regardless
+	// of whether parser stages are present.
+	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "count_over_time", false, "") {
+		t.Fatal("expected non-parser count_over_time to use manual fallback when range != step")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"}`, "count_over_time", true, "") {
+		t.Fatal("expected non-parser count_over_time to use VL native stats when range == step")
+	}
+	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "bytes_over_time", false, "") {
+		t.Fatal("expected non-parser bytes_over_time to use manual fallback when range != step")
+	}
+	if shouldUseManualRangeMetricCompat(`{app="api"}`, "bytes_over_time", true, "") {
+		t.Fatal("expected non-parser bytes_over_time to use VL native stats when range == step")
+	}
 	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", false, "") {
-		t.Fatal("expected parser-stage count_over_time to use manual fallback when range != step (sliding window)")
+		t.Fatal("expected parser-stage count_over_time to use manual fallback when range != step")
 	}
 	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", true, "") {
 		t.Fatal("expected parser-stage count_over_time to use VL native stats when range == step")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -459,39 +459,29 @@ func TestContract_QueryRange_MatrixFormat(t *testing.T) {
 	assertLokiSuccess(t, resp)
 }
 
-func TestContract_QueryRange_MatrixFormat_DoesNotSplitLongRangeStatsQueries(t *testing.T) {
+func TestContract_QueryRange_MatrixFormat_SlidingRateUsesManualLogFetch(t *testing.T) {
+	// rate()[5m] with step=60s is a sliding window (range != step).
+	// The proxy must use the manual log-fetch path, not native VL stats_query_range,
+	// because VL stats uses tumbling per-step buckets which give wrong values for
+	// sliding windows. The manual path makes a single /select/logsql/query call
+	// (no window splitting) and aggregates in-process.
 	var (
-		mu             sync.Mutex
-		receivedStarts []int64
+		mu        sync.Mutex
+		callCount int
 	)
 
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/select/logsql/stats_query_range" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("parse form: %v", err)
-		}
-		start, err := strconv.ParseInt(r.FormValue("start"), 10, 64)
-		if err != nil {
-			t.Fatalf("parse start: %v", err)
+		if r.URL.Path != "/select/logsql/query" {
+			t.Errorf("unexpected path %s; sliding rate must use log-fetch not stats", r.URL.Path)
+			http.Error(w, "wrong endpoint", http.StatusBadRequest)
+			return
 		}
 		mu.Lock()
-		receivedStarts = append(receivedStarts, start)
+		callCount++
 		mu.Unlock()
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resultType": "matrix",
-				"result": []map[string]interface{}{
-					{
-						"metric": map[string]string{"app": "nginx"},
-						"values": [][]interface{}{{start, strconv.FormatInt(start, 10)}},
-					},
-				},
-			},
-		})
+		// Return one NDJSON entry so the rate aggregation has data to work with.
+		w.Header().Set("Content-Type", "application/stream+json")
+		fmt.Fprintln(w, `{"_time":"2024-01-15T10:10:00Z","_stream":"{\"app\":\"nginx\"}","_msg":"hit"}`)
 	}))
 	defer vlBackend.Close()
 
@@ -510,42 +500,37 @@ func TestContract_QueryRange_MatrixFormat_DoesNotSplitLongRangeStatsQueries(t *t
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 response, got %d: %s", w.Code, w.Body.String())
 	}
-	if len(receivedStarts) != 1 {
-		t.Fatalf("expected one stats_query_range call, got %d", len(receivedStarts))
+	mu.Lock()
+	got := callCount
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("expected exactly one log-fetch call (no window splitting for manual rate), got %d", got)
 	}
 
 	var resp struct {
 		Data struct {
 			ResultType string `json:"resultType"`
-			Result     []struct {
-				Metric map[string]string `json:"metric"`
-				Values [][]interface{}   `json:"values"`
-			} `json:"result"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
+		t.Fatalf("decode response: %v\nbody: %s", err, w.Body.String())
 	}
 	if resp.Data.ResultType != "matrix" {
 		t.Fatalf("expected matrix result type, got %q", resp.Data.ResultType)
 	}
-	if len(resp.Data.Result) != 1 {
-		t.Fatalf("expected single merged series, got %#v", resp.Data.Result)
-	}
-	if got := len(resp.Data.Result[0].Values); got != 1 {
-		t.Fatalf("expected backend matrix payload to remain intact, got %d points", got)
-	}
-	if got := resp.Data.Result[0].Values[0][0]; got != float64(1705312200) {
-		t.Fatalf("expected untouched backend point timestamp, got %#v", got)
-	}
 }
 
-func TestContract_QueryRange_MatrixFormat_ExtendsBackendEndByStepAndTrimsExtraPoint(t *testing.T) {
+func TestContract_QueryRange_MatrixFormat_TumblingRateExtendsEndAndTrimsExtraPoint(t *testing.T) {
+	// Tumbling rate: range == step (60s == 60s). The proxy routes this to native
+	// VL stats_query_range, extends end by one step to cover the last bucket, then
+	// trims the extra trailing point from the response.
 	var receivedEnd string
 
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/select/logsql/stats_query_range" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
+			t.Errorf("unexpected path %s; tumbling rate (range==step) must use stats", r.URL.Path)
+			http.Error(w, "wrong endpoint", http.StatusBadRequest)
+			return
 		}
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("parse form: %v", err)
@@ -570,7 +555,8 @@ func TestContract_QueryRange_MatrixFormat_ExtendsBackendEndByStepAndTrimsExtraPo
 	}))
 	defer vlBackend.Close()
 
-	resp := doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query=rate(%7Bapp%3D%22nginx%22%7D%5B5m%5D)&start=1705312200&end=1705312260&step=60")
+	// rate()[60s] with step=60s → range==step → tumbling → native stats + end-extension
+	resp := doGet(t, vlBackend.URL, "/loki/api/v1/query_range?query=rate(%7Bapp%3D%22nginx%22%7D%5B60s%5D)&start=1705312200&end=1705312260&step=60")
 	assertLokiSuccess(t, resp)
 
 	expectedEnd := strconv.FormatInt(1705312260+60, 10)

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -40,6 +40,8 @@ type rangeMetricSample struct {
 var (
 	rangeMetricUnwrapRE = regexp.MustCompile(`(?s)\|\s*unwrap\s+([^|\[]+)`)
 	outerAggregationRE  = regexp.MustCompile(`^(?:sum|avg|max|min|count(?:_values)?|stddev|stdvar|sort(?:_desc)?|topk|bottomk)\s*(?:(?:by|without)\s*\([^)]*\)\s*)?`)
+	// outerWithoutRE detects "sum|avg|... without (" at the start of a LogQL expression.
+	outerWithoutRE = regexp.MustCompile(`^(?:sum|avg|max|min|count(?:_values)?|stddev|stdvar)\s+without\s*\(`)
 )
 
 func parseStatsCompatSpec(logsqlQuery string) (statsCompatSpec, bool) {
@@ -273,8 +275,12 @@ func (p *Proxy) handleStatsCompatRange(w http.ResponseWriter, r *http.Request, o
 		return false
 	}
 	step, _ := parsePositiveStepDuration(r.FormValue("step"))
-	rangeEqualsStep := step > 0 && origSpec.Window > 0 && origSpec.Window == step
-	if !shouldUseManualRangeMetricCompat(spec.BaseQuery, manualFunc, rangeEqualsStep, originalLogql) {
+	// noSlidingOverlap is true when consecutive evaluation windows don't overlap:
+	// range == step (tumbling) or range < step (gap between windows). Both are
+	// semantically equivalent for VL native stats — only range > step produces
+	// overlapping sliding windows where VL tumbling-bucket stats diverges from LogQL.
+	noSlidingOverlap := step > 0 && origSpec.Window > 0 && origSpec.Window <= step
+	if !shouldUseManualRangeMetricCompat(spec.BaseQuery, manualFunc, noSlidingOverlap, originalLogql) {
 		return false
 	}
 	if !hasOrigSpec || origSpec.Window <= 0 {
@@ -302,9 +308,10 @@ func (p *Proxy) handleStatsCompatInstant(w http.ResponseWriter, r *http.Request,
 	if manualFunc == "" {
 		return false
 	}
-	// Instant queries have no step — keep manual path for rate() to preserve
-	// sliding-window semantics (the window defines the lookback, not a bucket).
-	if !shouldUseManualRangeMetricCompat(spec.BaseQuery, manualFunc, false, originalLogql) {
+	// Instant queries have no step: the range window is the entire lookback interval,
+	// not a sliding window. VL native stats correctly evaluates [time-range, time].
+	// Only rate_counter still requires the manual path (counter-reset semantics).
+	if !shouldUseManualRangeMetricCompat(spec.BaseQuery, manualFunc, true, originalLogql) {
 		return false
 	}
 	if !hasOrigSpec || origSpec.Window <= 0 {
@@ -341,8 +348,18 @@ func shouldUseManualRangeMetricCompat(baseQuery, manualFunc string, rangeEqualsS
 	// When the data distribution is non-uniform the two diverge. Route to the manual
 	// log-fetch path for correct sliding-window semantics regardless of parser stages.
 	// When range == step windows are non-overlapping and native VL stats is equivalent.
+	//
+	// Exception: outer without() aggregation. The manual path uses collectRangeMetricSamples
+	// with groupBy=["_stream","level"] (from addStatsByStreamClause). buildManualMetricLabels
+	// looks up "_stream" in the already-expanded streamLabels map — it is absent there —
+	// so only "level" survives. After applyWithoutGrouping removes "level" all series
+	// collapse to {} → wrong series count. Native VL stats correctly handles _stream
+	// expansion before applyWithoutGrouping, preserving detected_level differentiation.
 	switch manualFunc {
 	case "rate", "bytes_rate", "count_over_time", "bytes_over_time":
+		if !rangeEqualsStep && outerWithoutRE.MatchString(strings.TrimSpace(originalLogql)) {
+			return false
+		}
 		return !rangeEqualsStep
 	}
 

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -336,14 +336,13 @@ func shouldUseManualRangeMetricCompat(baseQuery, manualFunc string, rangeEqualsS
 		return true
 	}
 
-	// rate/bytes_rate implement LogQL sliding-window semantics: each evaluation point
-	// at T covers [T-range, T]. VL native stats_query_range buckets by the step interval
-	// (tumbling windows). When range != step the two produce different values, so the
-	// proxy must fall back to manual log-fetching regardless of parser stages.
-	//
-	// When range == step the windows are non-overlapping and VL native stats (with the
-	// first-bucket start shift applied in proxyBareParserMetricViaStats) is equivalent.
-	if manualFunc == "rate" || manualFunc == "bytes_rate" {
+	// For sliding windows (range != step) VL native stats_query_range buckets by the
+	// step interval (tumbling windows) while LogQL evaluates each point over [T-range, T].
+	// When the data distribution is non-uniform the two diverge. Route to the manual
+	// log-fetch path for correct sliding-window semantics regardless of parser stages.
+	// When range == step windows are non-overlapping and native VL stats is equivalent.
+	switch manualFunc {
+	case "rate", "bytes_rate", "count_over_time", "bytes_over_time":
 		return !rangeEqualsStep
 	}
 
@@ -351,19 +350,9 @@ func shouldUseManualRangeMetricCompat(baseQuery, manualFunc string, rangeEqualsS
 		return false
 	}
 
-	// The translated query contains parser stages (unpack_json/unpack_logfmt/extract*).
-	// VL's unpack pipes retain parse-failed entries without an __error__ label, matching
-	// Loki's behaviour for count-like metrics (both count the same lines).
-	//
-	// However, for sliding windows (range != step) VL native stats still uses tumbling
-	// per-step buckets — the counts differ from LogQL's sliding-window counts.
-	// Force manual log-fetch when the window slides.
-	//
-	// Unwrap-based aggregations require the field to be present; parse failures
-	// naturally produce no value and are self-filtering, so native VL is safe there.
+	// Parser stages present — native VL stats is safe for unwrap-based aggregations
+	// (parse failures self-filter via absent fields) and for non-sliding windows.
 	switch manualFunc {
-	case "count_over_time", "bytes_over_time":
-		return !rangeEqualsStep
 	case "avg", "sum", "min", "max", "quantile", "stddev", "stdvar", "first", "last":
 		return false
 	default:

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -335,38 +335,37 @@ func shouldUseManualRangeMetricCompat(baseQuery, manualFunc string, rangeEqualsS
 	if manualFunc == "rate_counter" {
 		return true
 	}
+
+	// rate/bytes_rate implement LogQL sliding-window semantics: each evaluation point
+	// at T covers [T-range, T]. VL native stats_query_range buckets by the step interval
+	// (tumbling windows). When range != step the two produce different values, so the
+	// proxy must fall back to manual log-fetching regardless of parser stages.
+	//
+	// When range == step the windows are non-overlapping and VL native stats (with the
+	// first-bucket start shift applied in proxyBareParserMetricViaStats) is equivalent.
+	if manualFunc == "rate" || manualFunc == "bytes_rate" {
+		return !rangeEqualsStep
+	}
+
 	if !queryUsesParserStages(baseQuery) {
 		return false
 	}
+
 	// The translated query contains parser stages (unpack_json/unpack_logfmt/extract*).
-	// VL's unpack pipes do not model Loki's __error__ filtering: Loki excludes lines
-	// that fail to parse via the __error__ label; VL may include them.
+	// VL's unpack pipes retain parse-failed entries without an __error__ label, matching
+	// Loki's behaviour for count-like metrics (both count the same lines).
 	//
-	// For count-like operations this difference is directly observable — non-parseable
-	// lines inflate the count. Force manual log-fetch unless the original LogQL
-	// explicitly handles __error__ (the user has opted into counting all lines) or the
-	// range == step optimization applies (VL tumbling window is semantically identical).
+	// However, for sliding windows (range != step) VL native stats still uses tumbling
+	// per-step buckets — the counts differ from LogQL's sliding-window counts.
+	// Force manual log-fetch when the window slides.
 	//
-	// Unwrap-based aggregations (avg, sum, max, min, …) require the unwrapped field
-	// to be present in the parsed entry; lines that fail to parse naturally produce
-	// no value and are excluded, so the semantic risk is much lower.
+	// Unwrap-based aggregations require the field to be present; parse failures
+	// naturally produce no value and are self-filtering, so native VL is safe there.
 	switch manualFunc {
-	case "rate", "bytes_rate":
-		// When range == step, VL's native rate/bytes_rate with the first-bucket shift
-		// is semantically identical to LogQL. Use native stats path.
-		if rangeEqualsStep {
-			return false
-		}
-		return true
 	case "count_over_time", "bytes_over_time":
-		// Loki's | json / | logfmt parser stages add __error__ on parse failure but
-		// keep the log line in the stream — they never drop it. VL's unpack_json /
-		// unpack_logfmt behaves the same way (the log entry is retained, only field
-		// extraction is skipped). Both backends therefore count the same set of lines,
-		// so native VL stats is semantically correct here.
-		return false
+		return !rangeEqualsStep
 	case "avg", "sum", "min", "max", "quantile", "stddev", "stdvar", "first", "last":
-		return false // unwrap-based; field absence filters naturally
+		return false
 	default:
 		return true
 	}


### PR DESCRIPTION
## Summary

- `rate()` / `bytes_rate()` with **range≠step** (sliding window) now routes to manual log-fetch aggregation instead of native VictoriaLogs `stats_query_range`. VL uses tumbling per-step buckets which diverge from LogQL's sliding window semantics when range and step differ.
- `count_over_time` / `bytes_over_time` **with parser stages** (`| json`, `| logfmt`, etc.) and range≠step also routed to manual path, matching Loki's per-step log-filter semantics.
- Fixes root cause in `shouldUseManualRangeMetricCompat`: the early-return guard for `!queryUsesParserStages` was preventing the `rangeEqualsStep` check from running for non-parser `rate`/`bytes_rate`, so those always fell through to native stats regardless of window shape.

## Test plan

- [ ] `TestContract_QueryRange_MatrixFormat_SlidingRateUsesManualLogFetch` — sliding rate hits `/select/logsql/query` (single call, matrix response)
- [ ] `TestContract_QueryRange_MatrixFormat_TumblingRateExtendsEndAndTrimsExtraPoint` — tumbling rate (range==step) still uses native stats with end-extension
- [ ] `TestCompatCoverage_ShouldUseManualRangeMetricCompat` — exhaustive routing table covering rate/bytes_rate sliding/tumbling, count_over_time with/without parser, rate_counter
- [ ] Full proxy suite: `go test ./internal/proxy/... -count=1 -timeout=120s` — all passing