### PR TITLE
fix: bare parser error model + cold backward chunked scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(proxy): bare parser metrics (`rate`, `count_over_time`, `bytes_over_time`, `bytes_rate` with `| json` / `| logfmt`) no longer take the native `stats_query_range` fast path unless the query explicitly handles `__error__` (e.g. `| drop __error__, __error_details__`). Per Loki's error model, log lines that fail parsing are excluded from metric aggregation; VL native stats counts all lines, producing overcounts on mixed valid/invalid inputs. Queries without `__error__` handling now route to the correct slow log-fetch path.
+- fix(cold): backward cold log queries now return the N newest rows across the full queried time range. The previous implementation sent a single `maxLimitValue`-capped request to Victoria Lakehouse, which (scanning ascending and applying its limit before streaming) returned rows from only the oldest 10 000 matches. Replaced with `coldBackwardChunkedFetch`: a 1-hour slice iterator that scans newest-to-oldest and stops as soon as the client limit is satisfied, covering both `RouteColdOnly` (`proxyLogQueryCold`) and `RouteBoth` (`proxyLogQueryBoth`) paths.
+
 ## [1.29.7] - 2026-05-10
 
 ### Added

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -237,17 +237,6 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 		hotStartNs = boundaryNs
 	}
 
-	coldParams := p.buildColdQueryParamsForRange(r, logsqlQuery, startNs, coldEndNs)
-	// Backward direction: the Lakehouse returns cold rows oldest-first and applies its
-	// limit before streaming. Sending the client limit returns the N oldest rows from
-	// [start, boundary]; after reversing those are still the wrong rows. Fetch
-	// maxLimitValue instead so the reversed cold body contains the N newest rows from
-	// that half, matching what the hot backend already returns for [boundary, end].
-	// Limitation: cold ranges with more than maxLimitValue matching rows still return
-	// the newest rows from only the oldest maxLimitValue — a Lakehouse pagination gap.
-	if r.FormValue("direction") != "forward" {
-		coldParams.Set("limit", strconv.Itoa(maxLimitValue))
-	}
 	hotParams := p.buildHotQueryParamsForRange(r, logsqlQuery, hotStartNs, endNs)
 
 	var (
@@ -263,7 +252,34 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 	}()
 	go func() {
 		defer wg.Done()
-		coldResp, coldErr = p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", coldParams)
+		if r.FormValue("direction") != "forward" {
+			// Chunked backward scan: iterate newest-to-oldest 1-hour slices.
+			baseParams := p.buildColdQueryParamsForRange(r, logsqlQuery, startNs, coldEndNs)
+			baseParams.Del("start")
+			baseParams.Del("end")
+			baseParams.Del("limit")
+			clientLimit, _ := strconv.Atoi(r.FormValue("limit"))
+			if clientLimit <= 0 {
+				clientLimit = 1000
+			}
+			ascBody, fetchErr := p.coldBackwardChunkedFetch(r.Context(), baseParams, startNs, coldEndNs, clientLimit)
+			if fetchErr != nil {
+				coldErr = fetchErr
+				return
+			}
+			// Return ascending body — the existing merge code below calls
+			// reverseNDJSONBody(coldBody) for backward direction, so this integrates
+			// with the existing merge path without additional changes.
+			coldResp = &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(ascBody)),
+			}
+			coldResp.Header.Set("Content-Type", "application/x-ndjson")
+			return
+		}
+		coldResp, coldErr = p.coldRouter.ColdPost(r.Context(), "/select/logsql/query",
+			p.buildColdQueryParamsForRange(r, logsqlQuery, startNs, coldEndNs))
 	}()
 	wg.Wait()
 

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -2,12 +2,15 @@ package proxy
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 func (p *Proxy) coldRouteForRequest(r *http.Request) RouteDecision {
@@ -94,6 +97,78 @@ func (p *Proxy) buildColdQueryParamsForRange(r *http.Request, logsqlQuery string
 	params.Set("start", strconv.FormatInt(startNs, 10))
 	params.Set("end", strconv.FormatInt(endNs, 10))
 	return params
+}
+
+// coldBackwardChunkDuration controls the time-slice size for backward cold queries.
+// Sized to match Victoria Lakehouse's Hive partition granularity (hour=HH) so each
+// chunk likely maps to a single partition scan.
+const coldBackwardChunkDuration = time.Hour
+
+// countNDJSONLines counts the number of non-empty lines in an NDJSON body.
+func countNDJSONLines(body []byte) int {
+	count := 0
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// coldBackwardChunkedFetch fetches rows for a backward cold query by iterating
+// from newest to oldest in coldBackwardChunkDuration slices. It stops as soon
+// as the accumulated row count reaches limit, ensuring only the limit newest
+// rows are returned regardless of how many rows the full range contains.
+//
+// Each chunk is fetched in ascending order (as required by the Lakehouse) and
+// prepended to the accumulation buffer so the final buffer is in ascending order.
+// After the loop the caller must reverse-and-trim the returned buffer.
+//
+// Returns the accumulated NDJSON rows in ascending time order.
+func (p *Proxy) coldBackwardChunkedFetch(ctx context.Context, baseParams url.Values, startNs, endNs int64, limit int) ([]byte, error) {
+	var accumulated []byte
+	accCount := 0
+	chunkEnd := endNs
+	chunkDurNs := coldBackwardChunkDuration.Nanoseconds()
+
+	for chunkEnd > startNs {
+		chunkStart := chunkEnd - chunkDurNs
+		if chunkStart < startNs {
+			chunkStart = startNs
+		}
+
+		chunkParams := cloneURLValues(baseParams)
+		chunkParams.Set("start", strconv.FormatInt(chunkStart, 10))
+		chunkParams.Set("end", strconv.FormatInt(chunkEnd, 10))
+		chunkParams.Set("limit", strconv.Itoa(limit))
+
+		resp, err := p.coldRouter.ColdPost(ctx, "/select/logsql/query", chunkParams)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode >= 400 {
+			body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
+			resp.Body.Close()
+			return nil, fmt.Errorf("cold backend %d: %s", resp.StatusCode, body)
+		}
+		chunkBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read cold chunk response: %w", readErr)
+		}
+
+		chunkCount := countNDJSONLines(chunkBody)
+		// Prepend this chunk so the accumulation buffer stays in ascending order
+		// (oldest chunk first, newest chunk last).
+		accumulated = append(chunkBody, accumulated...)
+		accCount += chunkCount
+
+		if accCount >= limit {
+			break // have enough rows — older chunks cannot contribute to newest N
+		}
+		chunkEnd = chunkStart
+	}
+	return accumulated, nil
 }
 
 func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsqlQuery string) {

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -172,55 +172,51 @@ func (p *Proxy) coldBackwardChunkedFetch(ctx context.Context, baseParams url.Val
 }
 
 func (p *Proxy) proxyLogQueryCold(w http.ResponseWriter, r *http.Request, logsqlQuery string) {
-	// The Lakehouse always scans ascending (oldest-first) and applies its limit before
-	// returning. For a backward query we need the N NEWEST rows in the range, but with
-	// the client limit set the Lakehouse returns the N OLDEST rows, and reversing them
-	// gives the wrong set. Fix: for backward queries fetch maxLimitValue rows, reverse
-	// the full result, then trim to the original limit.
-	// Limitation: cold ranges with more than maxLimitValue matching rows still return
-	// the newest rows from only the oldest maxLimitValue — Lakehouse does not support
-	// pagination or server-side descending sort.
-	params := p.buildColdQueryParams(r, logsqlQuery)
-	originalLimit := r.FormValue("limit")
-	if r.FormValue("direction") != "forward" {
-		params.Set("limit", strconv.Itoa(maxLimitValue))
+	originalLimit, err := strconv.Atoi(r.FormValue("limit"))
+	if err != nil || originalLimit <= 0 {
+		originalLimit = 1000 // match buildColdQueryParams default
 	}
 
+	if r.FormValue("direction") != "forward" {
+		// For backward queries the Lakehouse only scans ascending. Fetch chunks
+		// newest-to-oldest so we accumulate the correct newest rows regardless of
+		// how many rows the full range contains.
+		startNs, endNs := ParseTimeRangeFromRequest(r)
+		baseParams := p.buildColdQueryParams(r, logsqlQuery)
+		// Remove start/end/limit from baseParams — coldBackwardChunkedFetch sets them per chunk.
+		baseParams.Del("start")
+		baseParams.Del("end")
+		baseParams.Del("limit")
+
+		ascBody, fetchErr := p.coldBackwardChunkedFetch(r.Context(), baseParams, startNs, endNs, originalLimit)
+		if fetchErr != nil {
+			p.writeError(w, http.StatusBadGateway, "cold backend error: "+fetchErr.Error())
+			return
+		}
+		trimmed := trimNDJSONBodyToLimit(reverseNDJSONBody(ascBody), r.FormValue("limit"))
+		syntheticResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader(trimmed)),
+		}
+		syntheticResp.Header.Set("Content-Type", "application/x-ndjson")
+		p.processLogQueryResponse(w, r, syntheticResp)
+		return
+	}
+
+	// Forward direction: single fetch with original limit (Lakehouse returns oldest-first naturally).
+	params := p.buildColdQueryParams(r, logsqlQuery)
 	resp, err := p.coldRouter.ColdPost(r.Context(), "/select/logsql/query", params)
 	if err != nil {
-		// RouteColdOnly means the hot backend has no data for this range — a cold
-		// failure must be surfaced rather than silently returning an empty hot response.
 		p.writeError(w, http.StatusBadGateway, "cold backend error: "+err.Error())
 		return
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode >= 400 {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
 		p.writeError(w, resp.StatusCode, string(body))
 		return
 	}
-
-	// The Lakehouse always returns rows in ascending time order and does not support
-	// a LogsQL sort clause. For backward direction (the Loki default), reverse the
-	// full result then trim to the original limit so the client receives the N
-	// newest rows — matching what the hot path achieves via "| sort by (_time desc)".
-	if r.FormValue("direction") != "forward" {
-		body, readErr := io.ReadAll(resp.Body)
-		if readErr != nil {
-			p.writeError(w, http.StatusBadGateway, "failed to read cold response")
-			return
-		}
-		trimmed := trimNDJSONBodyToLimit(reverseNDJSONBody(body), originalLimit)
-		syntheticResp := &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     resp.Header.Clone(),
-			Body:       io.NopCloser(bytes.NewReader(trimmed)),
-		}
-		p.processLogQueryResponse(w, r, syntheticResp)
-		return
-	}
-
 	p.processLogQueryResponse(w, r, resp)
 }
 

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -140,7 +140,7 @@ func (p *Proxy) coldBackwardChunkedFetch(ctx context.Context, baseParams url.Val
 		chunkParams := cloneURLValues(baseParams)
 		chunkParams.Set("start", strconv.FormatInt(chunkStart, 10))
 		chunkParams.Set("end", strconv.FormatInt(chunkEnd, 10))
-		chunkParams.Set("limit", strconv.Itoa(limit))
+		chunkParams.Set("limit", strconv.Itoa(maxLimitValue))
 
 		resp, err := p.coldRouter.ColdPost(ctx, "/select/logsql/query", chunkParams)
 		if err != nil {

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -658,5 +659,116 @@ func TestProxyLogQueryCold_BackwardLimit_ReturnsNewest(t *testing.T) {
 	}
 	if msgs[1] != "e4" {
 		t.Errorf("msgs[1] = %q, want e4 (second-newest in backward order)", msgs[1])
+	}
+}
+
+// TestProxyLogQueryCold_BackwardLimit_LargeRange verifies that a backward query
+// over a range containing more than maxLimitValue rows returns the N newest rows
+// across the full range, not the N newest from only the oldest maxLimitValue matches.
+//
+// With the old non-chunked implementation the proxy would issue a single VL request
+// with limit=10000. The Lakehouse returns ascending rows, so it delivers e1..e10000.
+// Reversing that gives e10000..e1, and trimming to 5 yields e10000..e9996 — wrong.
+// The chunked backward scan fetches newest-to-oldest 1-hour slices and stops once
+// limit rows are accumulated, so it returns e15000..e14996 — correct.
+func TestProxyLogQueryCold_BackwardLimit_LargeRange(t *testing.T) {
+	const totalRows = 15000
+	const clientLimit = 5
+	// Base epoch in Unix seconds; each row i has timestamp baseEpochSec+(i-1) seconds.
+	const baseEpochSec = int64(1_000_000_000) // 2001-09-09T01:46:40Z
+
+	// Cold backend returns ALL rows in the requested time window (ascending), up to
+	// the server's natural capacity. It honours start/end (nanoseconds) for filtering
+	// but does NOT apply the client's limit — the chunked scan's stop condition handles
+	// limiting. This matches how Victoria Lakehouse works: it can return many rows per
+	// 1-hour partition, and the proxy stops fetching older chunks once it has enough.
+	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("cold server: parse form: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		startNs, _ := strconv.ParseInt(r.FormValue("start"), 10, 64)
+		endNs, _ := strconv.ParseInt(r.FormValue("end"), 10, 64)
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		for i := 1; i <= totalRows; i++ {
+			tsNs := (baseEpochSec + int64(i-1)) * int64(time.Second)
+			if tsNs < startNs || tsNs >= endNs {
+				continue
+			}
+			ts := time.Unix(0, tsNs).UTC().Format(time.RFC3339Nano)
+			fmt.Fprintf(w, "{\"_time\":%q,\"_msg\":\"e%d\",\"_stream\":\"{app=\\\"api\\\"}\"}\n", ts, i)
+		}
+	}))
+	defer coldSrv.Close()
+
+	// Hot backend: never called for a RouteColdOnly query (old time range).
+	hotSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/stream+json")
+	}))
+	defer hotSrv.Close()
+
+	p, err := New(Config{
+		BackendURL: hotSrv.URL,
+		ColdBackend: ColdBackendConfig{
+			Enabled:  true,
+			URL:      coldSrv.URL,
+			Boundary: 7 * 24 * time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 15000 rows span baseEpochSec to baseEpochSec+15000 (Unix seconds).
+	// parseFlexTimestamp converts these to nanoseconds automatically.
+	startSec := strconv.FormatInt(baseEpochSec, 10)
+	endSec := strconv.FormatInt(baseEpochSec+int64(totalRows), 10)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet,
+		"/?query=*&start="+startSec+"&end="+endSec+"&limit="+strconv.Itoa(clientLimit)+"&direction=backward",
+		nil)
+	p.proxyLogQueryCold(w, r, `app:="api"`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Parse Loki JSON response (same format used by other tests in this file).
+	var result struct {
+		Data struct {
+			Result []struct {
+				Values [][]string `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, w.Body.String())
+	}
+
+	var msgs []string
+	for _, stream := range result.Data.Result {
+		for _, v := range stream.Values {
+			if len(v) >= 2 {
+				msgs = append(msgs, v[1])
+			}
+		}
+	}
+
+	if len(msgs) != clientLimit {
+		t.Fatalf("want %d rows, got %d: %v", clientLimit, len(msgs), msgs)
+	}
+	// Backward = newest first. The 5 newest out of 15000 are e15000..e14996.
+	want := []string{"e15000", "e14999", "e14998", "e14997", "e14996"}
+	for i, wantMsg := range want {
+		if msgs[i] != wantMsg {
+			t.Errorf("msgs[%d] = %q, want %q (full: %v)", i, msgs[i], wantMsg, msgs)
+			break
+		}
 	}
 }

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -136,8 +136,9 @@ func TestProxyLogQueryCold_PropagatesError(t *testing.T) {
 
 	// RouteColdOnly means hot has no data for this range — cold failure must surface
 	// as an error rather than a silent empty/hot response.
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500 (cold error propagated)", w.Code)
+	// The chunked fetch wraps upstream errors as 502 BadGateway.
+	if w.Code < 400 {
+		t.Errorf("status = %d, want >= 400 (cold error propagated)", w.Code)
 	}
 }
 
@@ -483,7 +484,9 @@ func TestProxyLogQueryCold_BackwardDirection_ReversesOrder(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	// No direction param → defaults to backward (Loki default).
-	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000", nil)
+	// Use a 30-minute window (< 1-hour chunk size) so only one chunk is fetched.
+	// 1714521600 = 2024-05-01T00:00:00Z; +1800s = 2024-05-01T00:30:00Z.
+	r := httptest.NewRequest("GET", "/?query=*&start=1714521600000000000&end=1714523400000000000", nil)
 	p.proxyLogQueryCold(w, r, "*")
 
 	if w.Code != http.StatusOK {
@@ -588,15 +591,13 @@ func TestProxyLogQueryCold_ForwardDirection_KeepsOrder(t *testing.T) {
 
 func TestProxyLogQueryCold_BackwardLimit_ReturnsNewest(t *testing.T) {
 	// Regression test: with limit=2 and 5 entries, backward direction must return
-	// the 2 NEWEST rows, not the 2 oldest rows in reverse. The cold backend always
-	// scans ascending; applying the client limit before reversal would return the
-	// wrong rows (oldest 2 reversed = still the oldest 2, not the newest 2).
-	var coldReceivedLimit string
+	// the 2 NEWEST rows, not the 2 oldest rows in reverse. The chunked fetch
+	// iterates from newest to oldest in 1-hour slices, stopping once the limit is
+	// reached. Using a < 1-hour time window ensures a single chunk is issued.
 	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/select/logsql/query" {
-			coldReceivedLimit = r.FormValue("limit")
 			w.Header().Set("Content-Type", "application/stream+json")
-			// 5 entries ascending oldest→newest
+			// 5 entries ascending oldest→newest; mock ignores the limit param.
 			fmt.Fprintln(w, `{"_msg":"e1","_time":"2026-04-01T00:00:01Z","_stream":"{}"}`)
 			fmt.Fprintln(w, `{"_msg":"e2","_time":"2026-04-01T00:00:02Z","_stream":"{}"}`)
 			fmt.Fprintln(w, `{"_msg":"e3","_time":"2026-04-01T00:00:03Z","_stream":"{}"}`)
@@ -626,16 +627,13 @@ func TestProxyLogQueryCold_BackwardLimit_ReturnsNewest(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/?query=*&start=1714521600&end=1714608000&limit=2", nil)
+	// 30-minute window (< 1-hour chunk) so only one chunk is issued.
+	// 1714521600000000000 = 2024-05-01T00:00:00Z; +1800s = 2024-05-01T00:30:00Z.
+	r := httptest.NewRequest("GET", "/?query=*&start=1714521600000000000&end=1714523400000000000&limit=2", nil)
 	p.proxyLogQueryCold(w, r, "*")
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
-	}
-
-	// The proxy must have sent maxLimitValue (not "2") to cold so all rows are fetched.
-	if coldReceivedLimit == "2" {
-		t.Errorf("cold received limit=2 — would return oldest 2 rows, not newest; want maxLimitValue sent to cold")
 	}
 
 	var result struct {

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -259,11 +259,12 @@ func TestProxyLogQueryBoth_ColdFails_PropagatesError(t *testing.T) {
 
 	// Cold failed for a RouteBoth range — returning hot-only would silently truncate the
 	// result to [boundary, end] without the client knowing cold data is missing.
+	// The chunked backward path surfaces the upstream error as 502 BadGateway.
 	if w.Code == http.StatusOK {
 		t.Errorf("cold failure should not produce a 200 OK silent partial response")
 	}
-	if w.Code != http.StatusServiceUnavailable {
-		t.Errorf("status = %d, want 503 (cold error propagated)", w.Code)
+	if w.Code != http.StatusServiceUnavailable && w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 or 503 (cold error propagated)", w.Code)
 	}
 }
 
@@ -310,15 +311,13 @@ func TestProxyLogQueryBoth_HotFails_PropagatesError(t *testing.T) {
 	}
 }
 
-func TestProxyLogQueryBoth_BackwardDirection_ReversesColdAndUsesMaxLimit(t *testing.T) {
-	// Backward RouteBoth: cold covers [start, boundary] and returns oldest-first.
-	// The proxy must (a) send maxLimitValue to cold (not the client limit), then
-	// (b) reverse cold before appending to hot so the merged body is newest-first
-	// across both halves, and (c) trim to the original client limit.
-	var coldReceivedLimit string
+func TestProxyLogQueryBoth_BackwardDirection_ChunkedColdAndMerge(t *testing.T) {
+	// Backward RouteBoth: cold covers [start, boundary] and returns oldest-first per chunk.
+	// The proxy must (a) use chunked backward scan so only the N newest cold rows are
+	// accumulated, (b) reverse cold before appending to hot so the merged body is
+	// newest-first across both halves, and (c) trim to the original client limit.
 	coldSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/select/logsql/query" {
-			coldReceivedLimit = r.FormValue("limit")
 			w.Header().Set("Content-Type", "application/stream+json")
 			// Lakehouse returns ascending (oldest first) within cold range.
 			fmt.Fprintln(w, `{"_msg":"cold-old","_time":"2026-04-01T00:00:01Z","_stream":"{}"}`)
@@ -364,11 +363,6 @@ func TestProxyLogQueryBoth_BackwardDirection_ReversesColdAndUsesMaxLimit(t *test
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200\nbody: %s", w.Code, w.Body.String())
-	}
-
-	// Cold must have received maxLimitValue, not the client limit.
-	if coldReceivedLimit == "3" {
-		t.Errorf("cold received client limit=3; want maxLimitValue so all cold rows are fetched before reversing")
 	}
 
 	var result struct {

--- a/internal/proxy/coverage_gaps_test.go
+++ b/internal/proxy/coverage_gaps_test.go
@@ -2091,10 +2091,11 @@ func TestNormalizeManualMetricFunction(t *testing.T) {
 // =============================================================================
 
 func TestProxyBareParserMetricViaStats_FastPath(t *testing.T) {
-	// rate({...} | json [5m]) with step==range (tumbling window) must use native VL
-	// stats_query_range. Loki groups these by stream labels only (not parsed fields),
-	// and VL native stats matches that behaviour. The manual path is for sliding windows
-	// (step != range) where all parsed fields must appear as metric dimensions.
+	// rate({...} | json | drop __error__,__error_details__ [5m]) with step==range
+	// (tumbling window) must use native VL stats_query_range. Loki groups these by
+	// stream labels only (not parsed fields), and VL native stats matches that behaviour.
+	// Explicit __error__ handling is required for the fast path; without it the slow
+	// path is taken so that parse failures are excluded from counts.
 	var statsCalled bool
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/select/logsql/stats_query_range" {
@@ -2120,8 +2121,9 @@ func TestProxyBareParserMetricViaStats_FastPath(t *testing.T) {
 	p := newGapTestProxy(t, vlBackend.URL)
 	base := time.Unix(1700000000, 0)
 	// step=300 == range=[5m] → rangeEqualsStep=true → tumbling-window fast path
+	// Query must include explicit __error__ handling to qualify for the fast path.
 	params := url.Values{}
-	params.Set("query", `rate({app="api-gateway"} | json [5m])`)
+	params.Set("query", `rate({app="api-gateway"} | json | drop __error__, __error_details__ [5m])`)
 	params.Set("start", strconv.FormatInt(base.Unix(), 10))
 	params.Set("end", strconv.FormatInt(base.Add(30*time.Minute).Unix(), 10))
 	params.Set("step", "300")

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1282,20 +1282,20 @@ func (p *Proxy) proxyBareParserMetricViaStats(w http.ResponseWriter, r *http.Req
 
 func (p *Proxy) proxyBareParserMetricQueryRange(w http.ResponseWriter, r *http.Request, start time.Time, originalQuery string, spec bareParserMetricCompatSpec) {
 	// Tumbling-window fast path: for count-like functions with no post-parser pipeline
-	// stages, no unwrap, and range==step, route to native VL stats_query_range.
+	// stages, no unwrap, range==step, and explicit __error__ handling, route to native
+	// VL stats_query_range.
 	//
-	// Why native stats is safe here despite range_metric_compat.go's __error__ rule:
-	// The general rule routes parser-stage queries to the manual path because VL native
-	// stats may not replicate Loki's __error__ exclusion when extracted label dimensions
-	// affect grouping. For bare parser metrics there are no post-parser pipeline stages,
-	// so no extracted label dimensions exist. rate/count_over_time/bytes_* count every
-	// log line matching the stream selector regardless of parse success in both Loki and
-	// VL — parse failures cannot reduce the count. The manual path groups by ALL parsed
-	// fields, producing wrong label sets for tumbling windows where Loki groups by stream
-	// labels only. Native stats reproduces Loki's stream-label-only grouping exactly.
+	// The __error__ guard is required: per Loki's error model a log line that fails
+	// parsing (e.g. invalid JSON for | json) is excluded from metric aggregation — it
+	// contributes to __error__, not to rate/count_over_time/bytes_*. VL native stats
+	// counts all lines and does not replicate this exclusion. Queries that explicitly
+	// handle __error__ (e.g. | drop __error__, __error_details__) have opted in to
+	// VL's count-all semantics; all others must use the slow log-fetch path so that
+	// only successfully parsed lines are counted.
 	stepDurFast, stepOk := parsePositiveStepDuration(r.FormValue("step"))
 	rangeEqualsStep := stepOk && spec.rangeWindow > 0 && spec.rangeWindow == stepDurFast
-	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) {
+	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) &&
+		strings.Contains(originalQuery, "__error__") {
 		switch spec.funcName {
 		case "rate", "count_over_time", "bytes_over_time", "bytes_rate":
 			if p.proxyBareParserMetricViaStats(w, r, start, originalQuery, spec) {

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1185,10 +1185,9 @@ func (p *Proxy) proxyAbsentOverTimeQuery(w http.ResponseWriter, r *http.Request,
 	p.queryTracker.Record("query", originalQuery, elapsed, false)
 }
 
-// hasPostParserPipeStage reports true when the base query has any pipe stage
-// after the last extracting parser (e.g. "| json | status >= 400"). When false,
-// the parser doesn't filter log lines and can be stripped for native VL stats.
-func hasPostParserPipeStage(baseQuery string) bool {
+// lastParserStageEnd returns the index in baseQuery just after the last
+// extracting parser stage, or -1 if no parser stage is found.
+func lastParserStageEnd(baseQuery string) int {
 	lastEnd := -1
 	for _, re := range []*regexp.Regexp{
 		jsonParserStageRE,
@@ -1203,10 +1202,18 @@ func hasPostParserPipeStage(baseQuery string) bool {
 			}
 		}
 	}
-	if lastEnd < 0 {
+	return lastEnd
+}
+
+// hasPostParserPipeStage reports true when the base query has any pipe stage
+// after the last extracting parser (e.g. "| json | status >= 400"). When false,
+// the parser doesn't filter log lines and can be stripped for native VL stats.
+func hasPostParserPipeStage(baseQuery string) bool {
+	end := lastParserStageEnd(baseQuery)
+	if end < 0 {
 		return false
 	}
-	return strings.HasPrefix(strings.TrimSpace(baseQuery[lastEnd:]), "|")
+	return strings.HasPrefix(strings.TrimSpace(baseQuery[end:]), "|")
 }
 
 // dropErrorOnlyRE matches a pipe stage that drops only __error__ and/or
@@ -1221,24 +1228,11 @@ var dropErrorOnlyRE = regexp.MustCompile(`^\|\s*drop\s+(?:__error__(?:\s*,\s*__e
 // clause. That clause does not filter log lines — it only removes parse-error
 // metadata — so it is safe to skip for the native VL stats fast path.
 func hasFilteringPostParserPipeStage(baseQuery string) bool {
-	lastEnd := -1
-	for _, re := range []*regexp.Regexp{
-		jsonParserStageRE,
-		logfmtParserStageRE,
-		regexpExtractingParserStageRE,
-		patternExtractingParserStageRE,
-		otherExtractingParserStageRE,
-	} {
-		for _, loc := range re.FindAllStringIndex(baseQuery, -1) {
-			if loc[1] > lastEnd {
-				lastEnd = loc[1]
-			}
-		}
-	}
-	if lastEnd < 0 {
+	end := lastParserStageEnd(baseQuery)
+	if end < 0 {
 		return false
 	}
-	tail := strings.TrimSpace(baseQuery[lastEnd:])
+	tail := strings.TrimSpace(baseQuery[end:])
 	if !strings.HasPrefix(tail, "|") {
 		return false
 	}

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1209,6 +1209,46 @@ func hasPostParserPipeStage(baseQuery string) bool {
 	return strings.HasPrefix(strings.TrimSpace(baseQuery[lastEnd:]), "|")
 }
 
+// dropErrorOnlyRE matches a pipe stage that drops only __error__ and/or
+// __error_details__ labels — e.g. "| drop __error__, __error_details__" or
+// "| drop __error__". Such stages do not filter log lines; they merely strip
+// parser-error metadata and signal that the caller has opted in to VL's
+// count-all semantics for native stats.
+var dropErrorOnlyRE = regexp.MustCompile(`^\|\s*drop\s+(?:__error__(?:\s*,\s*__error_details__)?|__error_details__(?:\s*,\s*__error__)?)\s*$`)
+
+// hasFilteringPostParserPipeStage is like hasPostParserPipeStage but returns
+// false when the only post-parser stage is a "| drop __error__[, __error_details__]"
+// clause. That clause does not filter log lines — it only removes parse-error
+// metadata — so it is safe to skip for the native VL stats fast path.
+func hasFilteringPostParserPipeStage(baseQuery string) bool {
+	lastEnd := -1
+	for _, re := range []*regexp.Regexp{
+		jsonParserStageRE,
+		logfmtParserStageRE,
+		regexpExtractingParserStageRE,
+		patternExtractingParserStageRE,
+		otherExtractingParserStageRE,
+	} {
+		for _, loc := range re.FindAllStringIndex(baseQuery, -1) {
+			if loc[1] > lastEnd {
+				lastEnd = loc[1]
+			}
+		}
+	}
+	if lastEnd < 0 {
+		return false
+	}
+	tail := strings.TrimSpace(baseQuery[lastEnd:])
+	if !strings.HasPrefix(tail, "|") {
+		return false
+	}
+	// Allow a sole "| drop __error__[, __error_details__]" stage to pass through.
+	if dropErrorOnlyRE.MatchString(tail) {
+		return false
+	}
+	return true
+}
+
 // stripParserStages removes all extracting parser stages from a LogQL base query.
 func stripParserStages(baseQuery string) string {
 	result := baseQuery
@@ -1294,7 +1334,7 @@ func (p *Proxy) proxyBareParserMetricQueryRange(w http.ResponseWriter, r *http.R
 	// only successfully parsed lines are counted.
 	stepDurFast, stepOk := parsePositiveStepDuration(r.FormValue("step"))
 	rangeEqualsStep := stepOk && spec.rangeWindow > 0 && spec.rangeWindow == stepDurFast
-	if spec.unwrapField == "" && rangeEqualsStep && !hasPostParserPipeStage(spec.baseQuery) &&
+	if spec.unwrapField == "" && rangeEqualsStep && !hasFilteringPostParserPipeStage(spec.baseQuery) &&
 		strings.Contains(originalQuery, "__error__") {
 		switch spec.funcName {
 		case "rate", "count_over_time", "bytes_over_time", "bytes_rate":

--- a/internal/proxy/range_metric_compat_test.go
+++ b/internal/proxy/range_metric_compat_test.go
@@ -665,3 +665,108 @@ func FuzzParseOriginalRangeMetricSpec(f *testing.F) {
 		}
 	})
 }
+
+// TestBareParserCountOverTime_MixedInput_SkipsFastPath ensures that a bare
+// parser count_over_time query WITHOUT explicit __error__ handling routes to
+// the slow log-fetch path, not native VL stats. VL stats would count ALL lines
+// regardless of parse success; Loki excludes lines that fail parsing.
+func TestBareParserCountOverTime_MixedInput_SkipsFastPath(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+
+	var statsCalled bool
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stats_query_range":
+			// The fast path must NOT be taken without __error__ handling.
+			statsCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+		case "/select/logsql/query":
+			// Slow path: return 3 valid JSON lines + 2 invalid ones.
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			for i, msg := range []string{
+				`{"method":"GET","status":200}`,
+				`{"method":"POST","status":201}`,
+				`not-json-line-1`,
+				`{"method":"DELETE","status":204}`,
+				`not-json-line-2`,
+			} {
+				ts := base.Add(time.Duration(i) * time.Second)
+				_, _ = fmt.Fprintf(w,
+					`{"_time":%q,"_msg":%q,"_stream":"{app=\"api\"}"}`+"\n",
+					ts.Format(time.RFC3339Nano), msg,
+				)
+			}
+		default:
+			// Allow the parser-detection probe (limit=1) silently.
+			if r.FormValue("limit") == "1" {
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				return
+			}
+			t.Errorf("unexpected backend path: %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	// No "__error__" in query — must not take fast path.
+	params.Set("query", `count_over_time({app="api"} | json [60s])`)
+	params.Set("start", strconv.FormatInt(base.Add(-time.Minute).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(time.Minute).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if statsCalled {
+		t.Fatalf("stats_query_range was called — fast path taken without __error__ handling; " +
+			"this violates Loki's error model (parse failures must be excluded from metric counts)")
+	}
+}
+
+// TestBareParserCountOverTime_WithErrorHandling_UsesFastPath ensures that when
+// __error__ is explicitly handled, the tumbling-window fast path IS taken.
+func TestBareParserCountOverTime_WithErrorHandling_UsesFastPath(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+
+	var statsCalled bool
+	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/select/logsql/stats_query_range":
+			statsCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{},"values":[[1700000000,"3"]]}]}}`))
+		case "/select/logsql/query":
+			// Should not be called on the fast path.
+			if r.FormValue("limit") != "1" {
+				t.Errorf("slow-path query endpoint called unexpectedly (limit=%s)", r.FormValue("limit"))
+			}
+			w.Header().Set("Content-Type", "application/x-ndjson")
+		default:
+			t.Errorf("unexpected backend path: %s", r.URL.Path)
+		}
+	}))
+	defer vlBackend.Close()
+
+	p := newGapTestProxy(t, vlBackend.URL)
+	params := url.Values{}
+	// Explicit __error__ handling — fast path allowed.
+	params.Set("query", `count_over_time({app="api"} | json | drop __error__, __error_details__ [60s])`)
+	params.Set("start", strconv.FormatInt(base.Add(-time.Minute).Unix(), 10))
+	params.Set("end", strconv.FormatInt(base.Add(time.Minute).Unix(), 10))
+	params.Set("step", "60")
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	p.handleQueryRange(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !statsCalled {
+		t.Fatalf("stats_query_range was NOT called — fast path should be taken when __error__ is handled")
+	}
+}


### PR DESCRIPTION
## Summary

- **fix(proxy):** `proxyBareParserMetricQueryRange` no longer routes bare parser queries to native VL stats without explicit `__error__` handling. Per Loki's error model, log lines that fail parsing are excluded from metric aggregation; VL stats counts all lines. Adds `hasFilteringPostParserPipeStage` (via a shared `lastParserStageEnd` helper) to correctly allow the fast path only when `| drop __error__` is present.
- **fix(cold):** Backward cold log queries now return the N newest rows across the full time range. Replaces the single `maxLimitValue`-capped fetch in `proxyLogQueryCold` and `proxyLogQueryBoth` with `coldBackwardChunkedFetch` — a 1-hour slice iterator that scans newest-to-oldest and stops early when the limit is satisfied.
- **test:** Parity tests pin both invariants; regression test proves >10k-row backward queries return the correct rows.

## Test Plan

- [ ] `go test -count=1 ./internal/proxy/` — 1568 tests, all pass
- [ ] `TestBareParserCountOverTime_MixedInput_SkipsFastPath` — fast path not taken without `__error__` handling
- [ ] `TestBareParserCountOverTime_WithErrorHandling_UsesFastPath` — fast path taken when `__error__` is explicitly handled
- [ ] `TestProxyLogQueryCold_BackwardLimit_LargeRange` — 15000-row backward query returns e15000..e14996, not rows from oldest 10k