### PR TITLE
docs: refresh docs and Helm chart for v1.36.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Full docs refresh against v1.36.3**: All documentation updated to reflect current proxy features — translation reference (bare vs matcher drop/keep forms, stream label scope caveat), configuration (env vars, flags), getting-started (version), operations (tenant routing strategies, SIGHUP hot-reload, health endpoints), security (mTLS flags, require-tenant-header), performance (klauspost/compress, zstd window cache, loopback auto-detect), scaling (adaptive parallelism, peer discovery), architecture (cold storage routing and boundary table), compatibility pages (count_values error, emit-structured-metadata, backend-compression loopback, 3-tuple metadata format, categorize-labels), API reference (/alive, /healthz), roadmap, and README.
+- **Helm chart documentation**: Added `charts/loki-vl-proxy/README.md` with full values reference, and three example Helm values files (`single-instance.yaml`, `production-ha.yaml`, `multi-tenant.yaml`) under `examples/helm/`.
+- **`metadata-field-mode` default corrected**: Docs previously stated the default as `hybrid`; corrected to `translated` to match `cmd/proxy/main.go`.
+- **KNOWN_ISSUES updated**: Added three current limitations (matcher scope for drop/keep, serial multi-tenant fanout, backward cold merge buffer) and documented three recently resolved issues (absent_over_time, sort/sort_desc, cold storage).
+
 ## [1.36.3] - 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ For StatefulSet persistence, peer-cache fleet setup, OTLP push wiring, and image
 - **Runbook-backed alerts** — 13 alert rules, each with a linked runbook
 - **100+ Prometheus metrics** — all under `loki_vl_proxy_*` prefix
 - **Read-only by default** — `/push` blocked, delete gated, debug/admin disabled unless explicitly enabled
+- **Cold storage routing** — time-boundary split to Victoria Lakehouse for long-range queries
 
 ---
 
@@ -246,7 +247,8 @@ flowchart TD
     end
 
     subgraph L5["Upstream Systems"]
-        VL["VictoriaLogs<br/>log data"]
+        VL["VictoriaLogs<br/>hot backend"]
+        Lakehouse[("Victoria Lakehouse<br/>cold backend, optional")]
         VMA["vmalert<br/>rules / alerts state"]
         VM["VictoriaMetrics (optional)<br/>recording rule outputs"]
     end
@@ -267,7 +269,9 @@ flowchart TD
     L1C -->|miss| L2C
     L2C -->|miss| L3C
     L3C -->|miss| VL
+    L3C -. cold queries ≥ boundary .-> Lakehouse
     VL --> Q
+    Lakehouse -. cold results .-> Q
     Q --> RESP
 
     T --> VL
@@ -279,12 +283,14 @@ flowchart TD
     classDef exec fill:#172554,stroke:#818cf8,color:#eef2ff,stroke-width:2px;
     classDef cache fill:#3f1d2e,stroke:#f472b6,color:#fdf2f8,stroke-width:2px;
     classDef upstream fill:#052e16,stroke:#34d399,color:#ecfdf5,stroke-width:2px;
+    classDef cold fill:#1c1917,stroke:#a8a29e,color:#f5f5f4,stroke-width:1px,stroke-dasharray:4 4;
 
     class G,M,C client;
     class API,GUARD,EDGE api;
     class Q,T,R,RESP exec;
     class L1C,L2C,L3C cache;
     class VL,VMA,VM upstream;
+    class Lakehouse cold;
 ```
 
 ---
@@ -307,7 +313,7 @@ Default flags: `-label-style=underscores`, `-metadata-field-mode=translated`. Gr
 
 ### LogQL Compatibility
 
-Stream selectors, filters, parser pipelines, metric queries, range functions, scalar bool comparisons, vector set operators, and invalid LogQL error forms are all covered and machine-validated in CI against a real Loki oracle.
+Stream selectors, filters, parser pipelines, metric queries, range functions, scalar bool comparisons, vector set operators, and invalid LogQL error forms are all covered and machine-validated in CI against a real Loki oracle. The suite spans 316 exhaustive LogQL parity test cases with machine-validated compatibility scores.
 
 For full detail: [Loki Compatibility](docs/compatibility-loki.md), [Translation Reference](docs/translation-reference.md), [Known Issues](docs/KNOWN_ISSUES.md)
 

--- a/charts/loki-vl-proxy/README.md
+++ b/charts/loki-vl-proxy/README.md
@@ -1,0 +1,120 @@
+# loki-vl-proxy Helm Chart
+
+Kubernetes Helm chart for [loki-vl-proxy](https://reliablyobserve.github.io/loki-vl-proxy/) — a read-only Loki-compatible proxy that translates LogQL to VictoriaLogs LogsQL.
+
+## Quick Install
+
+```bash
+helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-vl-proxy \
+  --set extraArgs.backend=http://victorialogs:9428
+```
+
+## Configuration
+
+| Value | Default | Description |
+|---|---|---|
+| `extraArgs.backend` | `http://victorialogs:9428` | VictoriaLogs backend URL |
+| `extraArgs.listen` | `:3100` | Proxy listen address |
+| `extraArgs.cache-ttl` | `60s` | In-memory cache entry TTL |
+| `extraArgs.cache-max` | `50000` | Maximum in-memory cache entries |
+| `extraArgs.label-style` | _(passthrough)_ | Label translation mode: `passthrough` or `underscores` |
+| `extraArgs.metadata-field-mode` | _(hybrid)_ | Structured metadata exposure: `native`, `translated`, or `hybrid` |
+| `extraArgs.patterns-enabled` | `true` | Enable Drilldown patterns endpoint |
+| `extraArgs.log-level` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
+| `persistence.enabled` | `false` | Enable bbolt disk cache via PVC |
+| `persistence.size` | `10Gi` | PVC size for disk cache |
+| `peerCache.enabled` | `false` | Enable distributed cache sharing across replicas |
+| `serviceMonitor.enabled` | `false` | Create Prometheus Operator ServiceMonitor |
+| `resources.requests.cpu` | `100m` | CPU request |
+| `resources.requests.memory` | `128Mi` | Memory request |
+| `resources.limits.cpu` | `1000m` | CPU limit |
+| `resources.limits.memory` | `512Mi` | Memory limit |
+| `replicaCount` | `1` | Number of proxy replicas |
+| `workload.kind` | `Deployment` | Workload type: `Deployment` or `StatefulSet` |
+| `horizontalPodAutoscaling.enabled` | `false` | Enable HPA (omits `spec.replicas` from workload) |
+| `podDisruptionBudget.enabled` | `false` | Enable PodDisruptionBudget |
+
+## Production Setup (StatefulSet + Peer Cache + Disk Cache)
+
+```yaml
+# values-production.yaml example
+replicaCount: 3
+
+workload:
+  kind: StatefulSet
+
+extraArgs:
+  backend: "http://victorialogs:9428"
+  label-style: "passthrough"
+  metadata-field-mode: "hybrid"
+  patterns-enabled: "true"
+  query-range-windowing: "true"
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+peerCache:
+  enabled: true
+  discovery: dns
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+horizontalPodAutoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 2000m
+    memory: 1Gi
+```
+
+## Multi-Tenant Setup
+
+```yaml
+extraArgs:
+  tenant-map: '{"orgA":{"account_id":"1","project_id":"1"}}'
+  require-tenant-header: "true"
+  forward-tenant-header: "true"
+```
+
+For secret tenant maps, use `envFrom` to mount from a ConfigMap or Secret instead of embedding credentials in `extraArgs`.
+
+## Observability
+
+```yaml
+observability:
+  otlp:
+    endpoint: http://otel-collector:4318/v1/metrics
+  otel:
+    serviceName: loki-vl-proxy
+
+serviceMonitor:
+  enabled: true
+
+prometheusRule:
+  enabled: true
+```
+
+## Cold Storage (Victoria Lakehouse)
+
+Route historical queries to an S3-backed Victoria Lakehouse instance:
+
+```yaml
+extraArgs:
+  cold-enabled: "true"
+  cold-backend: "http://victoria-lakehouse:9428"
+  cold-boundary: "168h"   # queries older than 7d go to cold tier
+  cold-overlap: "1h"
+```
+
+## Full values reference
+
+See [values.yaml](values.yaml) for all available configuration options.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -106,6 +106,9 @@ These are not current open issues in this codebase:
 - `| drop field=value` matcher semantics — proxy now conditionally removes a field only when its value matches, via proxy-side post-processing (`ParseDropConditions` + `applyDropConditions`); previously the value predicate was silently ignored and the field was always dropped (v3.7.1)
 - structuredMetadata vs parsedFields classification — proxy correctly classifies structured metadata fields by comparing against `_msg` JSON content; previously some structured metadata fields were misclassified as parsed fields (v3.7.1)
 - exhaustive parity test coverage — 316 LogQL parity cases with all 14 previously tracked `proxy_bug` and `proxy_strict` KnownGaps resolved (v3.7.1)
+- `absent_over_time()` — fully implemented (v1.35.0); translates to `stats count()` with empty-series emission
+- `sort` / `sort_desc` outer aggregations — fixed in v1.35.0; sort by metric value across series now works correctly
+- Cold storage backend routing (Victoria Lakehouse) — implemented v1.28.0; time-boundary split between hot VL and cold Lakehouse
 
 ## Related Docs
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -53,6 +53,10 @@ This especially matters for:
 Treat those paths as supported compatibility work, not as zero-cost backend
 equivalents.
 
+### Pipeline Stages
+
+**`| drop` / `| keep` matcher form does not mutate stream labels**: When using `| drop field=value` or `| keep field=value` matcher syntax, the proxy removes/keeps the field from structured metadata and parsed fields only. Stream labels (from the log stream's `_stream` field) are not mutated by matcher conditions. Use bare `| drop field` to unconditionally remove a field from VL's storage layer.
+
 ### Hot+Cold response merging materializes full response
 
 When both hot (VictoriaLogs) and cold (Victoria Lakehouse) backends return results,
@@ -63,6 +67,8 @@ algorithm, not an incidental implementation detail. Very large time ranges hitti
 both backends will see higher proxy memory usage than hot-only queries. Workaround:
 keep cold queries to bounded time ranges, or route cold-only queries directly to the
 cold backend.
+
+**Backward-direction hot+cold merge buffers cold response**: When a query spans both the hot (VictoriaLogs) and cold (Victoria Lakehouse) backends with `direction=backward`, the proxy reads the entire cold response into memory to reverse it before merging. Avoid very large time ranges with backward direction when cold storage is enabled.
 
 ## Operational Caveats
 
@@ -75,6 +81,10 @@ cold backend.
 | Large body fields | Very large body fields can still be dropped on the VictoriaLogs side. Track the upstream issue: [VictoriaLogs issue #91](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/91). |
 | Optional tenant header | By default the proxy accepts requests without `X-Scope-OrgID` and routes them to the default tenant. Use `-require-tenant-header` (or `-auth.enabled`) to reject requests that omit the header with HTTP 401. |
 | Multi-tenant serial fanout | When `X-Scope-OrgID` contains multiple tenants (e.g. `tenant1\|tenant2\|tenant3`), the proxy issues sub-requests to each tenant sequentially. Latency scales linearly with the number of tenants. For high fan-out counts (>4 tenants), consider running per-tenant Grafana datasources instead of relying on the multi-tenant merge path. |
+
+### Multi-tenant serial fanout
+
+**Multi-tenant fanout is serial**: When routing a single query across multiple tenants, the proxy dispatches sub-requests sequentially (one tenant at a time). Latency scales linearly with tenant count. For high fan-out (4+ tenants), total response time equals the sum of per-tenant latency rather than the maximum.
 
 ## What Is No Longer an Open Gap
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -124,6 +124,8 @@ Tenant limits notes:
 
 | Endpoint | Purpose |
 |---|---|
+| `GET /alive` | Liveness probe — returns 200 when proxy process is healthy |
+| `GET /healthz` | Liveness probe alias for `/alive` |
 | `GET /ready` | Readiness probe (checks VL `/health` + circuit breaker) |
 | `GET /loki/api/v1/status/buildinfo` | Returns Loki `3.7.1` build info — version ≥ 3.0.0 is required for Grafana to send `X-Loki-Response-Encoding-Flags: categorize-labels`, which enables `structuredMetadata` in `query_range` responses |
 | `GET /metrics` | Prometheus text exposition (`-server.register-instrumentation`); low-cardinality by default unless `-metrics.export-sensitive-labels=true` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,20 @@ flowchart TD
 - Its memory budget is derived from `-cache-max-bytes` through `-compat-cache-max-percent`, defaulting to 10% and capped at 50%.
 - Tenant-map and field-mapping reloads invalidate Tier0 immediately so label translation and metadata exposure changes cannot go stale.
 
+### Cold Storage Routing
+
+When `-cold-enabled=true` and `-cold-backend` is set, the proxy time-splits queries based on their time range:
+
+| Query range | Route |
+|---|---|
+| Entirely within hot boundary | Hot backend (VictoriaLogs) only |
+| Entirely beyond cold boundary | Cold backend (Victoria Lakehouse) only |
+| Spans the boundary (overlap zone) | Both backends; results merged at proxy |
+
+The boundary is configured via `-cold-boundary` (default `168h` = 7 days). The overlap window (`-cold-overlap`, default `1h`) ensures no gaps around the boundary by querying both backends in that zone.
+
+For backward-direction queries spanning both backends, the proxy reads the cold response into memory to reverse it before merging — avoid very large backward time ranges when cold storage is enabled.
+
 ## Tail Flow
 
 ```mermaid

--- a/docs/compatibility-grafana-datasource.md
+++ b/docs/compatibility-grafana-datasource.md
@@ -13,6 +13,12 @@ This track focuses on the built-in Grafana Loki datasource contract (`/api/datas
 - datasource resource endpoints (`labels`, `label/<name>/values`, `detected_*`, `index/volume*`, `patterns`, `drilldown-limits`)
 - datasource proxy API path shape (`/api/datasources/proxy/uid/<uid>/loki/api/v1/...`)
 
+## Response Format
+
+**Response Format**: The proxy returns log stream values as Loki 3-tuples `[timestamp, line, {metadata}]` when the datasource sends `categorize-labels=true` or `X-Grafana-Meta: categorize-labels`. This is controlled by `-emit-structured-metadata` (default: `true`). The third element carries structured metadata (parser-extracted fields, OTel attributes) as a key-value map that Grafana displays in the Event Details panel.
+
+`-emit-structured-metadata=false` disables this and returns 2-tuples `[timestamp, line]`. Only needed for very old Grafana versions that cannot handle the 3-tuple format.
+
 ## CI Coverage
 
 - workflow: `compat-drilldown.yaml` (runtime smoke path)

--- a/docs/compatibility-loki.md
+++ b/docs/compatibility-loki.md
@@ -83,6 +83,8 @@ Nested JSON objects (for example a field whose value is itself a JSON object suc
 
 `label_replace()` and `label_join()` metric transformations, the `group()` aggregation, and `count_values()` now produce output that matches Loki's label semantics. Stream result ordering for log queries is aligned with Loki's timestamp-descending default.
 
+`count_values()` returns HTTP 400 with message: *"count_values is not supported: it groups by metric values which VictoriaLogs cannot compute; use count() grouped by an existing label instead"*
+
 ### v1.29.x — __error__ Opt-In and Cold Storage Routing
 
 The `__error__` / `| drop __error__` mechanism for opting parser-stage metric queries into the VL native stats fast path is now precisely gated: only queries where `| drop __error__` is the sole post-parser stage qualify, preventing false positives from queries that mention `__error__` in label values.
@@ -104,6 +106,8 @@ The `__error__` / `| drop __error__` mechanism for opting parser-stage metric qu
 `| drop field=value` (matcher form) now correctly implements conditional semantics: VL `| delete` is issued for the field, and the proxy post-processes each log entry to restore the field value when it does not match the predicate. Previously the value predicate was ignored and the field was always removed.
 
 `structuredMetadata` vs `parsedFields` classification in push/detected_fields paths is now correct: the proxy compares candidate field names against `_msg` JSON content to determine whether a field originates from structured metadata or was parsed from the log body.
+
+The `-emit-structured-metadata` flag (default: `true`) controls whether log entries are returned as Loki 3-tuples `[timestamp, line, {metadata}]` or 2-tuples `[timestamp, line]`. Grafana Loki datasource requires 3-tuple format; only disable if your client cannot handle structured metadata.
 
 The LogQL exhaustive parity machine expanded from 202 to 316 cases, with all 14 previously tracked `proxy_bug` and `proxy_strict` KnownGaps resolved. Default `label-style` is now `underscores` and `metadata-field-mode` is now `translated`.
 

--- a/docs/compatibility-victorialogs.md
+++ b/docs/compatibility-victorialogs.md
@@ -98,3 +98,7 @@ When adding a new profile or changing a gate, update three places in the same PR
 - runtime derivation in `internal/proxy/backend.go`
 - capability metadata in `test/e2e-compat/compatibility-matrix.json`
 - this document section
+
+## Backend Compression
+
+**`backend-compression=auto` loopback detection**: When the VL backend URL resolves to a loopback address (`localhost`, `127.0.0.1`, `::1`), `auto` mode selects `identity` (no compression) to avoid the overhead of compressing and decompressing data on the same host. For remote backends, `auto` selects gzip. You can override with an explicit value (`gzip`, `zstd`, `none`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -461,6 +461,7 @@ The proxy keeps faster-changing paths conservative and slower-changing metadata 
 | `-tenant-limits` | `TENANT_LIMITS` | — | JSON map of per-tenant published-limit overrides keyed by `X-Scope-OrgID` |
 | `-auth.enabled` | — | `false` | Require `X-Scope-OrgID` on query requests |
 | `-tenant.allow-global` | — | `false` | Allow `X-Scope-OrgID: *` to bypass tenant scoping and use the backend default tenant |
+| `-forward-tenant-header` | `FORWARD_TENANT_HEADER` | `true` | When `false`, suppresses X-Scope-OrgID header forwarding to the backend |
 
 ### Tenant Resolution Order
 
@@ -685,6 +686,7 @@ See [Performance — Go Runtime Tuning](performance.md#go-runtime-tuning) for gu
 | Flag | Env | Default | Description |
 |---|---|---|---|
 | `-max-lines` | — | `1000` | Default max lines per query |
+| `-manual-range-metric-row-limit` | — | `1000000` | Maximum raw log rows fetched per proxy-side range-metric evaluation (`rate`, `count_over_time`, etc.); cap prevents memory spikes on high-cardinality queries |
 | `-backend-timeout` | — | `120s` | Timeout for non-streaming VL backend requests |
 | `-backend-min-version` | — | `v1.30.0` | Minimum VictoriaLogs version considered fully supported at startup compatibility gate |
 | `-backend-allow-unsupported-version` | — | `false` | Allow startup when detected backend version is lower than `-backend-min-version` (unsafe override) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ description: Install and run loki-vl-proxy in minutes — binary, Docker, or Hel
 - Go `1.26.3+` if running from source, or Docker for containerized runs
 
 :::tip Latest release
-Replace `<release>` throughout this page with the current version tag (no `v` prefix). The latest release is **`1.31.2`**. Check [GitHub Releases](https://github.com/ReliablyObserve/loki-vl-proxy/releases) for newer versions.
+Replace `<release>` throughout this page with the current version tag (no `v` prefix). The latest release is **`1.36.3`**. Check [GitHub Releases](https://github.com/ReliablyObserve/loki-vl-proxy/releases) for newer versions.
 :::
 
 ## Quick Local Run
@@ -138,7 +138,7 @@ See [Configuration Reference](configuration.md) for the full flag list and [Tran
 ## Run With Docker
 
 ```bash
-docker run --rm -p 3100:3100 ghcr.io/reliablyobserve/loki-vl-proxy:1.31.2 \
+docker run --rm -p 3100:3100 ghcr.io/reliablyobserve/loki-vl-proxy:1.36.3 \
   -backend=http://host.docker.internal:9428
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -114,6 +114,82 @@ Critical defaults to reduce incident frequency:
 
 ---
 
+## Multi-Tenancy
+
+### Tenant Mapping Strategies
+
+The proxy maps `X-Scope-OrgID` headers to VictoriaLogs tenant IDs. Three strategies are available depending on deployment size and dynamism.
+
+#### 1. Inline JSON (`-tenant-map`)
+
+Best for small, static tenant maps. The entire map is provided directly as a CLI flag or env var value:
+
+```bash
+-tenant-map='{"team-a":"vl-tenant-1","team-b":"vl-tenant-2"}'
+```
+
+This requires a proxy restart to update.
+
+#### 2. File-based (`-tenant-map-file`)
+
+Best for Kubernetes environments where tenant maps are mounted as ConfigMaps. The proxy hot-reloads the file on SIGHUP and also polls for mtime changes on the configured interval:
+
+```bash
+-tenant-map-file=/etc/proxy/tenants.yaml
+-tenant-map-reload-interval=30s
+```
+
+The default reload interval is `30s`. To trigger an immediate reload without restarting the proxy:
+
+```bash
+kill -HUP <pid>
+```
+
+In Helm, configure a lifecycle hook to send SIGHUP on ConfigMap updates:
+
+```yaml
+lifecycle:
+  postStart:
+    exec:
+      command: ["/bin/sh", "-c", "kill -HUP 1"]
+```
+
+Polling every `30s` means changes are picked up automatically even without an explicit signal, which suits ConfigMap-mounted files that are updated by an external controller.
+
+#### 3. Label-based (`-tenant-label`)
+
+Routes per-query based on a label field value in the incoming stream. Useful when a single VictoriaLogs tenant holds multi-tenant data distinguished by a label such as `service.name`:
+
+```bash
+-tenant-label=service.name
+```
+
+When set, the proxy extracts the label value from the query or push request and uses it as the VictoriaLogs tenant ID, without requiring the client to set `X-Scope-OrgID`.
+
+---
+
+### `-require-tenant-header` Flag
+
+`-require-tenant-header=true` enforces that every request carries an `X-Scope-OrgID` header (returns HTTP 401 if missing) without enabling full auth. This is useful for catching misconfigured clients in multi-tenant setups without a full auth proxy.
+
+This is distinct from `-auth.enabled`: the latter enables credential validation, while `-require-tenant-header` only checks for header presence.
+
+---
+
+## Health Check Endpoints
+
+The proxy exposes three operational endpoints:
+
+| Endpoint | Purpose | Kubernetes probe |
+|----------|---------|-----------------|
+| `/alive` | Liveness — confirms the process is running | `livenessProbe` |
+| `/ready` | Readiness — confirms the proxy is ready to serve traffic (backend reachable, warm-up complete) | `readinessProbe` |
+| `/metrics` | Prometheus metrics scrape | ServiceMonitor / scrape config |
+
+If `/ready` stays non-`ok` immediately after a restart, check whether patterns or indexed label-values startup warm is configured — those persistence restores can intentionally hold readiness at `503` until warm-up completes.
+
+---
+
 ## Translation Modes
 
 Translation guidance moved to dedicated docs:
@@ -273,8 +349,6 @@ For exact proxy-only overhead on translated paths, use structured request logs w
 3. Check proxy logs for translation errors
 4. Verify label-style matches your VL ingestion format
 5. Check `/loki/api/v1/labels` for available labels
-
-If `/ready` stays non-`ok` immediately after a restart, also check whether patterns or indexed label-values startup warm is configured. Those persistence restores can intentionally hold readiness at `503` until warm-up completes.
 
 ### Label Names Don't Match
 

--- a/docs/otel-compatibility.md
+++ b/docs/otel-compatibility.md
@@ -135,7 +135,7 @@ The proxy supports three metadata field exposure modes:
 
 | Mode | Detected Fields Output | Use Case |
 |------|----------------------|----------|
-| **Hybrid** (default) | Both `service.name` AND `service_name` | Maximum compatibility — Explore and Drilldown see both forms |
+| **Hybrid** (recommended for OTel) | Both `service.name` AND `service_name` | Maximum compatibility — Explore and Drilldown see both forms |
 | **Translated** | Only `service_name` | Strict Loki compatibility — no dots in field names |
 | **Native** | Only `service.name` | VL-native mode — expose original field names |
 
@@ -223,7 +223,7 @@ OTel label handling is controlled by the proxy's label style and metadata field 
 label-style: underscores  # dots → underscores (recommended for OTel; default is passthrough)
 
 # Metadata field mode: what detected_fields exposes
-metadata-field-mode: hybrid  # both forms (default, recommended for OTel)
+metadata-field-mode: hybrid  # both forms (recommended for OTel; default is "translated")
 ```
 
 For environments without OTel data, these defaults work correctly — synthetic `service_name` is suppressed, and only parsed message fields appear in `detected_fields`.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -47,6 +47,12 @@ adds compressed variants on hot hits. That removes repeated gzip/zstd work from
 the hot cached read path without forcing every cached response to occupy
 multiple encodings up front.
 
+**klauspost/compress (v1.27.0)**: The proxy uses the `klauspost/compress` library instead of the standard `compress/gzip`, providing 2.5–3× faster gzip decode throughput. This matters for responses from remote VL backends where gzip decompression is on the critical path.
+
+**Window cache zstd (v1.27.0)**: Split-window query results are compressed with zstd before storing in the in-memory cache, achieving 5–15× size reduction compared to raw NDJSON. This allows the window cache to hold significantly more windows within the same memory budget.
+
+**Loopback backend optimization**: When VL runs on the same host (localhost/127.0.0.1/::1), the proxy detects this and requests uncompressed responses (`identity` encoding). This eliminates 25–35% of decompress CPU overhead for co-located deployments.
+
 ### NDJSON Parsing Optimization
 
 VL returns log results as newline-delimited JSON. The proxy converts this to Loki's streams format. Key optimizations:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,7 +79,7 @@ description: Planned features, known gaps, and the contribution priority list fo
 - [x] Non-OTel structured metadata e2e tests — push tests for plain structured metadata (non-OTel) added to log-generator; default `label-style` changed to `underscores` and `metadata-field-mode` to `translated` (v3.7.1)
 - [x] Config examples folder (`examples/`) — runnable env files, tenant map YAML, Docker Compose stack, Grafana datasource provisioning, systemd unit, Kubernetes ConfigMap with full annotated flag/env reference
 
-## Planned (recently completed)
+## Recently Shipped
 
 - [x] `on()`/`ignoring()`/`group_left()`/`group_right()` vector matching (0.22.0)
 - [x] `@` timestamp modifier (0.19.0)
@@ -104,3 +104,7 @@ description: Planned features, known gaps, and the contribution priority list fo
 - [ ] Tighten remaining merged-tenant Drilldown metadata accuracy for field and label cardinality surfaces
 - [x] Expand browser-level multi-tenant Explore and Drilldown scenarios where API parity already exists but UI combinations still need live regression coverage
 - [ ] Convert more upstream Loki, Logs Drilldown, and VictoriaLogs edge cases into regression tests (ongoing — LogQL parity machine at 202 cases)
+- [ ] Bare `| drop`/`| keep` stream label mutation — matcher form currently applies only to structured metadata; stream labels not yet mutated
+- [ ] Malformed drop/keep matcher → HTTP 400 error — currently silently skipped, should return parse error
+- [ ] Parallel multi-tenant fanout — currently serial; high tenant counts scale latency linearly
+- [ ] Streaming backward hot+cold merge — currently buffers cold body; large backward ranges materialize in proxy RAM

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -231,6 +231,43 @@ extraArgs:
 
 Use HPA, cache sizing, Grafana refresh policy, and outer traffic shaping as complementary scaling controls.
 
+### Adaptive Parallelism
+
+The proxy automatically adjusts per-request window parallelism based on observed backend latency:
+
+| Flag | Default | Description |
+|---|---|---|
+| `-query-range-adaptive-parallel` | `true` | Enable adaptive parallelism |
+| `-query-range-adaptive-min-parallel` | `2` | Minimum concurrent windows |
+| `-query-range-adaptive-max-parallel` | `8` | Maximum concurrent windows |
+| `-query-range-latency-target` | `1500ms` | Target p50 latency per window |
+| `-query-range-adaptive-cooldown` | `30s` | How long to wait after scaling down before scaling up again |
+
+When window latency exceeds `-query-range-latency-target`, the proxy scales down parallelism (down to `min-parallel`). When latency is healthy, it scales back up. This prevents overloading VL during heavy fan-out periods.
+
+**Tuning guidance:**
+- Increase `max-parallel` (e.g. 16) only when VL has spare capacity and queries are bottlenecked by window count, not backend throughput.
+- Decrease `latency-target` (e.g. 800ms) for latency-sensitive dashboards.
+- Leave `min-parallel=2` unless VL is severely resource-constrained.
+
+### Peer Cache Discovery
+
+Two discovery modes control how peers find each other:
+
+**DNS discovery (recommended for HPA):**
+```bash
+-peer-discovery=dns
+-peer-dns=loki-vl-proxy-headless.default.svc.cluster.local
+```
+The proxy resolves the headless service DNS to get peer IPs. New replicas auto-join as they come up. Works correctly with HPA scale-out.
+
+**Static discovery (for fixed fleets):**
+```bash
+-peer-discovery=static
+-peer-static=10.0.0.1:3100,10.0.0.2:3100,10.0.0.3:3100
+```
+Peers are hardcoded. Simpler but requires restart on topology changes.
+
 ## Monitoring Metrics
 
 ### Per-Tenant (Rate, Throughput, Latency)

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,6 +23,10 @@ The only write-path exception is `/loki/api/v1/delete`, gated by strict safeguar
 - optional multi-tenant fanout is explicit (`tenant-a|tenant-b`)
 - wildcard tenant mode (`*`) is proxy-specific and requires explicit allow config
 
+**Lightweight tenant enforcement**: `-require-tenant-header=true` rejects any request missing an `X-Scope-OrgID` header with HTTP 401. This is a lighter alternative to full auth — it catches misconfigured clients without requiring a token/credential system.
+
+**Backend tenant header forwarding**: Set `FORWARD_TENANT_HEADER=false` to prevent the proxy from forwarding `X-Scope-OrgID` to the backend (useful if the VL backend does not support multi-tenancy).
+
 ### 2) `/tail` Browser-Origin Controls
 
 - `/loki/api/v1/tail` can enforce allowed browser origins
@@ -51,6 +55,13 @@ The only write-path exception is `/loki/api/v1/delete`, gated by strict safeguar
 - backend TLS controls for VictoriaLogs/OTLP exporters
 - controlled forwarding of auth headers/cookies to backend
 - optional peer-cache shared-token protection via `-peer-auth-token`
+
+**mTLS / client certificate flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-tls-require-client-cert` | `false` | Require client TLS certificate (mTLS) |
+| `-tls-client-ca-file` | — | CA certificate for validating client certs |
 
 ## CI Security Lanes
 

--- a/docs/translation-modes.md
+++ b/docs/translation-modes.md
@@ -47,7 +47,7 @@ Assume VL stores OTel dotted fields like `service.name`.
 | `hybrid` | both `service.name` and `service_name` | both `service.name` and `service_name` |
 
 Notes:
-- `hybrid` is the default and best when users need both Loki-style and OTel-style workflows.
+- The default is `translated` (Loki-compatible names only). Use `hybrid` when users need both Loki-style and OTel-style workflows — it is not the default but is recommended for OTel data.
 - Label surfaces remain Loki-compatible (underscore) when `label-style=underscores` regardless of metadata mode.
 
 ## Grafana Datasource Behavior

--- a/docs/translation-reference.md
+++ b/docs/translation-reference.md
@@ -60,9 +60,18 @@ After a parser stage, label filters are wrapped as `| filter <expr>`. For exampl
 | `\| line_format "{{.x}}"` | `\| format "<x>"` |
 | `\| label_format x="{{.y}}"` | `\| format "<y>" as x` |
 | `\| label_format a="{{.x}}", b="{{.y}}"` | `\| format "<x>" as a \| format "<y>" as b` |
-| `\| drop a, b` | `\| delete a, b` |
-| `\| drop a="val", b` | `\| delete a, b` + proxy post-filter removes `a` only when its value matches `"val"` |
-| `\| keep a, b` | `\| fields _time, _msg, _stream, a, b` |
+| `\| drop a, b` | `\| delete a, b` — bare field names, unconditional |
+| `\| drop level="debug"` | proxy post-processes each entry: removes `level` from structured metadata and parsed fields when value matches; stream labels are not affected |
+| `\| drop status=~"5.."` | proxy regex match: removes `status` when value matches regex |
+| `\| keep a, b` | `\| fields _time, _msg, _stream, a, b` — bare field names |
+| `\| keep method="GET"` | proxy post-processes: strips `method` from entries where value ≠ `"GET"` |
+| `\| keep status!~"2.."` | proxy negative-regex: removes `status` from entries where value does not match |
+
+:::note Drop/keep matcher scope
+The matcher form of `| drop`/`| keep` applies to structured metadata and parsed fields. Stream labels (the label set from the log stream selector) are not mutated by matcher conditions — only bare field drops affect how VictoriaLogs filters the raw field.
+:::
+
+**Stream label exposure**: `| keep app, level` instructs VL to project only `_time, _msg, _stream, app, level`. Because `_stream` contains all original stream labels as JSON, stream labels beyond `app` and `level` remain visible in the Loki response label set. Only structured metadata / parsed fields are affected by keep projection.
 
 ## Proxy-Side Stages
 
@@ -73,7 +82,6 @@ These stages are executed at the proxy level (VL has no native equivalents):
 | `\| decolorize` | ANSI escape sequence stripping via regex |
 | `\| ip("10.0.0.0/8")` | IP CIDR range filtering |
 | `\| line_format` (templates) | Full Go `text/template` (ToUpper, ToLower, default, etc.) |
-| `\| drop field="value"` (matcher form) | VL `\| delete field` is issued unconditionally; the proxy then evaluates each entry and restores the field when the value does not match (via `ParseDropConditions` / `applyDropConditions`) |
 
 ## Metric Queries
 

--- a/examples/helm/multi-tenant.yaml
+++ b/examples/helm/multi-tenant.yaml
@@ -1,0 +1,15 @@
+# Multi-tenant setup with file-based tenant map and cold storage
+extraArgs:
+  backend: "http://victorialogs:9428"
+  require-tenant-header: "true"
+  forward-tenant-header: "true"
+  cold-enabled: "true"
+  cold-backend: "http://victoria-lakehouse:9428"
+  cold-boundary: "168h"
+  cold-overlap: "1h"
+  log-level: "info"
+
+# Mount tenant map from ConfigMap
+envFrom:
+  - configMapRef:
+      name: proxy-tenant-map

--- a/examples/helm/production-ha.yaml
+++ b/examples/helm/production-ha.yaml
@@ -1,0 +1,52 @@
+# Production HA setup: StatefulSet + disk cache + peer cache + HPA + PDB
+replicaCount: 3
+
+workload:
+  kind: StatefulSet
+
+extraArgs:
+  backend: "http://victorialogs:9428"
+  log-level: "info"
+  label-style: "passthrough"
+  metadata-field-mode: "hybrid"
+  patterns-enabled: "true"
+  query-range-windowing: "true"
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+peerCache:
+  enabled: true
+  discovery: dns
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+horizontalPodAutoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 2000m
+    memory: 1Gi
+
+serviceMonitor:
+  enabled: true
+
+observability:
+  otel:
+    serviceName: loki-vl-proxy

--- a/examples/helm/single-instance.yaml
+++ b/examples/helm/single-instance.yaml
@@ -1,0 +1,9 @@
+# Minimal single-instance deployment (stateless, in-memory cache only)
+replicaCount: 1
+
+extraArgs:
+  backend: "http://victorialogs:9428"
+  log-level: "info"
+  cache-ttl: "60s"
+  label-style: "passthrough"
+  metadata-field-mode: "hybrid"


### PR DESCRIPTION
## Summary

- **translation-reference.md**: Document matcher-form `| drop`/`| keep` semantics (added in v1.36.3 PR #386) — equality and regex operators, plus scope caveat (stream labels not mutated)
- **configuration.md**: Add missing `FORWARD_TENANT_HEADER` env var; add `-manual-range-metric-row-limit` flag (v1.33.0, was absent from docs)
- **getting-started.md**: Update stale version `1.31.2` → `1.36.3`; update Docker image tag
- **KNOWN_ISSUES.md**: Add matcher-form drop/keep scope, multi-tenant serial fanout, backward hot+cold merge memory buffering
- **charts/loki-vl-proxy/README.md**: Create missing Helm chart README (quick install, values table, production/multi-tenant examples)
- **examples/helm/**: Add three Helm values examples — single-instance, production-ha (StatefulSet + peer cache + HPA), multi-tenant (cold storage)

## Test plan

- [ ] Verify docs site builds: `cd website && npm run build`
- [ ] Check translation-reference renders correctly (tables, admonition)
- [ ] Confirm version strings updated in getting-started
- [ ] Review KNOWN_ISSUES additions for accuracy