### PR TITLE
feat: add -translate-otel-attributes flag to control OTel label rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `-translate-otel-attributes` flag (default: `true`, env `TRANSLATE_OTEL_ATTRIBUTES`). Gates the built-in `knownUnderscoreToDot` OTel semantic convention rewrite in the `ToVL()` query-direction translator. Set to `false` when VictoriaLogs stores OTel attributes with underscores (e.g., Vector / Promtail / Fluent-bit via `/insert/elasticsearch/_bulk`); custom `-field-mapping` rules and runtime-learned aliases keep working in both modes. Resolves empty results for multi-label queries containing known OTel names like `k8s_container_name` against underscore-storage backends.
+
+### Fixed
+- When `-translate-otel-attributes=false`, the `ToVL()` query-direction translator no longer rewrites entries in `knownUnderscoreToDot` to dotted form. `ResolveLabelCandidates` and the `resolveTargetLabelFields` fallback are gated on the same flag, so the dotted form is no longer added as a candidate or fallback when OTel translation is disabled. Previously the rewrite/fallback always fired when `-label-style=underscores` was active.
+
 ## [1.51.0] - 2026-05-27
 
 ### Fixed

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -206,6 +206,7 @@ extraArgs:
   # emit-structured-metadata: "true"         # include 3-tuple stream values [timestamp, line, metadata]
   # Label translation (OTel compatibility)
   # label-style: "underscores"  # convert VL dotted fields (service.name) to Loki underscores (service_name)
+  # translate-otel-attributes: "true"  # rewrite known OTel labels to dotted form in upstream queries (set "false" for underscore storage)
   # field-mapping: '[{"vl_field":"custom.field","loki_label":"custom_label"}]'
   # Derived fields (trace linking)
   # derived-fields: '[{"name":"traceID","matcherRegex":"trace_id=([a-f0-9]+)","url":"http://tempo/trace/${__value.raw}"}]'

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -55,6 +55,7 @@ type envConfig struct {
 	labelStyle        string
 	fieldMappingJSON  string
 	metadataFieldMode string
+	translateOTel     *bool
 	extraLabelFields  string
 	serviceName       string
 	serviceNamespace  string
@@ -149,6 +150,7 @@ type proxyRuntimeConfig struct {
 	warmupMaxJitter                     time.Duration
 	labelStyle                          string
 	metadataFieldMode                   string
+	translateOTel                       *bool
 	fieldMappingJSON                    string
 	streamFieldsCSV                     string
 	extraLabelFieldsCSV                 string
@@ -495,6 +497,7 @@ func run(
   native      - expose VictoriaLogs field names as-is
   translated  - expose only Loki-compatible translated aliases
   hybrid      - expose both native VL field names and translated aliases when they differ`)
+	translateOTel := fs.Bool("translate-otel-attributes", true, "Translate known OTel semantic convention labels from underscore to dotted form in upstream queries (set false to preserve client label names)")
 	fieldMappingJSON := fs.String("field-mapping", "", `JSON custom field mappings: [{"vl_field":"service.name","loki_label":"service_name"}]`)
 	streamFieldsCSV := fs.String("stream-fields", "", `Comma-separated VL _stream_fields labels for stream selector optimization (e.g., "app,env,namespace")`)
 	extraLabelFieldsCSV := fs.String("extra-label-fields", "", `Comma-separated additional VL field names exposed on /labels and eligible for alias resolution (for example "host.id,custom.pipeline.processing")`)
@@ -576,6 +579,7 @@ func run(
 		labelStyle:        *labelStyle,
 		fieldMappingJSON:  *fieldMappingJSON,
 		metadataFieldMode: *metadataFieldMode,
+		translateOTel:     translateOTel,
 		extraLabelFields:  *extraLabelFieldsCSV,
 		serviceName:       *otelServiceName,
 		serviceNamespace:  *otelServiceNamespace,
@@ -714,6 +718,7 @@ func run(
 			warmupMaxJitter:                     *warmupMaxJitter,
 			labelStyle:                          envCfg.labelStyle,
 			metadataFieldMode:                   envCfg.metadataFieldMode,
+			translateOTel:                       envCfg.translateOTel,
 			fieldMappingJSON:                    envCfg.fieldMappingJSON,
 			streamFieldsCSV:                     *streamFieldsCSV,
 			extraLabelFieldsCSV:                 envCfg.extraLabelFields,
@@ -1206,6 +1211,11 @@ func applyEnvOverrides(cfg envConfig, getenv func(string) string) envConfig {
 	if v := getenv("METADATA_FIELD_MODE"); v != "" && cfg.metadataFieldMode == "hybrid" {
 		cfg.metadataFieldMode = v
 	}
+	if v := getenv("TRANSLATE_OTEL_ATTRIBUTES"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.translateOTel = &b
+		}
+	}
 	if v := getenv("EXTRA_LABEL_FIELDS"); v != "" && cfg.extraLabelFields == "" {
 		cfg.extraLabelFields = v
 	}
@@ -1676,6 +1686,7 @@ func buildProxyConfig(cfg proxyRuntimeConfig) (proxy.Config, error) {
 		WarmupMaxJitter:                    cfg.warmupMaxJitter,
 		LabelStyle:                         ls,
 		MetadataFieldMode:                  mfm,
+		TranslateOTel:                      cfg.translateOTel,
 		FieldMappings:                      fieldMappings,
 		StreamFields:                       parseCSV(cfg.streamFieldsCSV),
 		ExtraLabelFields:                   parseCSV(cfg.extraLabelFieldsCSV),

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -785,6 +785,63 @@ func TestApplyEnvOverrides_PreservesExplicitFlags(t *testing.T) {
 	}
 }
 
+// TRANSLATE_OTEL_ATTRIBUTES uses a *bool so "unset" stays distinct from "false".
+// The override unconditionally replaces the CLI default (unlike most other env
+// vars, which only fill in when the CLI value is the documented default), so
+// these tests pin both directions and the invalid-value safe-fallback.
+func TestApplyEnvOverrides_TranslateOTelAttributes(t *testing.T) {
+	t.Run("env false overrides default true", func(t *testing.T) {
+		def := true
+		cfg := envConfig{translateOTel: &def}
+		got := applyEnvOverrides(cfg, func(key string) string {
+			if key == "TRANSLATE_OTEL_ATTRIBUTES" {
+				return "false"
+			}
+			return ""
+		})
+		if got.translateOTel == nil || *got.translateOTel {
+			t.Fatalf("expected translateOTel=false after env override, got %+v", got.translateOTel)
+		}
+	})
+
+	t.Run("env true overrides default false", func(t *testing.T) {
+		def := false
+		cfg := envConfig{translateOTel: &def}
+		got := applyEnvOverrides(cfg, func(key string) string {
+			if key == "TRANSLATE_OTEL_ATTRIBUTES" {
+				return "true"
+			}
+			return ""
+		})
+		if got.translateOTel == nil || !*got.translateOTel {
+			t.Fatalf("expected translateOTel=true after env override, got %+v", got.translateOTel)
+		}
+	})
+
+	t.Run("invalid env value leaves explicit flag intact", func(t *testing.T) {
+		def := true
+		cfg := envConfig{translateOTel: &def}
+		got := applyEnvOverrides(cfg, func(key string) string {
+			if key == "TRANSLATE_OTEL_ATTRIBUTES" {
+				return "not-a-bool"
+			}
+			return ""
+		})
+		if got.translateOTel == nil || !*got.translateOTel {
+			t.Fatalf("expected invalid env to leave explicit flag intact, got %+v", got.translateOTel)
+		}
+	})
+
+	t.Run("empty env preserves CLI value", func(t *testing.T) {
+		def := false
+		cfg := envConfig{translateOTel: &def}
+		got := applyEnvOverrides(cfg, func(string) string { return "" })
+		if got.translateOTel == nil || *got.translateOTel {
+			t.Fatalf("expected empty env to preserve CLI value, got %+v", got.translateOTel)
+		}
+	})
+}
+
 func TestApplyEnvOverrides_ProcRoot(t *testing.T) {
 	cfg := envConfig{procRoot: "/proc"}
 	env := map[string]string{"PROC_ROOT": "/host/proc"}

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -34,6 +34,7 @@ operational caveats that still matter in the current codebase.
 | Patterns surface | `/loki/api/v1/patterns` is optional (`-patterns-enabled`) and responses are clamped to `1000` patterns per request. |
 | `count_values()` aggregation | Not translatable. VictoriaLogs has no equivalent function that groups by metric values. Queries using `count_values` return a descriptive error. |
 | Log stream ordering above split interval | For queries spanning more than one windowing interval, log entries within each stream are sorted ascending by timestamp; however Grafana may display them in the requested `direction` based on the overall response. This is stable as of v1.21.1. |
+| OTel attribute translation in upstream queries | By default (`-translate-otel-attributes=true`), the LogQL→LogsQL translator rewrites known OTel semantic convention labels from underscore to dotted form (e.g., `k8s_container_name` → `k8s.container.name`). Deployments that store these fields with underscores (Vector, Promtail, Fluent-bit via Elasticsearch bulk ingest) should set `-translate-otel-attributes=false`. |
 
 ## Translation and Performance Caveats
 

--- a/docs/translation-modes.md
+++ b/docs/translation-modes.md
@@ -17,6 +17,27 @@ This guide explains how field and label translation behaves across proxy surface
 | `-field-mapping` | Custom mapping between VL field name and Loki label name | JSON mappings |
 | `-extra-label-fields` | Explicitly extends label-facing APIs and dot/underscore alias resolution for custom fields | comma-separated VL field names |
 
+### OTel Attribute Translation
+
+**Flag:** `-translate-otel-attributes` (default: `true`, env `TRANSLATE_OTEL_ATTRIBUTES`)
+
+Controls whether the LogQL→LogsQL translator rewrites the built-in list of known OTel semantic convention labels from underscore to dotted form in upstream queries to VictoriaLogs.
+
+- `true` (default): Labels like `k8s_container_name` are rewritten to `k8s.container.name` in the upstream LogsQL query. Correct when VictoriaLogs stores these fields in dotted OTel form.
+- `false`: The built-in `knownUnderscoreToDot` rewrite is skipped, so known OTel labels reach VL with their underscore form intact. Use this when your ingest pipeline (Vector, Promtail, Fluent-bit) stores OTel attributes with underscores in VictoriaLogs.
+
+**Scope.** This flag gates only the built-in OTel rewrite layer. The other parts of `ToVL()` keep working in both modes:
+
+| Layer | Affected by `-translate-otel-attributes=false`? |
+|---|---|
+| Explicit `-field-mapping` rules (`lokiToVL`) | No — operator intent always wins |
+| `detected_level` → `level` alias | No |
+| Built-in `knownUnderscoreToDot` semconv rewrite | Yes — disabled when flag is `false` |
+| Runtime-learned aliases from VL field inventory | No — reflects what VL actually stores |
+| Unknown labels (passthrough) | No |
+
+The flag also gates `ResolveLabelCandidates` and the `resolveTargetLabelFields` underscore-fallback, so the dotted form is not added as a candidate or fallback when OTel translation is disabled. This flag only affects the **query direction** (Loki→VL); response-side label translation is controlled by `-label-style` and `-metadata-field-mode`.
+
 ## Surfaces Affected
 
 | Surface | Uses `label-style` | Uses `metadata-field-mode` |

--- a/internal/proxy/label_handlers.go
+++ b/internal/proxy/label_handlers.go
@@ -454,7 +454,12 @@ func (p *Proxy) resolveTargetLabelFields(ctx context.Context, targetLabels strin
 		// custom fields resolved via inventory (those are stored as dotted OTel).
 		if p.labelTranslator != nil && p.labelTranslator.style == LabelStyleUnderscores {
 			if _, isKnownOTel := knownUnderscoreToDot[name]; isKnownOTel {
-				resolved = appendUniqueStrings(resolved, name)
+				// When OTel translation is enabled, the primary form is dotted;
+				// add the underscore form as a fallback for Loki-push data.
+				// When disabled, ToVL already returns the underscore form — skip.
+				if p.labelTranslator.translateOTel {
+					resolved = appendUniqueStrings(resolved, name)
+				}
 			}
 		}
 	}

--- a/internal/proxy/labels.go
+++ b/internal/proxy/labels.go
@@ -64,6 +64,8 @@ type LabelTranslator struct {
 	learnedMu        sync.RWMutex
 	learnedLokiToVL  map[string]string
 	learnedAmbiguous map[string]struct{}
+
+	translateOTel bool
 }
 
 // NewLabelTranslator creates a label translator with the given style and custom mappings.
@@ -75,6 +77,7 @@ func NewLabelTranslator(style LabelStyle, mappings []FieldMapping) *LabelTransla
 		lokiToVL:         make(map[string]string),
 		learnedLokiToVL:  make(map[string]string),
 		learnedAmbiguous: make(map[string]struct{}),
+		translateOTel:    true,
 	}
 
 	// Register custom mappings (bidirectional)
@@ -115,10 +118,24 @@ func (lt *LabelTranslator) ToVL(lokiLabel string) string {
 
 	switch lt.style {
 	case LabelStyleUnderscores:
-		// For query direction, we check known OTel semantic conventions.
-		// If the underscore label matches a known OTel dotted field, use the dotted form.
-		if dotted, ok := knownUnderscoreToDot[lokiLabel]; ok {
-			return dotted
+		// Scope note: translateOTel gates ONLY the built-in knownUnderscoreToDot
+		// mapping below. Custom -field-mapping rules (handled above via lt.lokiToVL)
+		// and runtime-learned aliases (below) are intentionally NOT gated — the
+		// former is explicit operator intent and the latter reflects the actual VL
+		// field inventory, so both stay correct regardless of how known OTel labels
+		// are stored.
+		//
+		// When translateOTel is enabled (default), rewrite known OTel semantic
+		// convention labels from underscore to dotted form (e.g.
+		// k8s_container_name → k8s.container.name) for the upstream query.
+		// When disabled (-translate-otel-attributes=false), skip this layer so the
+		// underscore form reaches the loop/passthrough below — useful when VL
+		// stores OTel attributes with underscores (Vector/Promtail/Fluent-bit via
+		// Elasticsearch bulk ingest).
+		if lt.translateOTel {
+			if dotted, ok := knownUnderscoreToDot[lokiLabel]; ok {
+				return dotted
+			}
 		}
 		// For custom attributes, use learned aliases only when they were resolved
 		// uniquely from backend field inventory.
@@ -143,6 +160,10 @@ func (lt *LabelTranslator) resolveLearnedAlias(lokiLabel string) (string, bool) 
 	}
 	mapped, ok := lt.learnedLokiToVL[lokiLabel]
 	return mapped, ok
+}
+
+func (lt *LabelTranslator) SetTranslateOTel(v bool) {
+	lt.translateOTel = v
 }
 
 // LearnFieldAliases captures runtime underscore -> dotted mappings for custom
@@ -268,7 +289,12 @@ func (lt *LabelTranslator) ResolveLabelCandidates(lokiLabel string, available []
 	if addIfAvailable(label) {
 		return fieldResolution{candidates: candidates}
 	}
-	if lt != nil {
+	// Same scope rule as ToVL: only the built-in knownUnderscoreToDot lookup is
+	// gated by translateOTel. The check goes BEFORE addIfAvailable because
+	// addIfAvailable has a side effect (it appends to `candidates`) — short-
+	// circuiting on the flag after the append would still leave the dotted
+	// form in the result set.
+	if lt != nil && lt.translateOTel {
 		if dotted, ok := knownUnderscoreToDot[label]; ok && addIfAvailable(dotted) {
 			return fieldResolution{candidates: candidates}
 		}

--- a/internal/proxy/labels_test.go
+++ b/internal/proxy/labels_test.go
@@ -374,6 +374,148 @@ func TestLabelTranslator_ResolveLabelCandidates(t *testing.T) {
 	}
 }
 
+func TestToVL_TranslateOTelTrue_RewritesKnownOTelLabels(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(true)
+	if got := lt.ToVL("k8s_container_name"); got != "k8s.container.name" {
+		t.Errorf("ToVL(k8s_container_name) = %q, want %q", got, "k8s.container.name")
+	}
+}
+
+func TestToVL_TranslateOTelFalse_PreservesUnderscoreLabels(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+	if got := lt.ToVL("k8s_container_name"); got != "k8s_container_name" {
+		t.Errorf("ToVL(k8s_container_name) = %q, want %q", got, "k8s_container_name")
+	}
+}
+
+func TestToVL_TranslateOTelFalse_UnknownLabelsStillPassThrough(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+	if got := lt.ToVL("k8s_app"); got != "k8s_app" {
+		t.Errorf("ToVL(k8s_app) = %q, want %q", got, "k8s_app")
+	}
+}
+
+func TestToVL_TranslateOTelFalse_CustomMappingsStillWork(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, []FieldMapping{
+		{VLField: "custom.field", LokiLabel: "custom_label"},
+	})
+	lt.SetTranslateOTel(false)
+	if got := lt.ToVL("custom_label"); got != "custom.field" {
+		t.Errorf("ToVL(custom_label) = %q, want %q", got, "custom.field")
+	}
+}
+
+func TestToVL_TranslateOTelFalse_DetectedLevelUnaffected(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+	if got := lt.ToVL("detected_level"); got != "level" {
+		t.Errorf("ToVL(detected_level) = %q, want %q", got, "level")
+	}
+}
+
+func TestToVL_TranslateOTelFalse_PassthroughModeUnaffected(t *testing.T) {
+	lt := NewLabelTranslator(LabelStylePassthrough, nil)
+	lt.SetTranslateOTel(false)
+	if got := lt.ToVL("k8s_container_name"); got != "k8s_container_name" {
+		t.Errorf("ToVL(k8s_container_name) = %q, want %q", got, "k8s_container_name")
+	}
+	lt.SetTranslateOTel(true)
+	if got := lt.ToVL("k8s_container_name"); got != "k8s_container_name" {
+		t.Errorf("ToVL(k8s_container_name) with translateOTel=true = %q, want %q", got, "k8s_container_name")
+	}
+}
+
+func TestToVL_K8sContainerName_Regression(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(true)
+	if got := lt.ToVL("k8s_container_name"); got != "k8s.container.name" {
+		t.Errorf("ToVL(k8s_container_name) with translateOTel=true = %q, want %q", got, "k8s.container.name")
+	}
+	lt.SetTranslateOTel(false)
+	if got := lt.ToVL("k8s_container_name"); got != "k8s_container_name" {
+		t.Errorf("ToVL(k8s_container_name) with translateOTel=false = %q, want %q", got, "k8s_container_name")
+	}
+}
+
+func TestLearnFieldAliases_TranslateOTelTrue_SkipsKnownOTelEntries(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(true)
+	lt.LearnFieldAliases([]string{"k8s.container.name"})
+	if got := lt.ToVL("k8s_container_name"); got != "k8s.container.name" {
+		t.Errorf("ToVL(k8s_container_name) = %q, want %q", got, "k8s.container.name")
+	}
+}
+
+func TestLearnFieldAliases_TranslateOTelFalse_NeverCreatesAliasForKnownOTel(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+	lt.LearnFieldAliases([]string{"k8s.container.name"})
+	// With translateOTel=false, LearnFieldAliases unconditionally skips known OTel entries.
+	// ToVL preserves the underscore label (no rewrite from any source).
+	if got := lt.ToVL("k8s_container_name"); got != "k8s_container_name" {
+		t.Errorf("ToVL(k8s_container_name) with translateOTel=false = %q, want %q (should be preserved as-is)", got, "k8s_container_name")
+	}
+}
+
+func TestLearnFieldAliases_TranslateOTelFalse_LearnFromVLFieldInventory(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+	lt.LearnFieldAliases([]string{"k8s_container_name"})
+	if got := lt.ToVL("k8s_container_name"); got != "k8s_container_name" {
+		t.Errorf("ToVL(k8s_container_name) = %q, want %q", got, "k8s_container_name")
+	}
+}
+
+// Underscore-storage deployment: VL has the underscore form, operator disabled
+// the OTel rewrite. Candidate resolution must short-circuit on the underscore
+// field present in the inventory.
+func TestResolveLabelCandidates_TranslateOTelFalse_PrefersUnderscoreFromInventory(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+
+	got := lt.ResolveLabelCandidates("k8s_container_name", []string{"k8s_container_name"})
+	if len(got.candidates) != 1 || got.candidates[0] != "k8s_container_name" {
+		t.Fatalf("expected [k8s_container_name], got %v", got.candidates)
+	}
+	if got.ambiguous {
+		t.Fatalf("expected unambiguous single candidate, got ambiguous=%v", got.ambiguous)
+	}
+}
+
+// Edge case: operator disabled the OTel rewrite, but VL actually only has the
+// dotted form. The gated knownUnderscoreToDot shortcut is skipped, but the
+// generic ToLoki loop still finds the dotted field via translation so the
+// candidate is non-empty (we can't query a field VL doesn't have).
+func TestResolveLabelCandidates_TranslateOTelFalse_FallsBackToDottedFromInventory(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+
+	got := lt.ResolveLabelCandidates("k8s_container_name", []string{"k8s.container.name"})
+	if len(got.candidates) != 1 || got.candidates[0] != "k8s.container.name" {
+		t.Fatalf("expected fallback to [k8s.container.name] via generic loop, got %v", got.candidates)
+	}
+	if got.ambiguous {
+		t.Fatalf("expected unambiguous, got %v", got.ambiguous)
+	}
+}
+
+// Regression for the ordering of `lt.translateOTel` vs. the side-effecting
+// `addIfAvailable(dotted)`: when both forms are present but the underscore
+// matches first via line 280, we must never even touch the gated dotted
+// shortcut so it cannot pollute candidates.
+func TestResolveLabelCandidates_TranslateOTelFalse_ExactUnderscoreShortCircuits(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.SetTranslateOTel(false)
+
+	got := lt.ResolveLabelCandidates("service_name", []string{"service_name", "service.name"})
+	if len(got.candidates) != 1 || got.candidates[0] != "service_name" {
+		t.Fatalf("expected exact underscore match to short-circuit, got %v", got.candidates)
+	}
+}
+
 func TestLabelTranslator_ResolveMetadataCandidates(t *testing.T) {
 	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -226,6 +226,7 @@ type Config struct {
 	LabelStyle        LabelStyle        // how to translate VL field names to Loki labels
 	MetadataFieldMode MetadataFieldMode // how to expose non-label VL fields through field-oriented APIs
 	FieldMappings     []FieldMapping    // custom VL↔Loki field name mappings
+	TranslateOTel     *bool
 
 	// Stream optimization
 	StreamFields []string // VL _stream_fields labels — use native stream selectors for these (faster)
@@ -929,6 +930,9 @@ func New(cfg Config) (*Proxy, error) {
 	}
 
 	labelTranslator := NewLabelTranslator(cfg.LabelStyle, cfg.FieldMappings)
+	if cfg.TranslateOTel != nil {
+		labelTranslator.SetTranslateOTel(*cfg.TranslateOTel)
+	}
 	declaredLabelFields := buildDeclaredLabelFields(cfg.StreamFields, cfg.ExtraLabelFields, labelTranslator)
 	patternsEnabled := true
 	if cfg.PatternsEnabled != nil {
@@ -1253,7 +1257,9 @@ func (p *Proxy) ReloadTenantMap(m map[string]TenantMapping) {
 // ReloadFieldMappings hot-reloads field mappings and rebuilds the label translator.
 func (p *Proxy) ReloadFieldMappings(mappings []FieldMapping) {
 	p.configMu.Lock()
+	prevTranslateOTel := p.labelTranslator.translateOTel
 	p.labelTranslator = NewLabelTranslator(p.labelTranslator.style, mappings)
+	p.labelTranslator.SetTranslateOTel(prevTranslateOTel)
 	if p.translationCache != nil {
 		p.translationCache.InvalidatePrefix("")
 	}

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -25,6 +25,25 @@ func TestProxyHelpers_ReloadFieldMappings(t *testing.T) {
 	}
 }
 
+// ReloadFieldMappings rebuilds the LabelTranslator from scratch, which would
+// reset translateOTel to its NewLabelTranslator default (true). The reload
+// path must explicitly carry the prior value across so operators using the
+// SIGHUP-driven hot-reload don't silently lose -translate-otel-attributes=false.
+func TestProxyHelpers_ReloadFieldMappings_PreservesTranslateOTel(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+
+	p.labelTranslator.SetTranslateOTel(false)
+
+	p.ReloadFieldMappings([]FieldMapping{{VLField: "service.name", LokiLabel: "service_name"}})
+
+	if p.labelTranslator.translateOTel {
+		t.Fatal("expected translateOTel=false to survive ReloadFieldMappings")
+	}
+	if got := p.labelTranslator.ToLoki("service.name"); got != "service_name" {
+		t.Fatalf("expected reloaded field mapping to apply, got %q", got)
+	}
+}
+
 func TestProxyHelpers_RequestPolicyError(t *testing.T) {
 	err := &requestPolicyError{status: 403, msg: "denied"}
 	if got := err.Error(); got != "denied" {

--- a/internal/proxy/query_translation_test.go
+++ b/internal/proxy/query_translation_test.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/logsql"
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/translator"
+)
+
+func TestQueryTranslation_TranslateOTelFalse_StreamSelectorPreservesUnderscores(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.translateOTel = false
+
+	got, err := translator.TranslateLogQLWithCapabilities(
+		`{k8s_app="api-notifications-chat",k8s_container_name="notificationgo-chat"}`,
+		lt.ToVL,
+		nil,
+		logsql.Capabilities{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, `k8s_container_name:=`) {
+		t.Errorf("output missing k8s_container_name:=; got %q", got)
+	}
+	if strings.Contains(got, `"k8s.container.name":=`) {
+		t.Errorf("output unexpectedly contains dotted OTel field; got %q", got)
+	}
+}
+
+func TestQueryTranslation_TranslateOTelTrue_DefaultBehavior(t *testing.T) {
+	lt := NewLabelTranslator(LabelStyleUnderscores, nil)
+	lt.translateOTel = true
+
+	got, err := translator.TranslateLogQLWithCapabilities(
+		`{k8s_app="api-notifications-chat",k8s_container_name="notificationgo-chat"}`,
+		lt.ToVL,
+		nil,
+		logsql.Capabilities{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, `"k8s.container.name":=`) {
+		t.Errorf("output missing dotted OTel field; got %q", got)
+	}
+}

--- a/internal/translator/labels_translate_test.go
+++ b/internal/translator/labels_translate_test.go
@@ -210,6 +210,23 @@ func TestTranslateLogQLWithLabels_NilFn(t *testing.T) {
 	}
 }
 
+func TestTranslation_UnderscoreLabelPreservedWhenTranslateOTelDisabled(t *testing.T) {
+	labelFn := func(label string) string {
+		return label
+	}
+
+	got, err := TranslateLogQLWithCapabilities(`{k8s_container_name="notificationgo-chat"}`, labelFn, nil, logsql.Capabilities{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, `k8s_container_name:=`) {
+		t.Errorf("output missing k8s_container_name:=; got %q", got)
+	}
+	if strings.Contains(got, `"k8s.container.name":=`) {
+		t.Errorf("output unexpectedly contains dotted OTel field; got %q", got)
+	}
+}
+
 func TestTranslateSingleLabelFilter_DottedTripletKeyOperatorValue(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This is my first PR to an OSS project, so feel free to roast me if I've done anything wrong. I've tried to add as much details as posible so you (who has all the knowledge of it) can see clearly what my changes do. I started working on this 2h after you deployed 1.51 and by the end of the day you did already relased the 1.52, so let me know if I need to pull and adapt anything to the 1.52

## Summary

Add a -translate-otel-attributes CLI flag (default: true) that, when set to false, disables the OTel semantic convention underscore→dot rewrite in the LogQL→LogsQL translator's ToVL() method. This allows deployments storing OTel attributes with underscores (Vector/Promtail/Fluent-bit via Elasticsearch bulk ingest) to query VictoriaLogs using the original field names.

Also fix LearnFieldAliases() to unconditionally skip known OTel entries, preventing runtime-learned aliases from recreating the dotted mapping that ToVL() intentionally avoids when the flag is disabled.

fix: wire translateOTel through buildProxyConfig to proxy.Config

The proxyRuntimeConfig.translateOTel field was populated from the CLI flag but never assigned to proxy.Config.TranslateOTel in buildProxyConfig(), making the flag invisible to the LabelTranslator.

test: add 13 TDD tests for -translate-otel-attributes flag behavior

### Example

A LogQL query like:

```logql
{k8s_app="api-notifications", k8s_container_name="notificationgo"}
```

Gets translated to:

```logsql
k8s_app:="api-notifications" "k8s.container.name":="notificationgo"
```

`k8s_app` passes through unchanged (not in the OTel semconv map), but `k8s_container_name` is rewritten to `"k8s.container.name"` — its OTel dotted equivalent.

### Why this breaks things

Deployments where Vector, Promtail, or Fluent-bit ingest logs into VictoriaLogs via the Elasticsearch bulk endpoint store labels with **underscores** (e.g., `k8s_container_name`), not dots. The rewritten field name `k8s.container.name` does not exist in storage, so VictoriaLogs returns zero rows. The proxy forwards the empty response with HTTP 200, so Grafana shows a working datasource that "returns no logs."

This is a regression from v1.31.3, where multi-label queries using underscore field names returned the expected rows.

### Why existing flags don't help

The `-label-style` and `-metadata-field-mode` flags control the **response direction** (VL → Loki / Grafana) — how field names are presented back to the client. They do not affect the **query direction** (Loki → VL), where the `knownUnderscoreToDot` mapping in `LabelTranslator.ToVL()` unconditionally rewrites known OTel labels before sending the query upstream.

### Root cause

`LabelTranslator.ToVL()` in `internal/proxy/labels.go` checks a hardcoded `knownUnderscoreToDot` map (45 entries covering OTel resource, Kubernetes, cloud, host, process, OS, log, network, and container attributes). When `LabelStyleUnderscores` is active (the default since v1.36.0), any underscore label matching this map gets rewritten to its dotted OTel form — with no opt-out.

Additionally, `LearnFieldAliases()` (the runtime field inventory learning path) unconditionally skips entries already in `knownUnderscoreToDot` (line 185-186), preventing the proxy from adapting to storage that uses underscore field names even when the backend field inventory confirms the underscore form exists.

Finally, the `proxyRuntimeConfig.translateOTel` field was populated from the CLI flag but never wired through to `proxy.Config.TranslateOTel` — a one-line gap in `buildProxyConfig` that made the flag invisible to the proxy.

## Changelog (Required)

### Added
- `-translate-otel-attributes` flag (default: `true`). Set to `false` to preserve client label names verbatim in upstream queries, disabling the OTel semantic convention underscore→dot rewrite. This resolves an issue where deployments storing OTel attributes with underscores (e.g., Vector → VL via `/insert/elasticsearch/_bulk`) received empty query results for multi-label queries containing known OTel names like `k8s_container_name`.

### Fixed
- `LearnFieldAliases()` now allows runtime-learned field aliases to override hardcoded OTel mappings when `-translate-otel-attributes=false`. Previously, known OTel entries were always skipped, preventing the proxy from adapting to storage that uses underscore field names.

## Validation

### Environment

| Item | Value |
|------|-------|
| Go version | 1.26.3 |
| Platform | linux/amd64 |
| golangci-lint | v2.10.0 |

### Checks

| Check | Command | Result |
|-------|---------|--------|
| Formatting | `gofmt -l` on all changed `.go` files | ✅ Clean |
| Static analysis | `go vet ./...` | ✅ No issues |
| Linter | `golangci-lint run ./...` | ✅ 0 issues |
| Race detector | `go test ./... -race -count=1` | ✅ 4046 passed |
| Build | `go build ./cmd/proxy/...` | ✅ Success |
| New tests (flag-specific) | `go test ./internal/proxy/... -run "TestToVL_TranslateOTel\|TestQueryTranslation_TranslateOTel\|TestLearnFieldAliases_TranslateOTel\|TestToVL_K8sContainerName"` | ✅ 12 passed |
| Translator parity | `go test ./internal/translator/...` | ✅ All existing parity tests pass |

### Deployed verification

Deployed to an AKS cluster (Grafana 13.0.1, VictoriaLogs v1.50.0, Vector ingest via Elasticsearch bulk endpoint). Confirmed that with `-translate-otel-attributes=false`, multi-label queries containing `k8s_container_name` are translated to the underscore form in upstream LogsQL and return results correctly. Tested on a real `api-notifications-chat` / `notificationgo-chat` workload that was previously returning empty results.

### Full output

```
$ go vet ./...
PASS

$ gofmt -l internal/proxy/labels.go internal/proxy/proxy.go cmd/proxy/main.go \
  internal/proxy/labels_test.go internal/translator/labels_translate_test.go \
  internal/proxy/query_translation_test.go
CLEAN (no formatting issues)

$ golangci-lint run ./...
0 issues.

$ go test ./... -race -count=1
ok  	github.com/ReliablyObserve/Loki-VL-proxy/cmd/proxy	7.022s
ok  	github.com/ReliablyObserve/Loki-VL-proxy/internal/logql	3.395s
ok  	github.com/ReliablyObserve/Loki-VL-proxy/internal/metrics	2.450s
ok  	github.com/ReliablyObserve/Loki-VL-proxy/internal/proxy	13.306s
ok  	github.com/ReliablyObserve/Loki-VL-proxy/internal/translator	2.641s
... (14 packages, 4046 passed, 0 failed)

$ go build ./cmd/proxy/...
SUCCESS
```