### PR TITLE
fix(helm): remove invalid flags, add Helm ↔ binary flag parity CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -830,6 +830,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.3"
+          cache: true
+
       - name: Install Helm
         uses: azure/setup-helm@v5
 
@@ -841,3 +846,6 @@ jobs:
 
       - name: Helm template env alias regression
         run: helm template loki-vl-proxy charts/loki-vl-proxy -f scripts/ci/helm-env-alias-values.yaml >/dev/null
+
+      - name: Helm ↔ binary flag parity
+        run: ./scripts/ci/validate_helm_flags.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Helm chart: remove invalid `backend-read-buffer-size` / `backend-write-buffer-size` flags** ([#391](https://github.com/ReliablyObserve/loki-vl-proxy/issues/391)): The chart shipped two `extraArgs` flags that do not exist in the binary, causing startup failure with `flag provided but not defined`. Also removed invalid commented `disk-cache-encryption-key`. Added 19 previously undocumented Go flags to `values.yaml` for full 1:1 parity.
+
+### Added
+
+- **Helm ↔ binary flag parity CI gate**: Go tests (`TestHelmExtraArgsFlagParity`, `TestHelmExtraArgsCoverage`) and a rendered-template validation script (`validate_helm_flags.sh`) now run in CI. Any new flag added to Go without a `values.yaml` entry (or vice versa) will fail CI.
+
 ## [1.37.1] - 2026-05-21
 
 ### Fixed

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -67,6 +67,8 @@ extraArgs:
   # 50 000 entries × ~1-2 KB average = 50-100 MB — fits well within the 512 Mi
   # memory limit below after GOMEMLIMIT headroom. Lower if pods are memory-constrained.
   cache-max: "50000"
+  # cache-disabled: "false"                  # disable in-memory cache entirely (testing/benchmarking)
+  # coalescer-disabled: "false"              # disable singleflight request coalescing
 
   # --- query_range window cache ---
   # Loki-aligned split/fanout defaults:
@@ -125,11 +127,10 @@ extraArgs:
   # Remote backends continue to use zstd/gzip. Override with "none", "gzip",
   # or "zstd" if your deployment topology requires a fixed policy.
   backend-compression: "auto"
-  # Transport read/write buffer sizes (bytes). Go default is 4 KB.
-  # 64 KB reduces read syscall count ~7× for typical 27 KB VL responses.
-  # Lower only in very memory-constrained environments (many pods, tiny limits).
-  backend-read-buffer-size: "65536"
-  backend-write-buffer-size: "65536"
+  # cb-fail-threshold: "5"                  # circuit breaker failure threshold within window
+  # cb-open-duration: "10s"                 # circuit breaker open duration before probe
+  # cb-window-duration: "30s"               # circuit breaker sliding window for failure counting
+  # manual-range-metric-row-limit: "1000000"  # max log rows per manual range-metric call
 
   # --- Frontend/client-facing compression ---
   # gzip for broad Loki/Grafana compatibility; route-aware policy raises the
@@ -171,7 +172,6 @@ extraArgs:
   # disk-cache-flush-size: "100"
   # disk-cache-flush-interval: "5s"
   # disk-cache-max-bytes: "21474836480" # 20Gi safety cap (0 = unlimited)
-  # disk-cache-encryption-key: ""
   # otlp-endpoint: "http://otel-collector:4318/v1/metrics"
   # otlp-interval: "30s"
   # otlp-compression: "gzip"
@@ -202,6 +202,8 @@ extraArgs:
   # - https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/configuration.md#compatibility-profiles
   # - https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/api-reference.md
   # - https://github.com/ReliablyObserve/Loki-VL-proxy/blob/main/docs/compatibility-matrix.md
+  # metadata-field-mode: "translated"        # field exposure: native | translated | hybrid
+  # emit-structured-metadata: "true"         # include 3-tuple stream values [timestamp, line, metadata]
   # Label translation (OTel compatibility)
   # label-style: "underscores"  # convert VL dotted fields (service.name) to Loki underscores (service_name)
   # field-mapping: '[{"vl_field":"custom.field","loki_label":"custom_label"}]'
@@ -229,6 +231,15 @@ extraArgs:
   # System metrics scope override (chart auto-injects when systemMetrics.hostProc.enabled=true):
   # proc-root: "/host/proc"
   #
+  # Go runtime tuning (see also goMemLimitPercent/goMemLimit Helm values):
+  # go-mem-limit: "0"                          # explicit GOMEMLIMIT in bytes (overrides go-mem-limit-percent)
+  # go-mem-limit-percent: "85"                 # percentage of container memory limit for GOMEMLIMIT
+  # go-gc-percent: "200"                       # GOGC target percentage (-1 for Go default 100)
+  #
+  # Patterns file-based config (see also patternsCustom Helm values):
+  # patterns-custom: ""                        # JSON array or newline patterns prepended to /loki/api/v1/patterns
+  # patterns-custom-file: ""                   # path to custom patterns file
+  #
   # Full optional flag catalog (commented defaults from runtime):
   # cache-max-bytes: "268435456"                # 256Mi L1 max bytes
   # compat-cache-enabled: "true"                # enable Tier0 compatibility-edge cache
@@ -248,6 +259,14 @@ extraArgs:
   # response-gzip: "true"
   # max-lines: "1000"
   # auth.enabled: "false"                       # require tenant header
+  # require-tenant-header: "false"             # reject requests missing X-Scope-OrgID with 401
+  # forward-tenant-header: "true"              # forward X-Scope-OrgID to upstream backend
+  # tenant-label: ""                           # VL field name for label-based tenant routing
+  # tenant-map-file: ""                        # path to YAML/JSON tenant map file (hot-reloaded)
+  # tenant-map-reload-interval: "30s"          # poll interval for tenant map file changes
+  # tenant-limits-allow-publish: ""            # comma-separated limit fields published on /config/tenant/v1/limits
+  # tenant-default-limits: ""                  # JSON map of default published limits overrides
+  # tenant-limits: ""                          # JSON map of per-tenant published limits overrides
   # tenant.allow-global: "false"                # allow global tenant map wildcard entry
   # metrics.max-tenants: "256"
   # metrics.max-clients: "256"

--- a/cmd/proxy/helm_parity_test.go
+++ b/cmd/proxy/helm_parity_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestHelmExtraArgsFlagParity ensures every flag referenced in the Helm chart's
+// values.yaml (both active and commented extraArgs) corresponds to a flag
+// registered by the binary's FlagSet. This prevents the class of bug where the
+// chart ships a flag name that does not exist in the binary (issue #391).
+func TestHelmExtraArgsFlagParity(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine source file path")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	goFlags := extractGoFlags(t, filepath.Join(repoRoot, "cmd", "proxy", "main.go"))
+	if len(goFlags) == 0 {
+		t.Fatal("extracted 0 Go flags from main.go — parser is broken")
+	}
+
+	valuesPath := filepath.Join(repoRoot, "charts", "loki-vl-proxy", "values.yaml")
+	helmActive, helmCommented := extractHelmExtraArgs(t, valuesPath)
+
+	for flag := range helmActive {
+		if !goFlags[flag] {
+			t.Errorf("active extraArgs flag %q in values.yaml is not a valid binary flag", flag)
+		}
+	}
+
+	for flag := range helmCommented {
+		if !goFlags[flag] {
+			t.Errorf("commented extraArgs flag %q in values.yaml is not a valid binary flag", flag)
+		}
+	}
+}
+
+// TestHelmExtraArgsCoverage ensures every Go flag is documented in values.yaml
+// (either as an active key, a commented key, or handled by dedicated Helm values).
+func TestHelmExtraArgsCoverage(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine source file path")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	goFlags := extractGoFlags(t, filepath.Join(repoRoot, "cmd", "proxy", "main.go"))
+
+	valuesPath := filepath.Join(repoRoot, "charts", "loki-vl-proxy", "values.yaml")
+	helmActive, helmCommented := extractHelmExtraArgs(t, valuesPath)
+
+	deploymentPath := filepath.Join(repoRoot, "charts", "loki-vl-proxy", "templates", "deployment.yaml")
+	templateFlags := extractTemplateFlags(t, deploymentPath)
+
+	// Flags handled by dedicated Helm values (not extraArgs).
+	// These are injected by deployment.yaml template logic or by dedicated
+	// Helm values sections, so they don't need extraArgs entries.
+	chartManaged := map[string]bool{
+		"peer-self":       true, // injected by peerCache template logic
+		"peer-discovery":  true, // injected by peerCache template logic
+		"peer-dns":        true, // injected by peerCache template logic
+		"peer-static":     true, // injected by peerCache template logic
+		"disk-cache-path": true, // injected when persistence.enabled=true
+	}
+
+	for flag := range goFlags {
+		if chartManaged[flag] {
+			continue
+		}
+		if templateFlags[flag] {
+			continue
+		}
+		if helmActive[flag] || helmCommented[flag] {
+			continue
+		}
+		t.Errorf("Go flag %q has no entry in values.yaml (active, commented, or template-injected)", flag)
+	}
+}
+
+var flagDefRe = regexp.MustCompile(`fs\.\w+\("([a-zA-Z][a-zA-Z0-9._-]*)"`)
+
+func extractGoFlags(t *testing.T, mainGoPath string) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(mainGoPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainGoPath, err)
+	}
+	flags := make(map[string]bool)
+	for _, m := range flagDefRe.FindAllSubmatch(data, -1) {
+		flags[string(m[1])] = true
+	}
+	return flags
+}
+
+func extractHelmExtraArgs(t *testing.T, valuesPath string) (active, commented map[string]bool) {
+	t.Helper()
+	f, err := os.Open(valuesPath)
+	if err != nil {
+		t.Fatalf("open %s: %v", valuesPath, err)
+	}
+	defer f.Close()
+
+	active = make(map[string]bool)
+	commented = make(map[string]bool)
+
+	// Match lines like:
+	//   flag-name: "value"         (active)
+	//   # flag-name: "value"       (commented)
+	activeRe := regexp.MustCompile(`^\s{2}([a-zA-Z][a-zA-Z0-9._-]+):\s`)
+	commentRe := regexp.MustCompile(`^\s{2}#\s*([a-zA-Z][a-zA-Z0-9._-]+):\s`)
+
+	inExtraArgs := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "extraArgs:") {
+			inExtraArgs = true
+			continue
+		}
+		if inExtraArgs && len(line) > 0 && line[0] != ' ' && line[0] != '#' {
+			break
+		}
+		if !inExtraArgs {
+			continue
+		}
+
+		if m := activeRe.FindStringSubmatch(line); m != nil && !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			active[m[1]] = true
+		}
+		if m := commentRe.FindStringSubmatch(line); m != nil {
+			commented[m[1]] = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", valuesPath, err)
+	}
+	return active, commented
+}
+
+var templateFlagRe = regexp.MustCompile(`-([a-zA-Z][a-zA-Z0-9._-]+)=`)
+
+func extractTemplateFlags(t *testing.T, deploymentPath string) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(deploymentPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", deploymentPath, err)
+	}
+	flags := make(map[string]bool)
+	for _, m := range templateFlagRe.FindAllSubmatch(data, -1) {
+		flags[string(m[1])] = true
+	}
+	return flags
+}

--- a/scripts/ci/validate_helm_flags.sh
+++ b/scripts/ci/validate_helm_flags.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# validate_helm_flags.sh — CI gate ensuring Helm chart extraArgs stay in sync
+# with the binary's registered flags.
+#
+# Two checks:
+#   1) Render `helm template` with default values and verify every rendered
+#      -flag=value argument corresponds to a flag the binary accepts.
+#   2) Run the Go parity test (TestHelmExtraArgsFlagParity +
+#      TestHelmExtraArgsCoverage) which validates the static values.yaml
+#      against the source-level flag definitions.
+#
+# Usage:
+#   ./scripts/ci/validate_helm_flags.sh          # full check (build + template + Go tests)
+#   ./scripts/ci/validate_helm_flags.sh --quick   # Go tests only (no binary build)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MODE="${1:-full}"
+
+echo "=== Helm ↔ Binary Flag Parity Check ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Step 1: Go parity tests (source-level validation)
+# -------------------------------------------------------------------
+echo "--- Running Go parity tests ---"
+go test ./cmd/proxy/ -run 'TestHelmExtraArgs' -count=1 -v
+echo ""
+
+if [ "$MODE" = "--quick" ]; then
+  echo "OK (quick mode — skipped template rendering)"
+  exit 0
+fi
+
+# -------------------------------------------------------------------
+# Step 2: Build binary and validate rendered Helm template args
+# -------------------------------------------------------------------
+echo "--- Extracting valid flags from source ---"
+VALID_FLAGS=$(grep -E 'fs\.(String|Int|Bool|Duration|Float64|Int64)\(' cmd/proxy/main.go \
+  | sed -E 's/.*fs\.[A-Za-z0-9]+\("([^"]+)".*/\1/' \
+  | sort -u)
+
+echo "  $(echo "$VALID_FLAGS" | wc -l | tr -d ' ') flags registered"
+echo ""
+
+echo "--- Rendering Helm template ---"
+RENDERED="$(helm template test-release charts/loki-vl-proxy/ 2>&1)"
+
+# Extract -flag=value from rendered args lines (format: - "-flag=value").
+# Only look at lines inside the args: block that start with - "-.
+RENDERED_FLAGS=$(echo "$RENDERED" \
+  | sed -n '/^[[:space:]]*args:/,/^[[:space:]]*[a-z]/p' \
+  | grep -E '^\s+- "-' \
+  | sed -E 's/.*"-([a-zA-Z][a-zA-Z0-9._-]*)=.*/\1/' \
+  | sort -u)
+
+echo "  $(echo "$RENDERED_FLAGS" | wc -l | tr -d ' ') unique flags in rendered template"
+echo ""
+
+echo "--- Validating rendered flags ---"
+EXIT=0
+while IFS= read -r flag; do
+  [ -z "$flag" ] && continue
+  if ! echo "$VALID_FLAGS" | grep -qx "$flag"; then
+    echo "ERROR: rendered flag '$flag' is not a valid binary flag"
+    EXIT=1
+  fi
+done <<< "$RENDERED_FLAGS"
+
+if [ "$EXIT" -eq 0 ]; then
+  echo "OK: All rendered Helm template flags are valid binary flags"
+fi
+
+exit "$EXIT"


### PR DESCRIPTION
## Summary

Fixes the bug reported in #391 by @a-bali — the Helm chart shipped `backend-read-buffer-size` and `backend-write-buffer-size` as active `extraArgs`, but neither flag exists in the binary. This caused loki-vl-proxy to fail on startup with:

```
flag provided but not defined: -backend-read-buffer-size
```

- Remove `backend-read-buffer-size` and `backend-write-buffer-size` from active `extraArgs`
- Remove commented `disk-cache-encryption-key` (also not a valid binary flag)
- Add 19 previously undocumented Go flags to `values.yaml` comments for full 1:1 parity
- Add CI gate so this class of bug cannot recur — any new flag added to Go without a `values.yaml` entry (or vice versa) will fail CI

## What changed

| File | Change |
|------|--------|
| `charts/loki-vl-proxy/values.yaml` | Remove 3 invalid flags, add 19 missing flags as comments |
| `cmd/proxy/helm_parity_test.go` | Go tests: every `values.yaml` flag must exist in binary, every binary flag must be documented in `values.yaml` |
| `scripts/ci/validate_helm_flags.sh` | Shell script: validates rendered `helm template` output against valid source flags |
| `.github/workflows/ci.yaml` | Add `Helm ↔ binary flag parity` step to `helm` CI job |

## CI enforcement (prevents regression)

Two layers of validation run on every PR:

1. **Go parity tests** (`TestHelmExtraArgsFlagParity` + `TestHelmExtraArgsCoverage`) — parse `main.go` flag definitions and cross-reference with `values.yaml` entries in both directions
2. **Rendered template validation** — runs `helm template` with default values and verifies every `-flag=value` in the rendered Deployment corresponds to a real binary flag

Prevents this class of bug from ever happening again — any new flag added to Go without a `values.yaml` entry (or vice versa) will fail CI.

## Test plan

- [x] `go test ./cmd/proxy/ -run TestHelmExtraArgs` — 2 parity tests pass
- [x] `./scripts/ci/validate_helm_flags.sh` — full validation passes (Go tests + rendered template)
- [x] `helm lint charts/loki-vl-proxy/` — passes
- [x] Existing Helm regression tests pass (quoted args, env alias)
- [x] Full `cmd/proxy/` test suite passes (107 tests with `-race`)

Closes #391