### PR TITLE
feat: -require-tenant-header flag and configurable range-metric row limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-require-tenant-header` flag**: Enforce the `X-Scope-OrgID` header on every request without enabling full Loki auth mode. When set, requests that omit the header receive `HTTP 401 missing X-Scope-OrgID header`. By default the proxy accepts header-less requests and routes them to the default tenant.
+
+  This flag is independent of `-auth.enabled`. The distinction: `-auth.enabled` validates the *value* of the header (full Loki token auth); `-require-tenant-header` only checks that the header is *present*. Use `-require-tenant-header` when your gateway always injects `X-Scope-OrgID` and you want the proxy to reject anything that slips through without it — without standing up a full Loki auth pipeline.
+
+  No action required for existing deployments. The default is `false`, preserving the current behavior.
+
+- **`-manual-range-metric-row-limit` flag** (default: `1000000`): Configurable cap on the number of log rows the proxy fetches when computing `rate`, `count_over_time`, `bytes_over_time`, or `bytes_rate` by scanning raw log lines (the "manual range-metric compatibility" path used when native VictoriaLogs statistics cannot be applied). The cap was previously hard-coded to 1,000,000.
+
+  Lower values reduce peak proxy memory for very high-cardinality queries at the cost of potentially truncated series. Raise above the default only if you see result truncation and can tolerate higher memory usage. The default preserves existing behavior — no tuning needed unless you hit the limit.
+
 ### Fixed
 
 - **Underscore proxy: Drilldown log count blank for Loki-push services**: When using `-label-style=underscores`, `sum by (service_name) (count_over_time(...))` queries returned `service_name=""` for services whose labels were stored as Loki stream labels (not VL dotted fields). The proxy translated `by(service_name)` → `by(service.name)`, but VL returned an empty value when no dotted field existed — Grafana Drilldown then displayed the label name as text instead of a numeric count. Fixed by expanding the `by()` clause to include both forms; VL groups by whichever exists and the response is coalesced to prefer the non-empty value.
 
-## [1.32.3] - 2026-05-14
+### Documentation
+
+- **Hot+cold merge memory behavior** (`docs/KNOWN_ISSUES.md`): Documented that queries spanning both the hot (VictoriaLogs) and cold (Victoria Lakehouse) backends materialize the full merged result set in proxy memory before writing to the client. For backward-direction queries the cold result must be buffered entirely before it can be reversed — this is a structural constraint of the merge algorithm, not a fixable bug. Very large time ranges covering both backends will see higher proxy memory usage than hot-only queries. Mitigation: bound cold query time ranges, or route cold-only queries directly to the cold backend.
 
 ### CI
 
@@ -35,13 +49,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fix(e2e): log-generator now starts by default (`profiles: ["ui"]` removed) — cold stacks no longer have zero ingestion, enabling pattern clustering in Drilldown. `LOG_INTERVAL` 10→2, `LOG_BATCH` 8→15 raises throughput from ~8.6 to ~75 lines/s so the pattern miner sees enough volume per time-step bucket for stable clustering and a continuous Drilldown timeline. Added `GOMEMLIMIT=2GiB` to `loki-vl-proxy-patterns-autodetect` consistent with other proxy variants.
+- **Local compose stack: `/loki/api/v1/patterns` always empty** (`test/e2e-compat`): The `log-generator` service was gated behind a Docker Compose `ui` profile, so running `docker compose up` without `--profile ui` started the full proxy stack with zero log ingestion. The proxy's pattern miner had nothing to cluster, leaving the patterns endpoint empty. The profile gate has been removed — `log-generator` now starts alongside the proxy by default.
+
+  Log throughput was also raised from ~8.6 to ~75 lines/s (`LOG_INTERVAL` 10→2, `LOG_BATCH` 8→15) so the miner receives enough log lines per time bucket to produce stable clusters and a continuous timeline in Grafana Logs Drilldown. Memory limit `GOMEMLIMIT=2GiB` added to `loki-vl-proxy-patterns-autodetect` consistent with other proxy containers.
+
+  Affects the local `test/e2e-compat` compose stack only. Automated CI tests run without the compose stack and are not affected.
 
 ## [1.32.0] - 2026-05-13
 
+### Breaking Changes
+
+> **Review this section before upgrading from any version that predates 1.32.0.**
+
+- **`offset` is no longer silently dropped**: Before this release, LogQL queries containing an `offset` modifier (e.g. `rate({app="nginx"}[5m] offset 1h)`) were accepted without error, but the offset was silently ignored — the proxy returned data for the *current* evaluation window as if no offset were specified. Starting with 1.32.0, the offset is applied correctly: the evaluation window is shifted backward by the specified duration before the query is dispatched to VictoriaLogs.
+
+  **Who is affected**: Any dashboard, alert, or recording rule that uses an `offset` modifier and was relying (intentionally or not) on the proxy returning current-time data. After upgrading, those queries will return data from the offset-shifted window, which is the correct Loki-compatible behavior.
+
+  **How to check**: Search your dashboards and alert rules for queries containing `offset`. If they were authored knowing offset was broken and worked around the limitation by other means, review them before upgrading.
+
+- **Multiple distinct offsets in the same query now return HTTP 400**: A query that applies different offset values to different range vectors — for example `rate({app="a"}[5m] offset 1h) + rate({app="b"}[5m] offset 2h)` — now returns `HTTP 400` with a descriptive error message. Previously, the proxy silently used only the first offset it found, producing incorrect results for the vector with the other offset.
+
+  **Who is affected**: Queries combining range vectors with *different* offsets. Queries where all range vectors share the *same* offset (e.g. `rate(...)[5m] offset 1h) + rate(...)[5m] offset 1h)`) continue to work correctly.
+
+  **How to fix**: Split the query into two separate queries, one per offset value, and combine the results in Grafana. Alternatively, rewrite to use the same offset across all range vectors if the intent allows it.
+
 ### Added
 
-- `offset` directive support: LogQL queries containing `rate({...}[5m] offset 1h)` now correctly shift the evaluation window backward by the offset duration. The proxy strips the `offset` clause and adjusts `start`/`end` (range queries) or `time` (instant queries) before dispatch. Multiple distinct offsets in the same query return HTTP 400.
+- **`offset` directive support**: The proxy now correctly handles the LogQL `offset` modifier on range vectors. The proxy strips the `offset` clause from the query sent to VictoriaLogs and instead shifts the request's `start`/`end` parameters (range queries) or `time` parameter (instant queries) backward by the offset duration, producing semantically correct results without requiring native VictoriaLogs offset support.
 
 ## [1.31.4] - 2026-05-13
 

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -72,6 +72,7 @@ type proxyRuntimeConfig struct {
 	tenantDefaultLimitsJSON             string
 	tenantLimitsJSON                    string
 	maxLines                            int
+	rangeMetricRowLimit                 int
 	backendTimeout                      time.Duration
 	cbFailThreshold                     int
 	cbOpenDuration                      time.Duration
@@ -121,6 +122,7 @@ type proxyRuntimeConfig struct {
 	recentTailRefreshWindow             time.Duration
 	recentTailRefreshMaxStaleness       time.Duration
 	authEnabled                         bool
+	requireTenantHeader                 bool
 	allowGlobalTenant                   bool
 	registerInstrumentation             *bool
 	enablePprof                         bool
@@ -397,6 +399,7 @@ func run(
 
 	// Grafana datasource compatibility
 	maxLines := fs.Int("max-lines", 1000, "Default max lines per query")
+	rangeMetricRowLimit := fs.Int("manual-range-metric-row-limit", 1_000_000, "Maximum log rows fetched per manual range-metric compatibility call (rate, count_over_time, etc.). Lower values bound memory at the cost of result truncation for high-cardinality queries.")
 	backendTimeout := fs.Duration("backend-timeout", 120*time.Second, "Timeout for non-streaming requests to the VictoriaLogs backend")
 	cbFailThreshold := fs.Int("cb-fail-threshold", 5, "Circuit breaker: failures within -cb-window-duration before opening")
 	cbOpenDuration := fs.Duration("cb-open-duration", 10*time.Second, "Circuit breaker: how long to stay open before allowing probe requests")
@@ -451,6 +454,7 @@ func run(
 
 	// Loki-style auth / instrumentation controls
 	authEnabled := fs.Bool("auth.enabled", false, "Require X-Scope-OrgID on query requests. When false, requests without a tenant header use the backend default tenant.")
+	requireTenantHeader := fs.Bool("require-tenant-header", false, "Reject requests missing X-Scope-OrgID with HTTP 401. Independent of -auth.enabled; use when you want tenant enforcement without full auth.")
 	registerInstrumentation := fs.Bool("server.register-instrumentation", true, "Register instrumentation handlers such as /metrics")
 	enablePprof := fs.Bool("server.enable-pprof", false, "Expose /debug/pprof/* handlers")
 	enableQueryAnalytics := fs.Bool("server.enable-query-analytics", false, "Expose /debug/queries query analytics")
@@ -604,6 +608,7 @@ func run(
 			tenantDefaultLimitsJSON:             envCfg.tenantDefaultJSON,
 			tenantLimitsJSON:                    envCfg.tenantLimitsJSON,
 			maxLines:                            *maxLines,
+			rangeMetricRowLimit:                 *rangeMetricRowLimit,
 			backendTimeout:                      *backendTimeout,
 			cbFailThreshold:                     *cbFailThreshold,
 			cbOpenDuration:                      *cbOpenDuration,
@@ -653,6 +658,7 @@ func run(
 			recentTailRefreshWindow:             *recentTailRefreshWindow,
 			recentTailRefreshMaxStaleness:       *recentTailRefreshMaxStaleness,
 			authEnabled:                         *authEnabled,
+			requireTenantHeader:                 *requireTenantHeader,
 			allowGlobalTenant:                   *allowGlobalTenant,
 			registerInstrumentation:             registerInstrumentation,
 			enablePprof:                         *enablePprof,
@@ -1452,6 +1458,7 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		TenantDefaultLimits:                tenantDefaultLimits,
 		TenantLimits:                       tenantLimits,
 		MaxLines:                           cfg.maxLines,
+		RangeMetricRowLimit:                cfg.rangeMetricRowLimit,
 		BackendTimeout:                     cfg.backendTimeout,
 		CBFailThreshold:                    cfg.cbFailThreshold,
 		CBOpenDuration:                     cfg.cbOpenDuration,
@@ -1500,6 +1507,7 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		RecentTailRefreshWindow:            cfg.recentTailRefreshWindow,
 		RecentTailRefreshMaxStaleness:      cfg.recentTailRefreshMaxStaleness,
 		AuthEnabled:                        cfg.authEnabled,
+		RequireTenantHeader:                cfg.requireTenantHeader,
 		AllowGlobalTenant:                  cfg.allowGlobalTenant,
 		RegisterInstrumentation:            cfg.registerInstrumentation,
 		EnablePprof:                        cfg.enablePprof,

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -53,6 +53,17 @@ This especially matters for:
 Treat those paths as supported compatibility work, not as zero-cost backend
 equivalents.
 
+### Hot+Cold response merging materializes full response
+
+When both hot (VictoriaLogs) and cold (Victoria Lakehouse) backends return results,
+the proxy materializes the full merged response in memory before writing it to the
+client. For backward-direction queries the cold result set must be read fully to
+reverse ordering before merging — this is a structural constraint of the merge
+algorithm, not an incidental implementation detail. Very large time ranges hitting
+both backends will see higher proxy memory usage than hot-only queries. Workaround:
+keep cold queries to bounded time ranges, or route cold-only queries directly to the
+cold backend.
+
 ## Operational Caveats
 
 | Area | Current state |
@@ -62,7 +73,7 @@ equivalents.
 | Startup warm readiness | When patterns or label-values startup warm is configured, readiness can remain `503` until disk restore or peer warm completes. |
 | Older VictoriaLogs metadata paths | Newer VictoriaLogs versions let the proxy prefer stream-only metadata APIs. Older versions may fall back to broader field APIs, which can change how strictly stream-shaped some browse endpoints feel. |
 | Large body fields | Very large body fields can still be dropped on the VictoriaLogs side. Track the upstream issue: [VictoriaLogs issue #91](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/91). |
-| Optional tenant header | The proxy accepts requests without an `X-Scope-OrgID` header and routes them to the default tenant. In deployments where tenant isolation is required, callers must supply the header; the proxy does not enforce a hard rejection. Add `X-Scope-OrgID` enforcement at the ingress/gateway layer if you need a strict tenant boundary. |
+| Optional tenant header | By default the proxy accepts requests without `X-Scope-OrgID` and routes them to the default tenant. Use `-require-tenant-header` (or `-auth.enabled`) to reject requests that omit the header with HTTP 401. |
 | Multi-tenant serial fanout | When `X-Scope-OrgID` contains multiple tenants (e.g. `tenant1\|tenant2\|tenant3`), the proxy issues sub-requests to each tenant sequentially. Latency scales linearly with the number of tenants. For high fan-out counts (>4 tenants), consider running per-tenant Grafana datasources instead of relying on the multi-tenant merge path. |
 
 ## What Is No Longer an Open Gap

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -66,7 +66,7 @@ func (e *requestPolicyError) Error() string { return e.msg }
 func (p *Proxy) validateTenantHeader(r *http.Request) error {
 	orgID := strings.TrimSpace(r.Header.Get("X-Scope-OrgID"))
 	if orgID == "" {
-		if p.authEnabled {
+		if p.authEnabled || p.requireTenantHeader {
 			return &requestPolicyError{
 				status: http.StatusUnauthorized,
 				msg:    "missing X-Scope-OrgID header",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -116,11 +116,17 @@ type Config struct {
 	CBWindowDuration  time.Duration            // circuit breaker: sliding window for failure counting (default 30s)
 	CoalescerDisabled bool                     // disable singleflight coalescing; every request makes its own backend call
 	TenantMap         map[string]TenantMapping // string org ID → VL account/project
-	AuthEnabled       bool
-	AllowGlobalTenant bool
+	AuthEnabled          bool
+	RequireTenantHeader  bool
+	AllowGlobalTenant    bool
 
 	// Grafana datasource compatibility
 	MaxLines           int               // default max lines per query (0=1000)
+	// RangeMetricRowLimit caps the number of log rows fetched per collectRangeMetricSamples
+	// call used by manual range-metric compatibility (rate, count_over_time, etc.).
+	// 0 means use the built-in default of 1,000,000. Lower values bound memory at the cost
+	// of potential result truncation for very high-cardinality queries.
+	RangeMetricRowLimit int
 	ForwardHeaders     []string          // HTTP headers to forward from client to VL backend
 	ForwardCookies     []string          // Cookie names to forward from client to VL backend
 	BackendHeaders     map[string]string // static headers to add to all VL requests
@@ -350,6 +356,7 @@ type Proxy struct {
 	configMu                              sync.RWMutex // protects tenantMap and labelTranslator
 	tenantMap                             map[string]TenantMapping
 	authEnabled                           bool
+	requireTenantHeader                   bool
 	allowGlobalTenant                     bool
 	maxLines                              int
 	forwardHeaders                        []string          // headers to copy from client request to VL
@@ -380,6 +387,7 @@ type Proxy struct {
 	enableQueryAnalytics                  bool
 	adminAuthToken                        string
 	metricsConcurrencyLimiter             chan struct{}
+	rangeMetricRowLimit                   int // max rows fetched per collectRangeMetricSamples call (0=1_000_000)
 	tailAllowedOrigins                    map[string]struct{}
 	tailMode                              TailMode
 	metricsTrustProxyHeaders              bool
@@ -917,8 +925,10 @@ func New(cfg Config) (*Proxy, error) {
 		breaker:                               mw.NewCircuitBreaker(cbFail, 3, cbOpen, cbWindow),
 		tenantMap:                             cfg.TenantMap,
 		authEnabled:                           cfg.AuthEnabled,
+		requireTenantHeader:                   cfg.RequireTenantHeader,
 		allowGlobalTenant:                     cfg.AllowGlobalTenant,
 		maxLines:                              maxLines,
+		rangeMetricRowLimit:                   cfg.RangeMetricRowLimit,
 		forwardHeaders:                        cfg.ForwardHeaders,
 		forwardCookies:                        forwardCookies,
 		backendHeaders:                        backendHeaders,

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -706,7 +706,12 @@ func (p *Proxy) collectRangeMetricSamples(ctx context.Context, baseQuery string,
 	params.Set("start", formatVLTimestamp(start.UTC().Format(time.RFC3339Nano)))
 	params.Set("end", formatVLTimestamp(end.UTC().Format(time.RFC3339Nano)))
 	// Keep this high to avoid truncating series for compatibility stats functions.
-	params.Set("limit", "1000000")
+	// Configurable via -manual-range-metric-row-limit; default 1,000,000.
+	rowLimit := p.rangeMetricRowLimit
+	if rowLimit <= 0 {
+		rowLimit = 1_000_000
+	}
+	params.Set("limit", strconv.Itoa(rowLimit))
 
 	resp, err := p.vlPost(ctx, "/select/logsql/query", params)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Security hardening**: New `-require-tenant-header` flag rejects requests missing `X-Scope-OrgID` with HTTP 401, independent of `-auth.enabled`. Operators can now enforce tenant isolation without enabling the full Loki auth mode — addresses review finding that the two concerns were conflated.
- **DoS cap**: New `-manual-range-metric-row-limit` flag (default 1,000,000) makes the row cap in `collectRangeMetricSamples` configurable. Lower values bound proxy memory for high-cardinality `rate`/`count_over_time` queries.
- **Docs**: Documented hot+cold response merge full-materialization constraint in `KNOWN_ISSUES.md`. Updated optional tenant header caveat to reference the new flag.

## Test Plan

- [ ] All 2518 existing tests pass (`go test ./... -count=1`)
- [ ] Start proxy with `-require-tenant-header`; request without header → HTTP 401
- [ ] Start proxy with `-require-tenant-header=false` (default); request without header → passes through
- [ ] Start proxy with `-manual-range-metric-row-limit=1000`; verify flag is accepted