### PR TITLE
fix(ci): harden GHCR badge workflow against empty API outputs

### DIFF
--- a/.github/workflows/ghcr-badges.yaml
+++ b/.github/workflows/ghcr-badges.yaml
@@ -14,7 +14,7 @@ jobs:
   update-ghcr-badges:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Fetch GHCR pull counts
         id: pulls
@@ -23,14 +23,14 @@ jobs:
         run: |
           MAIN=$(gh api /orgs/ReliablyObserve/packages/container/loki-vl-proxy --jq '.download_count' 2>/dev/null || echo 0)
           CHART=$(gh api '/orgs/ReliablyObserve/packages/container/charts%2Floki-vl-proxy' --jq '.download_count' 2>/dev/null || echo 0)
-          echo "main=$MAIN" >> "$GITHUB_OUTPUT"
-          echo "chart=$CHART" >> "$GITHUB_OUTPUT"
+          echo "main=${MAIN:-0}" >> "$GITHUB_OUTPUT"
+          echo "chart=${CHART:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Write badge JSON files
         run: |
           fmt() {
             python3 -c "
-          n = $1
+          n = int('$1') if '$1' else 0
           if n >= 1_000_000:
               print(f'{n/1_000_000:.1f}M')
           elif n >= 1_000:
@@ -40,8 +40,10 @@ jobs:
           "
           }
 
-          MAIN_FMT=$(fmt ${{ steps.pulls.outputs.main }})
-          CHART_FMT=$(fmt ${{ steps.pulls.outputs.chart }})
+          MAIN_VAL="${{ steps.pulls.outputs.main }}"
+          CHART_VAL="${{ steps.pulls.outputs.chart }}"
+          MAIN_FMT=$(fmt "${MAIN_VAL:-0}")
+          CHART_FMT=$(fmt "${CHART_VAL:-0}")
 
           mkdir -p /tmp/badges
           cat > /tmp/badges/ghcr-pulls.json <<EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GHCR badge workflow hardened against empty API outputs**: `checkout@v6` → `checkout@v4` (v6 does not exist); shell defaults prevent empty `GITHUB_OUTPUT` values; Python `fmt()` handles empty string instead of causing `SyntaxError`.
+
 ## [1.39.0] - 2026-05-23
 
 ### Performance


### PR DESCRIPTION
## Problem

The `GHCR Pull Badges` workflow failed on the first run after merge because:

1. `actions/checkout@v6` does not exist — should be `@v4`
2. When the GHCR API is rate-limited, `steps.pulls.outputs.main` can be empty. The bare `${{ steps.pulls.outputs.main }}` GHA expression expands to nothing in the shell, so `fmt` was called with no argument, causing `python3 -c "n = "` → `SyntaxError: invalid syntax`

## Fix

- `checkout@v6` → `checkout@v4`
- Shell-default outputs to `0` when writing `GITHUB_OUTPUT` (`${MAIN:-0}`)
- Assign GHA outputs to shell vars with `:-0` fallback before calling `fmt`
- Python `fmt()` uses `int('$1') if '$1' else 0` to handle empty string input safely