### PR TITLE
fix(offset): reject mixed-offset expressions with HTTP 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(e2e): log-generator now starts by default (`profiles: ["ui"]` removed) — cold stacks no longer have zero ingestion, enabling pattern clustering in Drilldown. `LOG_INTERVAL` 10→2, `LOG_BATCH` 8→15 raises throughput from ~8.6 to ~75 lines/s so the pattern miner sees enough volume per time-step bucket for stable clustering and a continuous Drilldown timeline. Added `GOMEMLIMIT=2GiB` to `loki-vl-proxy-patterns-autodetect` consistent with other proxy variants.
+- fix(offset): reject mixed-offset expressions (`rate(a[5m] offset 1h) + rate(b[5m])`) with HTTP 400 instead of silently returning wrong data. The proxy applies a global time shift, which cannot correctly serve expressions where some range vectors carry an offset and others do not. Queries where all range vectors share the same offset continue to work.
 
 ## [1.32.0] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Mixed-offset expressions now return HTTP 400**: A LogQL expression where some range vectors carry an `offset` and others do not — e.g. `rate({app="a"}[5m] offset 1h) + rate({app="b"}[5m])` — now returns `HTTP 400` with a descriptive error instead of silently returning incorrect data. The proxy implements offset support via a global time shift applied to `start`/`end`; that shift cannot correctly serve a mix of offset-bearing and non-offset range vectors in the same expression.
+
+  **Who is affected**: Queries combining `offset`-bearing and non-`offset` range vectors in a single expression. Queries where all range vectors share the same offset (e.g. both use `offset 1h`) continue to work.
+
+  **How to fix**: Split the expression into two separate queries — one with the offset applied, one without — and combine the results in Grafana. Alternatively, add the same offset to all range vectors if the intent allows it.
+
+### Fixed
+
+- **Mixed-offset correctness**: The proxy previously applied only the first offset value it encountered in a query, silently ignoring offsets on other range vectors. A query like `rate({app="a"}[5m] offset 1h) + rate({app="b"}[5m])` would return data for `b` from the wrong time window. These queries now return HTTP 400. See breaking change note above.
+
 ## [1.32.1] - 2026-05-14
 
 ### Fixed
 
 - fix(e2e): log-generator now starts by default (`profiles: ["ui"]` removed) — cold stacks no longer have zero ingestion, enabling pattern clustering in Drilldown. `LOG_INTERVAL` 10→2, `LOG_BATCH` 8→15 raises throughput from ~8.6 to ~75 lines/s so the pattern miner sees enough volume per time-step bucket for stable clustering and a continuous Drilldown timeline. Added `GOMEMLIMIT=2GiB` to `loki-vl-proxy-patterns-autodetect` consistent with other proxy variants.
-- fix(offset): reject mixed-offset expressions (`rate(a[5m] offset 1h) + rate(b[5m])`) with HTTP 400 instead of silently returning wrong data. The proxy applies a global time shift, which cannot correctly serve expressions where some range vectors carry an offset and others do not. Queries where all range vectors share the same offset continue to work.
 
 ## [1.32.0] - 2026-05-13
 

--- a/internal/proxy/offset_test.go
+++ b/internal/proxy/offset_test.go
@@ -61,6 +61,21 @@ func TestExtractLogQLOffset(t *testing.T) {
 			wantQuery:  `rate({app="a"}[5m]) + rate({app="b"}[5m])`,
 		},
 		{
+			name:    "mixed: one vector with offset, one without — must error",
+			input:   `rate({app="a"}[5m] offset 1h) + rate({app="b"}[5m])`,
+			wantErr: true,
+		},
+		{
+			name:    "mixed: offset on inner, bare outer — must error",
+			input:   `sum(count_over_time({app="a"}[5m] offset 1h)) / sum(count_over_time({app="b"}[1h]))`,
+			wantErr: true,
+		},
+		{
+			name:    "mixed: three vectors, only two with offset — must error",
+			input:   `rate({app="a"}[5m] offset 1h) + rate({app="b"}[5m] offset 1h) + rate({app="c"}[5m])`,
+			wantErr: true,
+		},
+		{
 			name:       "no space before offset keyword",
 			input:      `rate({app="nginx"}[5m]offset 1h)`,
 			wantOffset: time.Hour,

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -401,6 +401,11 @@ var (
 	// range window bracket, e.g. "[5m] offset 1h". Capture group 1 is the
 	// duration string. Supports negative offsets: "[5m] offset -30m".
 	logqlOffsetRE = regexp.MustCompile(`\]\s*offset\s+(-?[\w.]+)`)
+
+	// rangeVectorRE matches LogQL range-vector duration brackets such as [5m], [1h],
+	// [500ms], [1.5m]. Leading \d anchors the match to numeric durations, avoiding
+	// false positives from regex character classes in filter expressions (e.g. [a-z]).
+	rangeVectorRE = regexp.MustCompile(`\[\d[\d.]*[smhdwy]\w*\]`)
 )
 
 // hasTextExtractionParser returns true when the LogQL query contains any
@@ -440,12 +445,32 @@ func removeParserStage(logql, parser string) string {
 
 // extractLogQLOffset finds a LogQL offset modifier (e.g. "[5m] offset 1h"),
 // strips all occurrences from the query, and returns the offset duration.
-// Returns an error when multiple *different* offset values are present — Loki
-// rejects such queries. Returns zero duration + unchanged query when no offset found.
+//
+// Errors when:
+//   - multiple *different* offset values are present (Loki rejects such queries), or
+//   - some range vectors carry an offset and others do not ("mixed" expression).
+//     Mixed expressions cannot be handled by a global time shift: only the
+//     offset vectors should look at historical data, while the unshifted ones
+//     must evaluate at the original window — impossible with a single start/end
+//     adjustment. Example: rate(a[5m] offset 1h) + rate(b[5m]) is rejected.
+//
+// Returns zero duration + unchanged query when no offset is found.
 func extractLogQLOffset(logql string) (time.Duration, string, error) {
 	matches := logqlOffsetRE.FindAllStringSubmatch(logql, -1)
 	if len(matches) == 0 {
 		return 0, logql, nil
+	}
+
+	// Detect mixed expressions: some range vectors have an offset, others do not.
+	// rangeVectorRE counts all duration brackets ([5m], [1h], …); logqlOffsetRE
+	// counts only those followed by an offset clause. If the counts differ, the
+	// expression mixes offset and non-offset vectors.
+	allVectors := rangeVectorRE.FindAllString(logql, -1)
+	if len(allVectors) > len(matches) {
+		return 0, logql, fmt.Errorf(
+			"offset applied to %d of %d range vectors; loki-vl-proxy requires a uniform offset across all range vectors since it applies a global time shift — use a consistent offset or split into separate queries",
+			len(matches), len(allVectors),
+		)
 	}
 
 	seen := map[string]time.Duration{}
@@ -456,7 +481,7 @@ func extractLogQLOffset(logql string) (time.Duration, string, error) {
 		}
 	}
 	if len(seen) > 1 {
-		return 0, logql, fmt.Errorf("found %d offsets while expecting at most 1", len(seen))
+		return 0, logql, fmt.Errorf("found %d distinct offsets while expecting at most 1", len(seen))
 	}
 
 	var offset time.Duration


### PR DESCRIPTION
## Summary

- **Correctness fix**: `rate(a[5m] offset 1h) + rate(b[5m])` previously returned wrong data silently. The global time shift correctly moved `a` to historical data but also shifted `b` (which has no offset) to the same 1h-ago window — both vectors ended up reading from the wrong time range.
- **Detection**: `rangeVectorRE` counts all duration brackets (`[5m]`, `[1h]`, …) in the query; `logqlOffsetRE` counts only those carrying an offset clause. When the counts differ, some vectors are unshifted — the proxy now returns HTTP 400 with a clear message explaining the limitation.
- **Unchanged behavior**: queries where every range vector carries the same offset (e.g. `rate(a[5m] offset 1h) + rate(b[5m] offset 1h)`) continue to work via global time shift.

## Root cause

Loki evaluates `offset` per range vector. The proxy implements offset support as a uniform `start`/`end` (or `time`) shift applied before backend dispatch — a deliberate simplification that works when all vectors share the same offset but breaks for mixed expressions.

## Test Plan

- [ ] `go test ./internal/proxy/... -run TestExtractLogQLOffset` — 13 tests including 3 new mixed-expression cases
- [ ] `go test ./...` — 2521 tests, no regressions
- [ ] `rate({app="nginx"}[5m] offset 1h) + rate({app="nginx"}[5m])` → HTTP 400
- [ ] `rate({app="nginx"}[5m] offset 1h) + rate({app="nginx"}[5m] offset 1h)` → succeeds, data from 1h ago