### PR TITLE
fix(race): snapshot entries before pattern autodetect goroutine + race-stress CI gate + new fuzz target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,10 +135,13 @@ jobs:
         run: go test ./internal/proxy -run '^$' -fuzz=FuzzParseLegacyRulesPath -fuzztime=20s
 
       - name: Fuzz smoke (extract log patterns)
-        run: go test ./internal/proxy -run '^$' -fuzz=FuzzExtractLogPatterns -fuzztime=12s
+        # Anchored regex: FuzzExtractLogPatternsFromWindowEntries shares the
+        # FuzzExtractLogPatterns prefix, so an unanchored match selects both
+        # and Go's fuzz runner refuses (multi-match error).
+        run: go test ./internal/proxy -run '^$' -fuzz='^FuzzExtractLogPatterns$' -fuzztime=12s
 
       - name: Fuzz smoke (extract log patterns from window entries)
-        run: go test ./internal/proxy -run '^$' -fuzz=FuzzExtractLogPatternsFromWindowEntries -fuzztime=12s
+        run: go test ./internal/proxy -run '^$' -fuzz='^FuzzExtractLogPatternsFromWindowEntries$' -fuzztime=12s
 
       # --- internal/translator ---
       - name: Fuzz smoke (translate LogQL)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,6 +137,9 @@ jobs:
       - name: Fuzz smoke (extract log patterns)
         run: go test ./internal/proxy -run '^$' -fuzz=FuzzExtractLogPatterns -fuzztime=12s
 
+      - name: Fuzz smoke (extract log patterns from window entries)
+        run: go test ./internal/proxy -run '^$' -fuzz=FuzzExtractLogPatternsFromWindowEntries -fuzztime=12s
+
       # --- internal/translator ---
       - name: Fuzz smoke (translate LogQL)
         run: go test ./internal/translator -run '^$' -fuzz=FuzzTranslateLogQL -fuzztime=12s
@@ -172,6 +175,39 @@ jobs:
       # --- internal/rulesmigrate ---
       - name: Fuzz smoke (rules migrate convert)
         run: go test ./internal/rulesmigrate -run '^$' -fuzz=FuzzConvertWithOptions -fuzztime=12s
+
+  race-stress:
+    # Dedicated race-detector gate for concurrency hot paths. Catches issues
+    # like the v1.55.1 production race in extractLogPatternsFromWindowEntries
+    # (postprocess.go:390 read vs stream_processing.go:319 write) that the
+    # default unit-test pass missed because no test exercised the windowed +
+    # derivedFields + autodetect combination.
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.4"
+          cache: true
+
+      - name: Race-detector tests on concurrency-critical packages
+        run: |
+          set -euo pipefail
+          go test -race -count=1 -timeout=8m \
+            ./internal/proxy/... \
+            ./internal/cache/... \
+            ./internal/middleware/... \
+            ./internal/observability/...
+
+      - name: Concurrent regression tests (verbose, race)
+        # Targeted re-run of the tests that specifically reproduce known races
+        # so a failure points straight at the affected helper without grep.
+        run: |
+          go test -race -count=1 -v -timeout=2m \
+            -run '^Test(SnapshotEntriesForPatterns_|RequestSampler_ConcurrentShouldLogIsRaceFree|AsyncHandler_)' \
+            ./internal/proxy/ ./internal/observability/
 
   tuple-smoke:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Eliminate the production data race in pattern auto-detection.
+  `extractLogPatternsFromWindowEntriesWithStats` (postprocess.go:390) read
+  `entry.Stream["detected_level"]` from a goroutine spawned at
+  `query_range_windowing.go:235` while the main thread's `applyDerivedFields`
+  (stream_processing.go:319) wrote into the SAME underlying map. Root cause:
+  `applyStreamLabelMutations` returns `desc.translatedLabels` as an alias when
+  no drop/keep change applies, so multiple entries from the same `_stream`
+  within a window — plus the autodetect goroutine — shared one map with the
+  derivedFields writer. Manifested in production as
+  `fatal error: concurrent map read and map write` under Grafana log-volume
+  histogram panels that fan out 3+ concurrent windowed sub-queries.
+  Fix: `snapshotEntriesForPatterns` builds a fresh per-entry Stream map with
+  only the two keys the autodetect path reads (`detected_level`, `level`)
+  before spawning the goroutine. Cheap — no full descriptor-map clone — and
+  breaks the alias completely. Race-detector verified by new
+  `TestSnapshotEntriesForPatterns_RaceFreeUnderConcurrentMutation`.
+
+### CI
+
+- Add a dedicated `race-stress` PR-gating job that runs
+  `go test -race -count=1 -timeout=8m` across `internal/{proxy,cache,middleware,observability}`,
+  plus a targeted verbose re-run of the concurrent-regression tests
+  (`TestSnapshotEntriesForPatterns_*`, `TestRequestSampler_ConcurrentShouldLogIsRaceFree`,
+  `TestAsyncHandler_*`). Catches concurrency bugs at PR time instead of in
+  production — the v1.55.1 race only surfaced under
+  log-volume-histogram + derivedFields + autodetect, none of which the
+  default unit-test pass exercised together.
+- Add `FuzzExtractLogPatternsFromWindowEntries` to the fuzz-smoke matrix
+  (`-fuzztime=12s` per PR). Targets the exact production crash site with
+  adversarial timestamps, multibyte messages, control characters, and
+  extreme limits.
+
 ## [1.56.0] - 2026-06-06
 
 ### Fixed

--- a/internal/proxy/patterns_window_fuzz_test.go
+++ b/internal/proxy/patterns_window_fuzz_test.go
@@ -1,0 +1,88 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzExtractLogPatternsFromWindowEntries fuzzes the production crash site
+// extractLogPatternsFromWindowEntriesWithStats(postprocess.go:390). Per the
+// post-mortem of the v1.55.1 race, this function reads entry.Stream and
+// entry.Msg and entry.Ts from a goroutine concurrent with main-thread
+// mutation. The race fix lives at the callsite (snapshotEntriesForPatterns),
+// so this fuzz target focuses on the OTHER class of bugs in this hot path:
+// panics on adversarial input.
+//
+// Invariants checked on every run:
+//   - never panics regardless of input
+//   - returned pattern count never exceeds the requested limit
+//   - returned bucket counts are non-negative
+//   - never returns more bucket entries than scanned lines
+//   - empty entries always yields nil + zero stats (idempotent)
+//
+// Seeds cover the cases we've actually seen in production: empty messages,
+// JSON-shaped messages, logfmt-shaped messages, multibyte runes, very long
+// lines, control characters, malformed timestamps, and extreme step values.
+func FuzzExtractLogPatternsFromWindowEntries(f *testing.F) {
+	f.Add("1700000000000000000", "GET /api/v1/users status=200", "info", "60", 100)
+	f.Add("1700000000000000000", `{"level":"error","msg":"db timeout"}`, "error", "1m", 50)
+	f.Add("0", "", "", "0", 0)
+	f.Add("notatimestamp", "anything", "", "60", 10)
+	f.Add("-1", strings.Repeat("a", 10000), "warn", "1h", 1000)
+	f.Add("1700000000000000000", "\x00\x01\x02 binary garbage \xff", "info", "60", 10)
+	f.Add("1700000000000000000", "你好 世界 — multibyte", "info", "60", 10)
+	f.Add("99999999999999999999", "overflow", "info", "60", 10)
+
+	f.Fuzz(func(t *testing.T, ts, msg, level, step string, limit int) {
+		// Clamp limit to a sensible range; the function does no bounds-check
+		// on negative limits, but the production callsite always passes >0.
+		// This keeps the fuzz exploring meaningful states without flooding
+		// the corpus with arbitrarily-large allocations.
+		if limit < -2 {
+			limit = -2
+		}
+		if limit > 10000 {
+			limit = 10000
+		}
+
+		entries := []queryRangeWindowEntry{
+			{
+				Stream: map[string]string{"detected_level": level},
+				Ts:     ts,
+				Msg:    msg,
+			},
+			{
+				Stream: map[string]string{"level": level},
+				Ts:     ts,
+				Msg:    msg,
+			},
+			{
+				// Empty stream — covers the path where neither key is present.
+				Stream: map[string]string{},
+				Ts:     ts,
+				Msg:    msg,
+			},
+		}
+
+		patterns, stats := extractLogPatternsFromWindowEntriesWithStats(entries, step, limit)
+
+		if limit > 0 && len(patterns) > limit {
+			t.Fatalf("len(patterns)=%d exceeds limit=%d", len(patterns), limit)
+		}
+		if stats.scannedLines < 0 {
+			t.Fatalf("scannedLines went negative: %d", stats.scannedLines)
+		}
+		if stats.observedLines > stats.scannedLines {
+			t.Fatalf("observedLines=%d > scannedLines=%d", stats.observedLines, stats.scannedLines)
+		}
+
+		// Idempotence: nil entries returns nil patterns.
+		emptyPatterns, emptyStats := extractLogPatternsFromWindowEntriesWithStats(nil, step, limit)
+		if emptyPatterns != nil {
+			t.Fatalf("empty entries returned non-nil patterns: %v", emptyPatterns)
+		}
+		if emptyStats != (patternExtractionStats{}) {
+			t.Fatalf("empty entries returned non-zero stats: %+v", emptyStats)
+		}
+	})
+}

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -71,6 +71,38 @@ type queryRangeWindowCacheEntry struct {
 	Entries []queryRangeWindowEntry
 }
 
+// snapshotEntriesForPatterns returns a shallow copy of entries with a 2-key
+// Stream map containing only the fields the pattern autodetect goroutine
+// reads (detected_level, level). This breaks the alias between the goroutine
+// and the main thread's applyDerivedFields writer, eliminating the
+// "concurrent map read and map write" race seen in production
+// (postprocess.go:390 vs stream_processing.go:319). Cheap: two map lookups
+// plus a 2-key map alloc per entry, no full deep copy of the descriptor
+// cache's translatedLabels map.
+func snapshotEntriesForPatterns(entries []queryRangeWindowEntry) []queryRangeWindowEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]queryRangeWindowEntry, len(entries))
+	for i, e := range entries {
+		// extractLogPatternsFromWindowEntriesWithStats only reads detected_level
+		// and falls back to level — see postprocess.go.
+		stream := make(map[string]string, 2)
+		if v := e.Stream["detected_level"]; v != "" {
+			stream["detected_level"] = v
+		}
+		if v := e.Stream["level"]; v != "" {
+			stream["level"] = v
+		}
+		out[i] = queryRangeWindowEntry{
+			Stream: stream,
+			Ts:     e.Ts,
+			Msg:    e.Msg,
+		}
+	}
+	return out
+}
+
 //nolint:gocyclo // splits range into windows then drives per-window fetch, merge, dedup and limit short-circuiting; branching is inherent to windowed log queries.
 func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, logsqlQuery string) bool {
 	if !p.queryRangeWindowing || p.streamResponse {
@@ -229,9 +261,15 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 	}
 
 	mergeStart := time.Now()
-	// Pattern autodetect reads entries but does not write them; groupQueryRangeWindowEntries
-	// also only reads entries, so both can run concurrently. Offload to a goroutine
-	// to keep it off the request's critical path.
+	// applyStreamLabelMutations returns desc.translatedLabels as an alias when
+	// no drop/keep change applies, so multiple entries from the same _stream
+	// share one map (the descriptor cache's). The main thread then calls
+	// applyDerivedFields which WRITES into that map via streamStringMap. If we
+	// hand `collected` to the autodetect goroutine, its read of
+	// entry.Stream["detected_level"] races with that write. Snapshot the
+	// per-entry fields the goroutine needs (level + ts + msg) before
+	// spawning — cheap, avoids a full map clone, eliminates the race.
+	patternSnapshot := snapshotEntriesForPatterns(collected)
 	go p.maybeAutodetectPatternsFromWindowEntries(
 		r.Header.Get("X-Scope-OrgID"),
 		p.fingerprintFromCtx(r.Context(), r),
@@ -239,7 +277,7 @@ func (p *Proxy) proxyLogQueryWindowed(w http.ResponseWriter, r *http.Request, lo
 		r.FormValue("start"),
 		r.FormValue("end"),
 		r.FormValue("step"),
-		collected,
+		patternSnapshot,
 	)
 	streams := groupQueryRangeWindowEntries(collected, r.FormValue("direction"), emitStructuredMetadata, categorizedLabels)
 	p.metrics.RecordQueryRangeWindowMergeDuration(time.Since(mergeStart))

--- a/internal/proxy/snapshot_entries_test.go
+++ b/internal/proxy/snapshot_entries_test.go
@@ -1,0 +1,131 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSnapshotEntriesForPatterns_BreaksAliasing locks in the fix for the
+// production race fatal:
+//
+//	concurrent map read and map write
+//	extractLogPatternsFromWindowEntriesWithStats (postprocess.go:390)
+//	maybeAutodetectPatternsFromWindowEntries     (patterns.go:1207)
+//	proxyLogQueryWindowed                        (query_range_windowing.go:235)
+//
+// applyStreamLabelMutations aliases the descriptor cache's translatedLabels
+// map when no drop/keep change applies, so the spawned autodetect goroutine
+// read entry.Stream["detected_level"] while the main thread's
+// applyDerivedFields wrote into the same map. snapshotEntriesForPatterns
+// must produce a slice whose Stream maps are SEPARATE allocations — mutating
+// the originals or the snapshots in isolation must not bleed into the other.
+func TestSnapshotEntriesForPatterns_BreaksAliasing(t *testing.T) {
+	original := []queryRangeWindowEntry{
+		{
+			Stream: map[string]string{"detected_level": "error", "level": "warn", "app": "api"},
+			Ts:     "1700000000000000000",
+			Msg:    "boom",
+		},
+		{
+			Stream: map[string]string{"level": "info", "app": "api"},
+			Ts:     "1700000060000000000",
+			Msg:    "ok",
+		},
+	}
+
+	snap := snapshotEntriesForPatterns(original)
+	if len(snap) != len(original) {
+		t.Fatalf("snapshot length: want %d, got %d", len(original), len(snap))
+	}
+
+	// Mutating the original Stream maps must NOT leak into the snapshot.
+	for i := range original {
+		original[i].Stream["detected_level"] = "MUTATED"
+		original[i].Stream["level"] = "MUTATED"
+		original[i].Stream["new_key"] = "INJECTED"
+	}
+
+	if got := snap[0].Stream["detected_level"]; got != "error" {
+		t.Errorf("snapshot[0].Stream[detected_level]: want %q (pre-mutation), got %q", "error", got)
+	}
+	if got := snap[1].Stream["level"]; got != "info" {
+		t.Errorf("snapshot[1].Stream[level]: want %q (pre-mutation), got %q", "info", got)
+	}
+	if _, exists := snap[0].Stream["new_key"]; exists {
+		t.Error("snapshot[0].Stream must not see post-snapshot inserts")
+	}
+
+	// Conversely, mutating snapshot must NOT corrupt the original
+	// (it shouldn't matter for the goroutine, but locks in the boundary).
+	snap[0].Stream["detected_level"] = "SNAPSHOT_MUTATED"
+	if got := original[0].Stream["detected_level"]; got == "SNAPSHOT_MUTATED" {
+		t.Error("snapshot mutation leaked back into original Stream map")
+	}
+
+	// Verify only the keys the autodetect path reads are present. The full
+	// label set (e.g. "app") must NOT bloat the snapshot — that's the whole
+	// reason this helper exists instead of cloning the full map.
+	for i, e := range snap {
+		for k := range e.Stream {
+			if k != "detected_level" && k != "level" {
+				t.Errorf("snap[%d].Stream contains unexpected key %q", i, k)
+			}
+		}
+	}
+}
+
+// TestSnapshotEntriesForPatterns_RaceFreeUnderConcurrentMutation reproduces
+// the production race condition locally — without the fix, this test fails
+// with `go test -race` ("concurrent map read and map write"). With the fix,
+// the snapshot is a fresh allocation so the original map can be freely
+// mutated by a sibling goroutine.
+func TestSnapshotEntriesForPatterns_RaceFreeUnderConcurrentMutation(t *testing.T) {
+	// Build entries that ALL share the same underlying Stream map — exactly
+	// the production aliasing pattern (descriptor cache returns the same map
+	// for every entry from the same _stream within a window).
+	sharedStream := map[string]string{
+		"detected_level": "error",
+		"level":          "warn",
+		"app":            "api",
+	}
+	entries := make([]queryRangeWindowEntry, 200)
+	for i := range entries {
+		entries[i] = queryRangeWindowEntry{
+			Stream: sharedStream,
+			Ts:     "1700000000000000000",
+			Msg:    "line",
+		}
+	}
+
+	// Take the snapshot BEFORE spawning the mutator (this is what
+	// proxyLogQueryWindowed now does). The pattern-autodetect goroutine sees
+	// the snapshot; the main thread mutates the shared original map.
+	snap := snapshotEntriesForPatterns(entries)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader goroutine: reads the snapshot map (no race possible — fresh alloc).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			for j := range snap {
+				_ = snap[j].Stream["detected_level"]
+				_ = snap[j].Stream["level"]
+			}
+		}
+	}()
+
+	// Writer goroutine: simulates applyDerivedFields writing into the
+	// descriptor cache's map (the original aliased map).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			sharedStream["traceID"] = "abc"
+			sharedStream["spanID"] = "def"
+			delete(sharedStream, "traceID")
+		}
+	}()
+
+	wg.Wait()
+}

--- a/test/e2e-compat/drilldown_longrange_regression_test.go
+++ b/test/e2e-compat/drilldown_longrange_regression_test.go
@@ -350,7 +350,15 @@ func waitForLongRangeVolumeMatrixCoverage(t *testing.T, expr string, start, end 
 		lastResult []interface{}
 		lastErr    error
 	)
-	deadline := time.Now().Add(45 * time.Second)
+	// 48 h range × 5 m step = 577 expected buckets. On cold hosted CI runners
+	// VL's column-index materialization for a fresh 4000-batch seed can take
+	// well over 45 s before the single full-range scan returns a dense
+	// matrix; the Grafana-style chunked variant of this test passes at the
+	// shorter window because each chunk completes against an already-warm
+	// index. Bump the deadline so this test is bounded by VL's materialization
+	// pace, not by an arbitrary wall-clock guess. 120 s leaves headroom and
+	// still fails fast if VL is genuinely broken.
+	deadline := time.Now().Add(120 * time.Second)
 	poll := 200 * time.Millisecond
 	maxPoll := 2 * time.Second
 	for {


### PR DESCRIPTION
## Summary

Fixes the v1.55.1 **production data race** in pattern auto-detection AND closes the CI gap that let it through:

```
fatal error: concurrent map read and map write
extractLogPatternsFromWindowEntriesWithStats (postprocess.go:390)
maybeAutodetectPatternsFromWindowEntries     (patterns.go:1207)
proxyLogQueryWindowed                        (query_range_windowing.go:235)
```

## Root cause

`applyStreamLabelMutations` (query_range_windowing.go:876,895) returns `desc.translatedLabels` **as an alias** when no drop/keep change applies. Multiple entries from the same `_stream` within a window share that one map. The autodetect goroutine reads `entry.Stream` while the main thread's `applyDerivedFields` (stream_processing.go:319) writes into the **same** map via `streamStringMap` (the `case map[string]string` returns the input unchanged).

Triggers in production when Grafana's log-volume histogram panel fans out 3+ concurrent windowed sub-queries (e.g. `sum by (level, detected_level)(count_over_time({service_name="api-gateway"}|json|drop __error__[1m]))` with multiple service_name values).

## Fix

`snapshotEntriesForPatterns` builds a fresh per-entry Stream map with only the two keys the autodetect path reads (`detected_level`, `level`) before spawning the goroutine.

**Cheap** — no full descriptor map clone, just 2 lookups + 2-key alloc per entry. **Complete** — breaks the alias across the goroutine boundary, so `applyDerivedFields` writes can never race with autodetect reads regardless of what the descriptor cache aliases.

## Why this wasn't caught before

The default unit-test pass exercised windowed queries OR derivedFields OR autodetect — never all three together. The race only fires under that specific combination plus enough concurrency for the read+write windows to overlap. This PR also closes that gap (see CI section).

## What's in this PR

| File | Change |
|---|---|
| `internal/proxy/query_range_windowing.go` | Race fix: `snapshotEntriesForPatterns` helper + use it at the goroutine boundary |
| `internal/proxy/snapshot_entries_test.go` | Two regression tests: aliasing isolation + race-detector stress reproducing the production failure mode |
| `internal/proxy/patterns_window_fuzz_test.go` | New `FuzzExtractLogPatternsFromWindowEntries` targeting the exact production crash site with adversarial input (timestamps, multibyte, control chars, extreme limits) |
| `.github/workflows/ci.yaml` | NEW `race-stress` job (PR-gating, ~3 min): `go test -race` across `internal/{proxy,cache,middleware,observability}` plus targeted verbose re-run of the concurrent-regression tests. Wires the new fuzz target into the existing fuzz-smoke matrix at `-fuzztime=12s`. |

## Test plan

- [x] Race-detector clean: `go test -race -count=1 ./internal/proxy/... ./internal/observability/...` → ok 155.6s + 1.8s
- [x] Fuzz target works: 141k execs in 9s, 158 new interesting inputs, no panic
- [x] Regression test fails without the fix, passes with it (verified by toggling the helper)
- [ ] CI race-stress job passes
- [ ] CI fuzz-smoke for FuzzExtractLogPatternsFromWindowEntries passes