### PR TITLE
fix(proxy): bare drop/keep stream labels, malformed matcher HTTP 400, parallel fanout, bounded cold buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bare `| drop field` / `| keep field` now mutates stream labels**: Added `ParseBareDropFields`, `ParseBareKeepFields`, and `applyBareFieldMutationToStreamLabels`. Both streaming and buffered response paths now remove bare-dropped fields from the stream label set and filter stream labels to only kept fields, matching Loki behaviour. Label translation (underscore↔dot) is applied when running with `-label-style=underscores`.
+- **Malformed drop/keep matchers return HTTP 400**: `ValidateDropKeepSyntax` now walks the pipeline and returns a parse error for any `| drop` / `| keep` item that contains `=` but uses an unsupported operator (e.g. `!=~`). Previously these were silently skipped.
+
+### Performance
+
+- **Multi-tenant fanout is now parallel**: Replaced the serial tenant loop in `multitenant.go` with concurrent goroutines (`sync.WaitGroup`); tenant sub-requests run in parallel, results merged in original index order for deterministic output.
+- **Backward cold merge read bounded to `limit` lines**: Replaced unbounded `io.ReadAll(coldResp.Body)` with `readAndReverseNDJSON(r, limit)` which reads at most `limit` NDJSON lines via a ring buffer before reversing, preventing unbounded memory growth for large cold responses.
+
 ## [1.37.0] - 2026-05-21
 
 ### Documentation

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -480,6 +480,10 @@ func reverseNDJSONBody(body []byte) []byte {
 // ring is still correct for callers that pass an unbounded upstream reader: it
 // naturally selects the newest (last) limit rows from an ascending body.
 func readAndReverseNDJSON(r io.Reader, limit int) ([]byte, error) {
+	const maxRingSize = 5000
+	if limit > maxRingSize {
+		limit = maxRingSize
+	}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 	// ring is a circular buffer that always retains the last `limit` lines seen.

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -481,7 +481,7 @@ func reverseNDJSONBody(body []byte) []byte {
 // naturally selects the newest (last) limit rows from an ascending body.
 func readAndReverseNDJSON(r io.Reader, limit int) ([]byte, error) {
 	const maxRingSize = 5000
-	if limit > maxRingSize {
+	if limit <= 0 || limit > maxRingSize {
 		limit = maxRingSize
 	}
 	sc := bufio.NewScanner(r)

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -350,12 +350,16 @@ func (p *Proxy) proxyLogQueryBoth(w http.ResponseWriter, r *http.Request, logsql
 	if r.FormValue("direction") == "forward" {
 		merged = MergeNDJSON(coldResp.Body, hotResp.Body)
 	} else {
-		coldBody, readErr := io.ReadAll(coldResp.Body)
+		limit, _ := strconv.Atoi(r.FormValue("limit"))
+		if limit <= 0 {
+			limit = 1000
+		}
+		coldReversed, readErr := readAndReverseNDJSON(coldResp.Body, limit)
 		if readErr != nil {
 			p.writeError(w, http.StatusBadGateway, "failed to read cold response")
 			return
 		}
-		merged = MergeNDJSON(hotResp.Body, bytes.NewReader(reverseNDJSONBody(coldBody)))
+		merged = MergeNDJSON(hotResp.Body, bytes.NewReader(coldReversed))
 	}
 	// Read merged NDJSON up to the per-request limit to avoid buffering 2× the
 	// data when both hot and cold backends return full-limit responses.
@@ -460,6 +464,57 @@ func reverseNDJSONBody(body []byte) []byte {
 		lines[i], lines[j] = lines[j], lines[i]
 	}
 	return bytes.Join(lines, []byte("\n"))
+}
+
+// readAndReverseNDJSON reads non-empty NDJSON lines from r using a ring buffer of
+// size limit, keeping only the last (newest) limit lines. It then reverses them
+// in-place and returns a newline-joined byte slice.
+//
+// This replaces io.ReadAll + reverseNDJSONBody for backward cold queries: the ring
+// buffer caps peak memory to limit lines regardless of how many the upstream sends,
+// and combining read + reverse into one pass avoids the extra allocation that
+// reverseNDJSONBody needs for its output slice.
+//
+// In the proxyLogQueryBoth backward path coldBackwardChunkedFetch already bounds the
+// cold body to ≤ limit rows, so the ring buffer discards nothing in practice. The
+// ring is still correct for callers that pass an unbounded upstream reader: it
+// naturally selects the newest (last) limit rows from an ascending body.
+func readAndReverseNDJSON(r io.Reader, limit int) ([]byte, error) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	// ring is a circular buffer that always retains the last `limit` lines seen.
+	ring := make([][]byte, limit)
+	head := 0 // next write position (mod limit)
+	total := 0
+	for sc.Scan() {
+		line := bytes.TrimRight(sc.Bytes(), "\r")
+		if len(line) == 0 {
+			continue
+		}
+		cp := make([]byte, len(line))
+		copy(cp, line)
+		ring[head%limit] = cp
+		head++
+		total++
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	n := total
+	if n > limit {
+		n = limit
+	}
+	// Reconstruct the last n lines in ascending order from the ring buffer.
+	lines := make([][]byte, n)
+	start := head - n
+	for i := 0; i < n; i++ {
+		lines[i] = ring[(start+i)%limit]
+	}
+	// Reverse so the newest (last ascending) line becomes first.
+	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
+		lines[i], lines[j] = lines[j], lines[i]
+	}
+	return bytes.Join(lines, []byte("\n")), nil
 }
 
 // readNDJSONToLimit reads at most limit non-empty NDJSON lines from r, returning

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -487,7 +487,10 @@ func readAndReverseNDJSON(r io.Reader, limit int) ([]byte, error) {
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 	// ring is a circular buffer that always retains the last `limit` lines seen.
-	ring := make([][]byte, limit)
+	// Allocated to the compile-time constant maxRingSize so the allocation size is
+	// independent of the user-supplied limit; limit (bounded above) controls only the
+	// circular-buffer modulus, not the backing array length.
+	ring := make([][]byte, maxRingSize)
 	head := 0 // next write position (mod limit)
 	total := 0
 	for sc.Scan() {

--- a/internal/proxy/cold_dispatch_test.go
+++ b/internal/proxy/cold_dispatch_test.go
@@ -772,3 +772,58 @@ func TestProxyLogQueryCold_BackwardLimit_LargeRange(t *testing.T) {
 		}
 	}
 }
+
+func TestReadAndReverseNDJSON(t *testing.T) {
+	t.Run("empty body", func(t *testing.T) {
+		out, err := readAndReverseNDJSON(strings.NewReader(""), 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 0 {
+			t.Errorf("expected empty output, got %q", out)
+		}
+	})
+
+	t.Run("single line", func(t *testing.T) {
+		const line = `{"_msg":"only"}`
+		out, err := readAndReverseNDJSON(strings.NewReader(line+"\n"), 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(out) != line {
+			t.Errorf("got %q, want %q", out, line)
+		}
+	})
+
+	t.Run("three lines reversed", func(t *testing.T) {
+		input := "line1\nline2\nline3\n"
+		out, err := readAndReverseNDJSON(strings.NewReader(input), 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := strings.Split(string(out), "\n")
+		if len(got) != 3 {
+			t.Fatalf("expected 3 lines, got %d: %q", len(got), out)
+		}
+		if got[0] != "line3" || got[1] != "line2" || got[2] != "line1" {
+			t.Errorf("wrong order: %v", got)
+		}
+	})
+
+	t.Run("limit caps lines kept", func(t *testing.T) {
+		// 5 lines in body but limit=2; ring buffer retains the last 2 lines, reversed.
+		input := "a\nb\nc\nd\ne\n"
+		out, err := readAndReverseNDJSON(strings.NewReader(input), 2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := strings.Split(string(out), "\n")
+		if len(got) != 2 {
+			t.Fatalf("expected 2 lines (limit=2), got %d: %q", len(got), out)
+		}
+		// Last 2 of ascending [a,b,c,d,e] are [d,e] → reversed → [e,d]
+		if got[0] != "e" || got[1] != "d" {
+			t.Errorf("got %v, want [e d]", got)
+		}
+	})
+}

--- a/internal/proxy/http_utils.go
+++ b/internal/proxy/http_utils.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/metrics"
 	mw "github.com/ReliablyObserve/Loki-VL-proxy/internal/middleware"
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/translator"
 	"github.com/klauspost/compress/zstd"
 	fj "github.com/valyala/fastjson"
 )
@@ -234,6 +235,23 @@ func validateLogQLSyntax(query string) string {
 		return `parse error : syntax error: unexpected IDENT`
 	}
 
+	// Reject | drop / | keep stages with malformed matcher items (e.g. !=~).
+	if err := validateDropKeepSyntax(query); err != "" {
+		return err
+	}
+
+	return ""
+}
+
+// validateDropKeepSyntax returns an error message if the query contains | drop
+// or | keep stages with malformed matcher items using unsupported operators.
+func validateDropKeepSyntax(query string) string {
+	if !strings.Contains(query, "drop ") && !strings.Contains(query, "keep ") {
+		return "" // fast path: no drop/keep stage present
+	}
+	if err := translator.ValidateDropKeepSyntax(query); err != nil {
+		return err.Error()
+	}
 	return ""
 }
 

--- a/internal/proxy/label_handlers.go
+++ b/internal/proxy/label_handlers.go
@@ -17,7 +17,7 @@ import (
 //	fallback /select/logsql/field_names for older backends
 func (p *Proxy) handleLabels(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "labels", p.handleLabels) {
+	if p.handleMultiTenantFanout(w, r, "labels") {
 		return
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")
@@ -96,7 +96,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordRequest("label_values", http.StatusOK, time.Since(start))
 		return
 	}
-	if p.handleMultiTenantFanout(w, r, "label_values", p.handleLabelValues) {
+	if p.handleMultiTenantFanout(w, r, "label_values") {
 		return
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")
@@ -203,7 +203,7 @@ func (p *Proxy) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 // VL:   GET /select/logsql/streams?query={...}&start=...&end=...
 func (p *Proxy) handleSeries(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "series", p.handleSeries) {
+	if p.handleMultiTenantFanout(w, r, "series") {
 		return
 	}
 	r = withOrgID(r)
@@ -305,7 +305,7 @@ func (p *Proxy) handleSeries(w http.ResponseWriter, r *http.Request) {
 // Response: {"streams":N, "chunks":N, "entries":N, "bytes":N}
 func (p *Proxy) handleIndexStats(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "index_stats", p.handleIndexStats) {
+	if p.handleMultiTenantFanout(w, r, "index_stats") {
 		return
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")
@@ -457,7 +457,7 @@ func (p *Proxy) resolveTargetLabelFields(ctx context.Context, targetLabels strin
 // handleDetectedFields returns detected field names.
 func (p *Proxy) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "detected_fields", p.handleDetectedFields) {
+	if p.handleMultiTenantFanout(w, r, "detected_fields") {
 		return
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")
@@ -519,7 +519,7 @@ func (p *Proxy) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 // Response: {"values":["debug","info","warn","error"],"limit":1000}
 func (p *Proxy) handleDetectedFieldValues(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "detected_field_values", p.handleDetectedFieldValues) {
+	if p.handleMultiTenantFanout(w, r, "detected_field_values") {
 		return
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 )
 
-func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, endpoint string, single func(http.ResponseWriter, *http.Request)) bool {
+func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, endpoint string) bool {
 	orgID := strings.TrimSpace(r.Header.Get("X-Scope-OrgID"))
 	if !hasMultiTenantOrgID(orgID) {
 		return false
@@ -88,7 +88,30 @@ func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, 
 			subReq.Header = filteredReq.Header.Clone()
 			subReq.Header.Set("X-Scope-OrgID", tenantID)
 			rec := httptest.NewRecorder()
-			single(rec, subReq)
+			switch endpoint {
+			case "labels":
+				p.handleLabels(rec, subReq)
+			case "label_values":
+				p.handleLabelValues(rec, subReq)
+			case "series":
+				p.handleSeries(rec, subReq)
+			case "index_stats":
+				p.handleIndexStats(rec, subReq)
+			case "query":
+				p.handleQuery(rec, subReq)
+			case "query_range":
+				p.handleQueryRange(rec, subReq)
+			case "volume":
+				p.handleVolume(rec, subReq)
+			case "volume_range":
+				p.handleVolumeRange(rec, subReq)
+			case "detected_field_values":
+				p.handleDetectedFieldValues(rec, subReq)
+			case "patterns":
+				p.handlePatterns(rec, subReq)
+			case "detected_labels":
+				p.handleDetectedLabels(rec, subReq)
+			}
 			results[i] = tenantResult{tenantID: tenantID, rec: rec, failed: rec.Code >= 400}
 		}(i, tenantID)
 	}

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, endpoint string, single func(http.ResponseWriter, *http.Request)) bool {
@@ -71,27 +72,41 @@ func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, 
 		return true
 	}
 
-	// TODO: fanout is serial — each tenant sub-request blocks the next. For high
-	// fan-out counts (>4 tenants) parallel dispatch would reduce latency. Tracked
-	// in docs/KNOWN_ISSUES.md under "Multi-tenant serial fanout".
+	type tenantResult struct {
+		tenantID string
+		rec      *httptest.ResponseRecorder
+		failed   bool
+	}
+
+	results := make([]tenantResult, len(filteredTenants))
+	var wg sync.WaitGroup
+	for i, tenantID := range filteredTenants {
+		wg.Add(1)
+		go func(i int, tenantID string) {
+			defer wg.Done()
+			subReq := filteredReq.Clone(filteredReq.Context())
+			subReq.Header = filteredReq.Header.Clone()
+			subReq.Header.Set("X-Scope-OrgID", tenantID)
+			rec := httptest.NewRecorder()
+			single(rec, subReq)
+			results[i] = tenantResult{tenantID: tenantID, rec: rec, failed: rec.Code >= 400}
+		}(i, tenantID)
+	}
+	wg.Wait()
+
+	// Collect results in original order (deterministic merge).
 	successTenants := make([]string, 0, len(filteredTenants))
 	failedTenants := make([]string, 0)
 	recorders := make([]*httptest.ResponseRecorder, 0, len(filteredTenants))
-	for _, tenantID := range filteredTenants {
-		subReq := filteredReq.Clone(filteredReq.Context())
-		subReq.Header = filteredReq.Header.Clone()
-		subReq.Header.Set("X-Scope-OrgID", tenantID)
-
-		rec := httptest.NewRecorder()
-		single(rec, subReq)
-		if rec.Code >= 400 {
+	for _, r := range results {
+		if r.failed {
 			p.log.Warn("multi-tenant sub-request failed, skipping tenant",
-				"endpoint", endpoint, "tenant", tenantID, "status", rec.Code)
-			failedTenants = append(failedTenants, tenantID)
+				"endpoint", endpoint, "tenant", r.tenantID, "status", r.rec.Code)
+			failedTenants = append(failedTenants, r.tenantID)
 			continue
 		}
-		successTenants = append(successTenants, tenantID)
-		recorders = append(recorders, rec)
+		successTenants = append(successTenants, r.tenantID)
+		recorders = append(recorders, r.rec)
 	}
 
 	if len(recorders) == 0 {

--- a/internal/proxy/multitenant.go
+++ b/internal/proxy/multitenant.go
@@ -88,30 +88,7 @@ func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, 
 			subReq.Header = filteredReq.Header.Clone()
 			subReq.Header.Set("X-Scope-OrgID", tenantID)
 			rec := httptest.NewRecorder()
-			switch endpoint {
-			case "labels":
-				p.handleLabels(rec, subReq)
-			case "label_values":
-				p.handleLabelValues(rec, subReq)
-			case "series":
-				p.handleSeries(rec, subReq)
-			case "index_stats":
-				p.handleIndexStats(rec, subReq)
-			case "query":
-				p.handleQuery(rec, subReq)
-			case "query_range":
-				p.handleQueryRange(rec, subReq)
-			case "volume":
-				p.handleVolume(rec, subReq)
-			case "volume_range":
-				p.handleVolumeRange(rec, subReq)
-			case "detected_field_values":
-				p.handleDetectedFieldValues(rec, subReq)
-			case "patterns":
-				p.handlePatterns(rec, subReq)
-			case "detected_labels":
-				p.handleDetectedLabels(rec, subReq)
-			}
+			p.serveEndpoint(endpoint, rec, subReq)
 			results[i] = tenantResult{tenantID: tenantID, rec: rec, failed: rec.Code >= 400}
 		}(i, tenantID)
 	}
@@ -169,6 +146,33 @@ func (p *Proxy) handleMultiTenantFanout(w http.ResponseWriter, r *http.Request, 
 		p.cache.SetWithTTL(cacheKey, body, CacheTTLs[endpoint])
 	}
 	return true
+}
+
+func (p *Proxy) serveEndpoint(endpoint string, w http.ResponseWriter, r *http.Request) {
+	switch endpoint {
+	case "labels":
+		p.handleLabels(w, r)
+	case "label_values":
+		p.handleLabelValues(w, r)
+	case "series":
+		p.handleSeries(w, r)
+	case "index_stats":
+		p.handleIndexStats(w, r)
+	case "query":
+		p.handleQuery(w, r)
+	case "query_range":
+		p.handleQueryRange(w, r)
+	case "volume":
+		p.handleVolume(w, r)
+	case "volume_range":
+		p.handleVolumeRange(w, r)
+	case "detected_field_values":
+		p.handleDetectedFieldValues(w, r)
+	case "patterns":
+		p.handlePatterns(w, r)
+	case "detected_labels":
+		p.handleDetectedLabels(w, r)
+	}
 }
 
 type lokiStringListResponse struct {

--- a/internal/proxy/patterns.go
+++ b/internal/proxy/patterns.go
@@ -107,7 +107,7 @@ func (p *Proxy) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordRequest("patterns", http.StatusOK, time.Since(start))
 		return
 	}
-	if p.handleMultiTenantFanout(w, r, "patterns", p.handlePatterns) {
+	if p.handleMultiTenantFanout(w, r, "patterns") {
 		return
 	}
 	r = withOrgID(r)
@@ -1340,7 +1340,7 @@ func (p *Proxy) handleTenantLimitsConfig(w http.ResponseWriter, r *http.Request)
 // handleDetectedLabels returns stream-level labels (similar to detected_fields but for stream labels).
 func (p *Proxy) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "detected_labels", p.handleDetectedLabels) {
+	if p.handleMultiTenantFanout(w, r, "detected_labels") {
 		return
 	}
 	orgID := r.Header.Get("X-Scope-OrgID")

--- a/internal/proxy/perf_hardening_test.go
+++ b/internal/proxy/perf_hardening_test.go
@@ -579,7 +579,7 @@ func TestHandleMultiTenantFanoutRejectsExcessiveTenantCount(t *testing.T) {
 	r.Header.Set("X-Scope-OrgID", strings.Join(tenants, "|"))
 	w := httptest.NewRecorder()
 
-	if !p.handleMultiTenantFanout(w, r, "labels", p.handleLabels) {
+	if !p.handleMultiTenantFanout(w, r, "labels") {
 		t.Fatal("expected multi-tenant fanout path to handle oversized tenant set")
 	}
 	if w.Code != http.StatusBadRequest {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1437,7 +1437,7 @@ func (p *Proxy) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	categorizedLabels := requestWantsCategorizedLabels(r)
 	emitStructuredMetadata := p.shouldEmitStructuredMetadata(r)
 	tupleMode := tupleModeForRequest(categorizedLabels, emitStructuredMetadata)
-	if p.handleMultiTenantFanout(w, r, "query_range", p.handleQueryRange) {
+	if p.handleMultiTenantFanout(w, r, "query_range") {
 		return
 	}
 	cacheKey := ""
@@ -1656,7 +1656,7 @@ func (p *Proxy) handleQuery(w http.ResponseWriter, r *http.Request) {
 		p.queryTracker.Record("query", logqlQuery, elapsed, false)
 		return
 	}
-	if p.handleMultiTenantFanout(w, r, "query", p.handleQuery) {
+	if p.handleMultiTenantFanout(w, r, "query") {
 		return
 	}
 

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -455,3 +455,74 @@ func TestApplyDropConditionsToStreamLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyBareFieldMutationToStreamLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		dropFields  []string
+		keepFields  []string
+		rawLabels   map[string]string
+		translated  map[string]string
+		wantLabels  map[string]string
+		wantChange  bool
+	}{
+		{
+			name:       "bare drop removes stream label",
+			dropFields: []string{"app"},
+			rawLabels:  map[string]string{"app": "api", "env": "prod"},
+			translated: map[string]string{"app": "api", "env": "prod"},
+			wantLabels: map[string]string{"env": "prod"},
+			wantChange: true,
+		},
+		{
+			name:       "bare keep removes non-kept stream labels",
+			keepFields: []string{"env"},
+			rawLabels:  map[string]string{"app": "api", "env": "prod"},
+			translated: map[string]string{"app": "api", "env": "prod"},
+			wantLabels: map[string]string{"env": "prod"},
+			wantChange: true,
+		},
+		{
+			name:       "bare drop of absent field is no-op",
+			dropFields: []string{"missing"},
+			rawLabels:  map[string]string{"app": "api", "env": "prod"},
+			translated: map[string]string{"app": "api", "env": "prod"},
+			wantLabels: map[string]string{"app": "api", "env": "prod"},
+			wantChange: false,
+		},
+		{
+			name:       "bare keep with all fields retained is no-op",
+			keepFields: []string{"app", "env"},
+			rawLabels:  map[string]string{"app": "api", "env": "prod"},
+			translated: map[string]string{"app": "api", "env": "prod"},
+			wantLabels: map[string]string{"app": "api", "env": "prod"},
+			wantChange: false,
+		},
+		{
+			name:       "no drop or keep fields is no-op",
+			rawLabels:  map[string]string{"app": "api"},
+			translated: map[string]string{"app": "api"},
+			wantLabels: map[string]string{"app": "api"},
+			wantChange: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got, changed := applyBareFieldMutationToStreamLabels(tt.dropFields, tt.keepFields, tt.rawLabels, tt.translated, nil)
+			if changed != tt.wantChange {
+				t.Fatalf("changed=%v want=%v", changed, tt.wantChange)
+			}
+			if !changed {
+				got = tt.translated
+			}
+			if len(got) != len(tt.wantLabels) {
+				t.Fatalf("got labels %v, want %v", got, tt.wantLabels)
+			}
+			for k, v := range tt.wantLabels {
+				if got[k] != v {
+					t.Fatalf("label %q: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/internal/proxy/stream_metadata_test.go
+++ b/internal/proxy/stream_metadata_test.go
@@ -458,13 +458,13 @@ func TestApplyDropConditionsToStreamLabels(t *testing.T) {
 
 func TestApplyBareFieldMutationToStreamLabels(t *testing.T) {
 	tests := []struct {
-		name        string
-		dropFields  []string
-		keepFields  []string
-		rawLabels   map[string]string
-		translated  map[string]string
-		wantLabels  map[string]string
-		wantChange  bool
+		name       string
+		dropFields []string
+		keepFields []string
+		rawLabels  map[string]string
+		translated map[string]string
+		wantLabels map[string]string
+		wantChange bool
 	}{
 		{
 			name:       "bare drop removes stream label",

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -198,6 +198,16 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, origi
 				translatedLabels = newLabels
 			}
 		}
+		// Apply bare-field drop/keep to stream labels.
+		// | drop f removes f from the stream label set unconditionally.
+		// | keep f1, f2 removes any stream label NOT in the keep list.
+		bareDropFields := translator.ParseBareDropFields(originalQuery)
+		bareKeepFields := translator.ParseBareKeepFields(originalQuery)
+		if len(bareDropFields) > 0 || len(bareKeepFields) > 0 {
+			if _, newLabels, changed := applyBareFieldMutationToStreamLabels(bareDropFields, bareKeepFields, streamLabels, translatedLabels, p.labelTranslator); changed {
+				translatedLabels = newLabels
+			}
+		}
 
 		stream := map[string]interface{}{
 			"stream": translatedLabels,
@@ -582,6 +592,19 @@ func (p *Proxy) vlReaderToLokiStreams(r io.Reader, originalQuery, step string, c
 				streamLabels = newLabels
 			}
 		}
+		// Apply bare-field drop/keep to stream labels.
+		// | drop f removes f from the stream label set unconditionally.
+		// | keep f1, f2 removes any stream label NOT in the keep list.
+		{
+			bareDropFields := translator.ParseBareDropFields(originalQuery)
+			bareKeepFields := translator.ParseBareKeepFields(originalQuery)
+			if len(bareDropFields) > 0 || len(bareKeepFields) > 0 {
+				if newKey, newLabels, changed := applyBareFieldMutationToStreamLabels(bareDropFields, bareKeepFields, desc.rawLabels, streamLabels, p.labelTranslator); changed {
+					streamKey = newKey
+					streamLabels = newLabels
+				}
+			}
+		}
 		se, ok := streamMap[streamKey]
 		if !ok {
 			se = &streamEntry{
@@ -922,6 +945,87 @@ func applyDropConditionsToStreamLabels(conds []translator.DropCondition, rawLabe
 		}
 	}
 	return canonicalLabelsKey(newRaw), newTranslated, true
+}
+
+// applyBareFieldMutationToStreamLabels handles bare | drop and | keep stream-label mutations.
+// | drop fields: removes each bare-dropped field from the stream label set.
+// | keep fields: removes any stream label not in the keep list.
+// Returns the new stream key, translated labels map, and whether any change occurred.
+func applyBareFieldMutationToStreamLabels(
+	dropFields, keepFields []string,
+	rawLabels, translatedLabels map[string]string,
+	lt *LabelTranslator,
+) (newKey string, newTranslated map[string]string, changed bool) {
+	if len(dropFields) == 0 && len(keepFields) == 0 {
+		return "", nil, false
+	}
+
+	// Build set structures for O(1) lookup.
+	dropSet := make(map[string]struct{}, len(dropFields))
+	for _, f := range dropFields {
+		dropSet[f] = struct{}{}
+		if lt != nil {
+			dropSet[lt.ToVL(f)] = struct{}{}
+		}
+	}
+
+	keepSet := make(map[string]struct{}, len(keepFields))
+	for _, f := range keepFields {
+		keepSet[f] = struct{}{}
+		if lt != nil {
+			keepSet[lt.ToVL(f)] = struct{}{}
+		}
+	}
+
+	// Determine which raw (VL dotted) labels to remove.
+	toRemove := make(map[string]struct{})
+	for rawKey := range rawLabels {
+		// Drop: remove if in drop set.
+		if _, ok := dropSet[rawKey]; ok {
+			toRemove[rawKey] = struct{}{}
+			continue
+		}
+		// Keep: remove if NOT in keep set (and keep set is non-empty).
+		if len(keepFields) > 0 {
+			// Translate rawKey to loki label for keep-set lookup.
+			lokiKey := rawKey
+			if lt != nil {
+				lokiKey = lt.ToLoki(rawKey)
+			}
+			if _, ok := keepSet[rawKey]; !ok {
+				if _, ok2 := keepSet[lokiKey]; !ok2 {
+					toRemove[rawKey] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(toRemove) == 0 {
+		return "", nil, false
+	}
+
+	// Build new raw/translated maps without the removed keys.
+	newRaw := make(map[string]string, len(rawLabels)-len(toRemove))
+	for k, v := range rawLabels {
+		if _, skip := toRemove[k]; !skip {
+			newRaw[k] = v
+		}
+	}
+	newTrans := make(map[string]string, len(translatedLabels))
+	for k, v := range translatedLabels {
+		// Find the VL key for this translated key.
+		vlKey := k
+		if lt != nil {
+			vlKey = lt.ToVL(k)
+		}
+		if _, skip := toRemove[vlKey]; !skip {
+			newTrans[k] = v
+		}
+	}
+
+	// Rebuild the stream key from newRaw.
+	key := canonicalLabelsKey(newRaw)
+	return key, newTrans, true
 }
 
 // applyKeepConditions removes fields from sm/pf where a keep condition exists for that field

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -140,6 +140,8 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, origi
 	exposureCache := make(map[string][]metadataFieldExposure, 16)
 	dropConditions := translator.ParseDropConditions(originalQuery)
 	keepConditions := translator.ParseKeepConditions(originalQuery)
+	bareDropFields := translator.ParseBareDropFields(originalQuery)
+	bareKeepFields := translator.ParseBareKeepFields(originalQuery)
 	smBuf2 := metadataMapPool.Get().(map[string]string)
 	pfBuf2 := metadataMapPool.Get().(map[string]string)
 	defer func() {
@@ -201,8 +203,6 @@ func (p *Proxy) streamLogQuery(w http.ResponseWriter, resp *http.Response, origi
 		// Apply bare-field drop/keep to stream labels.
 		// | drop f removes f from the stream label set unconditionally.
 		// | keep f1, f2 removes any stream label NOT in the keep list.
-		bareDropFields := translator.ParseBareDropFields(originalQuery)
-		bareKeepFields := translator.ParseBareKeepFields(originalQuery)
 		if len(bareDropFields) > 0 || len(bareKeepFields) > 0 {
 			if _, newLabels, changed := applyBareFieldMutationToStreamLabels(bareDropFields, bareKeepFields, streamLabels, translatedLabels, p.labelTranslator); changed {
 				translatedLabels = newLabels
@@ -486,6 +486,8 @@ func (p *Proxy) vlReaderToLokiStreams(r io.Reader, originalQuery, step string, c
 	needsClassification := emitStructuredMetadata || categorizedLabels
 	dropConditions := translator.ParseDropConditions(originalQuery)
 	keepConditions := translator.ParseKeepConditions(originalQuery)
+	bareDropFields2 := translator.ParseBareDropFields(originalQuery)
+	bareKeepFields2 := translator.ParseBareKeepFields(originalQuery)
 
 	var (
 		miner        *patternMiner
@@ -595,14 +597,10 @@ func (p *Proxy) vlReaderToLokiStreams(r io.Reader, originalQuery, step string, c
 		// Apply bare-field drop/keep to stream labels.
 		// | drop f removes f from the stream label set unconditionally.
 		// | keep f1, f2 removes any stream label NOT in the keep list.
-		{
-			bareDropFields := translator.ParseBareDropFields(originalQuery)
-			bareKeepFields := translator.ParseBareKeepFields(originalQuery)
-			if len(bareDropFields) > 0 || len(bareKeepFields) > 0 {
-				if newKey, newLabels, changed := applyBareFieldMutationToStreamLabels(bareDropFields, bareKeepFields, desc.rawLabels, streamLabels, p.labelTranslator); changed {
-					streamKey = newKey
-					streamLabels = newLabels
-				}
+		if len(bareDropFields2) > 0 || len(bareKeepFields2) > 0 {
+			if newKey, newLabels, changed := applyBareFieldMutationToStreamLabels(bareDropFields2, bareKeepFields2, desc.rawLabels, streamLabels, p.labelTranslator); changed {
+				streamKey = newKey
+				streamLabels = newLabels
 			}
 		}
 		se, ok := streamMap[streamKey]

--- a/internal/proxy/tenant_test.go
+++ b/internal/proxy/tenant_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -442,9 +443,12 @@ func TestTenant_ExplicitMappingOverridesDefaultTenantAlias(t *testing.T) {
 }
 
 func TestTenant_MultiTenantQueryAllowedOnLabels(t *testing.T) {
+	var mu sync.Mutex
 	var seenAccountIDs []string
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		seenAccountIDs = append(seenAccountIDs, r.Header.Get("AccountID"))
+		mu.Unlock()
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"values": []map[string]interface{}{
 				{"value": "app", "hits": 10},
@@ -544,9 +548,12 @@ func TestTenant_MultiTenantQueryRangeInjectsTenantLabel(t *testing.T) {
 }
 
 func TestTenant_MultiTenantQueryRangeFiltersByTenantSelector(t *testing.T) {
+	var mu sync.Mutex
 	var seenAccountIDs []string
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		seenAccountIDs = append(seenAccountIDs, r.Header.Get("AccountID"))
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		_, _ = w.Write([]byte(`{"_time":"2026-04-04T10:00:00Z","_msg":"line","_stream":"{app=\"api\"}","app":"api"}` + "\n"))
 	}))

--- a/internal/proxy/tenant_test.go
+++ b/internal/proxy/tenant_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -634,9 +635,9 @@ func TestTenant_MultiTenantQueryRangeSortsStreamsAcrossTenants(t *testing.T) {
 }
 
 func TestTenant_MultiTenantLabelsUsesMergedCache(t *testing.T) {
-	var calls int
+	var calls atomic.Int64
 	vlBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"values": []map[string]interface{}{
 				{"value": "app", "hits": 10},
@@ -669,8 +670,8 @@ func TestTenant_MultiTenantLabelsUsesMergedCache(t *testing.T) {
 		}
 	}
 
-	if calls != 2 {
-		t.Fatalf("expected first request to fan out twice and second request to hit merged cache, got %d backend calls", calls)
+	if calls.Load() != 2 {
+		t.Fatalf("expected first request to fan out twice and second request to hit merged cache, got %d backend calls", calls.Load())
 	}
 }
 

--- a/internal/proxy/volume.go
+++ b/internal/proxy/volume.go
@@ -179,7 +179,7 @@ func requestedVolumeTargetLabels(r *http.Request) string {
 // Response: {"status":"success","data":{"resultType":"vector","result":[{"metric":{...},"value":[ts,"count"]}]}}
 func (p *Proxy) handleVolume(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "volume", p.handleVolume) {
+	if p.handleMultiTenantFanout(w, r, "volume") {
 		return
 	}
 	r = withOrgID(r)
@@ -301,7 +301,7 @@ func (p *Proxy) refreshVolumeCacheAsync(orgID, cacheKey, rawQuery, start, end, t
 // Response: {"status":"success","data":{"resultType":"matrix","result":[{"metric":{...},"values":[[ts,"count"],...]}]}}
 func (p *Proxy) handleVolumeRange(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	if p.handleMultiTenantFanout(w, r, "volume_range", p.handleVolumeRange) {
+	if p.handleMultiTenantFanout(w, r, "volume_range") {
 		return
 	}
 	r = withOrgID(r)

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -273,6 +273,157 @@ func ParseKeepConditions(logqlQuery string) []DropCondition {
 	return conds
 }
 
+// ParseBareDropFields returns the bare field names from `| drop field` stages.
+// These are fields that are unconditionally deleted at the VL level via | delete,
+// but the proxy must also strip them from stream labels since _stream is not touched by VL's | delete.
+func ParseBareDropFields(logqlQuery string) []string {
+	remaining := strings.TrimSpace(logqlQuery)
+	if strings.HasPrefix(remaining, "{") {
+		end := findMatchingBrace(remaining)
+		if end < 0 {
+			return nil
+		}
+		remaining = strings.TrimSpace(remaining[end+1:])
+	}
+	var result []string
+	for remaining != "" {
+		remaining = strings.TrimSpace(remaining)
+		if remaining == "" {
+			break
+		}
+		if strings.HasPrefix(remaining, "|= ") || strings.HasPrefix(remaining, "|=\"") ||
+			strings.HasPrefix(remaining, "|~ ") || strings.HasPrefix(remaining, "|~\"") ||
+			strings.HasPrefix(remaining, "|> ") || strings.HasPrefix(remaining, "|>\"") ||
+			strings.HasPrefix(remaining, "|>`") {
+			_, remaining = extractPipelineStage(remaining[2:])
+			continue
+		}
+		if len(remaining) >= 2 && remaining[0] == '!' && (remaining[1] == '=' || remaining[1] == '~' || remaining[1] == '>') {
+			_, remaining = extractPipelineStage(remaining[2:])
+			continue
+		}
+		if !strings.HasPrefix(remaining, "|") {
+			break
+		}
+		remaining = strings.TrimSpace(remaining[1:])
+		stage, rest := extractPipelineStage(remaining)
+		remaining = rest
+		stage = strings.TrimSpace(stage)
+		if strings.HasPrefix(stage, "drop ") {
+			bareFields, _ := splitDropSpec(stage[5:])
+			result = append(result, bareFields...)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// ParseBareKeepFields returns the bare field names from `| keep field` stages.
+// VL projects these via | fields _time, _msg, _stream, ..., but _stream carries all
+// original stream labels; the proxy must filter the stream label set to only the kept fields.
+func ParseBareKeepFields(logqlQuery string) []string {
+	remaining := strings.TrimSpace(logqlQuery)
+	if strings.HasPrefix(remaining, "{") {
+		end := findMatchingBrace(remaining)
+		if end < 0 {
+			return nil
+		}
+		remaining = strings.TrimSpace(remaining[end+1:])
+	}
+	var result []string
+	for remaining != "" {
+		remaining = strings.TrimSpace(remaining)
+		if remaining == "" {
+			break
+		}
+		if strings.HasPrefix(remaining, "|= ") || strings.HasPrefix(remaining, "|=\"") ||
+			strings.HasPrefix(remaining, "|~ ") || strings.HasPrefix(remaining, "|~\"") ||
+			strings.HasPrefix(remaining, "|> ") || strings.HasPrefix(remaining, "|>\"") ||
+			strings.HasPrefix(remaining, "|>`") {
+			_, remaining = extractPipelineStage(remaining[2:])
+			continue
+		}
+		if len(remaining) >= 2 && remaining[0] == '!' && (remaining[1] == '=' || remaining[1] == '~' || remaining[1] == '>') {
+			_, remaining = extractPipelineStage(remaining[2:])
+			continue
+		}
+		if !strings.HasPrefix(remaining, "|") {
+			break
+		}
+		remaining = strings.TrimSpace(remaining[1:])
+		stage, rest := extractPipelineStage(remaining)
+		remaining = rest
+		stage = strings.TrimSpace(stage)
+		if strings.HasPrefix(stage, "keep ") {
+			bareFields, _ := splitDropSpec(stage[5:])
+			result = append(result, bareFields...)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// ValidateDropKeepSyntax returns a parse error if the query contains | drop or | keep
+// stages with malformed matcher items — items that look like matchers (contain "=")
+// but use unsupported operators. Callers should return HTTP 400.
+func ValidateDropKeepSyntax(logqlQuery string) error {
+	remaining := strings.TrimSpace(logqlQuery)
+	if strings.HasPrefix(remaining, "{") {
+		end := findMatchingBrace(remaining)
+		if end < 0 {
+			return nil
+		}
+		remaining = strings.TrimSpace(remaining[end+1:])
+	}
+	for remaining != "" {
+		remaining = strings.TrimSpace(remaining)
+		if remaining == "" {
+			break
+		}
+		if strings.HasPrefix(remaining, "|= ") || strings.HasPrefix(remaining, "|=\"") ||
+			strings.HasPrefix(remaining, "|~ ") || strings.HasPrefix(remaining, "|~\"") ||
+			strings.HasPrefix(remaining, "|> ") || strings.HasPrefix(remaining, "|>\"") ||
+			strings.HasPrefix(remaining, "|>`") {
+			_, remaining = extractPipelineStage(remaining[2:])
+			continue
+		}
+		if len(remaining) >= 2 && remaining[0] == '!' && (remaining[1] == '=' || remaining[1] == '~' || remaining[1] == '>') {
+			_, remaining = extractPipelineStage(remaining[2:])
+			continue
+		}
+		if !strings.HasPrefix(remaining, "|") {
+			break
+		}
+		remaining = strings.TrimSpace(remaining[1:])
+		stage, rest := extractPipelineStage(remaining)
+		remaining = rest
+		stage = strings.TrimSpace(stage)
+		var spec string
+		if strings.HasPrefix(stage, "drop ") {
+			spec = stage[5:]
+		} else if strings.HasPrefix(stage, "keep ") {
+			spec = stage[5:]
+		} else {
+			continue
+		}
+		for _, item := range splitDropItems(spec) {
+			item = strings.TrimSpace(item)
+			if item == "" || !strings.Contains(item, "=") {
+				continue
+			}
+			// Item looks like a matcher but has "=" — validate it.
+			if _, _, _, ok := parseDropMatcher(item); !ok {
+				return fmt.Errorf("parse error at line 1, col 1: invalid drop/keep matcher %q: unsupported operator (!=~ is not a valid Loki operator)", item)
+			}
+		}
+	}
+	return nil
+}
+
 // splitDropSpec parses a drop spec into bare field names and matcher conditions.
 // Example: `level="debug", trace_id` → bareFields: ["trace_id"], conditions: [{level = debug}]
 func splitDropSpec(spec string) (bareFields []string, conditions []DropCondition) {

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -876,3 +876,139 @@ func TestLabelJoinTranslation(t *testing.T) {
 		}
 	}
 }
+
+func TestParseBareDropFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		logql string
+		want  []string
+	}{
+		{
+			name:  "bare drop extracts fields",
+			logql: `{app="api"} | json | drop level, env`,
+			want:  []string{"level", "env"},
+		},
+		{
+			name:  "bare drop ignores matcher form",
+			logql: `{app="api"} | drop level="debug"`,
+			want:  nil,
+		},
+		{
+			name:  "bare drop mixed - returns only bare fields",
+			logql: `{app="api"} | drop level, status=~"5.."`,
+			want:  []string{"level"},
+		},
+		{
+			name:  "no drop stage returns nil",
+			logql: `{app="api"} | json`,
+			want:  nil,
+		},
+		{
+			name:  "multiple drop stages accumulate bare fields",
+			logql: `{app="api"} | drop level | drop env`,
+			want:  []string{"level", "env"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseBareDropFields(tt.logql)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i, v := range tt.want {
+				if got[i] != v {
+					t.Fatalf("index %d: got %q, want %q", i, got[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBareKeepFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		logql string
+		want  []string
+	}{
+		{
+			name:  "bare keep extracts fields",
+			logql: `{app="api"} | keep app, level`,
+			want:  []string{"app", "level"},
+		},
+		{
+			name:  "bare keep ignores matcher form",
+			logql: `{app="api"} | keep method="GET"`,
+			want:  nil,
+		},
+		{
+			name:  "no keep stage returns nil",
+			logql: `{app="api"} | json`,
+			want:  nil,
+		},
+		{
+			name:  "keep with mixed bare and matcher returns only bare",
+			logql: `{app="api"} | keep app, status="200"`,
+			want:  []string{"app"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseBareKeepFields(tt.logql)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i, v := range tt.want {
+				if got[i] != v {
+					t.Fatalf("index %d: got %q, want %q", i, got[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateDropKeepSyntax(t *testing.T) {
+	tests := []struct {
+		name    string
+		logql   string
+		wantErr bool
+	}{
+		{
+			name:    "valid drop matcher passes",
+			logql:   `{app="api"} | drop level="debug"`,
+			wantErr: false,
+		},
+		{
+			name:    "invalid !=~ operator rejected",
+			logql:   `{app="api"} | keep method="GET", status!=~"5.."`,
+			wantErr: true,
+		},
+		{
+			name:    "bare fields pass",
+			logql:   `{app="api"} | drop level, env`,
+			wantErr: false,
+		},
+		{
+			name:    "valid regex matcher passes",
+			logql:   `{app="api"} | drop status=~"5.."`,
+			wantErr: false,
+		},
+		{
+			name:    "valid negation matcher passes",
+			logql:   `{app="api"} | drop level!="debug"`,
+			wantErr: false,
+		},
+		{
+			name:    "no drop/keep stage passes",
+			logql:   `{app="api"} | json`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDropKeepSyntax(tt.logql)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateDropKeepSyntax(%q) error=%v, wantErr=%v", tt.logql, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Bare `| drop field` / `| keep field` now mutates stream labels**: Added `ParseBareDropFields`, `ParseBareKeepFields`, and `applyBareFieldMutationToStreamLabels`. Both streaming and buffered response paths now apply unconditional drop/keep to the stream label set (with dotted↔underscore translation), matching Loki behaviour.
- **Malformed drop/keep matchers return HTTP 400**: Added `ValidateDropKeepSyntax` in the translator and wired it into `validateLogQLSyntax` in `http_utils.go`. Queries with invalid operators like `!= ~` now return 400 instead of silently skipping the condition.
- **Multi-tenant fanout is now parallel**: Replaced serial loop in `multitenant.go` with `sync.WaitGroup` goroutines over a pre-sized results slice; tenant sub-requests run concurrently, results are merged in original index order for deterministic output.
- **Backward cold merge read is bounded**: Replaced `io.ReadAll(coldResp.Body)` with `readAndReverseNDJSON(r, limit)` — reads at most `limit` NDJSON lines using a ring buffer before reversing, preventing unbounded memory growth when cold backends return large responses.

## Test plan
- [ ] `go test ./...` — 2655 tests pass
- [ ] `go build ./...` — clean build