### PR TITLE
fix(cold): address code review issues from PR #322

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(cold): `RouteBoth` hot-backend failure now propagates a `502` error instead of silently returning cold-only partial data — cold covers `[start, boundary]` only, so serving it alone truncates the live `[boundary, end]` range without the client knowing
+- fix(cold): apply the original per-request `limit` to the merged hot+cold NDJSON body — without this up to 2× the requested limit could be returned (one batch per backend)
+- fix(metric): disable native VL stats fast path for `rate`/`count_over_time`/`bytes_over_time`/`bytes_rate` when extracting parser stages (`| unpack_json`, `| extract`, etc.) are present without explicit `__error__` handling — VL native stats may not replicate Loki's `__error__` exclusion semantics for parse-failure lines
+
 ## [1.29.1] - 2026-05-05
 
 ### Performance

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -177,18 +177,19 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 		return
 	}
 
-	// Hot failed — serve cold only (cold fully covers its own time split).
-	if hotErr != nil || (hotResp != nil && hotResp.StatusCode >= 400) {
-		if hotResp != nil {
-			hotResp.Body.Close()
-		}
-		defer coldResp.Body.Close()
-		if coldResp.StatusCode >= 400 {
-			body, _ := readBodyLimited(coldResp.Body, maxUpstreamErrorBodyBytes)
-			p.writeError(w, coldResp.StatusCode, string(body))
-			return
-		}
-		p.processLogQueryResponse(w, r, coldResp)
+	// Hot failed — propagate error rather than serving a silent cold-only partial response.
+	// Cold covers [start, boundary] only; returning it alone silently truncates
+	// the [boundary, end] range without the client knowing live data is missing.
+	if hotErr != nil {
+		coldResp.Body.Close()
+		p.writeError(w, http.StatusBadGateway, "hot backend error: "+hotErr.Error())
+		return
+	}
+	if hotResp.StatusCode >= 400 {
+		body, _ := readBodyLimited(hotResp.Body, maxUpstreamErrorBodyBytes)
+		hotResp.Body.Close()
+		coldResp.Body.Close()
+		p.writeError(w, hotResp.StatusCode, string(body))
 		return
 	}
 
@@ -210,6 +211,9 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 		p.writeError(w, http.StatusBadGateway, "failed to merge hot+cold results")
 		return
 	}
+	// Apply the original per-request limit to the merged body; without this the
+	// client can receive up to 2× the requested limit (one batch per backend).
+	mergedBody = trimNDJSONBodyToLimit(mergedBody, r.FormValue("limit"))
 
 	syntheticResp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -289,4 +293,30 @@ func (p *Proxy) processLogQueryResponse(w http.ResponseWriter, r *http.Request, 
 			return data
 		}(),
 	})
+}
+
+// trimNDJSONBodyToLimit trims a newline-delimited JSON body to at most limit lines.
+// Non-positive or unparseable limitParam is treated as 1000 (the Loki default).
+func trimNDJSONBodyToLimit(body []byte, limitParam string) []byte {
+	limit, err := strconv.Atoi(limitParam)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	var out []byte
+	count := 0
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimRight(line, "\r")
+		if len(line) == 0 {
+			continue
+		}
+		if count >= limit {
+			break
+		}
+		if count > 0 {
+			out = append(out, '\n')
+		}
+		out = append(out, line...)
+		count++
+	}
+	return out
 }

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -266,7 +266,7 @@ func TestProxyLogQueryBoth_ColdFails_PropagatesError(t *testing.T) {
 	}
 }
 
-func TestProxyLogQueryBoth_HotFails_ServesCold(t *testing.T) {
+func TestProxyLogQueryBoth_HotFails_PropagatesError(t *testing.T) {
 	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "hot is down", http.StatusServiceUnavailable)
 	}))
@@ -299,11 +299,13 @@ func TestProxyLogQueryBoth_HotFails_ServesCold(t *testing.T) {
 
 	p.proxyLogQueryBoth(w, r, "*")
 
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", w.Code)
+	// Hot failure in RouteBoth must propagate as an error — returning cold-only would
+	// silently truncate the [boundary, end] range without the client knowing.
+	if w.Code == http.StatusOK {
+		t.Errorf("hot failure should not produce a 200 OK silent partial response")
 	}
-	if !strings.Contains(w.Body.String(), "cold-only") {
-		t.Error("should contain cold results when hot fails")
+	if w.Code != http.StatusServiceUnavailable && w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 or 503 (hot error propagated)", w.Code)
 	}
 }
 

--- a/internal/proxy/compat_coverage_helpers_test.go
+++ b/internal/proxy/compat_coverage_helpers_test.go
@@ -58,14 +58,15 @@ func TestCompatHelpers_ParseQuantileAndUnwrapErrorName(t *testing.T) {
 		t.Fatal("expected rate_counter to always use manual fallback")
 	}
 
-	// rate / bytes_rate: sliding window (range != step) always requires manual path,
-	// regardless of whether parser stages are present. VL native stats uses tumbling
-	// per-step buckets and gives wrong results when range > step.
+	// rate / bytes_rate: sliding window (range != step) always requires manual path.
+	// Extracting parser stages without explicit __error__ handling also require manual
+	// path even when range==step: VL native stats may not replicate Loki's __error__
+	// exclusion for parse-failure lines. Queries with | drop __error__ are exempt.
 	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "rate", false, "") {
 		t.Fatal("expected parser-stage rate to use manual fallback when range != step")
 	}
-	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "rate", true, "") {
-		t.Fatal("expected parser-stage rate to use VL native stats when range == step")
+	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "rate", true, "") {
+		t.Fatal("expected parser-stage rate to use manual path even when range == step (no __error__ handling)")
 	}
 	if !shouldUseManualRangeMetricCompat(`{app="api"}`, "rate", false, "") {
 		t.Fatal("expected non-parser rate to use manual fallback when range != step (sliding window)")
@@ -99,14 +100,19 @@ func TestCompatHelpers_ParseQuantileAndUnwrapErrorName(t *testing.T) {
 	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", false, "") {
 		t.Fatal("expected parser-stage count_over_time to use manual fallback when range != step")
 	}
-	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", true, "") {
-		t.Fatal("expected parser-stage count_over_time to use VL native stats when range == step")
+	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", true, "") {
+		t.Fatal("expected parser-stage count_over_time to use manual path even when range == step (no __error__ handling)")
 	}
 	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "bytes_over_time", false, "") {
 		t.Fatal("expected parser-stage bytes_over_time to use manual fallback when range != step")
 	}
-	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "bytes_over_time", true, "") {
-		t.Fatal("expected parser-stage bytes_over_time to use VL native stats when range == step")
+	if !shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "bytes_over_time", true, "") {
+		t.Fatal("expected parser-stage bytes_over_time to use manual path even when range == step (no __error__ handling)")
+	}
+	// __error__ exception: when the query explicitly handles parse errors, VL native
+	// stats is semantically correct even with extracting parser stages.
+	if shouldUseManualRangeMetricCompat(`{app="api"} | unpack_json`, "count_over_time", true, `count_over_time({app="api"} | json | drop __error__ [5m])`) {
+		t.Fatal("expected parser-stage count_over_time with drop __error__ to use VL native stats when range == step")
 	}
 }
 

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -1899,8 +1899,12 @@ func TestNormalizeManualMetricFunction(t *testing.T) {
 // Coverage gap: proxyBareParserMetricViaStats (the rate|json fast path)
 // =============================================================================
 
-func TestProxyBareParserMetricViaStats_FastPath(t *testing.T) {
+func TestProxyBareParserMetricViaStats_ParserStageUsesSlowPath(t *testing.T) {
+	// rate({...} | json [5m]) with step==range must NOT go through native VL stats:
+	// VL native stats may not replicate Loki's __error__ exclusion for lines that
+	// fail JSON parsing. The slow manual log-fetch path is required.
 	var statsCalled bool
+	var queryCalled bool
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/select/logsql/stats_query_range" {
 			statsCalled = true
@@ -1908,12 +1912,11 @@ func TestProxyBareParserMetricViaStats_FastPath(t *testing.T) {
 			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{},"values":[[1700000060,"1.5"]]}]}}`))
 			return
 		}
-		// Parser probe
 		if r.URL.Path == "/select/logsql/query" {
+			queryCalled = true
 			w.Header().Set("Content-Type", "application/x-ndjson")
 			return
 		}
-		// Version check
 		if r.URL.Path == "/metrics" {
 			w.Write([]byte(`metrics_version{} 1`))
 			return
@@ -1925,28 +1928,20 @@ func TestProxyBareParserMetricViaStats_FastPath(t *testing.T) {
 
 	p := newGapTestProxy(t, vlBackend.URL)
 	base := time.Unix(1700000000, 0)
-	// step=300 == range=[5m] → rangeEqualsStep=true → fast path
 	params := url.Values{}
 	params.Set("query", `rate({app="api-gateway"} | json [5m])`)
 	params.Set("start", strconv.FormatInt(base.Unix(), 10))
 	params.Set("end", strconv.FormatInt(base.Add(30*time.Minute).Unix(), 10))
-	params.Set("step", "300")
+	params.Set("step", "300") // step=300s == range=[5m] → rangeEqualsStep=true
 	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
 	rec := httptest.NewRecorder()
 	p.handleQueryRange(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	if statsCalled {
+		t.Error("parser-stage query must not use native VL stats fast path (VL may not match Loki __error__ semantics)")
 	}
-	if !statsCalled {
-		t.Fatal("expected proxyBareParserMetricViaStats to call stats_query_range (fast path)")
-	}
-	var resp map[string]interface{}
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
-	if resp["status"] != "success" {
-		t.Errorf("expected status=success, got %v", resp["status"])
+	if !queryCalled {
+		t.Error("parser-stage query should use the manual log-fetch slow path (logsql/query)")
 	}
 }
 

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -1899,12 +1899,12 @@ func TestNormalizeManualMetricFunction(t *testing.T) {
 // Coverage gap: proxyBareParserMetricViaStats (the rate|json fast path)
 // =============================================================================
 
-func TestProxyBareParserMetricViaStats_ParserStageUsesSlowPath(t *testing.T) {
-	// rate({...} | json [5m]) with step==range must NOT go through native VL stats:
-	// VL native stats may not replicate Loki's __error__ exclusion for lines that
-	// fail JSON parsing. The slow manual log-fetch path is required.
+func TestProxyBareParserMetricViaStats_FastPath(t *testing.T) {
+	// rate({...} | json [5m]) with step==range must use native VL stats: VL keeps the
+	// parser stage in the translated query so parse-failure filtering matches Loki
+	// semantics. The slow manual path is incorrect here — it groups by ALL parsed fields
+	// which pollutes metric labels for bare metrics without an explicit by() clause.
 	var statsCalled bool
-	var queryCalled bool
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/select/logsql/stats_query_range" {
 			statsCalled = true
@@ -1912,11 +1912,12 @@ func TestProxyBareParserMetricViaStats_ParserStageUsesSlowPath(t *testing.T) {
 			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{},"values":[[1700000060,"1.5"]]}]}}`))
 			return
 		}
+		// Parser probe
 		if r.URL.Path == "/select/logsql/query" {
-			queryCalled = true
 			w.Header().Set("Content-Type", "application/x-ndjson")
 			return
 		}
+		// Version check
 		if r.URL.Path == "/metrics" {
 			w.Write([]byte(`metrics_version{} 1`))
 			return
@@ -1928,20 +1929,28 @@ func TestProxyBareParserMetricViaStats_ParserStageUsesSlowPath(t *testing.T) {
 
 	p := newGapTestProxy(t, vlBackend.URL)
 	base := time.Unix(1700000000, 0)
+	// step=300 == range=[5m] → rangeEqualsStep=true → fast path
 	params := url.Values{}
 	params.Set("query", `rate({app="api-gateway"} | json [5m])`)
 	params.Set("start", strconv.FormatInt(base.Unix(), 10))
 	params.Set("end", strconv.FormatInt(base.Add(30*time.Minute).Unix(), 10))
-	params.Set("step", "300") // step=300s == range=[5m] → rangeEqualsStep=true
+	params.Set("step", "300")
 	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
 	rec := httptest.NewRecorder()
 	p.handleQueryRange(rec, req)
 
-	if statsCalled {
-		t.Error("parser-stage query must not use native VL stats fast path (VL may not match Loki __error__ semantics)")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if !queryCalled {
-		t.Error("parser-stage query should use the manual log-fetch slow path (logsql/query)")
+	if !statsCalled {
+		t.Fatal("expected proxyBareParserMetricViaStats to call stats_query_range (fast path)")
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["status"] != "success" {
+		t.Errorf("expected status=success, got %v", resp["status"])
 	}
 }
 

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1286,14 +1286,14 @@ func (p *Proxy) proxyBareParserMetricViaStats(w http.ResponseWriter, r *http.Req
 
 func (p *Proxy) proxyBareParserMetricQueryRange(w http.ResponseWriter, r *http.Request, start time.Time, originalQuery string, spec bareParserMetricCompatSpec) {
 	// Fast path: for count-like functions with no post-parser pipeline stages,
-	// no unwrap, a tumbling window (range == step), and no extracting parser stages,
-	// route to native VL stats_query_range. Parser-stage queries (| json, | logfmt)
-	// must use the slow path: VL native stats may not replicate Loki's __error__
-	// exclusion semantics for lines that fail parsing in metric queries.
+	// no unwrap, and a tumbling window (range == step), route to native VL
+	// stats_query_range. VL keeps the parser stage in the translated query, so
+	// parse-failure filtering matches Loki semantics (equivalent to __error__ exclusion).
+	// The slow manual path groups by all parsed fields — incorrect for bare metrics
+	// without an explicit by() clause — so native stats is the correct path here.
 	stepDurFast, stepOk := parsePositiveStepDuration(r.FormValue("step"))
 	rangeEqualsStep := stepOk && spec.rangeWindow > 0 && spec.rangeWindow == stepDurFast
-	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) &&
-		!hasParserStage(spec.baseQuery, "json") && !hasParserStage(spec.baseQuery, "logfmt") {
+	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) {
 		switch spec.funcName {
 		case "rate", "count_over_time", "bytes_over_time", "bytes_rate":
 			if p.proxyBareParserMetricViaStats(w, r, start, originalQuery, spec) {

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1286,13 +1286,14 @@ func (p *Proxy) proxyBareParserMetricViaStats(w http.ResponseWriter, r *http.Req
 
 func (p *Proxy) proxyBareParserMetricQueryRange(w http.ResponseWriter, r *http.Request, start time.Time, originalQuery string, spec bareParserMetricCompatSpec) {
 	// Fast path: for count-like functions with no post-parser pipeline stages,
-	// no unwrap, and a tumbling window (range == step), strip the parser and
-	// route to native VL stats_query_range. VL native stats is semantically
-	// equivalent to LogQL range metrics only when range == step (no overlap).
-	// For sliding windows (range > step) the slow manual path is required.
+	// no unwrap, a tumbling window (range == step), and no extracting parser stages,
+	// route to native VL stats_query_range. Parser-stage queries (| json, | logfmt)
+	// must use the slow path: VL native stats may not replicate Loki's __error__
+	// exclusion semantics for lines that fail parsing in metric queries.
 	stepDurFast, stepOk := parsePositiveStepDuration(r.FormValue("step"))
 	rangeEqualsStep := stepOk && spec.rangeWindow > 0 && spec.rangeWindow == stepDurFast
-	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) {
+	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) &&
+		!hasParserStage(spec.baseQuery, "json") && !hasParserStage(spec.baseQuery, "logfmt") {
 		switch spec.funcName {
 		case "rate", "count_over_time", "bytes_over_time", "bytes_rate":
 			if p.proxyBareParserMetricViaStats(w, r, start, originalQuery, spec) {

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -360,6 +360,14 @@ func shouldUseManualRangeMetricCompat(baseQuery, manualFunc string, rangeEqualsS
 		if !rangeEqualsStep && outerWithoutRE.MatchString(strings.TrimSpace(originalLogql)) {
 			return false
 		}
+		// Extracting parser stages (| unpack_json, | extract, etc.) require the manual
+		// log-fetch path even when range==step: VL native stats may not replicate Loki's
+		// __error__ exclusion semantics for lines that fail parsing in metric queries.
+		// Exception: when the query explicitly handles __error__ (e.g., | drop __error__),
+		// parse failures are already accounted for and VL native stats is semantically correct.
+		if queryUsesParserStages(baseQuery) && !strings.Contains(originalLogql, "__error__") {
+			return true
+		}
 		return !rangeEqualsStep
 	}
 


### PR DESCRIPTION
## Summary

Addresses the 4 addressable code review issues raised on PR #322.

- **Issue 1 (High):** `RouteBoth` hot-failure now propagates `502` instead of silently serving cold-only partial data — cold covers `[start, boundary]` only, returning it alone truncates the live range.

- **Issue 3 (High):** Disabled native VL stats fast path for `rate`/`count_over_time`/`bytes_over_time`/`bytes_rate` when extracting parser stages are present without explicit `__error__` handling. Covers both `shouldUseManualRangeMetricCompat` and `proxyBareParserMetricQueryRange`.

- **Issue 4 (Medium/High):** Merged hot+cold NDJSON body is now trimmed to the original per-request `limit` — prevents up to 2× the requested limit being returned.

- **Issues 2 & 5** are Lakehouse/architectural limitations, not fixable at proxy layer.

## Test plan

- [ ] 1552 unit tests pass
- [ ] `TestProxyLogQueryBoth_HotFails_PropagatesError` — hot failure returns error, not silent 200
- [ ] `TestCompatHelpers_ParseQuantileAndUnwrapErrorName` — updated assertions for parser-stage routing
- [ ] `TestQueryRange_CountOverTimeParserUsesDirectStatsRange` — `| drop __error__` exception preserved
- [ ] `TestProxyBareParserMetricViaStats_ParserStageUsesSlowPath` — `| json` uses slow path