### PR TITLE
build(deps): bump Go toolchain to 1.26.5 for stdlib CVE fixes

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -207,7 +207,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install Helm
@@ -264,7 +264,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install Helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Build
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Tuple contract gate (default 2-tuple + categorize-labels 3-tuple)
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       # --- internal/proxy ---
@@ -192,7 +192,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Race-detector tests on concurrency-critical packages
@@ -225,7 +225,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4
@@ -273,7 +273,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Run benchmarks
@@ -601,7 +601,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: gofmt -s (Go Report Card parity)
@@ -657,7 +657,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4
@@ -734,7 +734,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4
@@ -791,7 +791,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: actions/setup-node@v7
@@ -872,7 +872,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Stress tests (concurrency + race detector)
@@ -896,7 +896,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Memory-leak tests (bounded heap growth + race detector)
@@ -918,7 +918,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install Helm

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/compat-drilldown.yaml
+++ b/.github/workflows/compat-drilldown.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7

--- a/.github/workflows/compat-loki.yaml
+++ b/.github/workflows/compat-loki.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7

--- a/.github/workflows/compat-vl.yaml
+++ b/.github/workflows/compat-vl.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7

--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/pr-quality-report.yaml
+++ b/.github/workflows/pr-quality-report.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install Helm

--- a/.github/workflows/security-heavy.yaml
+++ b/.github/workflows/security-heavy.yaml
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Longer fuzzing
@@ -130,7 +130,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/security-pr.yaml
+++ b/.github/workflows/security-pr.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Gitleaks
@@ -156,7 +156,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: docker/setup-buildx-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Go toolchain bumped to 1.26.5** across the Dockerfile builder image, `go.mod`
+  (`bench/go.mod`), and every CI `setup-go` pin, to pick up the patched standard
+  library for **CVE-2026-42505** (crypto/tls Encrypted Client Hello information
+  disclosure) and **CVE-2026-39822** (`os.Root` symlink-following directory
+  traversal). Rebuilding the `loki-vl-proxy` and `healthcheck` binaries against the
+  fixed stdlib clears both findings from the Trivy filesystem scan that was failing
+  the Security workflow on `main`. No behavioral change.
+
 ## [1.62.0] - 2026-06-11
 
 ### Breaking Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 AS builder
+FROM golang:1.26.5-alpine3.22 AS builder
 WORKDIR /app
 ARG VERSION=dev
 ARG REVISION=unknown

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -1,3 +1,3 @@
 module github.com/ReliablyObserve/Loki-VL-proxy/bench
 
-go 1.26.4
+go 1.26.5

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ description: Install and run loki-vl-proxy in minutes — binary, Docker, or Hel
 
 - VictoriaLogs reachable from the proxy (`http://<host>:9428`)
 - Grafana using a Loki datasource
-- Go `1.26.4+` if running from source, or Docker for containerized runs
+- Go `1.26.5+` if running from source, or Docker for containerized runs
 
 :::tip Latest release
 Replace `<release>` throughout this page with the current version tag (no `v` prefix). The latest release is **`1.36.3`**. Check [GitHub Releases](https://github.com/ReliablyObserve/loki-vl-proxy/releases) for newer versions.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ReliablyObserve/Loki-VL-proxy
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## What
Bumps the Go toolchain **1.26.4 → 1.26.5** across the Dockerfile builder image, `go.mod` / `bench/go.mod`, and every CI `setup-go` pin.

## Why
The `Security / static → Trivy filesystem scan` job is failing on `main`. Trivy flags two Go **stdlib** CVEs embedded in the compiled `loki-vl-proxy` and `healthcheck` binaries:

- **CVE-2026-42505** — crypto/tls: Encrypted Client Hello information disclosure (GO-2026-5856)
- **CVE-2026-39822** — os.Root: symlink-following directory traversal (GO-2026-4970)

Both are fixed in **Go 1.26.5** (and 1.25.12). Rebuilding against the patched stdlib clears both from the binary scan.

## Verification
- `go build ./...` ✅  `go vet ./...` ✅  `go test ./...` → **4785 passed** ✅ (on go1.26.5)
- Historical Go-version reference in `docs/benchmarks.md` intentionally left untouched.

Part of a stacked series addressing the failing Security workflow, open Dependabot/code-scanning alerts, and VictoriaLogs v1.52 compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)