### PR TITLE
fix(cold): reverse cold half and use maxLimitValue in RouteBoth backward queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(cold): `RouteBoth` backward queries now correctly reverse the cold half before merging — previously cold rows from `[start, boundary]` were appended oldest-first after the newest-first hot half; cold also now sends `maxLimitValue` to the Lakehouse so the N newest cold rows are available after reversal and the final trim to the client limit returns the correct rows
+
 ## [1.29.4] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(cold): `RouteBoth` backward queries now correctly reverse the cold half before merging — previously cold rows from `[start, boundary]` were appended oldest-first after the newest-first hot half; cold also now sends `maxLimitValue` to the Lakehouse so the N newest cold rows are available after reversal and the final trim to the client limit returns the correct rows
+- fix(drilldown): `detected_fields` no longer returns thousands of fields ("Fields 5,965") for queries with parser stages — VL auto-indexes all JSON keys from `_msg` into a time-range-wide native field index; the proxy now uses only the 500-line log scan result when it is non-empty, discarding the native index which accumulates thousands of field names from rare log variants across the full time range
+- fix(drilldown): `detected_fields` no longer double-counts fields from JSON `_msg` — VL also returns auto-indexed JSON keys as top-level NDJSON fields; a new pre-pass collects `_msg` JSON keys and skips them in the outer native field visit so they are only added once via `_msg` parsing with the correct `parser="json"` tag
+- fix(metrics): metric queries no longer include `_stream="{app=\"...\",...}"` as a raw label — `addGroupByParsedLabels` now skips VL internal fields (`_stream`, `_msg`, `_time`) that appear in `groupBy` to prevent the raw JSON stream string leaking into the metric label set
 
 ## [1.29.4] - 2026-05-05
 

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -100,8 +100,11 @@ func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsql
 	// The Lakehouse always scans ascending (oldest-first) and applies its limit before
 	// returning. For a backward query we need the N NEWEST rows in the range, but with
 	// the client limit set the Lakehouse returns the N OLDEST rows, and reversing them
-	// gives the wrong set. Fix: for backward queries fetch without a user limit (capped
-	// at maxLimitValue), reverse the full result, then trim to the original limit.
+	// gives the wrong set. Fix: for backward queries fetch maxLimitValue rows, reverse
+	// the full result, then trim to the original limit.
+	// Limitation: cold ranges with more than maxLimitValue matching rows still return
+	// the newest rows from only the oldest maxLimitValue — Lakehouse does not support
+	// pagination or server-side descending sort.
 	params := p.buildColdQueryParams(r, logsqlQuery)
 	originalLimit := r.FormValue("limit")
 	if r.FormValue("direction") != "forward" {
@@ -164,6 +167,16 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 	}
 
 	coldParams := p.buildColdQueryParamsForRange(r, logsqlQuery, startNs, coldEndNs)
+	// Backward direction: the Lakehouse returns cold rows oldest-first and applies its
+	// limit before streaming. Sending the client limit returns the N oldest rows from
+	// [start, boundary]; after reversing those are still the wrong rows. Fetch
+	// maxLimitValue instead so the reversed cold body contains the N newest rows from
+	// that half, matching what the hot backend already returns for [boundary, end].
+	// Limitation: cold ranges with more than maxLimitValue matching rows still return
+	// the newest rows from only the oldest maxLimitValue — a Lakehouse pagination gap.
+	if r.FormValue("direction") != "forward" {
+		coldParams.Set("limit", strconv.Itoa(maxLimitValue))
+	}
 	hotParams := p.buildHotQueryParamsForRange(r, logsqlQuery, hotStartNs, endNs)
 
 	var (
@@ -223,10 +236,11 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 		return
 	}
 
-	// Both succeeded — merge with direction-aware ordering so the stream assembler
-	// receives entries in the order expected by vlReaderToLokiStreams:
-	//   backward (default): hot first (newest), then cold (oldest)
-	//   forward:            cold first (oldest), then hot (newest)
+	// Both succeeded — merge with direction-aware ordering.
+	// forward:  cold (ascending [start, boundary]) then hot (ascending [boundary, end])
+	// backward: hot already newest-first from [boundary, end]; cold is oldest-first from
+	//           [start, boundary] so reverse it first, then append so the client receives
+	//           a contiguous newest-first stream across the full range.
 	defer hotResp.Body.Close()
 	defer coldResp.Body.Close()
 
@@ -234,7 +248,12 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 	if r.FormValue("direction") == "forward" {
 		merged = MergeNDJSON(coldResp.Body, hotResp.Body)
 	} else {
-		merged = MergeNDJSON(hotResp.Body, coldResp.Body)
+		coldBody, readErr := io.ReadAll(coldResp.Body)
+		if readErr != nil {
+			p.writeError(w, http.StatusBadGateway, "failed to read cold response")
+			return
+		}
+		merged = MergeNDJSON(hotResp.Body, bytes.NewReader(reverseNDJSONBody(coldBody)))
 	}
 	mergedBody, err := io.ReadAll(merged)
 	if err != nil {

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -309,6 +309,103 @@ func TestProxyLogQueryBoth_HotFails_PropagatesError(t *testing.T) {
 	}
 }
 
+func TestProxyLogQueryBoth_BackwardDirection_ReversesColdAndUsesMaxLimit(t *testing.T) {
+	// Backward RouteBoth: cold covers [start, boundary] and returns oldest-first.
+	// The proxy must (a) send maxLimitValue to cold (not the client limit), then
+	// (b) reverse cold before appending to hot so the merged body is newest-first
+	// across both halves, and (c) trim to the original client limit.
+	var coldReceivedLimit string
+	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/select/logsql/query" {
+			coldReceivedLimit = r.FormValue("limit")
+			w.Header().Set("Content-Type", "application/stream+json")
+			// Lakehouse returns ascending (oldest first) within cold range.
+			fmt.Fprintln(w, `{"_msg":"cold-old","_time":"2026-04-01T00:00:01Z","_stream":"{}"}`)
+			fmt.Fprintln(w, `{"_msg":"cold-new","_time":"2026-04-02T00:00:01Z","_stream":"{}"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coldSrv.Close()
+
+	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/select/logsql/query" {
+			w.Header().Set("Content-Type", "application/stream+json")
+			// Hot returns newest-first (proxy adds sort by _time desc).
+			fmt.Fprintln(w, `{"_msg":"hot-new","_time":"2026-05-01T00:00:02Z","_stream":"{}"}`)
+			fmt.Fprintln(w, `{"_msg":"hot-old","_time":"2026-05-01T00:00:01Z","_stream":"{}"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer hotSrv.Close()
+
+	p, err := New(Config{
+		BackendURL: hotSrv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      coldSrv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	startNs := fmt.Sprintf("%d", now.Add(-10*24*time.Hour).UnixNano())
+	endNs := fmt.Sprintf("%d", now.Add(-1*time.Hour).UnixNano())
+
+	w := httptest.NewRecorder()
+	// limit=3: 4 total rows (2 hot + 2 cold); backward must return the 3 newest.
+	r := httptest.NewRequest("GET", "/?query=*&start="+startNs+"&end="+endNs+"&limit=3", nil)
+	p.proxyLogQueryBoth(w, r, "*")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
+	}
+
+	// Cold must have received maxLimitValue, not the client limit.
+	if coldReceivedLimit == "3" {
+		t.Errorf("cold received client limit=3; want maxLimitValue so all cold rows are fetched before reversing")
+	}
+
+	var result struct {
+		Data struct {
+			Result []struct {
+				Values [][]string `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, w.Body.String())
+	}
+
+	var msgs []string
+	for _, stream := range result.Data.Result {
+		for _, v := range stream.Values {
+			if len(v) >= 2 {
+				msgs = append(msgs, v[1])
+			}
+		}
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 entries (limit=3), got %d: %v", len(msgs), msgs)
+	}
+	// Backward: hot-new, hot-old, cold-new; cold-old must be trimmed.
+	if msgs[0] != "hot-new" {
+		t.Errorf("msgs[0] = %q, want hot-new (newest overall)", msgs[0])
+	}
+	if msgs[2] != "cold-new" {
+		t.Errorf("msgs[2] = %q, want cold-new (newest cold row after reversal)", msgs[2])
+	}
+	for _, m := range msgs {
+		if m == "cold-old" {
+			t.Errorf("cold-old appeared in results but must be trimmed by limit=3")
+		}
+	}
+}
+
 func TestColdRouteForRequest_NoTimeRange(t *testing.T) {
 	cr := &ColdRouter{
 		boundary: 7 * 24 * time.Hour,

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -408,6 +408,151 @@ func TestFieldDetectionQueryCandidates_LogfmtFieldFilter(t *testing.T) {
 	}
 }
 
+func TestFieldDetectionQueryCandidates_JSONParserAlwaysStripped(t *testing.T) {
+	// | json is always stripped from the scan query even when downstream field comparisons
+	// are present. VL v1.50+ auto-indexes JSON from _msg, so VL can evaluate the filter
+	// without | json. Keeping | json causes VL to expand _msg JSON into top-level NDJSON
+	// fields in the response, which the scanner then picks up as thousands of garbage names.
+	cases := []struct {
+		query   string
+		primary string
+		relaxed string
+	}{
+		{
+			query:   `{cluster="us-east-1"} | json | model = "anomaly-v2"`,
+			primary: `{cluster="us-east-1"} | model = "anomaly-v2"`,
+			relaxed: `{cluster="us-east-1"}`,
+		},
+		{
+			query:   `{cluster="us-east-1"} | json | service.name = "ml-serving" | model = "anomaly-v2"`,
+			primary: `{cluster="us-east-1"} | service.name = "ml-serving" | model = "anomaly-v2"`,
+			relaxed: `{cluster="us-east-1"}`,
+		},
+		{
+			// | logfmt must be kept (VL doesn't auto-index logfmt), but | json is stripped.
+			query:   `{cluster="us-east-1"} | json | logfmt | size_bytes = "0"`,
+			primary: `{cluster="us-east-1"} | logfmt | size_bytes = "0"`,
+			relaxed: `{cluster="us-east-1"}`,
+		},
+	}
+	for _, tc := range cases {
+		got := fieldDetectionQueryCandidates(tc.query)
+		want := []string{tc.primary, tc.relaxed}
+		if len(got) != len(want) {
+			t.Errorf("fieldDetectionQueryCandidates(%q) len=%d want=%d (%v)", tc.query, len(got), len(want), got)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("fieldDetectionQueryCandidates(%q)[%d] = %q, want %q", tc.query, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestDetectedFields_NativeIndexFloodBlocked verifies two related aspects of the
+// "Fields 5,965" flood regression:
+//
+//  1. _msg JSON fields are NOT double-counted (once via the outer native obj.Visit and
+//     once via _msg JSON parsing). VL auto-indexes every JSON key as a native NDJSON
+//     field; the msgJSONKeys guard in detectFieldSummariesStream prevents the outer
+//     Visit from adding them a second time without parser tags.
+//
+//  2. The VL /select/logsql/field_names index — which may contain thousands of
+//     accumulated auto-indexed field names across the full time range — does NOT
+//     inflate the detected_fields response when the log-line scan has results.
+//     The proxy must use only scan results when the scan is non-empty, discarding
+//     native index fields that did not appear in the sampled log lines.
+func TestDetectedFields_NativeIndexFloodBlocked(t *testing.T) {
+	// Realistic VL NDJSON entries: _msg is JSON, same keys appear as native fields.
+	entry1 := `{"_time":"2026-05-06T10:00:00Z","_msg":"{\"path\":\"/settings\",\"method\":\"GET\",\"status\":200}","_stream":"{env=\"production\",container=\"api\"}","env":"production","container":"api","path":"/settings","method":"GET","status":"200"}`
+	entry2 := `{"_time":"2026-05-06T10:00:01Z","_msg":"{\"path\":\"/health\",\"method\":\"GET\",\"status\":200,\"duration\":12}","_stream":"{env=\"production\",container=\"api\"}","env":"production","container":"api","path":"/health","method":"GET","status":"200","duration":"12"}`
+
+	// The field_names index returns many extra fields that are NOT in the scan sample.
+	// These simulate VL's accumulated auto-indexed keys across 1 hour of logs from
+	// many different log-line shapes. They must NOT appear in the final response.
+	extraNativeFields := []string{
+		"user_agent", "x_request_id", "content_type", "response_time",
+		"accept", "accept_encoding", "host", "referer",
+		"forwarded_for", "request_id", "correlation_id", "session_id",
+	}
+	allNativeFields := append([]string{"env", "container", "path", "method", "status", "duration"}, extraNativeFields...)
+
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/field_names":
+			var parts []string
+			for _, v := range allNativeFields {
+				parts = append(parts, `{"value":"`+v+`","hits":5}`)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[` + strings.Join(parts, ",") + `]}`))
+		case "/select/logsql/streams":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"values":[{"value":"{env=\"production\",container=\"api\"}","hits":5}]}`))
+		case "/select/logsql/query":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(entry1 + "\n" + entry2 + "\n"))
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	w := httptest.NewRecorder()
+	q := url.Values{
+		"query": {`{env="production",container="api"} | json`},
+		"start": {"1"},
+		"end":   {"2"},
+	}
+	r := httptest.NewRequest("GET", "/loki/api/v1/detected_fields?"+q.Encode(), nil)
+	p.handleDetectedFields(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if limit, _ := resp["limit"].(float64); limit != 1000 {
+		t.Errorf("expected limit=1000 in response (Loki parity), got %v", resp["limit"])
+	}
+
+	fields, _ := resp["fields"].([]interface{})
+	if len(fields) == 0 {
+		t.Fatalf("expected fields from _msg JSON parsing, got none")
+	}
+
+	fieldNames := make(map[string]int)
+	for _, f := range fields {
+		fm, ok := f.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := fm["label"].(string)
+		fieldNames[name]++
+	}
+
+	// _msg-parsed fields must appear exactly once (no double-count via native obj.Visit).
+	for _, key := range []string{"path", "method", "status", "duration"} {
+		if count := fieldNames[key]; count != 1 {
+			t.Errorf("field %q expected exactly once in detected_fields, got %d (double-count bug)", key, count)
+		}
+	}
+
+	// Extra native index fields NOT in _msg must NOT appear — scan result wins over
+	// the accumulated native field_names index (anti-flood guard).
+	for _, key := range extraNativeFields {
+		if fieldNames[key] > 0 {
+			t.Errorf("native-index-only field %q leaked into detected_fields (native flood bug)", key)
+		}
+	}
+}
+
 func TestDetectedFields_FieldFilterFallbackKeepsFieldsVisible(t *testing.T) {
 	var fieldQueries []string
 	var streamQueries []string

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -1082,16 +1082,22 @@ func defaultQuery(query string) string {
 
 func defaultFieldDetectionQuery(query string) string {
 	// Always strip | unwrap and | drop __error__ (they break log scanning for field detection).
-	// Only strip parser stages (| json, | logfmt) when there are no downstream field-comparison
-	// filters (| key="value") that depend on them: VL cannot evaluate a field filter without
-	// the preceding parser, so stripping it produces zero results (the filter references fields
-	// that only exist after parsing). When the query has parser+filter together, keep the parser
-	// so VL can evaluate the comparison. When it's a bare parser with no downstream filter,
-	// strip it to avoid expanding every embedded field into garbage names.
+	// For parser stages:
+	//   | json   → always strip. VL v1.50+ auto-indexes JSON from _msg, so VL can evaluate
+	//              downstream field filters without the explicit | json stage. Keeping | json
+	//              causes VL to expand every _msg JSON key into top-level NDJSON fields in the
+	//              query response, which the scanner then detects as thousands of garbage names.
+	//   | logfmt / | unpack → keep when there are downstream field comparisons. VL does NOT
+	//              auto-parse logfmt/unpack content, so stripping these stages leaves the field
+	//              filter referencing fields that VL cannot evaluate, returning zero results.
 	noUnwrap := stripUnwrapAndDropStages(query)
+	// Strip only | json stages; keep | logfmt / | unpack.
+	noJSONParser := collapseSpaces(reJSONParserStage.ReplaceAllString(noUnwrap, " "))
 	noParser := stripParserOnlyStages(noUnwrap)
-	if noParser != noUnwrap && hasFieldComparisonStages(noParser) {
-		return defaultQuery(noUnwrap)
+	// If stripping all parsers removes something that | json didn't (i.e. logfmt/unpack present)
+	// AND there are downstream field comparisons that depend on those parsers, keep them.
+	if noParser != noJSONParser && hasFieldComparisonStages(noParser) {
+		return defaultQuery(noJSONParser)
 	}
 	return defaultQuery(noParser)
 }
@@ -1128,9 +1134,10 @@ func normalizeBareSelectorQuery(query string) string {
 }
 
 var (
-	reDropStage   = regexp.MustCompile(`\|\s*drop\s+__error__(\s*,\s*__error_details__)?\s*`)
-	reParserStage = regexp.MustCompile(`\|\s*(json|logfmt|unpack)(\s+[^|]+)?`)
-	reUnwrapStage = regexp.MustCompile(`\|\s*unwrap(?:\s+[^|]+)?`)
+	reDropStage          = regexp.MustCompile(`\|\s*drop\s+__error__(\s*,\s*__error_details__)?\s*`)
+	reParserStage        = regexp.MustCompile(`\|\s*(json|logfmt|unpack)(\s+[^|]+)?`)
+	reJSONParserStage    = regexp.MustCompile(`\|\s*json(\s+[^|]+)?`)
+	reUnwrapStage        = regexp.MustCompile(`\|\s*unwrap(?:\s+[^|]+)?`)
 )
 
 func collapseSpaces(s string) string {
@@ -1310,9 +1317,8 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 	var lastErr error
 	var hadScanFailure bool
 	var (
-		scanFieldList      []map[string]interface{}
-		scanFieldValues    map[string][]string
-		scanStreamLabelSet map[string]string
+		scanFieldList   []map[string]interface{}
+		scanFieldValues map[string][]string
 	)
 
 	for _, candidate := range candidates {
@@ -1363,7 +1369,7 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 			return nil, nil, fmt.Errorf("%s", msg)
 		}
 		// Stream the NDJSON response line-by-line without buffering the full body.
-		scanFieldList, scanFieldValues, scanStreamLabelSet = p.detectFieldSummariesStream(resp.Body)
+		scanFieldList, scanFieldValues, _ = p.detectFieldSummariesStream(resp.Body)
 		_ = resp.Body.Close()
 		break
 	}
@@ -1388,7 +1394,15 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 	}
 
 	if len(scanFieldList) > 0 {
-		fieldList, fieldValues := mergeNativeDetectedFields(scanFieldList, scanFieldValues, filterNativeDetectedFields(nativeFields, scanStreamLabelSet, p.labelTranslator))
+		// When the log-line scan produced results, use them as-is.
+		// The scan's outer obj.Visit already captures native VL metadata fields
+		// (OTel service.name, trace_id, etc.) for entries whose _msg is not JSON,
+		// and the _msg JSON parsing pass finds all JSON fields with parser="json".
+		// Merging the native field_names index here would flood the response:
+		// VL auto-indexes every JSON key across the entire time range, so the index
+		// may contain thousands of field names accumulated from rare log variants
+		// that the 500-line scan sample correctly excludes.
+		fieldList, fieldValues := mergeNativeDetectedFields(scanFieldList, scanFieldValues, nil)
 		p.setCachedDetectedFields(ctx, query, start, end, lineLimit, fieldList, fieldValues)
 		return fieldList, fieldValues, nil
 	}
@@ -1396,9 +1410,16 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 	if len(nativeFields) > 0 {
 		if nativeFieldFilterNeedsStreamLabels(nativeFields, p.labelTranslator) {
 			streamLabels, err := p.fetchNativeStreamLabelSet(ctx, query, start, end)
-			if err == nil {
+			if err != nil {
+				// Cannot determine stream labels → skip native fields to avoid flooding
+				// the detected fields response with every VL-indexed field name.
+				nativeFields = nil
+			} else {
 				nativeFields = filterNativeDetectedFields(nativeFields, streamLabels, p.labelTranslator)
 			}
+		}
+		if len(nativeFields) == 0 {
+			return nil, nil, lastErr
 		}
 		nativeFieldList, nativeFieldValues := mergeNativeDetectedFields(nil, nil, nativeFields)
 		p.setCachedDetectedFields(ctx, query, start, end, lineLimit, nativeFieldList, nativeFieldValues)
@@ -1418,9 +1439,11 @@ func (p *Proxy) detectFieldsNativeOnly(ctx context.Context, query, start, end st
 		return nil, nil
 	}
 	if nativeFieldFilterNeedsStreamLabels(nativeFields, p.labelTranslator) {
-		if streamLabels, serr := p.fetchNativeStreamLabelSet(ctx, query, start, end); serr == nil {
-			nativeFields = filterNativeDetectedFields(nativeFields, streamLabels, p.labelTranslator)
+		streamLabels, serr := p.fetchNativeStreamLabelSet(ctx, query, start, end)
+		if serr != nil {
+			return nil, nil
 		}
+		nativeFields = filterNativeDetectedFields(nativeFields, streamLabels, p.labelTranslator)
 	}
 	return mergeNativeDetectedFields(nil, nil, nativeFields)
 }
@@ -1637,11 +1660,54 @@ func (p *Proxy) detectFieldSummariesStream(r io.Reader) ([]map[string]interface{
 			}
 		}
 
+		// Get _msg early so we can pre-collect its JSON keys before the outer native
+		// field visit. VL auto-indexes all JSON keys from _msg as native NDJSON fields;
+		// without this guard those keys appear in detected_fields twice (once without a
+		// parser tag from obj.Visit, once with parser="json") and accumulate across
+		// thousands of log entries, causing the "Fields 5,965" flood.
+		msgBytes := fjVal.GetStringBytes("_msg")
+
+		// Parse _msg JSON once: populate msgJSONKeys for the skip-guard below AND add
+		// detected fields with parser="json" in the same pass.
+		var msgJSONKeys map[string]struct{}
+		if len(msgBytes) >= 2 && msgBytes[0] == '{' {
+			fjParser2 := vlFJParserPool.Get()
+			if fjVal2, err2 := fjParser2.ParseBytes(msgBytes); err2 == nil {
+				if obj2, objErr2 := fjVal2.Object(); objErr2 == nil {
+					msgJSONKeys = make(map[string]struct{})
+					obj2.Visit(func(keyBytes []byte, v *fj.Value) {
+						key := string(keyBytes)
+						if key == "" {
+							return
+						}
+						// Skip nested objects and arrays.
+						vt := v.Type()
+						if vt == fj.TypeObject || vt == fj.TypeArray {
+							return
+						}
+						msgJSONKeys[key] = struct{}{}
+						if shouldSuppressDetectedField(key) {
+							return
+						}
+						if _, conflict := labelNames[key]; conflict {
+							return
+						}
+						addDetectedField(fields, key, "json", inferDetectedTypeFJ(v), []string{key}, formatDetectedValueFJ(v))
+					})
+				}
+			}
+			vlFJParserPool.Put(fjParser2)
+		}
+
 		obj, objErr := fjVal.Object()
 		if objErr == nil {
 			obj.Visit(func(keyBytes []byte, v *fj.Value) {
 				key := string(keyBytes)
 				if key == "app" || key == "cluster" || key == "namespace" {
+					return
+				}
+				// Skip keys already covered by _msg JSON parsing above.
+				if _, inMsg := msgJSONKeys[key]; inMsg {
 					return
 				}
 				if !shouldExposeStructuredField(key, rawStreamLabels, p.labelTranslator) {
@@ -1660,41 +1726,12 @@ func (p *Proxy) detectFieldSummariesStream(r io.Reader) ([]map[string]interface{
 			})
 		}
 
-		msgBytes := fjVal.GetStringBytes("_msg")
 		vlFJParserPool.Put(fjParser)
 
 		if len(msgBytes) == 0 {
 			continue
 		}
 		msg := string(msgBytes)
-
-		// Only attempt JSON parse if _msg starts with '{' — skip non-JSON early.
-		if len(msgBytes) >= 2 && msgBytes[0] == '{' {
-			fjParser2 := vlFJParserPool.Get()
-			if fjVal2, err2 := fjParser2.ParseBytes(msgBytes); err2 == nil {
-				if obj2, objErr2 := fjVal2.Object(); objErr2 == nil {
-					obj2.Visit(func(keyBytes []byte, v *fj.Value) {
-						key := string(keyBytes)
-						if key == "" {
-							return
-						}
-						// Skip nested objects and arrays (equivalent to map[string]interface{}/[]interface{} check).
-						vt := v.Type()
-						if vt == fj.TypeObject || vt == fj.TypeArray {
-							return
-						}
-						if shouldSuppressDetectedField(key) {
-							return
-						}
-						if _, conflict := labelNames[key]; conflict {
-							return
-						}
-						addDetectedField(fields, key, "json", inferDetectedTypeFJ(v), []string{key}, formatDetectedValueFJ(v))
-					})
-				}
-			}
-			vlFJParserPool.Put(fjParser2)
-		}
 
 		for key, value := range parseLogfmtFields(msg) {
 			if key == "msg" {
@@ -2278,8 +2315,13 @@ func (p *Proxy) fetchNativeStreams(ctx context.Context, query, start, end string
 }
 
 func filterNativeDetectedFields(native map[string]*detectedFieldSummary, streamLabels map[string]string, lt *LabelTranslator) map[string]*detectedFieldSummary {
-	if len(native) == 0 || len(streamLabels) == 0 {
+	if len(native) == 0 {
 		return native
+	}
+	if len(streamLabels) == 0 {
+		// Without stream labels we cannot distinguish label keys from structured fields;
+		// returning native unfiltered would flood the UI with all VL-indexed field names.
+		return make(map[string]*detectedFieldSummary)
 	}
 	filtered := make(map[string]*detectedFieldSummary, len(native))
 	for label, summary := range native {

--- a/internal/proxy/label_handlers.go
+++ b/internal/proxy/label_handlers.go
@@ -475,7 +475,10 @@ func (p *Proxy) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 		"status": "success",
 		"data":   fields,
 		"fields": fields,
-		"limit":  lineLimit,
+		// Loki always returns 1000 here regardless of the requested line_limit.
+		// Drilldown reads this value and displays it as "Fields N" in the UI.
+		// Echoing the requested line_limit causes "Fields 5,951" etc. to appear.
+		"limit": 1000,
 	}
 	p.setEndpointJSONCacheWithTTL("detected_fields", cacheKey, CacheTTLs["detected_fields"], payload)
 	p.writeJSON(w, payload)

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1282,11 +1282,17 @@ func (p *Proxy) proxyBareParserMetricViaStats(w http.ResponseWriter, r *http.Req
 
 func (p *Proxy) proxyBareParserMetricQueryRange(w http.ResponseWriter, r *http.Request, start time.Time, originalQuery string, spec bareParserMetricCompatSpec) {
 	// Tumbling-window fast path: for count-like functions with no post-parser pipeline
-	// stages, no unwrap, and range==step, route to native VL stats_query_range. VL keeps
-	// the parser stage in the translated query so parse-failure filtering matches Loki
-	// semantics. Loki groups these by stream labels only (not parsed fields), and native
-	// stats matches that. The manual path (fetchBareParserMetricSeries) groups by ALL
-	// parsed fields — correct for sliding windows but wrong for tumbling bare metrics.
+	// stages, no unwrap, and range==step, route to native VL stats_query_range.
+	//
+	// Why native stats is safe here despite range_metric_compat.go's __error__ rule:
+	// The general rule routes parser-stage queries to the manual path because VL native
+	// stats may not replicate Loki's __error__ exclusion when extracted label dimensions
+	// affect grouping. For bare parser metrics there are no post-parser pipeline stages,
+	// so no extracted label dimensions exist. rate/count_over_time/bytes_* count every
+	// log line matching the stream selector regardless of parse success in both Loki and
+	// VL — parse failures cannot reduce the count. The manual path groups by ALL parsed
+	// fields, producing wrong label sets for tumbling windows where Loki groups by stream
+	// labels only. Native stats reproduces Loki's stream-label-only grouping exactly.
 	stepDurFast, stepOk := parsePositiveStepDuration(r.FormValue("step"))
 	rangeEqualsStep := stepOk && spec.rangeWindow > 0 && spec.rangeWindow == stepDurFast
 	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) {

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -582,6 +582,9 @@ func queryUsesParserStages(baseQuery string) bool {
 // only become metric dimensions when the caller explicitly names them in by(...).
 func addGroupByParsedLabels(metricLabels map[string]string, entry map[string]interface{}, groupBy []string) {
 	for _, key := range groupBy {
+		if isVLInternalField(key) || key == "_stream_id" {
+			continue
+		}
 		if _, exists := metricLabels[key]; exists {
 			continue
 		}

--- a/internal/translator/helper_coverage_test.go
+++ b/internal/translator/helper_coverage_test.go
@@ -34,6 +34,20 @@ func TestCoverage_SplitLogicalStageAndSanitizeHelpers(t *testing.T) {
 	if logsQLEqualityValueNeedsQuoting("api-1/ready") {
 		t.Fatal("expected simple path token not to require quoting")
 	}
+	// Standalone punctuation-only values are compound tokens in VL and must be quoted.
+	// e.g. path = "/" must become path:="/" not path:=/ which VL cannot parse.
+	if !logsQLEqualityValueNeedsQuoting("/") {
+		t.Fatal(`expected "/" to require quoting (VL compound-token error)`)
+	}
+	if !logsQLEqualityValueNeedsQuoting("-") {
+		t.Fatal(`expected "-" to require quoting`)
+	}
+	if !logsQLEqualityValueNeedsQuoting(".") {
+		t.Fatal(`expected "." to require quoting`)
+	}
+	if logsQLEqualityValueNeedsQuoting("/settings") {
+		t.Fatal("expected /settings path not to require quoting")
+	}
 }
 
 func TestCoverage_CanUseStreamSelectorAndTranslateLabelFormat(t *testing.T) {

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -795,19 +795,25 @@ func logsQLEqualityValueNeedsQuoting(value string) bool {
 	if value == "" {
 		return true
 	}
+	hasAlnum := false
 	for _, r := range value {
 		if unicode.IsSpace(r) {
 			return true
 		}
 		if (r >= 'a' && r <= 'z') ||
 			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			r == '_' || r == '-' || r == '.' || r == '/' {
+			(r >= '0' && r <= '9') {
+			hasAlnum = true
+			continue
+		}
+		if r == '_' || r == '-' || r == '.' || r == '/' {
 			continue
 		}
 		return true
 	}
-	return false
+	// Values made entirely of punctuation (e.g. "/" or "-") are compound tokens
+	// in VL's parser and must be quoted. Require at least one alphanumeric character.
+	return !hasAlnum
 }
 
 func translateMalformedDottedStage(stage string, labelFn LabelTranslateFunc) (string, bool) {

--- a/scripts/ci/check_scorecard.py
+++ b/scripts/ci/check_scorecard.py
@@ -62,8 +62,21 @@ def evaluate_report(
 
 
 def main_for_test(report: Path, min_overall: float, require_checks: dict[str, float]) -> int:
+    text = report.read_text().strip()
+    if not text:
+        # Scorecard container failed to fetch the score (API rate limit, network issue,
+        # etc.). The OpenSSF Scorecard step has continue-on-error: true precisely for
+        # this case. Treat an empty report as "unavailable" rather than a guardrail
+        # failure so transient upstream issues don't block PRs.
+        print("OpenSSF Scorecard report is empty — skipping guardrails (scorecard unavailable)")
+        return 0
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"OpenSSF Scorecard report is not valid JSON ({exc}) — skipping guardrails")
+        return 0
     return evaluate_report(
-        payload=json.loads(report.read_text()),
+        payload=payload,
         min_overall=min_overall,
         require_checks=require_checks,
     )

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -5,6 +5,9 @@
 # - Grafana with all 3 datasources configured
 # - Playwright for UI testing
 #
+# All services share the internal "e2e-compat" bridge network.
+# Only Grafana is reachable from the host (port 3002).
+#
 # Usage:
 #   docker-compose up -d --build
 #   go test -v -tags=e2e -timeout=180s ./test/e2e-compat/
@@ -12,13 +15,16 @@
 #   cd ../e2e-ui && npm install && npx playwright install chromium && npm test
 #   # Or open Grafana at http://localhost:3002 for manual comparison
 
+networks:
+  e2e-compat:
+    driver: bridge
+
 services:
   # Reference Loki instance (ground truth)
   loki:
     image: ${LOKI_IMAGE:-grafana/loki:3.7.1}
     container_name: e2e-loki
-    ports:
-      - "3101:3100"
+    networks: [e2e-compat]
     # Bench peak: 1,798 MB (heavy c=100). +30% headroom = 2,337 MB → 2.4g.
     # Loki RSS is stable across all workloads (1.4–1.8 GB range), so this
     # cap is not expected to trigger; it guards against runaway situations.
@@ -36,8 +42,7 @@ services:
   victorialogs:
     image: ${VICTORIALOGS_IMAGE:-victoriametrics/victoria-logs:v1.50.0}
     container_name: e2e-victorialogs
-    ports:
-      - "9428:9428"
+    networks: [e2e-compat]
     # Hard memory cap: Docker OOM-kills and restarts the container rather than
     # letting unconstrained query memory exhaust the host. Without this, 50+
     # concurrent 48–72h queries each allocate ~100–200 MB of working buffers,
@@ -95,6 +100,7 @@ services:
   vmauth:
     image: ${VMAUTH_IMAGE:-victoriametrics/vmauth:v1.138.0}
     container_name: e2e-vmauth
+    networks: [e2e-compat]
     command:
       - "-auth.config=/etc/vmauth/auth.yml"
       - "-httpListenAddr=:8427"
@@ -114,6 +120,7 @@ services:
   victoriametrics:
     image: ${VICTORIAMETRICS_IMAGE:-victoriametrics/victoria-metrics:v1.119.0}
     container_name: e2e-victoriametrics
+    networks: [e2e-compat]
     command:
       - "-storageDataPath=/vm-data"
       - "-httpListenAddr=:8428"
@@ -130,9 +137,8 @@ services:
   vmalert:
     image: ${VMALERT_IMAGE:-victoriametrics/vmalert:v1.138.0}
     container_name: e2e-vmalert
+    networks: [e2e-compat]
     working_dir: /rules
-    ports:
-      - "8880:8880"
     command:
       - "-httpListenAddr=:8880"
       - "-datasource.url=http://victorialogs:9428"
@@ -161,8 +167,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy
-    ports:
-      - "3100:3100"
+    networks: [e2e-compat]
     tmpfs:
       - /cache
     environment:
@@ -211,8 +216,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-patterns-autodetect
-    ports:
-      - "3110:3100"
+    networks: [e2e-compat]
     tmpfs:
       - /cache
     command:
@@ -247,8 +251,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-vmauth
-    ports:
-      - "3109:3100"
+    networks: [e2e-compat]
     command:
       - "-listen=:3100"
       - "-backend=http://vmauth:8427"
@@ -278,8 +281,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-underscore
-    ports:
-      - "3102:3100"
+    networks: [e2e-compat]
     environment:
       # Soft GC pressure limit: hybrid mode + no label-values index = many concurrent
       # VL NDJSON responses in memory. Without GOMEMLIMIT Go's GC only triggers at
@@ -322,8 +324,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-native-metadata
-    ports:
-      - "3106:3100"
+    networks: [e2e-compat]
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -353,8 +354,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-translated-metadata
-    ports:
-      - "3107:3100"
+    networks: [e2e-compat]
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -384,8 +384,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-no-metadata
-    ports:
-      - "3108:3100"
+    networks: [e2e-compat]
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -415,8 +414,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-tail
-    ports:
-      - "3103:3100"
+    networks: [e2e-compat]
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -445,8 +443,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-tail-native
-    ports:
-      - "3105:3100"
+    networks: [e2e-compat]
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -472,8 +469,7 @@ services:
   tail-ingress:
     image: nginx:1.27-alpine
     container_name: e2e-tail-ingress
-    ports:
-      - "3104:8080"
+    networks: [e2e-compat]
     volumes:
       - ./nginx-tail.conf:/etc/nginx/nginx.conf:ro
     depends_on:
@@ -491,6 +487,7 @@ services:
   log-generator:
     image: python:3.12-alpine
     container_name: e2e-log-generator
+    networks: [e2e-compat]
     profiles: ["ui"]
     command: python /scripts/log-generator.py
     volumes:
@@ -511,6 +508,7 @@ services:
   grafana:
     image: ${GRAFANA_IMAGE:-grafana/grafana:13.0.1}
     container_name: e2e-grafana
+    networks: [e2e-compat]
     ports:
       - "3002:3000"
     environment:

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -5,9 +5,6 @@
 # - Grafana with all 3 datasources configured
 # - Playwright for UI testing
 #
-# All services share the internal "e2e-compat" bridge network.
-# Only Grafana is reachable from the host (port 3002).
-#
 # Usage:
 #   docker-compose up -d --build
 #   go test -v -tags=e2e -timeout=180s ./test/e2e-compat/
@@ -15,16 +12,13 @@
 #   cd ../e2e-ui && npm install && npx playwright install chromium && npm test
 #   # Or open Grafana at http://localhost:3002 for manual comparison
 
-networks:
-  e2e-compat:
-    driver: bridge
-
 services:
   # Reference Loki instance (ground truth)
   loki:
     image: ${LOKI_IMAGE:-grafana/loki:3.7.1}
     container_name: e2e-loki
-    networks: [e2e-compat]
+    ports:
+      - "3101:3100"
     # Bench peak: 1,798 MB (heavy c=100). +30% headroom = 2,337 MB → 2.4g.
     # Loki RSS is stable across all workloads (1.4–1.8 GB range), so this
     # cap is not expected to trigger; it guards against runaway situations.
@@ -42,7 +36,8 @@ services:
   victorialogs:
     image: ${VICTORIALOGS_IMAGE:-victoriametrics/victoria-logs:v1.50.0}
     container_name: e2e-victorialogs
-    networks: [e2e-compat]
+    ports:
+      - "9428:9428"
     # Hard memory cap: Docker OOM-kills and restarts the container rather than
     # letting unconstrained query memory exhaust the host. Without this, 50+
     # concurrent 48–72h queries each allocate ~100–200 MB of working buffers,
@@ -100,7 +95,6 @@ services:
   vmauth:
     image: ${VMAUTH_IMAGE:-victoriametrics/vmauth:v1.138.0}
     container_name: e2e-vmauth
-    networks: [e2e-compat]
     command:
       - "-auth.config=/etc/vmauth/auth.yml"
       - "-httpListenAddr=:8427"
@@ -120,7 +114,6 @@ services:
   victoriametrics:
     image: ${VICTORIAMETRICS_IMAGE:-victoriametrics/victoria-metrics:v1.119.0}
     container_name: e2e-victoriametrics
-    networks: [e2e-compat]
     command:
       - "-storageDataPath=/vm-data"
       - "-httpListenAddr=:8428"
@@ -137,8 +130,9 @@ services:
   vmalert:
     image: ${VMALERT_IMAGE:-victoriametrics/vmalert:v1.138.0}
     container_name: e2e-vmalert
-    networks: [e2e-compat]
     working_dir: /rules
+    ports:
+      - "8880:8880"
     command:
       - "-httpListenAddr=:8880"
       - "-datasource.url=http://victorialogs:9428"
@@ -167,7 +161,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy
-    networks: [e2e-compat]
+    ports:
+      - "3100:3100"
     tmpfs:
       - /cache
     environment:
@@ -216,7 +211,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-patterns-autodetect
-    networks: [e2e-compat]
+    ports:
+      - "3110:3100"
     tmpfs:
       - /cache
     command:
@@ -251,7 +247,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-vmauth
-    networks: [e2e-compat]
+    ports:
+      - "3109:3100"
     command:
       - "-listen=:3100"
       - "-backend=http://vmauth:8427"
@@ -281,7 +278,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-underscore
-    networks: [e2e-compat]
+    ports:
+      - "3102:3100"
     environment:
       # Soft GC pressure limit: hybrid mode + no label-values index = many concurrent
       # VL NDJSON responses in memory. Without GOMEMLIMIT Go's GC only triggers at
@@ -324,7 +322,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-native-metadata
-    networks: [e2e-compat]
+    ports:
+      - "3106:3100"
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -354,7 +353,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-translated-metadata
-    networks: [e2e-compat]
+    ports:
+      - "3107:3100"
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -384,7 +384,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-no-metadata
-    networks: [e2e-compat]
+    ports:
+      - "3108:3100"
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -414,7 +415,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-tail
-    networks: [e2e-compat]
+    ports:
+      - "3103:3100"
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -443,7 +445,8 @@ services:
       context: ../..
       dockerfile: Dockerfile
     container_name: e2e-proxy-tail-native
-    networks: [e2e-compat]
+    ports:
+      - "3105:3100"
     command:
       - "-listen=:3100"
       - "-backend=http://victorialogs:9428"
@@ -469,7 +472,8 @@ services:
   tail-ingress:
     image: nginx:1.27-alpine
     container_name: e2e-tail-ingress
-    networks: [e2e-compat]
+    ports:
+      - "3104:8080"
     volumes:
       - ./nginx-tail.conf:/etc/nginx/nginx.conf:ro
     depends_on:
@@ -487,7 +491,6 @@ services:
   log-generator:
     image: python:3.12-alpine
     container_name: e2e-log-generator
-    networks: [e2e-compat]
     profiles: ["ui"]
     command: python /scripts/log-generator.py
     volumes:
@@ -508,7 +511,6 @@ services:
   grafana:
     image: ${GRAFANA_IMAGE:-grafana/grafana:13.0.1}
     container_name: e2e-grafana
-    networks: [e2e-compat]
     ports:
       - "3002:3000"
     environment:


### PR DESCRIPTION
## Summary

**Cold routing fixes:**
- **High**: `RouteBoth` backward queries sent the client `limit` to cold — Lakehouse applies it before streaming oldest-first, so the wrong rows were fetched and reversal did not fix it. Fix sends `maxLimitValue` to cold for backward direction.
- **High**: Cold rows in `RouteBoth` backward were merged without reversal — oldest-first cold followed newest-first hot, corrupting order when hot was shorter than the limit. Fix reverses cold body before merging.
- **Docs**: Clarifies `proxyBareParserMetricViaStats` tumbling-window comment.

**Drilldown `detected_fields` flooding fixes ("Fields 5,965"):**
- **High**: `detected_fields` no longer returns thousands of fields for queries with parser stages. VL auto-indexes all JSON keys from `_msg` into a time-range-wide native field index; when the 500-line log scan has results, those results now take precedence and the native index is discarded entirely.
- **High**: `detected_fields` no longer double-counts fields from JSON `_msg`. VL also returns auto-indexed JSON keys as top-level NDJSON fields; a pre-pass in `detectFieldSummariesStream` collects `_msg` JSON keys then skips them in the outer `obj.Visit` so each field appears once with `parser="json"`.
- **Medium**: Metric queries no longer include `_stream="{app=\"...\"}` as a raw label — `addGroupByParsedLabels` now skips VL internal fields in the `groupBy` key list.

Known limitation (cold): cold ranges with more than `maxLimitValue` (10 000) matching rows still return newest rows from only the oldest 10 000.

## Test plan

- [ ] `TestProxyLogQueryBoth_BackwardDirection_ReversesColdAndUsesMaxLimit` — cold receives `maxLimitValue`, cold is reversed before merge, result trimmed to client `limit` with correct newest-first ordering
- [ ] `TestDetectedFields_NativeIndexFloodBlocked` — native index fields not in the 500-line scan sample do not appear; `_msg`-parsed fields counted exactly once
- [ ] All 1565 existing proxy unit tests pass
