### PR TITLE
fix(e2e): warm filtered label_values cache for Grafana resource subtests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- `test/e2e-compat`: warm the proxy's filtered label_values cache
+  (`/loki/api/v1/label/<X>/values?query={...}`) in `ensureDataIngested`
+  before the drilldown tests run. The proxy keeps THREE separate label
+  caches — unfiltered values, the `/labels` LIST, and filtered values —
+  and only the first two were being warmed. On hosted CI runners the
+  filtered cache stayed empty for 30–60 s after the unfiltered cache was
+  already hot, which flaked five Grafana resource subtests with
+  `data:[]` responses (`additional_label_values`,
+  `label_values_honor_limit`, `label_filters_apply_to_resource_values`,
+  `multi_tenant_resources_respect___tenant_id___filters`, and
+  `TestDrilldown_RuntimeFamilyContracts`). New `waitForProxyFilteredLabelValues`
+  helper polls the filtered endpoint with a 60 s timeout for the two
+  stream selectors the failing subtests exercise; total setup budget
+  stays well under the 300 s test-suite timeout.
+
 ## [1.55.2] - 2026-06-06
 
 ### CI

--- a/test/e2e-compat/compat_extended_test.go
+++ b/test/e2e-compat/compat_extended_test.go
@@ -53,6 +53,20 @@ func ensureDataIngested(t *testing.T) {
 		// labels_resource_supports_additional_tabs subtest, both of which
 		// don't call waitForProxyLabels themselves) sees a populated /labels.
 		waitForProxyLabelsContain(t, "cluster", 90*time.Second)
+		// /label/<X>/values WITH a stream-selector query parameter goes through
+		// yet another proxy cache (different from the unfiltered one warmed
+		// above by waitForProxyLabelValues and different from the /labels
+		// index warmed by waitForProxyLabelsContain). Drilldown's resource
+		// API (`.../resources/label/<X>/values?query={service_name=...}`)
+		// flows through this filtered path. Without an explicit warm-up the
+		// CI run sees an empty `{"data":[]}` from the proxy for ~30–60 s
+		// even though the unfiltered cache and /labels list are already hot,
+		// which flakes additional_label_values, label_values_honor_limit,
+		// label_filters_apply_to_resource_values,
+		// multi_tenant_resources_respect___tenant_id___filters and
+		// TestDrilldown_RuntimeFamilyContracts.
+		waitForProxyFilteredLabelValues(t, "cluster", `{service_name="api-gateway"}`, "us-east-1", 60*time.Second)
+		waitForProxyFilteredLabelValues(t, "namespace", `{service_name="api-gateway",cluster="us-east-1"}`, "prod", 60*time.Second)
 	})
 }
 
@@ -103,6 +117,46 @@ func waitForProxyLabelValues(t *testing.T, label, expectedValue string) {
 		time.Sleep(500 * time.Millisecond)
 	}
 	t.Logf("warning: proxy label_values for %s did not include %q after 90 s — label-values tests may flake", label, expectedValue)
+}
+
+// waitForProxyFilteredLabelValues polls /loki/api/v1/label/<name>/values WITH
+// a query=<stream-selector> parameter until expectedValue appears, or the
+// timeout elapses. The proxy keeps a separate cache for filtered label_values
+// (one keyed by name+selector) from the unfiltered cache warmed above by
+// waitForProxyLabelValues, and from the labels-LIST cache warmed by
+// waitForProxyLabelsContain. On hosted CI runners the filtered cache can
+// stay empty for 30–60 s after the unfiltered one is already hot — that's
+// what flakes the Grafana resource subtests
+// (additional_label_values, label_values_honor_limit,
+// label_filters_apply_to_resource_values,
+// multi_tenant_resources_respect___tenant_id___filters, and
+// TestDrilldown_RuntimeFamilyContracts), all of which hit the Grafana
+// `/resources/label/<X>/values?query={...}` resource that the proxy serves
+// from this exact filtered code path.
+//
+// Returns silently on success or timeout (timeout logs a warning, downstream
+// assertions then surface the real expectation failure with their original
+// message).
+func waitForProxyFilteredLabelValues(t *testing.T, label, streamSelector, expectedValue string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		now := time.Now()
+		params := url.Values{}
+		params.Set("query", streamSelector)
+		params.Set("start", fmt.Sprintf("%d", now.Add(-1*time.Hour).UnixNano()))
+		params.Set("end", fmt.Sprintf("%d", now.UnixNano()))
+		status, _, resp := doJSONGET(t, proxyURL+"/loki/api/v1/label/"+label+"/values?"+params.Encode(), nil)
+		if status == http.StatusOK {
+			for _, v := range extractStringArray(resp, "data") {
+				if v == expectedValue {
+					return
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Logf("warning: proxy filtered label_values for %s/%s did not include %q after %s — drilldown resource tests may flake", label, streamSelector, expectedValue, timeout)
 }
 
 // waitForProxyLabelsContain polls /loki/api/v1/labels until expectedLabel


### PR DESCRIPTION
  ## Summary

  Fixes the chronic `e2e-compat (drilldown)` failures on `main` after PR #426 squash-merged — the filtered-label-values cache was never warmed. Unblocks the stuck `publish-release` workflow.

  ## Root cause

  The proxy keeps THREE separate label caches:
  1. `/label/<X>/values` (unfiltered) — warmed by `waitForProxyLabelValues`
  2. `/labels` (label-LIST) — warmed by `waitForProxyLabelsContain` (added in #426)
  3. `/label/<X>/values?query={...}` (filtered) — never warmed ← this PR

  Grafana's `/api/datasources/uid/.../resources/label/<X>/values?query={...}` resource flows through cache #3. On hosted CI cache #3 stays empty for 30–60 s after caches #1 and #2 are already hot, so the subtests
  below fail in ~0.0 s with `{"data":[]}`.

  ## Failures fixed

  - `additional_label_values` (line 504)
  - `label_values_honor_limit` (line 606)
  - `label_filters_apply_to_resource_values` (line 619)
  - `multi_tenant_resources_respect___tenant_id___filters` (line 907)
  - `TestDrilldown_RuntimeFamilyContracts` (line 1281)

  ## Test plan

  - [x] Local cold-proxy reproduction of the full CI drilldown group regex: all 5 subtests PASS plus the rest of the group
  - [x] Setup budget under the 300 s suite timeout (2 × 60 s waits, vs 90 s in the earlier rejected attempt)
  - [ ] CI green on `e2e-compat (drilldown)`