### PR TITLE
fix(rules-migrate): validate rule LogQL with the typed AST before translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the proxy's query handlers already reject with HTTP 400 — previously slipped through
   rule-file conversion with the broken stage silently skipped; it now fails conversion
   with the same Loki-style parse error.
+- **LogQL parser no longer panics on an unterminated opaque function call.** A query
+  such as `(A00000(` — an unknown/opaque metric function (`label_replace`, `label_join`,
+  …) whose argument parentheses never close — made `consumeBalancedParens` return offset
+  0, and the caller then sliced `input[start:0]` and panicked with "slice bounds out of
+  range". Because `ValidateLogQL` runs on every `query`/`query_range` request (and now in
+  `rules-migrate`), a crafted query could panic the parser; it now returns a Loki-style
+  parse error. Found by fuzzing.
+- **`| drop`/`| keep` matchers using the `!~` operator are no longer silently dropped.**
+  `!~` is the only drop/keep operator with no `=`, and the matcher-vs-bare-field classifier
+  in `walkDropKeepStages` gated on `strings.Contains(item, "=")`, so a `field!~"re"`
+  conditional drop/keep was misread as a bare field name and lost during proxy
+  post-processing. It is now parsed as a matcher condition like the other three operators.
+  Found by the expanded drop/keep tests.
+
+### Changed
+- Expanded test coverage for the LogQL parser, translator, and `rules-migrate`: added
+  table-driven and fuzz tests for drop/keep matcher classification (all four operators,
+  malformed-form skipping), rule-expression validation (valid translation + malformed
+  rejection, error identifies group/rule), and unterminated-paren parser robustness.
+- Hardened the flaky `TestPeerCache_WriteThroughAndReadAheadBranches` test: it now waits
+  on the client-side write-through counter (incremented after the peer records the push)
+  instead of racing the server-side record against the counter, which intermittently
+  failed under loaded CI.
+- Removed the unused `translator.ValidateDropKeepSyntax` helper: malformed drop/keep
+  matchers cannot reach the translator from any entry point now that both the query
+  handlers and `rules-migrate` validate via the LogQL AST first. Added regression
+  tests locking the HTTP 400 contract for `query` and `query_range`.
 
 ## [1.60.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `rules-migrate` now validates rule expressions with the typed LogQL AST validator
+  before translation. Malformed LogQL — e.g. a `| drop level!=~"debug"` matcher, which
+  the proxy's query handlers already reject with HTTP 400 — previously slipped through
+  rule-file conversion with the broken stage silently skipped; it now fails conversion
+  with the same Loki-style parse error.
+
 ### Changed
 - Relocated the CI-consumed VL AST coverage registry (`vl-ast-coverage.json`) from
   `docs/` to `scripts/`, next to the checker script that reads it; the `docs/` tree
   now carries only documentation pages.
+- Removed the unused `translator.ValidateDropKeepSyntax` helper: malformed drop/keep
+  matchers cannot reach the translator from any entry point now that both the query
+  handlers and `rules-migrate` validate via the LogQL AST first. Added regression
+  tests locking the HTTP 400 contract for `query` and `query_range`.
 
 ## [1.59.0] - 2026-06-08
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,7 @@ no exploratory items are listed here.
 
 - [ ] Tighten remaining merged-tenant Drilldown metadata accuracy for field and label cardinality surfaces
 - [ ] Convert more upstream Loki, Logs Drilldown, and VictoriaLogs edge cases into regression tests (ongoing — LogQL parity machine at 555+ cases)
-- [ ] Malformed drop/keep matcher → HTTP 400 error — validation exists in `ValidateDropKeepSyntax`, wiring it into the handler (currently silently skipped)
+- [x] Malformed drop/keep matcher → HTTP 400 error — enforced by the typed LogQL AST validator in the `query`/`query_range` handlers (regression-locked), and `rules-migrate` now runs the same validator so malformed rule expressions fail conversion instead of silently skipping the broken stage
 - [ ] Migrate remaining string-based translation paths to the typed `logsql` AST builder — the backlog is tagged `TODO(ast-migration)` in code; `logql.Translate` is wired and its handler rollout follows the same path
 - [x] Expand browser-level multi-tenant Explore and Drilldown scenarios where API parity already exists but UI combinations still need live regression coverage
 - [x] `| keep field=value` stream label mutation — matcher form now applies to stream labels in addition to structured metadata and parsed fields (v1.50.1)

--- a/internal/cache/peer_coverage_test.go
+++ b/internal/cache/peer_coverage_test.go
@@ -251,23 +251,27 @@ func TestPeerCache_WriteThroughAndReadAheadBranches(t *testing.T) {
 		}
 
 		localCache.SetWithTTL(targetKey, []byte("payload"), 30*time.Second)
+		// Wait on the client-side WTPushes counter, which pushToOwner increments
+		// only AFTER the peer server has received the request and recorded `pushed`
+		// (peer.go). Polling the server-side `pushed` record alone races with that
+		// increment: the handler sets `pushed` and returns 204, but the client
+		// goroutine may not have reached WTPushes.Add(1) yet when the assertion runs
+		// — which flaked under loaded CI ("expected push count 1, got 0").
 		requireEventually(t, time.Second, func() bool {
-			mu.Lock()
-			defer mu.Unlock()
-			return pushed.key == targetKey
+			return pc.WTPushes.Load() == 1
 		})
 
 		mu.Lock()
 		got := pushed
 		mu.Unlock()
+		if got.key != targetKey {
+			t.Fatalf("unexpected pushed key %q, want %q", got.key, targetKey)
+		}
 		if string(got.body) != "payload" {
 			t.Fatalf("unexpected pushed body %q", string(got.body))
 		}
 		if got.ttl != "30000" {
 			t.Fatalf("unexpected pushed ttl %q", got.ttl)
-		}
-		if got := pc.WTPushes.Load(); got != 1 {
-			t.Fatalf("expected write-through push count 1, got %d", got)
 		}
 	})
 

--- a/internal/logql/drop_keep_matcher_validation_test.go
+++ b/internal/logql/drop_keep_matcher_validation_test.go
@@ -1,0 +1,79 @@
+package logql
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateLogQL_DropKeepMatchers locks the validation contract that the
+// proxy's query handlers and rules-migrate both depend on: the typed LogQL AST
+// validator must reject malformed `| drop`/`| keep` matchers (operators Loki's
+// label-name stages do not support, missing values, empty stages) with a
+// Loki-style parse error, while accepting every valid drop/keep form unchanged.
+//
+// Before this was enforced, a malformed matcher such as `status!=~"5.."` was
+// silently skipped during translation, dropping the stage without telling the
+// caller. See PR "validate rule LogQL with the typed AST before translation".
+func TestValidateLogQL_DropKeepMatchers(t *testing.T) {
+	valid := []string{
+		// Bare field lists.
+		`{app="api"} | drop trace_id`,
+		`{app="api"} | drop trace_id, span_id`,
+		`{app="api"} | keep app`,
+		`{app="api"} | keep app, level, status`,
+		// Matcher forms — every operator Loki accepts in drop/keep.
+		`{app="api"} | drop level="debug"`,
+		`{app="api"} | drop level!="debug"`,
+		`{app="api"} | drop level=~"debug|trace"`,
+		`{app="api"} | drop level!~"info|warn"`,
+		`{app="api"} | keep status="200"`,
+		`{app="api"} | keep status=~"2.."`,
+		// Mixed bare + matcher in one stage.
+		`{app="api"} | drop trace_id, level="debug"`,
+		`{app="api"} | keep app, status=~"2.."`,
+		// Drop/keep after a parser stage, and multiple stages.
+		`{app="api"} | json | drop __error__`,
+		`{app="api"} | logfmt | keep level, status`,
+		`{app="api"} | drop level="debug" | drop env="prod"`,
+		// Quoted values with regex/special characters.
+		`{app="api"} | drop path=~"/api/v1/.*"`,
+		`{app="api"} | drop msg!~"timeout.*exceeded"`,
+	}
+	for _, q := range valid {
+		t.Run("valid/"+q, func(t *testing.T) {
+			if msg := ValidateLogQL(q); msg != "" {
+				t.Fatalf("ValidateLogQL(%q) = %q, want valid", q, msg)
+			}
+		})
+	}
+
+	malformed := []struct {
+		name  string
+		query string
+		// substr is a stable fragment of the Loki-style error the validator must
+		// return. It must be non-empty (i.e. the query must be rejected).
+		substr string
+	}{
+		{"keep unsupported !=~ operator", `{app="api"} | keep method="GET", status!=~"5.."`, "expected STRING or RAWSTRING"},
+		{"drop unsupported !=~ operator", `{app="api"} | drop level!=~"debug"`, "expected STRING or RAWSTRING"},
+		{"drop doubled =~~ operator", `{app="api"} | drop level=~~"x"`, "expected STRING or RAWSTRING"},
+		{"keep matcher missing value", `{app="api"} | keep level=`, "expected STRING or RAWSTRING"},
+		{"drop matcher missing value", `{app="api"} | drop level=`, "expected STRING or RAWSTRING"},
+		{"empty drop stage", `{app="api"} | drop`, "at least one label name or matcher"},
+		{"empty keep stage", `{app="api"} | keep`, "at least one label name or matcher"},
+	}
+	for _, tc := range malformed {
+		t.Run("malformed/"+tc.name, func(t *testing.T) {
+			msg := ValidateLogQL(tc.query)
+			if msg == "" {
+				t.Fatalf("ValidateLogQL(%q) accepted a malformed drop/keep stage; want parse error", tc.query)
+			}
+			if !strings.HasPrefix(msg, "parse error") {
+				t.Errorf("ValidateLogQL(%q) = %q, want a Loki-style \"parse error ...\"", tc.query, msg)
+			}
+			if !strings.Contains(msg, tc.substr) {
+				t.Errorf("ValidateLogQL(%q) = %q, want it to contain %q", tc.query, msg, tc.substr)
+			}
+		})
+	}
+}

--- a/internal/logql/parser.go
+++ b/internal/logql/parser.go
@@ -181,7 +181,10 @@ func (p *parser) parsePrimary() (Expr, error) {
 		p.advance()
 		if p.cur.Typ == TokLParen {
 			p.advance() // consume '('
-			endPos := p.consumeBalancedParens()
+			endPos, ok := p.consumeBalancedParens()
+			if !ok || endPos < startPos {
+				return nil, fmt.Errorf("logql: unterminated '(' after %q", name)
+			}
 			raw := strings.TrimSpace(p.input[startPos:endPos])
 			return &OpaqueMetricExpr{Raw: raw}, nil
 		}
@@ -672,11 +675,14 @@ func (p *parser) consumeExplicitFieldList() {
 }
 
 // consumeBalancedParens consumes tokens including nested parentheses until the
-// matching close paren (which is also consumed). Returns the byte position in
-// p.input immediately after the closing ')'. Used for opaque function calls.
-func (p *parser) consumeBalancedParens() int {
+// matching close paren (which is also consumed). It returns the byte position in
+// p.input immediately after the closing ')' and ok=true. If the parentheses
+// never balance — EOF is reached with the depth still positive — it returns
+// ok=false so the caller can emit a parse error instead of slicing p.input with
+// a stale endPos of 0 (which panics for any startPos > 0). Used for opaque
+// function calls.
+func (p *parser) consumeBalancedParens() (endPos int, ok bool) {
 	depth := 1
-	endPos := 0
 	for depth > 0 && p.cur.Typ != TokEOF {
 		switch p.cur.Typ {
 		case TokLParen:
@@ -689,7 +695,10 @@ func (p *parser) consumeBalancedParens() int {
 		}
 		p.advance()
 	}
-	return endPos
+	if depth != 0 {
+		return 0, false
+	}
+	return endPos, true
 }
 
 // consumeRestOfStage reads tokens until the next pipeline operator, range

--- a/internal/logql/parser_unbalanced_paren_test.go
+++ b/internal/logql/parser_unbalanced_paren_test.go
@@ -1,0 +1,55 @@
+package logql
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParse_UnbalancedOpaqueParens guards against a parser panic on opaque
+// metric functions (label_replace, label_join, or any unknown function name)
+// whose argument parentheses never close. consumeBalancedParens returned 0 when
+// it hit EOF with parens still open, and the caller then sliced p.input[start:0]
+// — panicking with "slice bounds out of range". Since ValidateLogQL runs on
+// every proxy query, such an input must yield a parse error, never a panic.
+func TestParse_UnbalancedOpaqueParens(t *testing.T) {
+	inputs := []string{
+		`(A00000(`,
+		`A00000(`,
+		`label_replace(`,
+		`label_join(rate({app="x"}[5m])`,
+		`sum(unknownfn(`,
+		`(((`,
+		`foo(bar(baz(`,
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			// Parse must not panic and must report an error.
+			_, err := Parse(in)
+			if err == nil {
+				t.Errorf("Parse(%q) = nil error, want a parse error", in)
+			}
+			// ValidateLogQL must not panic and must return a non-empty message.
+			if msg := ValidateLogQL(in); msg == "" {
+				t.Errorf("ValidateLogQL(%q) = %q, want a parse error", in, msg)
+			} else if !strings.HasPrefix(msg, "parse error") {
+				t.Errorf("ValidateLogQL(%q) = %q, want a Loki-style \"parse error ...\"", in, msg)
+			}
+		})
+	}
+}
+
+// TestParse_BalancedOpaqueParens confirms the fix does not regress the
+// balanced-parens opaque-function path, which must still capture the raw text.
+func TestParse_BalancedOpaqueParens(t *testing.T) {
+	valid := []string{
+		`label_replace(rate({app="x"}[5m]), "dst", "$1", "src", "(.*)")`,
+		`label_join(rate({app="x"}[5m]), "dst", ",", "a", "b")`,
+	}
+	for _, in := range valid {
+		t.Run(in, func(t *testing.T) {
+			if msg := ValidateLogQL(in); msg != "" {
+				t.Errorf("ValidateLogQL(%q) = %q, want valid", in, msg)
+			}
+		})
+	}
+}

--- a/internal/proxy/drop_keep_validation_test.go
+++ b/internal/proxy/drop_keep_validation_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// Malformed drop/keep matchers (items that look like matchers but use operators
+// Loki's drop/keep stages do not support, e.g. `!=~`) must be rejected with a
+// Loki-style HTTP 400 parse error instead of being silently skipped. The typed
+// LogQL AST validator (validateLogQLSyntax inside validateQuery) enforces this
+// for both query_range and instant query; this test locks that contract.
+func TestHardening_MalformedDropKeepMatcherRejected(t *testing.T) {
+	p := newTestProxy(t, "http://unused")
+
+	cases := []struct {
+		name     string
+		path     string
+		handler  func(http.ResponseWriter, *http.Request)
+		query    string
+		wantCode int
+	}{
+		{
+			name:     "query_range malformed keep matcher",
+			path:     "/loki/api/v1/query_range",
+			handler:  p.handleQueryRange,
+			query:    `{app="api"} | keep method="GET", status!=~"5.."`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "query_range malformed drop matcher",
+			path:     "/loki/api/v1/query_range",
+			handler:  p.handleQueryRange,
+			query:    `{app="api"} | drop level!=~"debug"`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "instant query malformed drop matcher",
+			path:     "/loki/api/v1/query",
+			handler:  p.handleQuery,
+			query:    `count_over_time({app="api"} | drop level!=~"debug" [5m])`,
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", tc.path+"?query="+url.QueryEscape(tc.query), nil)
+			tc.handler(w, r)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("expected %d for %q, got %d (body: %s)", tc.wantCode, tc.query, w.Code, w.Body.String())
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, "parse error") || !strings.Contains(body, "bad_data") {
+				t.Errorf("expected Loki-style parse error envelope in body, got: %s", body)
+			}
+		})
+	}
+
+	// Valid drop/keep forms must NOT be rejected by validation.
+	valid := []string{
+		`{app="api"} | drop level="debug"`,
+		`{app="api"} | drop level!="debug"`,
+		`{app="api"} | keep status=~"5.."`,
+		`{app="api"} | drop level, env`,
+	}
+	for _, q := range valid {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/loki/api/v1/query_range?query="+url.QueryEscape(q), nil)
+		p.handleQueryRange(w, r)
+		if w.Code == http.StatusBadRequest {
+			t.Errorf("valid query %q rejected with 400 (body: %s)", q, w.Body.String())
+		}
+	}
+}

--- a/internal/rulesmigrate/fuzz_test.go
+++ b/internal/rulesmigrate/fuzz_test.go
@@ -7,6 +7,10 @@ func FuzzConvertWithOptions(f *testing.F) {
 		[]byte("groups:\n  - name: api\n    rules:\n      - alert: HighErrorRate\n        expr: sum by (app) (rate({app=\"api\"} |= \"error\" [5m]))\n"),
 		[]byte("compat.rules:\n  - name: api\n    rules:\n      - record: api_requests_total:rate5m\n        expr: sum by (app) (rate({app=\"api\"}[5m]))\n"),
 		[]byte("groups:\n  - name: risky\n    rules:\n      - alert: Join\n        expr: rate({app=\"api\"}[5m]) / on(app) group_left(team) rate({app=\"api\"}[5m])\n"),
+		// Malformed LogQL inside a rule expr — must fail conversion cleanly, never panic.
+		[]byte("groups:\n  - name: bad\n    rules:\n      - alert: BadDrop\n        expr: sum(rate({app=\"api\"} | drop level!=~\"x\" [5m]))\n"),
+		[]byte("groups:\n  - name: bad\n    rules:\n      - record: r\n        expr: '{app=\"api\"'\n"),
+		[]byte("groups:\n  - name: bad\n    rules:\n      - alert: A\n        expr: not logql\n"),
 		[]byte("not: [valid"),
 		[]byte(""),
 	}

--- a/internal/rulesmigrate/migrate.go
+++ b/internal/rulesmigrate/migrate.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ReliablyObserve/Loki-VL-proxy/internal/logql"
 	"github.com/ReliablyObserve/Loki-VL-proxy/internal/translator"
 	"gopkg.in/yaml.v3"
 )
@@ -104,6 +105,13 @@ func translateGroup(g Group, opts ConvertOptions) (Group, []Warning, error) {
 		ruleWarnings := analyzeRule(g.Name, r)
 		if len(ruleWarnings) > 0 && !opts.AllowRisky {
 			return Group{}, ruleWarnings, fmt.Errorf("rule %q in group %q requires manual review:\n%s", ruleName(r), g.Name, formatWarnings(ruleWarnings))
+		}
+		// Rule files do not pass through the proxy's query handlers, so malformed
+		// LogQL (e.g. a `| drop level!=~"x"` matcher) would otherwise be silently
+		// skipped during translation. Validate with the same typed AST validator
+		// the handlers use before translating.
+		if msg := logql.ValidateLogQL(r.Expr); msg != "" {
+			return Group{}, nil, fmt.Errorf("translate group %q rule %q: %s", g.Name, ruleName(r), msg)
 		}
 		translated, err := translator.TranslateLogQL(r.Expr)
 		if err != nil {

--- a/internal/rulesmigrate/migrate_test.go
+++ b/internal/rulesmigrate/migrate_test.go
@@ -90,6 +90,24 @@ groups:
 	}
 }
 
+func TestConvertRejectsMalformedDropKeepMatcher(t *testing.T) {
+	input := []byte(`
+groups:
+  - name: broken
+    rules:
+      - alert: BadDropMatcher
+        expr: 'sum(rate({app="api"} | drop level!=~"debug" [5m]))'
+`)
+
+	_, _, err := ConvertWithOptions(input, ConvertOptions{})
+	if err == nil {
+		t.Fatal("expected malformed drop/keep matcher to fail conversion")
+	}
+	if !strings.Contains(err.Error(), "parse error") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
 func TestConvertWithOptionsRejectsRiskyRulesByDefault(t *testing.T) {
 	input := []byte(`
 groups:

--- a/internal/rulesmigrate/migrate_validation_test.go
+++ b/internal/rulesmigrate/migrate_validation_test.go
@@ -1,0 +1,134 @@
+package rulesmigrate
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ruleFileYAML builds a single-group, single-alert-rule file around one LogQL
+// expression so the validation/translation path can be exercised per-expression.
+func ruleFileYAML(group, alert, expr string) []byte {
+	return []byte(fmt.Sprintf(
+		"groups:\n  - name: %s\n    rules:\n      - alert: %s\n        expr: '%s'\n",
+		group, alert, strings.ReplaceAll(expr, "'", "''"),
+	))
+}
+
+// TestConvert_TranslatesValidExpressions verifies a broad set of valid LogQL rule
+// expressions convert without error and produce a vlogs group whose expr was
+// rewritten away from the original LogQL.
+func TestConvert_TranslatesValidExpressions(t *testing.T) {
+	valid := []string{
+		`sum by (app) (rate({app="api"}[5m]))`,
+		`sum(rate({app="api"} |= "error" [5m]))`,
+		`count_over_time({app="api"} | json [5m])`,
+		`sum by (level) (count_over_time({app="api"} | logfmt [5m]))`,
+		`rate({app="api", env="prod"} != "debug" [1m])`,
+		`bytes_over_time({app="api"}[5m])`,
+		`sum by (path) (count_over_time({app="api"} | json | status>=400 [5m]))`,
+		`count_over_time({app="api"} | drop trace_id [5m])`,
+		`count_over_time({app="api"} | json | keep level, status [5m])`,
+		`rate({app=~"api-.*"}[5m])`,
+		`max_over_time({app="api"} | unwrap latency [5m])`,
+		`quantile_over_time(0.99, {app="api"} | unwrap latency [5m])`,
+	}
+	for _, expr := range valid {
+		t.Run(expr, func(t *testing.T) {
+			out, err := Convert(ruleFileYAML("api", "R", expr))
+			if err != nil {
+				t.Fatalf("Convert(%q) failed: %v", expr, err)
+			}
+			if !strings.Contains(string(out), "type: vlogs") {
+				t.Errorf("expected vlogs group type in output, got:\n%s", out)
+			}
+			if strings.Contains(string(out), "expr: '"+expr+"'") {
+				t.Errorf("expected expr to be translated away from original LogQL %q", expr)
+			}
+		})
+	}
+}
+
+// TestConvert_RejectsMalformedExpressions verifies malformed LogQL rule
+// expressions fail conversion with a parse error rather than silently producing
+// a broken or partially-translated rule. AllowRisky is used so the malformed
+// expression reaches the validator instead of being short-circuited by the
+// manual-review (risky) gate.
+func TestConvert_RejectsMalformedExpressions(t *testing.T) {
+	malformed := []string{
+		`{app="api"`, // unbalanced brace
+		`sum(rate({app="api"} | drop level!=~"debug" [5m]))`,           // malformed drop matcher
+		`sum(count_over_time({app="api"} | keep status!=~"5.." [5m]))`, // malformed keep matcher
+		`rate({app="api"} | keep level= [5m])`,                         // matcher missing value
+		`not logql at all`,                                             // not a query
+		`{}`,                                                           // empty selector
+		`rate({app="api"})`,                                            // range aggregation without range
+	}
+	for _, expr := range malformed {
+		t.Run(expr, func(t *testing.T) {
+			if _, err := Convert(ruleFileYAML("api", "R", expr)); err == nil {
+				t.Fatalf("Convert(%q) succeeded; want a parse error", expr)
+			}
+		})
+	}
+}
+
+// TestConvert_ErrorIdentifiesGroupAndRule verifies a malformed rule fails with an
+// error that names the group and rule so operators can locate it in a large file.
+func TestConvert_ErrorIdentifiesGroupAndRule(t *testing.T) {
+	_, err := Convert(ruleFileYAML("payments", "BadDropMatcher", `sum(rate({app="api"} | drop level!=~"x" [5m]))`))
+	if err == nil {
+		t.Fatal("expected malformed rule to fail conversion")
+	}
+	msg := err.Error()
+	for _, want := range []string{"payments", "BadDropMatcher", "parse error"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestConvert_MalformedDropKeepInRecordAndAlert verifies the malformed-matcher
+// guard applies to both alert and recording rules.
+func TestConvert_MalformedDropKeepInRecordAndAlert(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "alert rule",
+			yaml: "groups:\n  - name: g\n    rules:\n      - alert: A\n        expr: 'sum(rate({app=\"api\"} | drop level!=~\"x\" [5m]))'\n",
+		},
+		{
+			name: "recording rule",
+			yaml: "groups:\n  - name: g\n    rules:\n      - record: r\n        expr: 'sum(rate({app=\"api\"} | keep status!=~\"5..\" [5m]))'\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Convert([]byte(tc.yaml)); err == nil {
+				t.Fatalf("expected malformed %s to fail conversion", tc.name)
+			}
+		})
+	}
+}
+
+// TestConvert_ValidDropKeepFormsSurvive verifies that valid drop/keep forms are
+// NOT rejected by the new validation step (guards against the validator being
+// too aggressive and breaking legitimate rules).
+func TestConvert_ValidDropKeepFormsSurvive(t *testing.T) {
+	valid := []string{
+		`count_over_time({app="api"} | drop trace_id, span_id [5m])`,
+		`count_over_time({app="api"} | drop level="debug" [5m])`,
+		`count_over_time({app="api"} | drop level!="info" [5m])`,
+		`count_over_time({app="api"} | json | keep level=~"err.*" [5m])`,
+		`count_over_time({app="api"} | json | keep app, status [5m])`,
+	}
+	for _, expr := range valid {
+		t.Run(expr, func(t *testing.T) {
+			if _, err := Convert(ruleFileYAML("api", "R", expr)); err != nil {
+				t.Fatalf("Convert(%q) rejected a valid drop/keep form: %v", expr, err)
+			}
+		})
+	}
+}

--- a/internal/rulesmigrate/testdata/fuzz/FuzzConvertWithOptions/86d4697eceafcf7f
+++ b/internal/rulesmigrate/testdata/fuzz/FuzzConvertWithOptions/86d4697eceafcf7f
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0:\n- rules:\n  - expr: (A00000(")

--- a/internal/translator/drop_keep_parse_test.go
+++ b/internal/translator/drop_keep_parse_test.go
@@ -1,0 +1,200 @@
+package translator
+
+import (
+	"fmt"
+	"testing"
+)
+
+// dkKey renders a DropCondition as "field op value" for order-independent
+// comparison without touching the unexported compiled-regexp field.
+func dkKey(c DropCondition) string { return fmt.Sprintf("%s %s %s", c.Field, c.Op, c.Value) }
+
+func dkKeys(cs []DropCondition) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, dkKey(c))
+	}
+	return out
+}
+
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, g := range got {
+		seen[g]++
+	}
+	for _, w := range want {
+		if seen[w] == 0 {
+			return false
+		}
+		seen[w]--
+	}
+	return true
+}
+
+// TestParseDropKeepConditions_Table exercises the matcher/bare-field split for
+// `| drop` and `| keep` stages, including the defense-in-depth behavior that a
+// malformed matcher (one the upstream validator would already have rejected) is
+// silently skipped while valid items in the same stage are retained — rather
+// than panicking or corrupting the surrounding conditions.
+func TestParseDropKeepConditions_Table(t *testing.T) {
+	cases := []struct {
+		name      string
+		query     string
+		wantDrop  []string // matcher-form drop conditions
+		wantKeep  []string // matcher-form keep conditions
+		wantBareD []string
+		wantBareK []string
+	}{
+		{
+			name:      "drop bare fields only",
+			query:     `{app="api"} | drop trace_id, span_id`,
+			wantBareD: []string{"trace_id", "span_id"},
+		},
+		{
+			name:     "drop single matcher",
+			query:    `{app="api"} | drop level="debug"`,
+			wantDrop: []string{"level = debug"},
+		},
+		{
+			name:     "drop all operators",
+			query:    `{app="api"} | drop a="1" | drop b!="2" | drop c=~"3" | drop d!~"4"`,
+			wantDrop: []string{"a = 1", "b != 2", "c =~ 3", "d !~ 4"},
+		},
+		{
+			name:      "keep mixed bare and matcher",
+			query:     `{app="api"} | json | keep app, status="200"`,
+			wantKeep:  []string{"status = 200"},
+			wantBareK: []string{"app"},
+		},
+		{
+			name:      "malformed drop matcher skipped, valid items kept",
+			query:     `{app="api"} | drop a, level="x", bad!=~"y", b`,
+			wantDrop:  []string{"level = x"},
+			wantBareD: []string{"a", "b"},
+		},
+		{
+			name:      "malformed keep matcher skipped, valid items kept",
+			query:     `{app="api"} | keep app, status="200", bad!=~"z"`,
+			wantKeep:  []string{"status = 200"},
+			wantBareK: []string{"app"},
+		},
+		{
+			name:  "metric query has no drop/keep",
+			query: `sum by (app) (rate({app="api"}[5m]))`,
+		},
+		{
+			name:  "no pipeline",
+			query: `{app="api"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dkKeys(ParseDropConditions(tc.query)); !sameSet(got, tc.wantDrop) {
+				t.Errorf("ParseDropConditions = %v, want %v", got, tc.wantDrop)
+			}
+			if got := dkKeys(ParseKeepConditions(tc.query)); !sameSet(got, tc.wantKeep) {
+				t.Errorf("ParseKeepConditions = %v, want %v", got, tc.wantKeep)
+			}
+			if got := ParseBareDropFields(tc.query); !sameSet(got, tc.wantBareD) {
+				t.Errorf("ParseBareDropFields = %v, want %v", got, tc.wantBareD)
+			}
+			if got := ParseBareKeepFields(tc.query); !sameSet(got, tc.wantBareK) {
+				t.Errorf("ParseBareKeepFields = %v, want %v", got, tc.wantBareK)
+			}
+		})
+	}
+}
+
+// TestDropConditionMatches verifies the matcher predicate semantics used when the
+// proxy post-processes drop/keep stages, across all four operators.
+func TestDropConditionMatches(t *testing.T) {
+	mk := func(field, op, val string) DropCondition {
+		c, err := NewDropCondition(field, op, val)
+		if err != nil {
+			t.Fatalf("NewDropCondition(%q,%q,%q): %v", field, op, val, err)
+		}
+		return c
+	}
+	cases := []struct {
+		name  string
+		cond  DropCondition
+		value string
+		want  bool
+	}{
+		{"eq match", mk("level", "=", "debug"), "debug", true},
+		{"eq no match", mk("level", "=", "debug"), "info", false},
+		{"neq match", mk("level", "!=", "debug"), "info", true},
+		{"neq no match", mk("level", "!=", "debug"), "debug", false},
+		{"regex match", mk("level", "=~", "deb.*"), "debug", true},
+		{"regex no match", mk("level", "=~", "deb.*"), "info", false},
+		{"neg regex match", mk("level", "!~", "deb.*"), "info", true},
+		{"neg regex no match", mk("level", "!~", "deb.*"), "debug", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cond.Matches(tc.value); got != tc.want {
+				t.Errorf("%s.Matches(%q) = %v, want %v", dkKey(tc.cond), tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// FuzzParseDropKeepConsistency feeds arbitrary queries through all four
+// drop/keep parsers and asserts they never panic and never return an internally
+// inconsistent result (a condition with an empty field or unknown operator, or
+// an empty bare-field name).
+func FuzzParseDropKeepConsistency(f *testing.F) {
+	seeds := []string{
+		`{app="api"} | drop a, level="x", bad!=~"y", b`,
+		`{app="api"} | keep app, status="200", bad!=~"z"`,
+		`{app="api"} | drop level=~"a|b" | keep c!="d"`,
+		`{app="api"} | json | drop __error__, level="debug" | logfmt | keep msg`,
+		`{app="api"} | drop`,
+		`{app="api"} | keep =`,
+		`{app="api"} | drop ="value"`,
+		`| drop x`,
+		``,
+		`{app="api"}`,
+		`rate({app="api"}[5m])`,
+		`{app="api"} | drop "quoted", weird===, a=b=c`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, query string) {
+		drops := ParseDropConditions(query)
+		keeps := ParseKeepConditions(query)
+		bareD := ParseBareDropFields(query)
+		bareK := ParseBareKeepFields(query)
+
+		for _, set := range [][]DropCondition{drops, keeps} {
+			for _, c := range set {
+				if c.Field == "" {
+					t.Fatalf("condition with empty field from %q", query)
+				}
+				switch c.Op {
+				case "=", "!=", "=~", "!~":
+				default:
+					t.Fatalf("unknown op %q from %q", c.Op, query)
+				}
+				// Matches must never panic on arbitrary input.
+				_ = c.Matches("")
+				_ = c.Matches(c.Value)
+				_ = c.Matches("arbitrary_xyz")
+			}
+		}
+		// Bare field names are never empty. (The same field name may legitimately
+		// appear as a bare field in one stage and a matcher in another, so the two
+		// outputs are not required to be disjoint.)
+		for _, b := range append(append([]string{}, bareD...), bareK...) {
+			if b == "" {
+				t.Fatalf("empty bare field from %q", query)
+			}
+		}
+	})
+}

--- a/internal/translator/fuzz_test.go
+++ b/internal/translator/fuzz_test.go
@@ -204,6 +204,14 @@ func FuzzParseDropConditions(f *testing.F) {
 		// Quoted values with special chars
 		`{app="nginx"} | drop path="/api/v1/health"`,
 		`{app="nginx"} | drop msg=~"timeout.*exceeded"`,
+		// Malformed matcher forms — must be skipped without panicking, and must
+		// not corrupt the valid items sharing the stage.
+		`{app="nginx"} | drop bad!=~"x"`,
+		`{app="nginx"} | drop a, bad!=~"x", b`,
+		`{app="nginx"} | keep bad!=~"x", good="y"`,
+		`{app="nginx"} | drop level=`,
+		`{app="nginx"} | drop ="value"`,
+		`{app="nginx"} | drop weird===, a=b=c`,
 		// Empty / malformed
 		``,
 		`{app="nginx"}`,

--- a/internal/translator/testdata/fuzz/FuzzParseDropKeepConsistency/87b2b572b26b8851
+++ b/internal/translator/testdata/fuzz/FuzzParseDropKeepConsistency/87b2b572b26b8851
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("|drop 0|drop 0!~")

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -261,26 +261,34 @@ func walkDropKeepStages(logqlQuery string) dropKeepResult {
 			if item == "" {
 				continue
 			}
-			if strings.Contains(item, "=") {
-				field, op, val, ok := parseDropMatcher(item)
-				if !ok || field == "" {
-					continue
+			// Parse a matcher form (field OP value) for ANY supported operator —
+			// =, !=, =~, !~. parseDropMatcher must be tried first (mirroring
+			// splitDropSpec): the !~ operator is the only one with no '=', so
+			// gating on strings.Contains(item, "=") would misread a `field!~"re"`
+			// conditional drop/keep as a bare field name and silently lose it.
+			field, op, val, ok := parseDropMatcher(item)
+			if !ok || field == "" {
+				// Not a parseable matcher. A plain identifier (no operator) is a
+				// bare field; an item that still contains "=" is a malformed
+				// matcher (e.g. status!=~"5..") and is skipped — the upstream
+				// LogQL validator already rejects such queries with a parse error.
+				if !ok && !strings.Contains(item, "=") {
+					if isDrop {
+						res.dropBare = append(res.dropBare, item)
+					} else {
+						res.keepBare = append(res.keepBare, item)
+					}
 				}
-				dc, err := NewDropCondition(field, op, val)
-				if err != nil {
-					continue
-				}
-				if isDrop {
-					res.dropConds = append(res.dropConds, dc)
-				} else {
-					res.keepConds = append(res.keepConds, dc)
-				}
+				continue
+			}
+			dc, err := NewDropCondition(field, op, val)
+			if err != nil {
+				continue
+			}
+			if isDrop {
+				res.dropConds = append(res.dropConds, dc)
 			} else {
-				if isDrop {
-					res.dropBare = append(res.dropBare, item)
-				} else {
-					res.keepBare = append(res.keepBare, item)
-				}
+				res.keepConds = append(res.keepConds, dc)
 			}
 		}
 	}

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -198,17 +198,18 @@ func NewDropCondition(field, op, value string) (DropCondition, error) {
 
 // dropKeepResult holds the parsed contents of all | drop and | keep pipeline stages.
 type dropKeepResult struct {
-	dropBare   []string
-	dropConds  []DropCondition
-	keepBare   []string
-	keepConds  []DropCondition
-	parseError error
+	dropBare  []string
+	dropConds []DropCondition
+	keepBare  []string
+	keepConds []DropCondition
 }
 
-// walkDropKeepStages is the single shared walker for all ParseDrop*/ParseKeep*/Validate*
-// functions. It scans the pipeline stages of logqlQuery and returns bare field names and
-// matcher conditions found in | drop and | keep stages. Parse errors are returned in
-// result.parseError so callers can choose to propagate or silently ignore them.
+// walkDropKeepStages is the single shared walker for all ParseDrop*/ParseKeep*
+// functions. It scans the pipeline stages of logqlQuery and returns bare field names
+// and matcher conditions found in | drop and | keep stages. Malformed matcher items
+// cannot reach this walker through the query handlers or rules-migrate: both validate
+// queries with the typed LogQL AST validator (logql.ValidateLogQL) first, which
+// rejects them with a Loki-style parse error.
 func walkDropKeepStages(logqlQuery string) dropKeepResult {
 	var res dropKeepResult
 	remaining := strings.TrimSpace(logqlQuery)
@@ -263,9 +264,6 @@ func walkDropKeepStages(logqlQuery string) dropKeepResult {
 			if strings.Contains(item, "=") {
 				field, op, val, ok := parseDropMatcher(item)
 				if !ok || field == "" {
-					if !ok {
-						res.parseError = fmt.Errorf("parse error at line 1, col 1: invalid drop/keep matcher %q: unsupported operator (!=~ is not a valid Loki operator)", item)
-					}
 					continue
 				}
 				dc, err := NewDropCondition(field, op, val)
@@ -325,13 +323,6 @@ func ParseBareKeepFields(logqlQuery string) []string {
 		return nil
 	}
 	return fields
-}
-
-// ValidateDropKeepSyntax returns a parse error if the query contains | drop or | keep
-// stages with malformed matcher items — items that look like matchers (contain "=")
-// but use unsupported operators. Callers should return HTTP 400.
-func ValidateDropKeepSyntax(logqlQuery string) error {
-	return walkDropKeepStages(logqlQuery).parseError
 }
 
 // splitDropSpec parses a drop spec into bare field names and matcher conditions.

--- a/internal/translator/translator_test.go
+++ b/internal/translator/translator_test.go
@@ -1038,53 +1038,6 @@ func TestParseBareKeepFields(t *testing.T) {
 	}
 }
 
-func TestValidateDropKeepSyntax(t *testing.T) {
-	tests := []struct {
-		name    string
-		logql   string
-		wantErr bool
-	}{
-		{
-			name:    "valid drop matcher passes",
-			logql:   `{app="api"} | drop level="debug"`,
-			wantErr: false,
-		},
-		{
-			name:    "invalid !=~ operator rejected",
-			logql:   `{app="api"} | keep method="GET", status!=~"5.."`,
-			wantErr: true,
-		},
-		{
-			name:    "bare fields pass",
-			logql:   `{app="api"} | drop level, env`,
-			wantErr: false,
-		},
-		{
-			name:    "valid regex matcher passes",
-			logql:   `{app="api"} | drop status=~"5.."`,
-			wantErr: false,
-		},
-		{
-			name:    "valid negation matcher passes",
-			logql:   `{app="api"} | drop level!="debug"`,
-			wantErr: false,
-		},
-		{
-			name:    "no drop/keep stage passes",
-			logql:   `{app="api"} | json`,
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateDropKeepSyntax(tt.logql)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ValidateDropKeepSyntax(%q) error=%v, wantErr=%v", tt.logql, err, tt.wantErr)
-			}
-		})
-	}
-}
-
 // TestFieldFilterMigration verifies the logsql.FieldFilter-based translation
 // produces correct output for the cases required by the AST migration task.
 func TestFieldFilterMigration(t *testing.T) {

--- a/internal/translator/zz_audit_test.go
+++ b/internal/translator/zz_audit_test.go
@@ -1,0 +1,22 @@
+package translator
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAuditEscaping(t *testing.T) {
+	tests := []string{
+		`{app="x"} |= "error("`,
+		`{app="x"} |= "a.b"`,
+		`{app="x"} |= "C:\\"`,
+		`{app="x"} |= "C:\\" |= "must-also-match"`,
+		`{app="x", ns="prod\\"} |= "y"`,
+		`{app="evil\"} | stats count() | {x=\""}`,
+		`{app="x"} | level="err\\"`,
+	}
+	for _, q := range tests {
+		result, err := TranslateLogQL(q)
+		fmt.Printf("IN:  %s\nOUT: %s (err: %v)\n\n", q, result, err)
+	}
+}

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -799,7 +799,13 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_PLUGINS_PREINSTALL=victoriametrics-logs-datasource@0.26.3,grafana-lokiexplore-app
+      # Pin the Logs Drilldown plugin: an unpinned grafana-lokiexplore-app pulls
+      # whatever is latest at image-build time (now 2.1.1), which drifts the
+      # landing-page UI (e.g. the "Filter by labels" combobox) out from under the
+      # Playwright selectors — deterministically breaking e2e-ui (drilldown-core)
+      # and (drilldown-multitenant) in CI while a cached older plugin still passes
+      # locally. Bump this pin deliberately alongside any selector updates.
+      - GF_PLUGINS_PREINSTALL=victoriametrics-logs-datasource@0.26.3,grafana-lokiexplore-app@2.0.4
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-lokiexplore-app
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro


### PR DESCRIPTION
## Summary
Closes the last 'silently skipped' path for malformed drop/keep matchers in rule files, and — via the expanded fuzz/table tests this PR adds — fixes **two real correctness bugs** found in the LogQL parser and translator.

### Fixes
1. **rules-migrate validation** — rule files never passed through the proxy's query handlers, so a malformed matcher (`| drop level!=~"x"`) slipped through conversion with the broken stage silently dropped. `rules-migrate` now runs `logql.ValidateLogQL` before translating each rule and fails with a Loki-style parse error that names the group + rule.
2. **Parser panic on unterminated opaque parens (found by fuzzing)** — `(A00000(` (an opaque/unknown metric function whose `(` never closes) made `consumeBalancedParens` return offset 0; the caller then sliced `input[start:0]` and **panicked**. Since `ValidateLogQL` runs on *every* `query`/`query_range` request, a crafted query could panic the parser. Now returns a parse error.
3. **`!~` drop/keep matchers silently lost (found by expanded tests)** — `!~` is the only drop/keep operator with no `=`, and the matcher-vs-bare classifier in `walkDropKeepStages` gated on `strings.Contains(item, "=")`, so `field!~"re"` conditional drops/keeps were misread as bare field names and lost in proxy post-processing. Now parsed as matcher conditions like the other three operators.

### Tests
- New table + fuzz tests across `internal/logql`, `internal/translator`, `internal/rulesmigrate`: drop/keep classification (all four operators + malformed-skip), rule validation (valid translate + malformed reject + group/rule in error), and unterminated-paren parser robustness. Fuzz-found crashers captured as regression seeds.
- Hardened the flaky `TestPeerCache_WriteThroughAndReadAheadBranches` (the unrelated CI flake that was blocking this PR): waits on the client-side write-through counter rather than racing the server-side push record.
- Removed dead `translator.ValidateDropKeepSyntax`.

## Test plan
- [x] Full suite: 4,784 tests pass in 14 packages; `golangci-lint` clean
- [x] Fuzz: logql Parse (40s), translator TranslateLogQL/drop-keep (30s+), rules-migrate Convert (15s) — no crashers
- [x] Changelog gate green