### PR TITLE
fix(security): fingerprint Basic-Auth principal in request log (CodeQL go/clear-text-logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vulnerabilities** (including newer transitive advisories in dompurify,
   fast-uri and svgo, cleared via lockfile patch bumps); the site build and
   typecheck pass. Docs-site only — no proxy runtime change.
+- **Basic-Auth principal is now fingerprinted in the request log.** The
+  `auth.principal` field in the structured request log carried the Basic-Auth
+  username verbatim — credential material read from the `Authorization` header
+  (flagged by CodeQL `go/clear-text-logging` in
+  `internal/proxy/query_translation.go`). It is now routed through the same
+  `redactQuery` fingerprint (`sha256:<8hex> len=<n>`) used for raw queries, and
+  is emitted verbatim only under `-debug-log-raw-queries=true`. The Basic-Auth
+  password was never logged. Trusted-proxy `enduser.*` audit fields are
+  unchanged.
 
 ## [1.62.0] - 2026-06-11
 

--- a/internal/proxy/query_translation.go
+++ b/internal/proxy/query_translation.go
@@ -223,8 +223,12 @@ func (p *Proxy) requestLogger(endpoint, route string, next http.HandlerFunc) htt
 			logAttrs = append(logAttrs, "enduser.name", enduserName)
 		}
 		if authUser != "" {
+			// authUser is the Basic-Auth username, read from the Authorization
+			// header. It is credential material, so fingerprint it by default
+			// (raw only under -debug-log-raw-queries), mirroring how raw queries
+			// are redacted. Prevents clear-text logging of credentials.
 			logAttrs = append(logAttrs,
-				"auth.principal", authUser,
+				"auth.principal", redactQuery(authUser, p.debugLogRawQueries),
 				"auth.source", authSource,
 			)
 		}

--- a/internal/proxy/request_logger_semconv_test.go
+++ b/internal/proxy/request_logger_semconv_test.go
@@ -343,3 +343,59 @@ func TestParseGrafanaRuntimeMajor(t *testing.T) {
 		t.Fatalf("expected 0 for non-semver token, got %d", got)
 	}
 }
+
+func TestRequestLogger_RedactsBasicAuthPrincipal(t *testing.T) {
+	// The Basic-Auth username is credential material read from the Authorization
+	// header. By default it must be fingerprinted (never logged in clear text);
+	// under -debug-log-raw-queries it is emitted verbatim, mirroring how raw
+	// LogQL/LogsQL queries are handled. Regression guard for CodeQL
+	// go/clear-text-logging on internal/proxy/query_translation.go.
+	newReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?query=%7Bapp%3D%22x%22%7D", nil)
+		req.RemoteAddr = "10.0.0.10:1234"
+		req.SetBasicAuth("svc-account", "super-secret-password")
+		return req
+	}
+
+	// Default: redacted.
+	var buf bytes.Buffer
+	p := &Proxy{
+		log:     slog.New(slog.NewJSONHandler(&buf, nil)),
+		metrics: metrics.NewMetrics(),
+	}
+	h := p.requestLogger("query_range", "/loki/api/v1/query_range", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h.ServeHTTP(httptest.NewRecorder(), newReq())
+	payload := decodeLastJSONLogLine(t, &buf)
+
+	principal, _ := payload["auth.principal"].(string)
+	if principal == "svc-account" {
+		t.Fatalf("Basic-Auth username leaked in clear text into auth.principal: %q", principal)
+	}
+	if want := redactQuery("svc-account", false); principal != want {
+		t.Fatalf("auth.principal = %q, want fingerprint %q", principal, want)
+	}
+	if payload["auth.source"] != "basic_auth" {
+		t.Fatalf("auth.source = %#v, want basic_auth", payload["auth.source"])
+	}
+	if strings.Contains(buf.String(), "super-secret-password") {
+		t.Fatal("Basic-Auth password must never appear in the request log")
+	}
+
+	// Opt-in raw: verbatim.
+	var rawBuf bytes.Buffer
+	pRaw := &Proxy{
+		log:                slog.New(slog.NewJSONHandler(&rawBuf, nil)),
+		metrics:            metrics.NewMetrics(),
+		debugLogRawQueries: true,
+	}
+	hRaw := pRaw.requestLogger("query_range", "/loki/api/v1/query_range", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	hRaw.ServeHTTP(httptest.NewRecorder(), newReq())
+	rawPayload := decodeLastJSONLogLine(t, &rawBuf)
+	if rawPayload["auth.principal"] != "svc-account" {
+		t.Fatalf("under -debug-log-raw-queries auth.principal = %#v, want verbatim svc-account", rawPayload["auth.principal"])
+	}
+}


### PR DESCRIPTION
## What
Routes the Basic-Auth username (`auth.principal` in the structured request log) through the existing `redactQuery` fingerprint (`sha256:<8hex> len=<n>`) instead of logging it verbatim. Verbatim output remains available under `-debug-log-raw-queries=true`.

## Why
CodeQL **HIGH** `go/clear-text-logging` at `internal/proxy/query_translation.go:231`: the Basic-Auth username — credential material read from the `Authorization` header via `r.BasicAuth()` — flowed verbatim into the audit log. The password was never logged.

The fix mirrors the repo's established redaction idiom (`redactQuery`, gated by `-debug-log-raw-queries`). Trusted-proxy `enduser.*` audit-identity fields (from `X-Grafana-User` etc.) are intentionally unchanged — those are already-authenticated identities used for audit, not credential material.

## Verification
- New `TestRequestLogger_RedactsBasicAuthPrincipal`: asserts the username is fingerprinted by default, emitted verbatim under the debug flag, and the password never appears in the log. ✅
- Full `internal/proxy` package: **2323 passed** ✅

Part of a stacked series addressing the failing Security workflow and open code-scanning/Dependabot alerts.