### PR TITLE
fix: code-review findings — query-param leak, over-broad residual/hits suppression, helm metrics reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Upstream transport errors no longer leak query parameters.** Go's `http.Client` surfaces dial / TLS / timeout failures as a `*url.Error` whose message embeds the full backend URL — including the LogQL/LogsQL query — so those errors could leak query content (potentially sensitive log selectors) into error logs and handler error responses, even though the debug *request* log already redacts the query. Transport errors are now passed through `sanitizeUpstreamError`, which redacts the URL query while preserving the underlying cause (status mapping and the circuit breaker still classify correctly). No-op under `-debug-log-raw-queries=true`.
+
+### Fixed
+
+- **Grafana querySplitting residual suppression no longer blanks legitimate short-range queries.** The 24h+ split residual-chunk suppression triggered for any Grafana-sourced request with `range <= 2*step`, which could silently return an empty matrix for normal Explore/dashboard queries with a short range or a coarse step. It is now scoped to a true sub-step residual (`range < step`, i.e. less than one full bucket); a query spanning at least one step is served normally.
+- **High-cardinality `count() by(field)` window-sampling is now scoped to Grafana requests.** The window-sampled `/select/logsql/hits` path returns per-window-sampled top-N series rather than exact `stats_query_range` results — correct for rendering a Grafana chart, but the wrong default for a direct API client. It is now gated on `isGrafanaSourcedRequest`; non-Grafana callers get the exact direct path (bounded to `max-stats-query-series` top-N-by-count, like Loki's `max_query_series`).
+- **Helm: metrics listener, Service, and ServiceMonitor can no longer render contradictory configs.** The deployment's metrics `containerPort` is now derived from `extraArgs.metrics-listen` (so the named Service/ServiceMonitor target always matches where `/metrics` actually serves), and the chart fails fast when `service.metrics.enabled=true` is combined with an empty `metrics-listen` or `server.register-instrumentation=false` (configs that previously rendered cleanly then failed startup or scraped a dead port).
+- **Helm: default NetworkPolicy now allows ServiceMonitor metrics scraping.** When `serviceMonitor.enabled=true`, the NetworkPolicy automatically opens the metrics port (derived from `metrics-listen`) for Prometheus — previously it only opened the proxy port 3100, so enabling the ServiceMonitor under the default NetworkPolicy silently timed out the `/metrics` scrape. Restrict the scrape source via the new `networkPolicy.monitoringFrom`.
+
 ## [1.58.0] - 2026-06-07
 
 ### Added

--- a/charts/loki-vl-proxy/templates/_helpers.tpl
+++ b/charts/loki-vl-proxy/templates/_helpers.tpl
@@ -214,3 +214,40 @@ The computed value is emitted as bytes.
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+loki-vl-proxy.metricsPort — the effective port /metrics is served on, derived
+from extraArgs.metrics-listen (the binary's dedicated metrics listener), e.g.
+":9091" or "0.0.0.0:9091" → 9091. Falls back to .Values.service.metrics.port.
+Deriving the deployment containerPort (and, through the named port, the Service
+targetPort and ServiceMonitor target) from one source keeps them in lock-step
+with where the proxy actually listens — see loki-vl-proxy.validateMetrics.
+*/}}
+{{- define "loki-vl-proxy.metricsPort" -}}
+{{- $listen := "" -}}
+{{- with .Values.extraArgs -}}{{- $listen = (index . "metrics-listen" | toString) -}}{{- end -}}
+{{- if and $listen (contains ":" $listen) -}}
+{{- splitList ":" $listen | last -}}
+{{- else -}}
+{{- .Values.service.metrics.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+loki-vl-proxy.validateMetrics — fail-fast on a metrics config that renders
+cleanly but is internally inconsistent: the Service/ServiceMonitor would target
+a metrics port the binary never serves, or the binary would refuse to start
+(cmd/proxy/main.go validateMetricsListen). Invoked from the deployment.
+*/}}
+{{- define "loki-vl-proxy.validateMetrics" -}}
+{{- if .Values.service.metrics.enabled -}}
+{{- $listen := "" -}}{{- with .Values.extraArgs -}}{{- $listen = (index . "metrics-listen" | toString) -}}{{- end -}}
+{{- $reg := "" -}}{{- with .Values.extraArgs -}}{{- $reg = (index . "server.register-instrumentation" | toString) -}}{{- end -}}
+{{- if not (trim $listen) -}}
+{{- fail "service.metrics.enabled=true requires extraArgs.metrics-listen (e.g. \":9091\") so /metrics is served on the dedicated metrics port the Service and ServiceMonitor target; set it, or disable service.metrics." -}}
+{{- end -}}
+{{- if eq $reg "false" -}}
+{{- fail "service.metrics.enabled=true requires extraArgs.\"server.register-instrumentation\"=true; otherwise the metrics listener only returns 404 and the proxy fails to start (validateMetricsListen)." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/loki-vl-proxy/templates/deployment.yaml
+++ b/charts/loki-vl-proxy/templates/deployment.yaml
@@ -9,6 +9,7 @@
 {{- if and .Values.peerCache.enabled (hasKey .Values.extraArgs "peer-auth-token") }}
 {{- fail "extraArgs.peer-auth-token cannot be combined with peerCache.enabled=true; chart manages the flag via peerCache.authToken / peerCache.existingSecret. Remove the extraArgs entry." }}
 {{- end }}
+{{- include "loki-vl-proxy.validateMetrics" . }}
 apiVersion: apps/v1
 kind: {{ include "loki-vl-proxy.workloadKind" . }}
 metadata:
@@ -278,7 +279,7 @@ spec:
             # or extraArgs.server.register-instrumentation=false) don't end up
             # with a stale named containerPort the Service can't reach.
             - name: metrics
-              containerPort: 9091
+              containerPort: {{ include "loki-vl-proxy.metricsPort" . | int }}
               protocol: TCP
             {{- end }}
           {{- if .Values.probe.liveness.enabled }}

--- a/charts/loki-vl-proxy/templates/networkpolicy.yaml
+++ b/charts/loki-vl-proxy/templates/networkpolicy.yaml
@@ -27,6 +27,27 @@ spec:
       ports:
         - port: 3100
           protocol: TCP
+    {{- if .Values.serviceMonitor.enabled }}
+    {{- /*
+      Allow Prometheus to scrape the dedicated metrics port. Without this,
+      enabling serviceMonitor under the default NetworkPolicy (which otherwise
+      only opens the proxy port 3100) silently times out the /metrics scrape on
+      the metrics port. Restrict the source with networkPolicy.monitoringFrom
+      (a list of NetworkPolicyPeer); when empty the port is open to all sources
+      since /metrics is non-sensitive read-only counters.
+    */}}
+    {{- if .Values.networkPolicy.monitoringFrom }}
+    - from:
+        {{- toYaml .Values.networkPolicy.monitoringFrom | nindent 8 }}
+      ports:
+        - port: {{ include "loki-vl-proxy.metricsPort" . | int }}
+          protocol: TCP
+    {{- else }}
+    - ports:
+        - port: {{ include "loki-vl-proxy.metricsPort" . | int }}
+          protocol: TCP
+    {{- end }}
+    {{- end }}
   {{- with .Values.networkPolicy.egress }}
   egress:
     {{- toYaml . | nindent 4 }}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -687,6 +687,16 @@ networkPolicy:
       ports:
         - port: 3100
           protocol: TCP
+  # When serviceMonitor.enabled=true the chart automatically opens the metrics
+  # port (derived from extraArgs.metrics-listen) for Prometheus scraping —
+  # otherwise the scrape would time out under this NetworkPolicy. Restrict the
+  # scrape source here (a list of NetworkPolicyPeer, e.g. a namespaceSelector for
+  # your monitoring namespace); leave empty to allow the metrics port from any
+  # source (it serves only non-sensitive read-only counters).
+  monitoringFrom: []
+  #  - namespaceSelector:
+  #      matchLabels:
+  #        kubernetes.io/metadata.name: monitoring
   # Allow egress to VictoriaLogs backend
   egress:
     - to: []

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -595,6 +595,7 @@ func (p *Proxy) vlGetInner(ctx context.Context, path string, params url.Values) 
 	duration := time.Since(start)
 	serverPort, _ := strconv.Atoi(u.Port())
 	if err != nil {
+		err = p.sanitizeUpstreamError(err)
 		mappedStatus := statusFromUpstreamErr(err)
 		p.recordUpstreamObservation(ctx, "vl", http.MethodGet, path, u.Hostname(), serverPort, mappedStatus, duration, err)
 		if shouldRecordBreakerFailure(err) {
@@ -612,6 +613,30 @@ func (p *Proxy) vlGetInner(ctx context.Context, path string, params url.Values) 
 	// Any completed HTTP response proves backend reachability; keep breaker for transport failures only.
 	p.breaker.RecordSuccess()
 	return resp, nil
+}
+
+// sanitizeUpstreamError redacts query parameters from a transport error before
+// it is logged or returned to a handler. Go's http.Client surfaces dial / TLS /
+// timeout failures as a *url.Error whose Error() embeds the full request URL —
+// including the LogQL / LogsQL query in RawQuery — so without this the query
+// content (which may carry sensitive log selectors) leaks into error logs and
+// handler error responses, even though the debug request log already redacts it.
+// The wrapped underlying error is preserved so statusFromUpstreamErr and breaker
+// classification still see the real cause. No-op under -debug-log-raw-queries.
+func (p *Proxy) sanitizeUpstreamError(err error) error {
+	if err == nil || p.debugLogRawQueries {
+		return err
+	}
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		redactedURL := ue.URL
+		if u, perr := url.Parse(ue.URL); perr == nil && u.RawQuery != "" {
+			u.RawQuery = "redacted"
+			redactedURL = u.String()
+		}
+		return &url.Error{Op: ue.Op, URL: redactedURL, Err: ue.Err}
+	}
+	return err
 }
 
 func (p *Proxy) vlGet(ctx context.Context, path string, params url.Values) (*http.Response, error) {
@@ -650,6 +675,7 @@ func (p *Proxy) vlPostHTTP(ctx context.Context, path string, params url.Values) 
 	duration := time.Since(start)
 	serverPort, _ := strconv.Atoi(u.Port())
 	if err != nil {
+		err = p.sanitizeUpstreamError(err)
 		mappedStatus := statusFromUpstreamErr(err)
 		p.recordUpstreamObservation(ctx, "vl", http.MethodPost, path, u.Hostname(), serverPort, mappedStatus, duration, err)
 		return nil, err

--- a/internal/proxy/drilldown_regression_lock_test.go
+++ b/internal/proxy/drilldown_regression_lock_test.go
@@ -279,7 +279,9 @@ func TestLock_HitsRunsForAllRanges(t *testing.T) {
 // requests with the same shape must NOT trigger suppression — a raw API
 // client querying 1m of data legitimately wants whatever VL has.
 func TestLock_LeftoverChunkSuppressed(t *testing.T) {
-	// step=120 → suppression fires for range ≤ 240s.
+	// step=120 → suppression fires ONLY for a sub-step residual (range < step,
+	// i.e. < 120s). A range of one full step or more is a legitimate >=1-bucket
+	// query and must NOT be blanked.
 	cases := []struct {
 		name         string
 		startSec     int64
@@ -288,15 +290,17 @@ func TestLock_LeftoverChunkSuppressed(t *testing.T) {
 		source       string
 		wantSuppress bool
 	}{
-		// Grafana sources, leftover-sized → SUPPRESS.
+		// Grafana sources, sub-step residual (range < step) → SUPPRESS.
 		{"drilldown_60s_step120", 1700000000, 1700000060, "120", "drilldown", true},
-		{"drilldown_240s_step120", 1700000000, 1700000240, "120", "drilldown", true},
+		{"drilldown_119s_step120", 1700000000, 1700000119, "120", "drilldown", true},
 		{"explore_via_ua_60s", 1700000000, 1700000060, "120", "grafana-ua", true},
 		{"explore_via_hdr_60s", 1700000000, 1700000060, "120", "grafana-hdr", true},
-		// Grafana source but range > 2*step → do NOT suppress.
+		// Grafana source, range >= step (legitimate >=1-bucket query) → do NOT suppress.
+		{"drilldown_120s_step120", 1700000000, 1700000120, "120", "drilldown", false},
+		{"drilldown_240s_step120", 1700000000, 1700000240, "120", "drilldown", false},
 		{"drilldown_300s_step120", 1700000000, 1700000300, "120", "drilldown", false},
 		{"drilldown_1h_step120", 1700000000, 1700003600, "120", "drilldown", false},
-		// Non-Grafana caller with leftover-sized range → do NOT suppress.
+		// Non-Grafana caller with sub-step range → do NOT suppress.
 		{"raw_caller_60s_step120", 1700000000, 1700000060, "120", "", false},
 	}
 	for _, tc := range cases {

--- a/internal/proxy/metric_binary.go
+++ b/internal/proxy/metric_binary.go
@@ -35,19 +35,13 @@ func (p *Proxy) proxyStatsQueryRange(w http.ResponseWriter, r *http.Request, log
 	// engages at >= 2h). Hoisting the suppression here covers every path. Gated on
 	// isGrafanaSourcedRequest so non-Grafana clients still get exact small-range
 	// results. See [[grafana-loki-querysplitting-24h]].
-	if isGrafanaSourcedRequest(r) {
-		if sNs, sok := parseLokiTimeToUnixNano(r.FormValue("start")); sok {
-			if eNs, eok := parseLokiTimeToUnixNano(r.FormValue("end")); eok {
-				if stepDur, stepOK := parsePositiveStepDuration(r.FormValue("step")); stepOK && stepDur > 0 && eNs-sNs <= 2*stepDur.Nanoseconds() {
-					w.Header().Set("Content-Type", "application/json")
-					// Same marker the /hits path uses — TestLock_LeftoverChunkSuppressed
-					// pins this exact value; both routes suppress the same residual.
-					w.Header().Set("X-Proxy-Drilldown-Path", "hits-leftover-suppressed")
-					_, _ = w.Write(emptyLokiMatrix)
-					return
-				}
-			}
-		}
+	if isQuerySplitLeftoverChunk(r, r.FormValue("start"), r.FormValue("end"), r.FormValue("step")) {
+		w.Header().Set("Content-Type", "application/json")
+		// Same marker the /hits path uses — TestLock_LeftoverChunkSuppressed
+		// pins this exact value; both routes suppress the same residual.
+		w.Header().Set("X-Proxy-Drilldown-Path", "hits-leftover-suppressed")
+		_, _ = w.Write(emptyLokiMatrix)
+		return
 	}
 
 	originalLogql := resolveGrafanaRangeTemplateTokens(r.FormValue("query"), r.FormValue("start"), r.FormValue("end"), r.FormValue("step"))
@@ -316,6 +310,30 @@ func isGrafanaDrilldownRequest(r *http.Request) bool {
 // the leftover-chunk suppression for legitimate small queries — so the gates
 // in callers also bound the suppression to range ≤ 2 × step, which is too
 // small to plausibly be a real user query at chunked-merge step sizes.
+// isQuerySplitLeftoverChunk reports whether (startRaw,endRaw,stepRaw) describe the
+// tiny trailing RESIDUAL chunk Grafana's querySplitting emits past the 24h day
+// boundary: a Grafana-sourced request whose range is SHORTER THAN ONE STEP, so it
+// yields a single right-edge bucket that mergeFrames glues onto the main chunk as
+// a spike. The detector is `range < step` (strictly sub-step): a legitimate query
+// spans at least one full step (>=1 bucket), so this no longer blanks normal
+// Explore/dashboard queries with a short range or a coarse step — the earlier
+// `<= 2*step` form did, silently returning empty for real 1-2 bucket queries.
+func isQuerySplitLeftoverChunk(r *http.Request, startRaw, endRaw, stepRaw string) bool {
+	if !isGrafanaSourcedRequest(r) {
+		return false
+	}
+	sNs, sok := parseLokiTimeToUnixNano(startRaw)
+	eNs, eok := parseLokiTimeToUnixNano(endRaw)
+	if !sok || !eok || eNs <= sNs {
+		return false
+	}
+	stepDur, stepOK := parsePositiveStepDuration(stepRaw)
+	if !stepOK || stepDur <= 0 {
+		return false
+	}
+	return eNs-sNs < stepDur.Nanoseconds()
+}
+
 func isGrafanaSourcedRequest(r *http.Request) bool {
 	if isGrafanaDrilldownRequest(r) {
 		return true
@@ -1620,19 +1638,11 @@ func (p *Proxy) proxyStatsQueryRangeDrilldownHits(
 	// Gated on isGrafanaSourcedRequest — querySplitting fires for ANY Grafana
 	// client (Explore, Drilldown, dashboard panels) not just Drilldown, and
 	// Explore at 24h+ shows the same spike from the same residual chunk.
-	if isGrafanaSourcedRequest(r) {
-		if sNs, sok := parseLokiTimeToUnixNano(startRaw); sok {
-			if eNs, eok := parseLokiTimeToUnixNano(endRaw); eok {
-				if stepDur, stepOK := parsePositiveStepDuration(stepForHits); stepOK && stepDur > 0 {
-					if eNs-sNs <= 2*stepDur.Nanoseconds() {
-						w.Header().Set("Content-Type", "application/json")
-						w.Header().Set("X-Proxy-Drilldown-Path", "hits-leftover-suppressed")
-						_, _ = w.Write(emptyLokiMatrix)
-						return true
-					}
-				}
-			}
-		}
+	if isQuerySplitLeftoverChunk(r, startRaw, endRaw, stepForHits) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Proxy-Drilldown-Path", "hits-leftover-suppressed")
+		_, _ = w.Write(emptyLokiMatrix)
+		return true
 	}
 
 	// For long ranges, sample windows in parallel so the top-N spans the
@@ -2091,6 +2101,17 @@ func stripUnpackStagesForTopN(base string) string {
 // drops only the redundant `| unpack_logfmt`. Returns true iff it wrote a response;
 // false (without writing a body) so the caller falls through to the two-phase/direct.
 func (p *Proxy) tryHighCardCountByWindowedHits(w http.ResponseWriter, r *http.Request, logsqlQuery string) bool {
+	// Scope to Grafana-sourced requests. The windowed-/hits path returns
+	// per-window-sampled top-N series rather than exact stats_query_range results
+	// — that's the right trade-off for rendering a Grafana chart (Explore /
+	// Drilldown), where the full unbounded response is 40MB+/25s and would be
+	// cancelled, but it is the WRONG default for a direct API client that expects
+	// exact aggregation. Non-Grafana callers fall through to the exact direct path
+	// (bounded to maxStatsQuerySeries top-N-by-count, like Loki's max_query_series,
+	// with the two-phase fallback only on a 16MB overflow).
+	if !isGrafanaSourcedRequest(r) {
+		return false
+	}
 	spec, ok := parseStatsCompatSpec(logsqlQuery)
 	if !ok || spec.Func != "count" || len(spec.GroupBy) != 1 {
 		return false

--- a/internal/proxy/review_findings_test.go
+++ b/internal/proxy/review_findings_test.go
@@ -1,0 +1,90 @@
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeUpstreamError_RedactsQuery covers finding 1: transport errors are
+// *url.Error whose message embeds the full backend URL including the LogQL/LogsQL
+// query in RawQuery, leaking it into logs and handler error responses.
+func TestSanitizeUpstreamError_RedactsQuery(t *testing.T) {
+	underlying := errors.New("dial tcp 127.0.0.1:9428: connect: connection refused")
+	raw := &url.Error{
+		Op:  "Get",
+		URL: `http://victorialogs:9428/select/logsql/query?query=%7Bapp%3D%22secret%22%7D+%7C%3D+%22password%3Dhunter2%22&start=1`,
+		Err: underlying,
+	}
+
+	// Redaction on by default.
+	p := &Proxy{}
+	got := p.sanitizeUpstreamError(raw)
+	msg := got.Error()
+	for _, leak := range []string{"secret", "password", "hunter2", "query="} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("sanitized error still leaks %q: %s", leak, msg)
+		}
+	}
+	if !strings.Contains(msg, "redacted") {
+		t.Errorf("expected redacted marker, got: %s", msg)
+	}
+	// Underlying cause preserved so statusFromUpstreamErr / breaker still classify.
+	if !errors.Is(got, underlying) {
+		t.Errorf("sanitized error lost the underlying cause: %v", got)
+	}
+	// Path/host kept for diagnostics.
+	if !strings.Contains(msg, "victorialogs:9428") || !strings.Contains(msg, "/select/logsql/query") {
+		t.Errorf("expected host+path retained, got: %s", msg)
+	}
+
+	// Raw-query debug mode opts out of redaction.
+	pRaw := &Proxy{debugLogRawQueries: true}
+	if pRaw.sanitizeUpstreamError(raw).Error() != raw.Error() {
+		t.Error("debugLogRawQueries=true should not redact")
+	}
+	// Non-url errors and nil pass through.
+	plain := errors.New("boom")
+	if p.sanitizeUpstreamError(plain) != plain {
+		t.Error("non-url error should pass through unchanged")
+	}
+	if p.sanitizeUpstreamError(nil) != nil {
+		t.Error("nil should pass through")
+	}
+}
+
+// TestWindowedHits_GatedToGrafana covers finding 3: the window-sampled /hits
+// rewrite (lossy top-N sampling) must only apply to Grafana-sourced requests so
+// direct API clients keep exact stats semantics.
+func TestWindowedHits_GatedToGrafana(t *testing.T) {
+	p := &Proxy{}
+	q := `sum by (pod) (count_over_time({env="production"} | pod!="" [2m]))`
+	mk := func(grafana bool) *http.Request {
+		// 24h range so the >=2h gate would otherwise pass.
+		r := httptest.NewRequest(http.MethodGet,
+			"/loki/api/v1/query_range?start=1700000000000000000&end=1700086400000000000&step=120s&query="+url.QueryEscape(q), nil)
+		if grafana {
+			r.Header.Set("X-Query-Tags", "Source=grafana-lokiexplore-app")
+		}
+		return r
+	}
+
+	// Non-Grafana → must return false (falls through to exact path) without writing.
+	w := httptest.NewRecorder()
+	if p.tryHighCardCountByWindowedHits(w, mk(false), `pod!="" | stats by (pod) count()`) {
+		t.Error("windowed-hits ran for a non-Grafana request; API clients must get exact stats")
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("non-Grafana path wrote a body: %s", w.Body.String())
+	}
+
+	// Sanity: a Grafana request is NOT rejected by the source gate (it proceeds
+	// past it; later steps may still no-op without a backend, but it must not be
+	// short-circuited by isGrafanaSourcedRequest).
+	if !isGrafanaSourcedRequest(mk(true)) {
+		t.Error("expected the drilldown-tagged request to be Grafana-sourced")
+	}
+}


### PR DESCRIPTION
Addresses the five review findings on the merged Drilldown/cache work.

## 1. Security — upstream errors leaked query params
`http.Client` transport failures are `*url.Error` embedding the full backend URL (incl. the LogQL/LogsQL query), leaking into error logs/responses despite the debug-log redaction. New `sanitizeUpstreamError` redacts the URL query, preserves the underlying cause, no-op under `-debug-log-raw-queries`.

## 2. Correctness — residual suppression too broad
The 24h+ querySplitting residual suppression fired for `range <= 2*step`, blanking legitimate Grafana short-range/coarse-step queries. Narrowed to a true sub-step residual (`range < step`); shared `isQuerySplitLeftoverChunk` used by both the dispatch hoist and the `/hits` path. Lock test updated.

## 3. API contract — high-card `/hits` rewrite too broad
`tryHighCardCountByWindowedHits` (lossy per-window top-N sampling) now gated on `isGrafanaSourcedRequest`. Direct API clients get exact stats (direct path + `max-stats-query-series` cap, like Loki's `max_query_series`).

## 4. Helm — contradictory metrics configs
Deployment metrics `containerPort` derived from `extraArgs.metrics-listen` (named Service/ServiceMonitor target stays in lock-step); fail-fast when `service.metrics.enabled` is combined with empty `metrics-listen` or `register-instrumentation=false`. New `metricsPort`/`validateMetrics` helpers.

## 5. Helm — NetworkPolicy blocks metrics scraping
Default NetworkPolicy now opens the metrics port when `serviceMonitor.enabled` (was 3100-only → scrape timeouts). New `networkPolicy.monitoringFrom` to restrict the source.

## Test Plan
- [x] Unit: `TestSanitizeUpstreamError_RedactsQuery`, `TestWindowedHits_GatedToGrafana`; `TestLock_LeftoverChunkSuppressed` boundary updated
- [x] `helm template` verified: default / serviceMonitor-on (netpol opens metrics) / metrics-listen="" (fails) / register-instrumentation=false (fails) / custom `:9092` (port derives)
- [x] Full `go test ./internal/proxy/... ./internal/translator/...`, helm extraArgs parity, golangci-lint (0), vet, gofmt, asset-sync — all pass