### PR TITLE
fix(ci): auto-release exits cleanly when CHANGELOG [Unreleased] is empty

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -58,7 +58,7 @@ jobs:
           DOCS_OR_CI_ONLY="yes"
           while IFS= read -r file; do
             [ -z "$file" ] && continue
-            if ! echo "$file" | grep -Eq '^(README\.md|CHANGELOG\.md|docs/|\.github/)$'; then
+            if ! echo "$file" | grep -Eq '^(README\.md|CHANGELOG\.md|docs/|\.github/)'; then
               DOCS_OR_CI_ONLY="no"
               break
             fi
@@ -67,6 +67,13 @@ jobs:
           if [ "$DOCS_OR_CI_ONLY" = "yes" ]; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "Only docs/ci/metadata files changed; skipping release"
+            exit 0
+          fi
+
+          UNRELEASED_LINES=$(awk '/^## \[Unreleased\]/{f=1; next} /^## \[/{if(f) exit} f && /^[[:space:]]*[^[:space:]]/' CHANGELOG.md | wc -l | tr -d ' ')
+          if [ "${UNRELEASED_LINES}" -eq 0 ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "CHANGELOG [Unreleased] section is empty; skipping release (add changelog entries to enable)"
             exit 0
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- fix(ci): `auto-release` now exits cleanly with `should_release=false` when `## [Unreleased]` is empty — deps-bump and CI-only PRs previously reached `validate-release` and failed noisily; fixed `DOCS_OR_CI_ONLY` regex (trailing `$` prevented `docs/subpath` and `.github/subpath` from matching).
+
 ### Performance
 
 - perf(range_metric): add `stats_query_range` fast path for `sum by (...) (count_over_time/rate({...}[W]))` — replaces raw NDJSON log scan (39% CPU cold proxy) with VL pre-aggregated Prometheus buckets via `| stats by (...) count() as c`. Throughput improvement: 44→126 req/s (c=10) and 33→139 req/s (c=100) on heavy workload.


### PR DESCRIPTION
## Summary

- **Fix `DOCS_OR_CI_ONLY` regex**: the trailing `$` anchor made `docs/` and `.github/` alternatives match only the exact strings `"docs/"` / `".github/"` — subdirectory paths like `docs/benchmarks.md` and `.github/workflows/ci.yaml` never matched, causing the check to always fall through even for pure CI/docs commits
- **Add early CHANGELOG gate in `prepare-release`**: when `## [Unreleased]` has no content, exit with `should_release=false` instead of letting the workflow reach `validate-release` which fails noisily with exit code 1 — deps-bump and CI-only PRs now produce a clean green run rather than a red failure

## Root cause

PR #347 (mermaid deps bump) triggered `auto-release`, `prepare-release` set `should_release=true` (no release label → defaulted to patch), and `validate-release` hard-failed because `[Unreleased]` was empty. The fix moves the check earlier so the workflow exits cleanly with a human-readable message before any versioning logic runs.

## Test plan

- [ ] Merge a deps-bump or CI-only PR without CHANGELOG entries → `prepare-release` logs "CHANGELOG [Unreleased] section is empty; skipping release" and exits 0 with `should_release=false`; `validate-release` and release jobs are skipped entirely
- [ ] Merge a feature PR with CHANGELOG entries → release proceeds as before