### PR TITLE
docs: drop stale ast-migration tag references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -372,7 +372,7 @@ The parser includes a semantic pass for structural constraints (missing `| unwra
 See [LogQL Parser deep dive](logql-parser.md) for grammar, data flow diagrams, and extension points.
 
 ### Translator (`internal/translator/`)
-LogQL→LogsQL converter. Receives canonical LogQL (produced by `Expr.String()` after AST normalisation). Translation uses two tiers: stable string operations for well-understood paths (stream selectors, line filters, label format) and typed `logsql` builder calls for complex paths (stats aggregations, IP filters). Remaining string paths are tagged `TODO(ast-migration)` for future migration — run `grep -r "TODO(ast-migration)" internal/` to see the full backlog.
+LogQL→LogsQL converter. Receives canonical LogQL (produced by `Expr.String()` after AST normalisation). Translation uses two tiers: stable string operations for well-understood paths (stream selectors, line filters, label format) and typed `logsql` builder calls for complex paths (stats aggregations, IP filters).
 
 Typed errors in `internal/translator/errors.go` replace bare `fmt.Errorf` for two failure classes: `ParseError` (invalid LogQL input) and `UnsupportedError` (LogQL constructs with no LogsQL equivalent). Callers can type-assert to distinguish parse failures from unsupported-feature fallbacks.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,7 +107,7 @@ no exploratory items are listed here.
 - [ ] Tighten remaining merged-tenant Drilldown metadata accuracy for field and label cardinality surfaces
 - [ ] Convert more upstream Loki, Logs Drilldown, and VictoriaLogs edge cases into regression tests (ongoing — LogQL parity machine at 555+ cases)
 - [ ] Malformed drop/keep matcher → HTTP 400 error — validation exists in `ValidateDropKeepSyntax`, wiring it into the handler (currently silently skipped)
-- [ ] Migrate remaining string-based translation paths to the typed `logsql` AST builder — the backlog is tagged `TODO(ast-migration)` in code; `logql.Translate` is wired and its handler rollout follows the same path
+- [ ] Migrate remaining string-based translation paths to the typed `logsql` AST builder and roll `logql.Translate` into the proxy handlers — the typed translation path (`internal/logql/translate.go`) is implemented and tested; the handler call-site migration is the remaining step
 - [x] Expand browser-level multi-tenant Explore and Drilldown scenarios where API parity already exists but UI combinations still need live regression coverage
 - [x] `| keep field=value` stream label mutation — matcher form now applies to stream labels in addition to structured metadata and parsed fields (v1.50.1)
 - [x] Parallel multi-tenant fanout — goroutine-per-tenant dispatch with `sync.WaitGroup` (v1.43.0)


### PR DESCRIPTION
## Summary
- `grep -r 'TODO(ast-migration)' internal/` returns nothing on main — the tags referenced by `docs/architecture.md` and the roadmap no longer exist in code.
- Reword both spots: the typed translation path (`internal/logql/translate.go`) is implemented and tested; the proxy handler call-site migration is the remaining step.
- Docs-only, 2 lines.