### PR TITLE
fix: close review gaps in routing and chart defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Backend error bodies are now redacted on every remaining client-visible error path.**
+  1.58.1 routed the main handlers through `redactBackendError`, but several deeper paths
+  still returned raw VictoriaLogs `4xx`/`5xx` bodies — derived-volume hits, the
+  `stats_query_range`/`/hits` fast paths, the metric-range and query-translation backends,
+  and the detected-fields/label backends — and a VL parse/error message can echo the
+  translated LogsQL query (stream selectors, filter values). All of these now go through
+  `redactedBackendErrorMessage`/`redactedBackendStatusError`, which extract VL's message
+  and strip query-like content. The redactor also now masks single-quoted and
+  backtick-quoted literals (≥12 chars), not just double-quoted, so quoted values in VL
+  errors can no longer leak. No-op under `-debug-log-raw-queries=true`.
+
 ### Fixed
 
-- Hardened the review-gap fixes around backend error redaction, Drilldown metric routing, Helm freshness defaults, and metrics NetworkPolicy scoping so the defaults no longer leak backend parse details or surprise non-Grafana callers.
+- **Grafana Explore/dashboard metric ranges at 24h+ are no longer blanked by Drilldown
+  residual suppression.** The querySplitting residual-chunk suppression (empty matrix for
+  a sub-step trailing chunk) is now scoped to Drilldown-tagged traffic
+  (`isGrafanaDrilldownRequest`) instead of all Grafana-sourced requests
+  (`isGrafanaSourcedRequest`). Explore and dashboard panels rely on per-chunk axis
+  trimming alone, which keeps them spike-free without ever returning an empty chunk —
+  verified across all source tags in `TestLock_GrafanaMergedFrames_NoRightEdgeSpike`.
+- **Direct, non-Grafana high-cardinality `count() by(field)` queries now get exact stats.**
+  Window-sampled `/hits` (per-window top-N, right for Drilldown's visual exploration) was
+  applied to any high-cardinality field; it is now gated on Drilldown OR a Grafana-sourced
+  high-card field, so direct API clients and non-Grafana callers fall through to exact
+  `stats_query_range` aggregation (bounded by `max-stats-query-series`).
+- **Helm: enabling the ServiceMonitor no longer silently opens `/metrics` to all sources.**
+  With `serviceMonitor.enabled=true` and `networkPolicy.enabled=true`, the chart now
+  fails template rendering unless one of `networkPolicy.monitoringNamespace`,
+  `networkPolicy.monitoringFrom`, or the new explicit `networkPolicy.monitoringAllowAll=true`
+  is set — replacing the previous zero-config allow-all default for the metrics scrape
+  ingress rule.
+- **Helm: corrected stale chart documentation** for the stats-series default and the
+  peer-auth token wiring so the values reference matches the shipped behavior.
 - `rules-migrate` now validates rule expressions with the typed LogQL AST validator
   before translation. Malformed LogQL — e.g. a `| drop level!=~"debug"` matcher, which
   the proxy's query handlers already reject with HTTP 400 — previously slipped through
@@ -30,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Found by the expanded drop/keep tests.
 
 ### Changed
+- **Helm: `recent-tail-refresh-max-staleness` default lowered from 15s to 2s** to match
+  the binary default, so live-tail Explore stays fresh out of the box on chart deployments
+  (the 15s chart value previously exceeded the inner cache TTL and never bypassed).
 - Expanded test coverage for the LogQL parser, translator, and `rules-migrate`: added
   table-driven and fuzz tests for drop/keep matcher classification (all four operators,
   malformed-form skipping), rule-expression validation (valid translation + malformed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardened the review-gap fixes around backend error redaction, Drilldown metric routing, Helm freshness defaults, and metrics NetworkPolicy scoping so the defaults no longer leak backend parse details or surprise non-Grafana callers.
+
 ## [1.60.0] - 2026-06-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Helm: enabling the ServiceMonitor now requires an explicit metrics-scrape scope.**
+  With `serviceMonitor.enabled=true` and `networkPolicy.enabled=true`, the chart used to
+  render a NetworkPolicy that opened the `/metrics` port to **all** sources (zero-config
+  allow-all). It now **fails `helm template`/`helm upgrade`** unless one of
+  `networkPolicy.monitoringNamespace`, `networkPolicy.monitoringFrom`, or the new
+  `networkPolicy.monitoringAllowAll=true` is set. Affected: chart users with the
+  ServiceMonitor and NetworkPolicy both enabled and no scrape scope configured — their
+  next `helm upgrade` will error until they pick one. To restore the previous
+  open-to-all behavior, set `networkPolicy.monitoringAllowAll=true`; to scope it
+  (recommended), set `networkPolicy.monitoringNamespace` (a namespace name) or
+  `networkPolicy.monitoringFrom` (an explicit `NetworkPolicyPeer` list).
+
 ### Security
 
 - **Backend error bodies are now redacted on every remaining client-visible error path.**

--- a/charts/loki-vl-proxy/README.md
+++ b/charts/loki-vl-proxy/README.md
@@ -25,6 +25,9 @@ helm upgrade --install loki-vl-proxy oci://ghcr.io/reliablyobserve/charts/loki-v
 | `persistence.size` | `10Gi` | PVC size for disk cache |
 | `peerCache.enabled` | `false` | Enable distributed cache sharing across replicas |
 | `serviceMonitor.enabled` | `false` | Create Prometheus Operator ServiceMonitor |
+| `networkPolicy.monitoringNamespace` | `""` | Namespace allowed to scrape the metrics port when ServiceMonitor is enabled |
+| `networkPolicy.monitoringFrom` | `[]` | Explicit NetworkPolicy peers allowed to scrape the metrics port |
+| `networkPolicy.monitoringAllowAll` | `false` | Explicitly allow all sources to scrape metrics when ServiceMonitor is enabled |
 | `resources.requests.cpu` | `100m` | CPU request |
 | `resources.requests.memory` | `128Mi` | Memory request |
 | `resources.limits.cpu` | `1000m` | CPU limit |

--- a/charts/loki-vl-proxy/templates/networkpolicy.yaml
+++ b/charts/loki-vl-proxy/templates/networkpolicy.yaml
@@ -36,9 +36,8 @@ spec:
         1. networkPolicy.monitoringNamespace (convenience) — a namespace name,
            rendered as a namespaceSelector on kubernetes.io/metadata.name.
         2. networkPolicy.monitoringFrom (explicit) — a list of NetworkPolicyPeer.
-      monitoringFrom wins if both are set. When BOTH are empty the port is open
-      to all sources (zero-config default) — /metrics is non-sensitive read-only
-      counters, but scoping it with one of the above is recommended.
+      monitoringFrom wins if both are set. To intentionally allow scrapes from
+      any source, set networkPolicy.monitoringAllowAll=true explicitly.
     */}}
     {{- if .Values.networkPolicy.monitoringFrom }}
     - from:
@@ -54,10 +53,12 @@ spec:
       ports:
         - port: {{ include "loki-vl-proxy.metricsPort" . | int }}
           protocol: TCP
-    {{- else }}
+    {{- else if .Values.networkPolicy.monitoringAllowAll }}
     - ports:
         - port: {{ include "loki-vl-proxy.metricsPort" . | int }}
           protocol: TCP
+    {{- else }}
+      {{- fail "serviceMonitor.enabled=true with networkPolicy.enabled=true requires networkPolicy.monitoringNamespace, networkPolicy.monitoringFrom, or explicit networkPolicy.monitoringAllowAll=true for the metrics scrape ingress rule." }}
     {{- end }}
     {{- end }}
   {{- with .Values.networkPolicy.egress }}

--- a/charts/loki-vl-proxy/values.yaml
+++ b/charts/loki-vl-proxy/values.yaml
@@ -97,7 +97,7 @@ extraArgs:
   query-range-history-cache-ttl: "24h"
   recent-tail-refresh-enabled: "true"
   recent-tail-refresh-window: "2m"
-  recent-tail-refresh-max-staleness: "15s"
+  recent-tail-refresh-max-staleness: "2s"
   # Long-range phase controls (defaults shown here; uncomment to override quickly):
   # query-range-prefilter-index-stats: "true"          # preflight /select/logsql/hits to skip empty windows
   # query-range-prefilter-min-windows: "8"             # prefilter engages only when split windows >= this threshold
@@ -110,7 +110,7 @@ extraArgs:
   # query-range-background-warm: "true"                # continue warming failed windows in background
   # query-range-background-warm-max-windows: "24"      # cap background warm fanout
   # default-max-query-length: "0"                      # max query time range for all tenants (0 = unlimited; per-tenant limits override)
-  # max-stats-query-series: "5000"                      # max series returned by stats metric queries (count_over_time, rate, bytes_rate); 0 = built-in default of 5000
+  # max-stats-query-series: "500"                       # max series returned by stats metric queries (count_over_time, rate, bytes_rate); 0 = built-in default of 500
   # stats-query-range-concurrency: "4"                  # max concurrent stats_query_range calls to VL; higher = more VL CPU pressure; 0 = built-in default of 4
   # drilldown-burst-window-ms: "50"
   # drilldown-burst-max-fields: "30"
@@ -695,11 +695,11 @@ networkPolicy:
   #   1. monitoringNamespace (convenience) — just the namespace name; rendered as
   #      a namespaceSelector on kubernetes.io/metadata.name. e.g. "monitoring".
   #   2. monitoringFrom (explicit) — a list of NetworkPolicyPeer for full control.
-  # monitoringFrom takes precedence if both are set. If BOTH are left empty the
-  # metrics port is opened to ALL sources (zero-config default) — /metrics is
-  # non-sensitive read-only counters, but scoping it is recommended in production.
+  # monitoringFrom takes precedence if both are set. To intentionally keep the
+  # legacy allow-all scrape rule, set monitoringAllowAll=true explicitly.
   monitoringNamespace: ""  # e.g. "monitoring" or "prometheus"
   monitoringFrom: []
+  monitoringAllowAll: false
   #  - namespaceSelector:
   #      matchLabels:
   #        kubernetes.io/metadata.name: monitoring

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,7 +430,7 @@ These flags control Loki-compatible `query_range` split/merge execution with per
 | `-query-range-background-warm-max-windows` | — | `24` | Cap background warm fanout after a partial response |
 | `-recent-tail-refresh-enabled` | — | `true` | Enable near-now stale-cache bypass for `query_range`, `index/volume`, and `index/volume_range` |
 | `-recent-tail-refresh-window` | — | `2m` | Treat requests ending within this window from `now` as near-now |
-| `-recent-tail-refresh-max-staleness` | — | `15s` | Maximum acceptable cache age for near-now requests before forcing a fresh backend fetch |
+| `-recent-tail-refresh-max-staleness` | — | `2s` | Maximum acceptable cache age for near-now requests before forcing a fresh backend fetch |
 
 ### Loki-Aligned Defaults
 

--- a/docs/fleet-cache.md
+++ b/docs/fleet-cache.md
@@ -451,7 +451,7 @@ peerCache:
   selfAZ: "us-east-1a"
 ```
 
-When you use the Helm chart, prefer `peerCache.enabled=true` and let the chart wire the discovery flags. Use `extraArgs.peer-auth-token` only when you need a shared secret for peer fetches.
+When you use the Helm chart, prefer `peerCache.enabled=true` and let the chart wire the discovery flags. Use `peerCache.authToken` or `peerCache.existingSecret` when you need to provide the shared secret yourself; `extraArgs.peer-auth-token` is intentionally rejected while `peerCache.enabled=true` because the chart owns that CLI flag.
 
 ## Performance Characteristics
 

--- a/internal/cache/peer_coverage_test.go
+++ b/internal/cache/peer_coverage_test.go
@@ -251,23 +251,27 @@ func TestPeerCache_WriteThroughAndReadAheadBranches(t *testing.T) {
 		}
 
 		localCache.SetWithTTL(targetKey, []byte("payload"), 30*time.Second)
+		// Wait on the client-side WTPushes counter, which pushToOwner increments
+		// only AFTER the peer server has received the request and recorded `pushed`
+		// (peer.go). Polling the server-side `pushed` record alone races with that
+		// increment: the handler sets `pushed` and returns 204, but the client
+		// goroutine may not have reached WTPushes.Add(1) yet when the assertion runs
+		// — which flaked under loaded CI ("expected push count 1, got 0").
 		requireEventually(t, time.Second, func() bool {
-			mu.Lock()
-			defer mu.Unlock()
-			return pushed.key == targetKey
+			return pc.WTPushes.Load() == 1
 		})
 
 		mu.Lock()
 		got := pushed
 		mu.Unlock()
+		if got.key != targetKey {
+			t.Fatalf("unexpected pushed key %q, want %q", got.key, targetKey)
+		}
 		if string(got.body) != "payload" {
 			t.Fatalf("unexpected pushed body %q", string(got.body))
 		}
 		if got.ttl != "30000" {
 			t.Fatalf("unexpected pushed ttl %q", got.ttl)
-		}
-		if got := pc.WTPushes.Load(); got != 1 {
-			t.Fatalf("expected write-through push count 1, got %d", got)
 		}
 	})
 

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -719,11 +719,7 @@ func (p *Proxy) vlGetCoalesced(ctx context.Context, key, path string, params url
 		return nil, err
 	}
 	if status >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", status)
-		}
-		return nil, errors.New(msg)
+		return nil, p.redactedBackendStatusError("", status, body)
 	}
 	return body, nil
 }

--- a/internal/proxy/cold_dispatch.go
+++ b/internal/proxy/cold_dispatch.go
@@ -163,7 +163,7 @@ func (p *Proxy) coldBackwardChunkedFetch(ctx context.Context, baseParams url.Val
 		if resp.StatusCode >= 400 {
 			body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
 			resp.Body.Close()
-			return nil, fmt.Errorf("cold backend %d: %s", resp.StatusCode, body)
+			return nil, p.redactedBackendStatusError("cold backend", resp.StatusCode, body)
 		}
 		chunkBody, readErr := io.ReadAll(resp.Body)
 		resp.Body.Close()

--- a/internal/proxy/drilldown.go
+++ b/internal/proxy/drilldown.go
@@ -988,8 +988,8 @@ func (p *Proxy) volumeByDerivedLabels(ctx context.Context, query, start, end, ta
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= http.StatusBadRequest {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("derived volume hits request failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
+		return nil, fmt.Errorf("derived volume hits request failed: status=%d body=%s", resp.StatusCode, p.redactedBackendErrorMessage(resp.StatusCode, body))
 	}
 
 	body, _ := io.ReadAll(resp.Body)
@@ -1611,10 +1611,7 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 		if resp.StatusCode >= http.StatusInternalServerError {
 			errBody, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			msg := strings.TrimSpace(string(errBody))
-			if msg == "" {
-				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-			}
+			msg := p.redactedBackendErrorMessage(resp.StatusCode, errBody)
 			lastErr = fmt.Errorf("%s", msg)
 			hadScanFailure = true
 			continue
@@ -1622,10 +1619,7 @@ func (p *Proxy) detectFields(ctx context.Context, query, start, end string, line
 		if resp.StatusCode >= http.StatusBadRequest {
 			errBody, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			msg := strings.TrimSpace(string(errBody))
-			if msg == "" {
-				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-			}
+			msg := p.redactedBackendErrorMessage(resp.StatusCode, errBody)
 			// Collect native result before returning so the goroutine doesn't leak.
 			<-nativeCh
 			return nil, nil, fmt.Errorf("%s", msg)
@@ -2498,10 +2492,7 @@ func (p *Proxy) fetchNativeFieldValues(ctx context.Context, query, start, end, f
 		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		if resp.StatusCode >= http.StatusBadRequest {
-			msg := strings.TrimSpace(string(body))
-			if msg == "" {
-				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-			}
+			msg := p.redactedBackendErrorMessage(resp.StatusCode, body)
 			lastErr = fmt.Errorf("%s", msg)
 			if i+1 < len(candidates) {
 				p.observeInternalOperation(ctx, "discovery_fallback", "native_field_values_relaxed_after_error", 0)
@@ -2855,10 +2846,7 @@ func (p *Proxy) detectScannedLabels(ctx context.Context, query, start, end strin
 		if resp.StatusCode >= http.StatusBadRequest {
 			errBody, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			msg := strings.TrimSpace(string(errBody))
-			if msg == "" {
-				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-			}
+			msg := p.redactedBackendErrorMessage(resp.StatusCode, errBody)
 			lastErr = fmt.Errorf("%s", msg)
 			if i+1 < len(candidates) {
 				p.observeInternalOperation(ctx, "discovery_fallback", "detected_labels_relaxed_after_error", 0)

--- a/internal/proxy/drilldown_burst_coalescer.go
+++ b/internal/proxy/drilldown_burst_coalescer.go
@@ -378,7 +378,7 @@ func (p *Proxy) fusedFieldHits(
 
 		if resp.StatusCode >= 400 {
 			body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-			return nil, fmt.Errorf("fused stats_query_range %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			return nil, p.redactedBackendStatusError("fused stats_query_range", resp.StatusCode, body)
 		}
 
 		const maxFusedResponseBytes = 64 << 20

--- a/internal/proxy/drilldown_regression_lock_test.go
+++ b/internal/proxy/drilldown_regression_lock_test.go
@@ -260,12 +260,12 @@ func TestLock_HitsRunsForAllRanges(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Lock 3: Leftover-chunk suppression for ANY Grafana source.
+// Lock 3: Leftover-chunk suppression for Drilldown source.
 // ---------------------------------------------------------------------------
 
 // TestLock_LeftoverChunkSuppressed pins the rule:
 //
-//	end - start ≤ 2 × step AND any Grafana source signal → empty matrix
+//	end - start < step AND Drilldown source signal → empty matrix
 //
 // Why empty (not "best-effort distribute the few values"): the chunk is so
 // small that /hits can only produce a 1-bucket axis. Emitting the top-20
@@ -275,19 +275,16 @@ func TestLock_HitsRunsForAllRanges(t *testing.T) {
 // chart shows the 24h chunk's distributed series unaffected (losing ≤ 1 step
 // of width on the very right edge, which is invisible at typical render widths).
 //
-// All four Grafana source signals must trigger suppression. Non-Grafana
-// requests with the same shape must NOT trigger suppression — a raw API
-// client querying 1m of data legitimately wants whatever VL has.
+// Plain Grafana and non-Grafana requests with the same shape must NOT trigger
+// suppression — those callers legitimately want whatever VL has.
 func TestLock_LeftoverChunkSuppressedInHits(t *testing.T) {
 	// The Grafana 24h+ querySplitting residual is a sub-step chunk (range < step)
 	// that yields a single-bucket /hits frame; Grafana's mergeFrames collapses its
 	// N single-point series onto one edge of the merged chart (a right-edge spike
 	// or a left-edge "all data at the beginning" cluster). The /hits path suppresses
-	// it (X-Proxy-Drilldown-Path=hits-leftover-suppressed). Scope: ONLY Grafana
-	// sub-step requests reaching the high-card /hits path — a non-Grafana caller and
-	// any range >= one full step are served normally. (The proxy-wide dispatch-level
-	// blanking that over-blanked low-card dashboards stays removed; those take the
-	// exact stats path, not /hits — see TestWindowedHits_GatedToDrilldownOrHighCard.)
+	// it (X-Proxy-Drilldown-Path=hits-leftover-suppressed). Scope: ONLY Drilldown
+	// sub-step requests reaching the high-card /hits path — plain Grafana, a
+	// non-Grafana caller, and any range >= one full step are served normally.
 	cases := []struct {
 		name         string
 		startSec     int64
@@ -299,8 +296,8 @@ func TestLock_LeftoverChunkSuppressedInHits(t *testing.T) {
 		// Grafana, sub-step residual (range < step) → SUPPRESS.
 		{"drilldown_60s_step120", 1700000000, 1700000060, "120", "drilldown", true},
 		{"drilldown_119s_step120", 1700000000, 1700000119, "120", "drilldown", true},
-		{"explore_via_ua_60s", 1700000000, 1700000060, "120", "grafana-ua", true},
-		{"explore_via_hdr_60s", 1700000000, 1700000060, "120", "grafana-hdr", true},
+		{"grafana_ua_60s", 1700000000, 1700000060, "120", "grafana-ua", false},
+		{"grafana_hdr_60s", 1700000000, 1700000060, "120", "grafana-hdr", false},
 		// Grafana, range >= step (legitimate >=1-bucket query) → do NOT suppress.
 		{"drilldown_120s_step120", 1700000000, 1700000120, "120", "drilldown", false},
 		{"drilldown_240s_step120", 1700000000, 1700000240, "120", "drilldown", false},
@@ -562,8 +559,8 @@ func TestLock_FieldHasExistenceFilter_QuotedDotted(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestLock_IsGrafanaSourcedRequest pins which client signals count as
-// "Grafana source" for the leftover-chunk suppression. If any of these
-// stops being detected, Grafana clients lose the spike-suppression fix.
+// "Grafana source" for Grafana-only compatibility behavior such as
+// partial-results conversion and high-cardinality optimization.
 func TestLock_IsGrafanaSourcedRequest(t *testing.T) {
 	cases := []struct {
 		name string
@@ -904,17 +901,16 @@ func runChunkSim(t *testing.T, source string, chunks [][2]int64, step time.Durat
 }
 
 // TestLock_GrafanaMergedFrames_NoRightEdgeSpike is the headline regression
-// guard for the Drilldown / Explore right-edge spike. It runs the embedded
-// Grafana querySplitting + mergeFrames simulator for the four time ranges
-// the user reported broken (24h, 25h, 2d, 7d) for every Grafana source
-// signal, and asserts the rightmost bin holds < 40% of all nonzero
-// timestamps in the merged frame.
+// guard for the Drilldown right-edge spike. It runs the embedded Grafana
+// querySplitting + mergeFrames simulator for the four time ranges the user
+// reported broken (24h, 25h, 2d, 7d) for the Drilldown source tag, and asserts
+// the rightmost bin holds < 40% of all nonzero timestamps in the merged frame.
 //
 // If a future PR regresses ANY of:
 //   - leftover-chunk suppression
 //   - /hits-for-all-ranges routing
 //   - shared timestamp axis
-//   - source-tag-agnostic routing
+//   - Drilldown source-tag routing
 //
 // at least one of these subtests fails because the chunk-unique series
 // stack at the right edge again.
@@ -951,7 +947,7 @@ func TestLock_GrafanaMergedFrames_NoRightEdgeSpike(t *testing.T) {
 		{"2d", 48, 12},
 		{"7d", 168, 14},
 	}
-	sources := []string{"drilldown", "grafana-ua", "grafana-hdr"}
+	sources := []string{"drilldown"}
 
 	for _, source := range sources {
 		for _, rc := range rangeCases {

--- a/internal/proxy/drilldown_regression_lock_test.go
+++ b/internal/proxy/drilldown_regression_lock_test.go
@@ -901,16 +901,23 @@ func runChunkSim(t *testing.T, source string, chunks [][2]int64, step time.Durat
 }
 
 // TestLock_GrafanaMergedFrames_NoRightEdgeSpike is the headline regression
-// guard for the Drilldown right-edge spike. It runs the embedded Grafana
-// querySplitting + mergeFrames simulator for the four time ranges the user
-// reported broken (24h, 25h, 2d, 7d) for the Drilldown source tag, and asserts
-// the rightmost bin holds < 40% of all nonzero timestamps in the merged frame.
+// guard for the right-edge spike. It runs the embedded Grafana querySplitting +
+// mergeFrames simulator for the four time ranges the user reported broken (24h,
+// 25h, 2d, 7d) across ALL Grafana source tags — Drilldown, Explore via
+// User-Agent, and Explore/dashboard via header — and asserts the rightmost bin
+// holds < 40% of all nonzero timestamps in the merged frame.
+//
+// The non-Drilldown sources are kept on purpose even though residual suppression
+// is now scoped to Drilldown: they verify that per-chunk axis trimming alone
+// keeps Explore/dashboard metric ranges spike-free, so narrowing suppression to
+// Drilldown did not reintroduce the spike for the other sources.
 //
 // If a future PR regresses ANY of:
-//   - leftover-chunk suppression
+//   - leftover-chunk suppression (Drilldown)
+//   - per-chunk axis trimming (all sources)
 //   - /hits-for-all-ranges routing
 //   - shared timestamp axis
-//   - Drilldown source-tag routing
+//   - source-tag routing
 //
 // at least one of these subtests fails because the chunk-unique series
 // stack at the right edge again.
@@ -947,7 +954,7 @@ func TestLock_GrafanaMergedFrames_NoRightEdgeSpike(t *testing.T) {
 		{"2d", 48, 12},
 		{"7d", 168, 14},
 	}
-	sources := []string{"drilldown"}
+	sources := []string{"drilldown", "grafana-ua", "grafana-hdr"}
 
 	for _, source := range sources {
 		for _, rc := range rangeCases {

--- a/internal/proxy/http_utils.go
+++ b/internal/proxy/http_utils.go
@@ -340,7 +340,9 @@ var (
 	reErrSelector = regexp.MustCompile(`\{[^{}]*\}`)
 	// Long quoted literals — line-filter values, field values, an echoed query.
 	// Short quotes (e.g. unknown field "id") are left readable.
-	reErrQuoted = regexp.MustCompile(`"[^"]{12,}"`)
+	reErrQuoted         = regexp.MustCompile(`"[^"]{12,}"`)
+	reErrSingleQuoted   = regexp.MustCompile(`'[^']{12,}'`)
+	reErrBacktickQuoted = regexp.MustCompile("`[^`]{12,}`")
 	// Long hex/id runs (request ids, hashes).
 	reErrLongHex = regexp.MustCompile(`\b[0-9a-fA-F]{16,}\b`)
 )
@@ -358,11 +360,29 @@ func (p *Proxy) redactBackendError(body []byte) string {
 	msg = RedactSecrets(msg)
 	msg = reErrSelector.ReplaceAllString(msg, "{…}")
 	msg = reErrQuoted.ReplaceAllString(msg, `"…"`)
+	msg = reErrSingleQuoted.ReplaceAllString(msg, `'…'`)
+	msg = reErrBacktickQuoted.ReplaceAllString(msg, "`…`")
 	msg = reErrLongHex.ReplaceAllString(msg, "…")
 	if len(msg) > 500 {
 		msg = msg[:500] + "…"
 	}
 	return msg
+}
+
+func (p *Proxy) redactedBackendErrorMessage(status int, body []byte) string {
+	msg := p.redactBackendError(body)
+	if msg == "" {
+		return fmt.Sprintf("VL backend returned %d", status)
+	}
+	return msg
+}
+
+func (p *Proxy) redactedBackendStatusError(prefix string, status int, body []byte) error {
+	msg := p.redactedBackendErrorMessage(status, body)
+	if prefix == "" {
+		return errors.New(msg)
+	}
+	return fmt.Errorf("%s %d: %s", prefix, status, msg)
 }
 
 // lokiErrorType returns the Loki/Prometheus-style errorType for an HTTP status code.

--- a/internal/proxy/label_handlers.go
+++ b/internal/proxy/label_handlers.go
@@ -392,11 +392,7 @@ func (p *Proxy) computeIndexStatsResult(ctx context.Context, query, start, end s
 	defer resp.Body.Close()
 	body, _ := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
 	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
-		return nil, fmt.Errorf("%s", msg)
+		return nil, p.redactedBackendStatusError("", resp.StatusCode, body)
 	}
 
 	entries := sumHitsValues(body)

--- a/internal/proxy/metric_binary.go
+++ b/internal/proxy/metric_binary.go
@@ -334,10 +334,10 @@ func isQuerySplitResidual(r *http.Request) bool {
 // isQuerySplitResidualParams is isQuerySplitResidual with explicit start/end/step.
 // Deep handlers (the /hits leaf) must pass their captured raw values: by the time
 // a request reaches them the proxy may have rewritten r.URL for downstream VL
-// calls, so r.FormValue("start"/"end"/"step") can be empty. Only the Grafana-source
+// calls, so r.FormValue("start"/"end"/"step") can be empty. Only the Drilldown-source
 // check reads r (it uses headers, which persist).
 func isQuerySplitResidualParams(r *http.Request, startRaw, endRaw, stepRaw string) bool {
-	if !isGrafanaSourcedRequest(r) {
+	if !isGrafanaDrilldownRequest(r) {
 		return false
 	}
 	sNs, sok := parseLokiTimeToUnixNano(startRaw)
@@ -2130,7 +2130,7 @@ func stripUnpackStagesForTopN(base string) string {
 // guarantees each time window contributes its own top-K, so the merged set spans
 // the whole timeline — fixing the sparse/one-spike overview chart that the bounded
 // global top-N produced for churning short-lived values (pod, *_id). The /hits path
-// also suppresses Grafana's 24h querySplitting residual-chunk right-edge spike.
+// also suppresses Drilldown's 24h querySplitting residual-chunk right-edge spike.
 //
 // The level value-filter (detected_level → `| filter level:=...`) is preserved:
 // VL /hits accepts a column-indexed filter pipe (verified), and stripUnpackStagesForTopN
@@ -2139,20 +2139,20 @@ func stripUnpackStagesForTopN(base string) string {
 func (p *Proxy) tryHighCardCountByWindowedHits(w http.ResponseWriter, r *http.Request, logsqlQuery string) bool {
 	// The windowed-/hits path returns per-window-sampled top-N series rather than
 	// exact stats_query_range results. That visualization-optimized trade-off is
-	// right for Drilldown (visual exploration, any field) and for high-cardinality
-	// fields (trace_id, *_id, *_token — where the full unbounded response is
-	// 40MB+/25s and would be cancelled), but it is the WRONG default for a normal
-	// Grafana dashboard panel over a low-cardinality field (e.g. count by(status)),
-	// which expects exact aggregation. Scope to Drilldown OR a high-card field;
-	// everything else (normal dashboards, Explore low-card, non-Grafana API
-	// clients) falls through to the exact direct path (bounded to
+	// right for Drilldown (visual exploration, any field) and for Grafana-sourced
+	// high-cardinality fields (trace_id, *_id, *_token — where the full unbounded
+	// response is 40MB+/25s and would be cancelled), but it is the WRONG default
+	// for normal low-cardinality panels and direct API clients, which expect exact
+	// aggregation. Scope to Drilldown OR Grafana-sourced high-card fields;
+	// everything else (normal dashboards, Explore low-card, non-Grafana API clients)
+	// falls through to the exact direct path (bounded to
 	// maxStatsQuerySeries top-N-by-count, like Loki's max_query_series, with the
 	// two-phase fallback only on a 16MB overflow).
 	spec, ok := parseStatsCompatSpec(logsqlQuery)
 	if !ok || spec.Func != "count" || len(spec.GroupBy) != 1 {
 		return false
 	}
-	if !isGrafanaDrilldownRequest(r) && !isLikelyHighCardinalityField(spec.GroupBy[0]) {
+	if !isGrafanaDrilldownRequest(r) && (!isGrafanaSourcedRequest(r) || !isLikelyHighCardinalityField(spec.GroupBy[0])) {
 		return false
 	}
 	startRaw, endRaw, stepRaw := r.FormValue("start"), r.FormValue("end"), r.FormValue("step")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -322,7 +322,7 @@ type Config struct {
 	DefaultMaxQueryLength time.Duration
 	// MaxStatsQuerySeries caps the number of series returned by stats_query_range
 	// (count_over_time, rate, bytes_rate with explicit by()). Matches Loki's
-	// max_query_series behaviour. 0 means use the built-in default (5000).
+	// max_query_series behaviour. 0 means use the built-in default (500).
 	MaxStatsQuerySeries int
 	// StatsQueryRangeConcurrency limits the number of concurrent
 	// stats_query_range calls the proxy makes to VL. Each Drilldown Fields

--- a/internal/proxy/query_range_windowing.go
+++ b/internal/proxy/query_range_windowing.go
@@ -455,10 +455,7 @@ func (p *Proxy) fetchQueryRangeWindow(
 		} else {
 			errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 			_ = resp.Body.Close()
-			msg := strings.TrimSpace(string(errBody))
-			if msg == "" {
-				msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-			}
+			msg := p.redactedBackendErrorMessage(resp.StatusCode, errBody)
 			fetchErr = &queryRangeWindowHTTPError{status: resp.StatusCode, msg: msg}
 		}
 		lastFetchErr = fetchErr
@@ -588,10 +585,7 @@ func (p *Proxy) queryRangeWindowHitEstimate(
 			return hitEstimate, nil
 		}
 		if err == nil {
-			msg := strings.TrimSpace(string(body))
-			if msg == "" {
-				msg = fmt.Sprintf("VL backend returned %d", status)
-			}
+			msg := p.redactedBackendErrorMessage(status, body)
 			err = &queryRangeWindowHTTPError{status: status, msg: msg}
 		}
 		if attempt >= queryRangePrefilterAttempts || !shouldRetryQueryRangeWindow(err) {

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -1042,10 +1042,7 @@ func (p *Proxy) fetchBareParserMetricSeries(ctx context.Context, originalQuery s
 	defer resp.Body.Close()
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
+		msg := p.redactedBackendErrorMessage(resp.StatusCode, body)
 		return nil, &vlAPIError{status: resp.StatusCode, body: msg}
 	}
 
@@ -1197,7 +1194,7 @@ func (p *Proxy) fetchBareParserMetricSeriesViaHits(
 	defer resp.Body.Close()
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		return nil, fmt.Errorf("hits: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, p.redactedBackendStatusError("hits: status", resp.StatusCode, body)
 	}
 
 	body, err := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
@@ -1302,7 +1299,7 @@ func (p *Proxy) fetchBareParserCountBytesViaStats(
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		return nil, "", fmt.Errorf("stats_query_range %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, "", p.redactedBackendStatusError("stats_query_range", resp.StatusCode, body)
 	}
 
 	const maxBytes = 64 << 20
@@ -1425,7 +1422,7 @@ func (p *Proxy) fetchBareParserUnwrapViaStats(
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		return nil, fmt.Errorf("stats_query_range %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, p.redactedBackendStatusError("stats_query_range", resp.StatusCode, body)
 	}
 
 	const maxBytes = 64 << 20 // 64 MB

--- a/internal/proxy/range_metric_compat.go
+++ b/internal/proxy/range_metric_compat.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -804,7 +803,7 @@ func (p *Proxy) collectRangeMetricHits(
 
 	if resp.StatusCode >= 400 {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		return nil, fmt.Errorf("stats_query_range backend %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, p.redactedBackendStatusError("stats_query_range backend", resp.StatusCode, body)
 	}
 
 	const maxStatsResponseBytes = 64 << 20 // 64 MB
@@ -924,8 +923,8 @@ func (p *Proxy) collectRangeMetricSamples(ctx context.Context, baseQuery string,
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("backend returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
+		return nil, p.redactedBackendStatusError("backend returned", resp.StatusCode, body)
 	}
 
 	// seriesCache caches per (_stream + "|" + level) within this request.

--- a/internal/proxy/review_findings_test.go
+++ b/internal/proxy/review_findings_test.go
@@ -140,10 +140,9 @@ func TestPurgePeerCaches_ConcurrencyCapped(t *testing.T) {
 }
 
 // TestResidualBlankedThroughHandleQueryRange drives the REAL query_range entry
-// (handleQueryRange) for a Grafana sub-step metric residual and asserts it is
+// (handleQueryRange) for a Drilldown sub-step metric residual and asserts it is
 // blanked there — before routing — regardless of which downstream path would
-// otherwise serve it. This is the deterministic in-process guard for the
-// Drilldown high-cardinality "all data clusters at one edge" regression.
+// otherwise serve it. Plain Grafana Explore/dashboard traffic stays exact.
 func TestResidualBlankedThroughHandleQueryRange(t *testing.T) {
 	backend := newRecorderBackend()
 	// Catch-all already returns an empty matrix; make the stats/hits paths return
@@ -171,7 +170,7 @@ func TestResidualBlankedThroughHandleQueryRange(t *testing.T) {
 		{"pod_label_residual", `sum by (pod) (count_over_time({namespace="prod",pod!=""} [2m]))`, 1700000000, 1700000060, "120", "drilldown", true},
 		{"pod_residual_nanos", `sum by (pod) (count_over_time({namespace="prod",pod!=""} [2m]))`, 1700000000000000000, 1700000090000000000, "167s", "drilldown", true},
 		{"field_residual", `sum by (request_id) (count_over_time({namespace="prod"} | request_id!="" [2m]))`, 1700000000, 1700000060, "120", "drilldown", true},
-		{"explore_ua_residual", `sum by (pod) (count_over_time({namespace="prod",pod!=""} [2m]))`, 1700000000, 1700000060, "120", "grafana-ua", true},
+		{"grafana_ua_residual_not_blanked", `sum by (pod) (count_over_time({namespace="prod",pod!=""} [2m]))`, 1700000000, 1700000060, "120", "grafana-ua", false},
 		{"full_step_not_residual", `sum by (pod) (count_over_time({namespace="prod",pod!=""} [2m]))`, 1700000000, 1700000240, "120", "drilldown", false},
 		{"non_grafana_not_residual", `sum by (pod) (count_over_time({namespace="prod",pod!=""} [2m]))`, 1700000000, 1700000060, "120", "", false},
 		{"log_query_never_blanked", `{namespace="prod"}`, 1700000000, 1700000060, "120", "drilldown", false},
@@ -228,11 +227,59 @@ func TestRedactBackendError(t *testing.T) {
 	}
 }
 
+func TestRedactedBackendStatusError_RedactsQueryEcho(t *testing.T) {
+	p := &Proxy{}
+	body := []byte("{\"error\":\"cannot parse query {namespace=\\\"prod\\\",app=\\\"billing\\\"} |= `token=supersecretvalue`: unexpected token at offset deadbeefcafe1234\"}")
+
+	err := p.redactedBackendStatusError("stats_query_range", http.StatusInternalServerError, body)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "stats_query_range 500:") {
+		t.Fatalf("expected status prefix retained, got: %s", got)
+	}
+	for _, leak := range []string{"prod", "billing", "supersecretvalue", "deadbeefcafe1234"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("redacted status error still leaks %q: %s", leak, got)
+		}
+	}
+}
+
+func TestCollectRangeMetricSamples_RedactsBackendError(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			http.Error(w, "unexpected backend path: "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"cannot parse query {namespace=\"prod\",app=\"billing\"} |= \"password=hunter2sekret\": unexpected token at offset deadbeefcafe1234"}`))
+	}))
+	defer backend.Close()
+	p := newTestProxy(t, backend.URL)
+
+	_, err := p.collectRangeMetricSamples(
+		context.Background(),
+		`{namespace="prod",app="billing"} |= "password=hunter2sekret"`,
+		nil, nil, false, "", "",
+		time.Unix(1700000000, 0),
+		time.Unix(1700000060, 0),
+	)
+	if err == nil {
+		t.Fatal("expected backend error")
+	}
+	got := err.Error()
+	for _, leak := range []string{"prod", "billing", "password=hunter2sekret", "deadbeefcafe1234"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("manual range metric backend error still leaks %q: %s", leak, got)
+		}
+	}
+}
+
 // TestWindowedHits_GatedToDrilldownOrHighCard covers finding 3 (round 2): the
 // window-sampled /hits rewrite (lossy per-window top-N sampling) must apply ONLY
-// to Drilldown requests OR high-cardinality fields. A normal Grafana dashboard
-// panel over a low-cardinality field, an Explore low-card query, and a direct API
-// client must all fall through to exact stats_query_range.
+// to Drilldown requests OR Grafana-sourced high-cardinality fields. Direct API
+// clients must stay exact even for high-cardinality groupings.
 func TestWindowedHits_GatedToDrilldownOrHighCard(t *testing.T) {
 	p := &Proxy{}
 	// 24h range so the >=2h gate would otherwise pass.
@@ -263,11 +310,14 @@ func TestWindowedHits_GatedToDrilldownOrHighCard(t *testing.T) {
 
 	// Non-Grafana, low-card → exact. (Also covers finding-3 round 1.)
 	rejects("non-grafana low-card", mk(false, false), lowCard)
+	// Non-Grafana, high-card → exact API semantics; no sampled /hits rewrite.
+	rejects("non-grafana high-card", mk(false, false), highCard)
 	// Grafana dashboard/Explore (UA only, NOT Drilldown), low-card → exact.
 	rejects("grafana dashboard low-card", mk(false, true), lowCard)
 
-	// The gate ITSELF admits Drilldown (any field) and high-card fields. We assert
-	// the gate predicates rather than the full path (which needs a backend).
+	// The gate ITSELF admits Drilldown (any field) and Grafana-sourced high-card
+	// fields. We assert the source/cardinality predicates rather than the full path
+	// (which needs a backend).
 	if !isGrafanaDrilldownRequest(mk(true, true)) {
 		t.Error("drilldown-tagged request must be recognized as Drilldown")
 	}
@@ -280,5 +330,4 @@ func TestWindowedHits_GatedToDrilldownOrHighCard(t *testing.T) {
 	if isLikelyHighCardinalityField("status") {
 		t.Error("status must NOT be treated as high-cardinality")
 	}
-	_ = highCard
 }

--- a/internal/proxy/stream_processing.go
+++ b/internal/proxy/stream_processing.go
@@ -96,10 +96,7 @@ func (p *Proxy) proxyLogQuery(w http.ResponseWriter, r *http.Request, logsqlQuer
 	// Propagate VL error status to the client with Loki-compatible error format.
 	if resp.StatusCode >= 400 {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		errMsg := extractVLErrorMsg(body)
-		if errMsg == "" {
-			errMsg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
+		errMsg := p.redactedBackendErrorMessage(resp.StatusCode, body)
 		p.writeError(w, resp.StatusCode, errMsg)
 		return
 	}

--- a/internal/proxy/tail.go
+++ b/internal/proxy/tail.go
@@ -183,7 +183,7 @@ func (p *Proxy) preflightTailAccess(parent context.Context, logsqlQuery, startHi
 	}
 
 	body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-	msg := strings.TrimSpace(string(body))
+	msg := p.redactedBackendErrorMessage(resp.StatusCode, body)
 	if msg == "" {
 		msg = http.StatusText(resp.StatusCode)
 	}
@@ -245,7 +245,7 @@ func (p *Proxy) openNativeTailStream(parent context.Context, logsqlQuery string)
 
 	body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
 	_ = resp.Body.Close()
-	msg := strings.TrimSpace(string(body))
+	msg := p.redactedBackendErrorMessage(resp.StatusCode, body)
 	if msg == "" {
 		msg = http.StatusText(resp.StatusCode)
 	}
@@ -289,7 +289,7 @@ func (p *Proxy) writeSyntheticTailBatch(ctx context.Context, conn tailConn, logs
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := readBodyLimited(resp.Body, maxUpstreamErrorBodyBytes)
-		return fmt.Errorf("synthetic tail query failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("synthetic tail query failed: status=%d body=%s", resp.StatusCode, p.redactedBackendErrorMessage(resp.StatusCode, body))
 	}
 
 	scanner := bufio.NewScanner(resp.Body)

--- a/internal/proxy/volume.go
+++ b/internal/proxy/volume.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	stdjson "encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"sort"
@@ -280,11 +279,7 @@ func (p *Proxy) computeVolumeResult(ctx context.Context, query, start, end, targ
 	defer resp.Body.Close()
 	body, _ := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
 	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
-		return nil, fmt.Errorf("%s", msg)
+		return nil, p.redactedBackendStatusError("", resp.StatusCode, body)
 	}
 
 	return p.hitsToVolumeVector(body, targetLabels), nil
@@ -419,11 +414,7 @@ func (p *Proxy) computeVolumeRangeResult(ctx context.Context, query, start, end,
 	defer resp.Body.Close()
 	body, _ := readBodyLimited(resp.Body, maxBufferedBackendBodyBytes)
 	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
-		return nil, fmt.Errorf("%s", msg)
+		return nil, p.redactedBackendStatusError("", resp.StatusCode, body)
 	}
 
 	return p.hitsToVolumeMatrix(body, targetLabels, start, end, step, limit), nil
@@ -465,11 +456,7 @@ func (p *Proxy) computeVolumeRangeViaStats(ctx context.Context, logsqlQuery, tar
 		return nil, err
 	}
 	if resp.StatusCode >= http.StatusBadRequest {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = fmt.Sprintf("VL backend returned %d", resp.StatusCode)
-		}
-		return nil, fmt.Errorf("%s", msg)
+		return nil, p.redactedBackendStatusError("", resp.StatusCode, body)
 	}
 	consolidated := consolidateSingleLabelStats(body, vlField, targetLabel, limit)
 	var result map[string]interface{}

--- a/test/e2e-compat/docker-compose.yml
+++ b/test/e2e-compat/docker-compose.yml
@@ -799,7 +799,13 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_PLUGINS_PREINSTALL=victoriametrics-logs-datasource@0.26.3,grafana-lokiexplore-app
+      # Pin the Logs Drilldown plugin: an unpinned grafana-lokiexplore-app pulls
+      # whatever is latest at image-build time, which drifts the landing-page UI
+      # (e.g. the "Filter by labels" combobox role/name) out from under the
+      # Playwright selectors — deterministically breaking e2e-ui (drilldown-core)
+      # and (drilldown-multitenant) in CI while a cached older plugin still passes
+      # locally. Bump this pin deliberately alongside any selector updates.
+      - GF_PLUGINS_PREINSTALL=victoriametrics-logs-datasource@0.26.3,grafana-lokiexplore-app@2.0.4
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-lokiexplore-app
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro


### PR DESCRIPTION
## Summary

Closes a batch of review-gap findings around error redaction, Drilldown/Explore metric routing, and Helm metrics-scrape defaults — plus the CI fixes needed to land them.

### Security — backend error-body redaction completeness
1.58.1 routed the main handlers through `redactBackendError`, but several deeper paths still returned **raw VictoriaLogs error bodies**, which can echo the translated LogsQL query (stream selectors, filter values):
- derived-volume `/hits`, the `stats_query_range` and `/hits` fast paths, the metric-range and query-translation backends, and the detected-fields/label backends now all go through `redactedBackendErrorMessage` / `redactedBackendStatusError` (`backend.go`, `drilldown.go`, `volume.go`, `query_range_windowing.go`, `query_translation.go`, `range_metric_compat.go`, `label_handlers.go`, `cold_dispatch.go`, `tail.go`, `stream_processing.go`).
- the redactor now also masks **single-quoted and backtick-quoted** literals (≥12 chars), not just double-quoted (`http_utils.go`).
- No-op under `-debug-log-raw-queries=true`.

### Fixed — Drilldown/Explore metric routing
- **Explore/dashboard 24h+ ranges are no longer blanked by Drilldown residual suppression.** The querySplitting residual-chunk suppression is scoped to Drilldown-tagged traffic (`isGrafanaDrilldownRequest`) instead of all Grafana-sourced requests; Explore/dashboard rely on per-chunk axis trimming, which keeps them spike-free without ever returning an empty chunk.
- **Direct, non-Grafana high-cardinality `count() by(field)` queries get exact stats** again — window-sampled `/hits` is now gated on Drilldown OR a Grafana-sourced high-card field, so direct API/non-Grafana callers fall through to exact `stats_query_range`.

### Fixed — Helm
- **ServiceMonitor no longer silently opens `/metrics` to all sources.** With `serviceMonitor.enabled=true` + `networkPolicy.enabled=true`, the chart now fails rendering unless `networkPolicy.monitoringNamespace`, `networkPolicy.monitoringFrom`, or the new explicit `networkPolicy.monitoringAllowAll=true` is set.
- **`recent-tail-refresh-max-staleness` default 15s → 2s** to match the binary default (the 15s chart value exceeded the inner cache TTL and never bypassed → stale live-tail on chart deployments).
- Corrected stale stats-series and peer-auth chart docs.

### Test / CI hardening (to land the above)
- **Restored the `grafana-ua` / `grafana-hdr` cases in `TestLock_GrafanaMergedFrames_NoRightEdgeSpike`** instead of dropping them: they now positively prove that narrowing residual suppression to Drilldown did **not** reintroduce the right-edge spike for Explore/dashboard (axis-trimming covers them). `review_findings_test.go` updated so the residual test asserts grafana-ua is *not blanked*. New `redactedBackend*` redaction tests assert the query echo is stripped.
- Detailed CHANGELOG under `[Unreleased]`.

> Note: the unrelated drilldown e2e-ui CI flake was root-caused separately (the Logs Drilldown plugin was preinstalled unpinned, so CI pulled 2.1.1 and broke the "Filter by labels" selector) and pinned to `@2.0.4` on main; this branch inherits that pin via the merge.

## Test plan
- [x] `go test ./...` green; `golangci-lint` clean
- [x] e2e-ui `@drilldown-core` (3/3) + `@drilldown-mt` (7/7) green locally against the rebuilt stack
- [x] helm template: default render; ServiceMonitor unscoped fails as expected; `monitoringNamespace` renders a namespaceSelector; `monitoringAllowAll=true` renders an explicit open metrics rule
- [x] CHANGELOG gate green