### PR TITLE
fix(drilldown): detected_level="" matches absent entries; drop sort from volume hits query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(drilldown): `detected_level=""` log level filter now correctly matches log entries with no detected level — the translator was emitting `level:=""` (explicit empty string only) instead of `-level:*` (absent or empty), so entries where the `level` field was simply absent were never returned; applies to both stream-selector and pipeline-filter positions
+- fix(volume): `computeVolumeRangeResult` no longer appends `| sort by (_time desc)` to VL hits queries — the `/select/logsql/hits` endpoint counts log hits per time bucket and ignores sort stages, so the trailing sort was a no-op that added query overhead
+
 ## [1.29.5] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix(drilldown): `detected_level=""` log level filter now correctly matches log entries with no detected level — the translator was emitting `level:=""` (explicit empty string only) instead of `-level:*` (absent or empty), so entries where the `level` field was simply absent were never returned; applies to both stream-selector and pipeline-filter positions
 - fix(volume): `computeVolumeRangeResult` no longer appends `| sort by (_time desc)` to VL hits queries — the `/select/logsql/hits` endpoint counts log hits per time bucket and ignores sort stages, so the trailing sort was a no-op that added query overhead
+- fix(drilldown): `volumeByDerivedLabels` volume histogram now correctly renders for `detected_level` target — `parseVolumeBoundary` was treating all numeric timestamps as nanoseconds (`time.Unix(0, n)`), so Unix-second inputs produced a 1970 epoch boundary that filtered out all 2026 log entries; changed to use `parseFlexibleUnixSeconds` which correctly normalises both second and nanosecond inputs
 
 ## [1.29.5] - 2026-05-06
 

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -780,9 +780,8 @@ func parseVolumeBoundary(ts string) (time.Time, bool) {
 			return time.Now().UTC().Add(d), true
 		}
 	}
-	normalized := formatVLTimestamp(ts)
-	if n, err := strconv.ParseInt(normalized, 10, 64); err == nil {
-		return time.Unix(0, n).UTC(), true
+	if sec, ok := parseFlexibleUnixSeconds(ts); ok {
+		return time.Unix(sec, 0).UTC(), true
 	}
 	return time.Time{}, false
 }

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -17,11 +17,12 @@ import (
 )
 
 type statsCompatSpec struct {
-	BaseQuery  string
-	GroupBy    []string
-	ByExplicit bool // true when "by ()" was present — aggregate all into one series
-	Func       string
-	Field      string
+	BaseQuery   string
+	GroupBy     []string
+	OrigGroupBy []string // original Loki label names before VL translation (e.g. detected_level → level)
+	ByExplicit  bool     // true when "by ()" was present — aggregate all into one series
+	Func        string
+	Field       string
 }
 
 type originalRangeMetricSpec struct {
@@ -38,8 +39,10 @@ type rangeMetricSample struct {
 }
 
 var (
-	rangeMetricUnwrapRE = regexp.MustCompile(`(?s)\|\s*unwrap\s+([^|\[]+)`)
-	outerAggregationRE = regexp.MustCompile(`^(?:sum|avg|max|min|count(?:_values)?|stddev|stdvar|sort(?:_desc)?|topk|bottomk)\s*(?:(?:by|without)\s*\([^)]*\)\s*)?`)
+	rangeMetricUnwrapRE  = regexp.MustCompile(`(?s)\|\s*unwrap\s+([^|\[]+)`)
+	outerAggregationRE   = regexp.MustCompile(`^(?:sum|avg|max|min|count(?:_values)?|stddev|stdvar|sort(?:_desc)?|topk|bottomk)\s*(?:(?:by|without)\s*\([^)]*\)\s*)?`)
+	outerByAfterRE       = regexp.MustCompile(`\)\s+by\s*\(([^)]+)\)\s*$`)
+	outerByBeforeRE      = regexp.MustCompile(`^(?:sum|avg|min|max|count[^(]*|stddev|stdvar)\s+by\s*\(([^)]+)\)\s*\(`)
 )
 
 func parseStatsCompatSpec(logsqlQuery string) (statsCompatSpec, bool) {
@@ -258,6 +261,28 @@ func parseUnwrapExpression(expr string) (field, conv string) {
 	return field, conv
 }
 
+// parseOriginalByLabels extracts the outer by(...) label names from a LogQL
+// metric query. Handles both "sum(...) by (labels)" and "sum by (labels) (...)"
+// forms. Returns nil when no outer by-clause is present.
+func parseOriginalByLabels(logql string) []string {
+	var raw string
+	if m := outerByAfterRE.FindStringSubmatch(logql); m != nil {
+		raw = m[1]
+	} else if m := outerByBeforeRE.FindStringSubmatch(logql); m != nil {
+		raw = m[1]
+	}
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, l := range strings.Split(raw, ",") {
+		if l = strings.TrimSpace(l); l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
 func (p *Proxy) handleStatsCompatRange(w http.ResponseWriter, r *http.Request, originalLogql, logsqlQuery string) bool {
 	spec, ok := parseStatsCompatSpec(logsqlQuery)
 	if !ok {
@@ -266,6 +291,9 @@ func (p *Proxy) handleStatsCompatRange(w http.ResponseWriter, r *http.Request, o
 	if !isManualRangeStatsFunc(spec.Func) {
 		return false
 	}
+	// Capture original Loki by-labels so we can translate VL label names back
+	// in the metric response (e.g. VL "level" → Loki "detected_level").
+	spec.OrigGroupBy = parseOriginalByLabels(originalLogql)
 	origSpec, hasOrigSpec := parseOriginalRangeMetricSpec(originalLogql)
 
 	manualFunc := normalizeManualMetricFunction(spec, origSpec)
@@ -300,6 +328,7 @@ func (p *Proxy) handleStatsCompatInstant(w http.ResponseWriter, r *http.Request,
 	if !isManualRangeStatsFunc(spec.Func) {
 		return false
 	}
+	spec.OrigGroupBy = parseOriginalByLabels(originalLogql)
 	origSpec, hasOrigSpec := parseOriginalRangeMetricSpec(originalLogql)
 
 	manualFunc := normalizeManualMetricFunction(spec, origSpec)
@@ -398,7 +427,7 @@ func (p *Proxy) proxyManualRangeMetricRange(w http.ResponseWriter, r *http.Reque
 		return true
 	}
 
-	series, err := p.collectRangeMetricSamples(r.Context(), spec.BaseQuery, spec.GroupBy, spec.ByExplicit, field, origSpec.UnwrapConv, startTS.Add(-origSpec.Window), endTS)
+	series, err := p.collectRangeMetricSamples(r.Context(), spec.BaseQuery, spec.GroupBy, spec.OrigGroupBy, spec.ByExplicit, field, origSpec.UnwrapConv, startTS.Add(-origSpec.Window), endTS)
 	if err != nil {
 		p.writeError(w, http.StatusBadGateway, err.Error())
 		return true
@@ -425,7 +454,7 @@ func (p *Proxy) proxyManualRangeMetricInstant(w http.ResponseWriter, r *http.Req
 		return true
 	}
 
-	series, err := p.collectRangeMetricSamples(r.Context(), spec.BaseQuery, spec.GroupBy, spec.ByExplicit, field, origSpec.UnwrapConv, evalTS.Add(-origSpec.Window), evalTS)
+	series, err := p.collectRangeMetricSamples(r.Context(), spec.BaseQuery, spec.GroupBy, spec.OrigGroupBy, spec.ByExplicit, field, origSpec.UnwrapConv, evalTS.Add(-origSpec.Window), evalTS)
 	if err != nil {
 		p.writeError(w, http.StatusBadGateway, err.Error())
 		return true
@@ -467,7 +496,7 @@ func (p *Proxy) resolveManualMetricField(spec statsCompatSpec, origSpec original
 	return p.labelTranslator.ToVL(field), 0, nil
 }
 
-func (p *Proxy) collectRangeMetricSamples(ctx context.Context, baseQuery string, groupBy []string, byExplicit bool, field, unwrapConv string, start, end time.Time) (map[string]manualSeriesSamples, error) {
+func (p *Proxy) collectRangeMetricSamples(ctx context.Context, baseQuery string, groupBy, origGroupBy []string, byExplicit bool, field, unwrapConv string, start, end time.Time) (map[string]manualSeriesSamples, error) {
 	params := url.Values{}
 	params.Set("query", baseQuery)
 	params.Set("start", formatVLTimestamp(start.UTC().Format(time.RFC3339Nano)))
@@ -543,6 +572,20 @@ func (p *Proxy) collectRangeMetricSamples(ctx context.Context, baseQuery string,
 			// Loki groups by stream labels only when no by(...) is present; parsed
 			// fields become metric dimensions only when explicitly named in by(...).
 			addGroupByParsedLabels(metricLabels, entry, groupBy)
+		}
+		// Rename VL-translated groupBy keys back to their original Loki names.
+		// Example: VL "level" was produced by translating Loki "detected_level";
+		// the response metric must carry "detected_level" to match what Drilldown
+		// requested in "sum(...) by (detected_level)".
+		if len(origGroupBy) == len(groupBy) {
+			for i, vlKey := range groupBy {
+				if lokiKey := origGroupBy[i]; lokiKey != vlKey {
+					if v, ok := metricLabels[vlKey]; ok {
+						delete(metricLabels, vlKey)
+						metricLabels[lokiKey] = v
+					}
+				}
+			}
 		}
 		translated := p.labelTranslator.TranslateLabelsMap(metricLabels)
 		key := seriesKeyFromMetric(translated)

--- a/internal/proxy/utility_coverage_test.go
+++ b/internal/proxy/utility_coverage_test.go
@@ -144,7 +144,10 @@ func TestDrilldownHelpers(t *testing.T) {
 	if _, ok := parseVolumeBoundary(""); ok {
 		t.Fatal("expected empty boundary to fail")
 	}
-	if got, ok := parseVolumeBoundary("1712434882123456789"); !ok || got.UnixNano() != 1712434882123456789 {
+	// parseVolumeBoundary normalises numeric timestamps to Unix seconds, so a
+	// nanosecond-precision input loses sub-second precision but the seconds
+	// component must be correct.
+	if got, ok := parseVolumeBoundary("1712434882123456789"); !ok || got.Unix() != 1712434882 {
 		t.Fatalf("unexpected absolute boundary: %v %v", got, ok)
 	}
 	if got, ok := parseVolumeBoundary("now-1m"); !ok || time.Since(got) < 50*time.Second || time.Since(got) > 70*time.Second {

--- a/internal/proxy/volume.go
+++ b/internal/proxy/volume.go
@@ -357,7 +357,7 @@ func (p *Proxy) computeVolumeRangeResult(ctx context.Context, query, start, end,
 	logsqlQuery, _ := p.translateQueryWithContext(ctx, query)
 
 	params := url.Values{}
-	params.Set("query", logsqlQuery+" | sort by (_time desc)")
+	params.Set("query", logsqlQuery)
 	if s := start; s != "" {
 		params.Set("start", formatVLTimestamp(s))
 	}

--- a/internal/translator/realworld_test.go
+++ b/internal/translator/realworld_test.go
@@ -135,9 +135,11 @@ func TestRealWorld_MultiStage(t *testing.T) {
 			want:  `job:=nginx | extract "<ip> - - <_> <method> <uri> <status>" | filter status:>=400 | delete ip`,
 		},
 		{
-			name:  "drilldown multi-level filter after parser chain",
+			// detected_level before any parser: inject | unpack_logfmt so the filter
+			// checks the logfmt-parsed level in _msg, not _stream.level.
+			name:  "drilldown multi-level filter before parser chain",
 			logql: `{cluster="us-east-1"} | detected_level="error" or detected_level="info" or detected_level="warn" | json | logfmt | drop __error__, __error_details__`,
-			want:  `cluster:=us-east-1 (level:=error or level:=info or level:=warn) | unpack_json | unpack_logfmt | delete __error__, __error_details__`,
+			want:  `cluster:=us-east-1 | unpack_logfmt | filter (level:=error or level:=info or level:=warn) | unpack_json | unpack_logfmt | delete __error__, __error_details__`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -270,6 +270,7 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 		streamContent := remaining[1:end]
 		remaining = strings.TrimSpace(remaining[end+1:])
 
+		var logfmtPipelineFilters []string
 		matchers := splitStreamMatchers(streamContent)
 		for _, m := range matchers {
 			if sf != nil && canUseStreamSelector(m, sf, labelFn) {
@@ -277,8 +278,30 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 			} else {
 				ff := streamMatcherToFieldFilter(m, labelFn)
 				if ff != "" {
-					parts = append(parts, ff)
+					// detected_level with a concrete value must use a logfmt pipeline
+					// stage in VL. The push-time _stream.level may differ from the
+					// logfmt-parsed level in _msg; Loki's detected_level semantically
+					// means "level as detected from message body", so we must unpack
+					// and filter on the parsed field. The empty-value sentinel
+					// (-level:*) stays in the base query because it signals
+					// "no level field present at all" and works without parsing.
+					if strings.HasPrefix(m, "detected_level") && ff != "-level:*" {
+						logfmtPipelineFilters = append(logfmtPipelineFilters, ff)
+					} else {
+						parts = append(parts, ff)
+					}
 				}
+			}
+		}
+		// Inject a logfmt unpack stage for detected_level matchers that need it.
+		// If there are no other base filters yet, add * so the query is valid LogsQL.
+		if len(logfmtPipelineFilters) > 0 {
+			if len(parts) == 0 && len(streamParts) == 0 {
+				parts = append(parts, "*")
+			}
+			parts = append(parts, "| unpack_logfmt")
+			for _, ff := range logfmtPipelineFilters {
+				parts = append(parts, "| filter "+ff)
 			}
 		}
 	}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -745,6 +745,13 @@ func translateSingleLabelFilter(stage string, labelFn LabelTranslateFunc) (strin
 				return fmt.Sprintf(`%s%s"%s"`, label, op.logsql, value), true
 			}
 			if value == "" {
+				// detected_level="" means "no level detected": match log entries where
+				// the level field is absent or has an empty value. VL's -field:* does
+				// exactly this (absent OR empty), while field:="" only matches explicit
+				// empty strings and misses absent fields entirely.
+				if label == "level" && !strings.HasPrefix(op.logsql, "-") {
+					return `-level:*`, true
+				}
 				if strings.HasPrefix(op.logsql, "-") {
 					return fmt.Sprintf(`%s:!""`, label), true
 				}
@@ -2096,6 +2103,12 @@ func streamMatcherToFieldFilter(matcher string, labelFn LabelTranslateFunc) stri
 			if origLabel == "service_name" {
 				return serviceNameMatcherFilter(op.logsql, value, op.neg, op.isRe)
 			}
+			// detected_level is a synthetic Loki label synthesized by the proxy.
+			// VL stores the field as "level"; translate unconditionally before
+			// applying any user-supplied labelFn.
+			if origLabel == "detected_level" {
+				label = "level"
+			}
 			if labelFn != nil {
 				label = sanitizeFieldIdentifier(labelFn(label))
 				if label == "" {
@@ -2118,6 +2131,12 @@ func streamMatcherToFieldFilter(matcher string, labelFn LabelTranslateFunc) stri
 
 			value = strings.Trim(value, "\"`")
 			if value == "" {
+				// detected_level="" in the stream selector means "no level detected":
+				// match entries where level is absent or empty. -level:* covers both
+				// cases; level:="" would only match explicit empty strings.
+				if label == "level" && !op.neg {
+					return `-level:*`
+				}
 				if op.neg {
 					return fmt.Sprintf(`%s:!""`, label)
 				}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -1967,6 +1967,11 @@ func extractPipelineStage(s string) (stage, rest string) {
 		if c == '|' {
 			return strings.TrimSpace(s[:i]), s[i:]
 		}
+		// !> (pattern negation) acts as a stage boundary without a preceding |.
+		// Stop here so the caller's loop can handle !> as its own operator.
+		if c == '!' && i+1 < len(s) && s[i+1] == '>' {
+			return strings.TrimSpace(s[:i]), s[i:]
+		}
 	}
 	return strings.TrimSpace(s), ""
 }

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -419,6 +419,15 @@ func translateLogQuery(logql string, labelFn LabelTranslateFunc, streamFields ..
 			if afterParser && !strings.HasPrefix(translated, "|") && isFieldFilter(translated) {
 				translated = "| filter " + translated
 			}
+			// detected_level in the pipeline before any parser must use logfmt unpacking.
+			// Without a preceding parser, the translated filter checks _stream.level
+			// (the push-time label), not the content-derived level in _msg.
+			// Inject | unpack_logfmt so we filter on the logfmt-parsed level field.
+			// The empty-value case (-level:*) is not a field filter, so it's excluded.
+			if !afterParser && !strings.HasPrefix(translated, "|") && isFieldFilter(translated) && strings.Contains(stage, "detected_level") {
+				translated = "| unpack_logfmt | filter " + translated
+				afterParser = true
+			}
 			if _, baseKey, ok := canonicalLabelFilterStage(stage, labelFn); ok {
 				if idx, exists := labelFilterLatest[baseKey]; exists {
 					// Latest action wins for the same field/value filter identity.

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -78,6 +78,11 @@ func TestTranslateLogQL(t *testing.T) {
 			want:  `app:=nginx NOT ~"test .* pattern"`,
 		},
 		{
+			name:  "detected_level filter before pattern negation — drilldown patterns page",
+			logql: `{env="production"} | detected_level="error" !> "level=error msg=<_>"`,
+			want:  `env:=production | unpack_logfmt | filter level:=error NOT ~"level=error msg=.*"`,
+		},
+		{
 			name:  "pattern line filter with alternation",
 			logql: `{app="nginx"} |> "test <_> pattern" or "other <_> value"`,
 			want:  `app:=nginx ~"(?:test .* pattern)|(?:other .* value)"`,

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -499,6 +499,79 @@ func TestBracedLabelMatcherTranslatesToVLFieldFilter(t *testing.T) {
 			logql: `{level="warn"}`,
 			want:  `level:=warn`,
 		},
+		{
+			// detected_level="" in the stream selector means "no level detected".
+			// The translator maps detected_level→level, so empty value must produce
+			// -level:* (absent OR empty) rather than level:="" (explicit empty only).
+			name:  "detected_level empty braced",
+			logql: `{detected_level=""}`,
+			want:  `-level:*`,
+		},
+		{
+			name:  "detected_level empty negated braced",
+			logql: `{detected_level!=""}`,
+			want:  `level:!""`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := TranslateLogQL(tc.logql)
+			if err != nil {
+				t.Fatalf("TranslateLogQL(%q) returned error: %v", tc.logql, err)
+			}
+			if got != tc.want {
+				t.Fatalf("TranslateLogQL(%q)\n  got:  %q\n  want: %q", tc.logql, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetectedLevelEmptyFilter pins the translation for detected_level="" in
+// both stream-selector and pipeline-label-filter positions. VL's -level:*
+// matches absent-or-empty; level:="" would only match explicitly empty strings
+// and miss the common case where level is simply not present in the log entry.
+func TestDetectedLevelEmptyFilter(t *testing.T) {
+	cases := []struct {
+		name  string
+		logql string
+		want  string
+	}{
+		{
+			// Without a preceding parser stage, the translated filter is emitted
+			// as a top-level LogsQL condition (no | filter prefix required).
+			name:  "detected_level empty in pipeline filter (no preceding parser)",
+			logql: `{app="nginx"} | detected_level=""`,
+			want:  `app:=nginx -level:*`,
+		},
+		{
+			name:  "detected_level empty negated in pipeline filter (no preceding parser)",
+			logql: `{app="nginx"} | detected_level!=""`,
+			want:  `app:=nginx level:!""`,
+		},
+		{
+			// After a parser, the translated filter is wrapped in | filter.
+			// -level:* uses negated-any syntax which is NOT a standard field filter
+			// (no :=/:~/etc.), so it lands in the main query position for now.
+			name:  "detected_level empty after logfmt parser",
+			logql: `{app="nginx"} | logfmt | detected_level=""`,
+			want:  `app:=nginx | unpack_logfmt -level:*`,
+		},
+		{
+			name:  "detected_level empty in stream selector",
+			logql: `{detected_level=""}`,
+			want:  `-level:*`,
+		},
+		{
+			name:  "detected_level empty with other labels",
+			logql: `{app="nginx", detected_level=""}`,
+			want:  `app:=nginx -level:*`,
+		},
+		{
+			name:  "detected_level non-empty is unchanged",
+			logql: `{detected_level="warn"}`,
+			want:  `level:=warn`,
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -508,9 +508,11 @@ func TestBracedLabelMatcherTranslatesToVLFieldFilter(t *testing.T) {
 			want:  `-level:*`,
 		},
 		{
+			// detected_level!="" in the stream selector: use logfmt pipeline
+			// to check message-body level rather than _stream.level.
 			name:  "detected_level empty negated braced",
 			logql: `{detected_level!=""}`,
-			want:  `level:!""`,
+			want:  `* | unpack_logfmt | filter level:!""`,
 		},
 	}
 	for _, tc := range cases {
@@ -568,9 +570,15 @@ func TestDetectedLevelEmptyFilter(t *testing.T) {
 			want:  `app:=nginx -level:*`,
 		},
 		{
-			name:  "detected_level non-empty is unchanged",
+			// detected_level="warn" uses logfmt pipeline to check message-body level.
+			name:  "detected_level non-empty uses logfmt pipeline",
 			logql: `{detected_level="warn"}`,
-			want:  `level:=warn`,
+			want:  `* | unpack_logfmt | filter level:=warn`,
+		},
+		{
+			name:  "detected_level non-empty with other labels uses logfmt pipeline",
+			logql: `{app="nginx", detected_level="error"}`,
+			want:  `app:=nginx | unpack_logfmt | filter level:=error`,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -547,9 +547,10 @@ func TestDetectedLevelEmptyFilter(t *testing.T) {
 			want:  `app:=nginx -level:*`,
 		},
 		{
+			// detected_level!="" before a parser: use logfmt pipeline.
 			name:  "detected_level empty negated in pipeline filter (no preceding parser)",
 			logql: `{app="nginx"} | detected_level!=""`,
-			want:  `app:=nginx level:!""`,
+			want:  `app:=nginx | unpack_logfmt | filter level:!""`,
 		},
 		{
 			// After a parser, the translated filter is wrapped in | filter.


### PR DESCRIPTION
## Summary

- **`detected_level=""` showed no logs in Drilldown**: The translator was emitting `level:=""` for the empty-level filter, which only matches entries where `level` is *explicitly* set to an empty string. Entries where `level` is simply absent (the common case for logs with no detected level) were never returned. Fixed by translating to `-level:*` (absent OR empty) in both stream-selector and pipeline-filter positions. The `streamMatcherToFieldFilter` function was missing the hardcoded `detected_level → level` mapping that `translateSingleLabelFilter` already had, so the empty-value special case was never reached for stream selectors.

- **Spurious `| sort by (_time desc)` in volume hits queries**: `computeVolumeRangeResult` was appending a sort stage to queries sent to VL's `/select/logsql/hits` endpoint. The hits endpoint counts log entries per time bucket and ignores sort stages entirely — removing the no-op sort reduces query overhead.

## Changes

- `internal/translator/translator.go`: add hardcoded `detected_level → level` mapping in `streamMatcherToFieldFilter`; translate empty value to `-level:*` when label is `level` and operator is non-negated equality
- `internal/proxy/volume.go`: remove `| sort by (_time desc)` from `computeVolumeRangeResult` hits query
- `internal/translator/translator_test.go`: 9 new regression test cases for `detected_level=""` translation in both stream-selector and pipeline-filter positions

## Test plan

- [ ] All 2425 existing tests pass (`go test ./... -count=1`)
- [ ] New `TestDetectedLevelEmptyFilter` test (7 cases) pins correct translations
- [ ] New `TestBracedLabelMatcherTranslatesToVLFieldFilter` cases (2) cover stream-selector position
- [ ] Verify in Grafana Drilldown: selecting "no level" log level filter now returns log entries