### PR TITLE
ci(security): pin all Actions to SHAs, add dependabot cooldown, fix nosemgrep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # Let new releases bake before opening a PR (supply-chain hardening).
+    cooldown:
+      default-days: 7
     groups:
       actions-minor:
         patterns: ["*"]
@@ -19,6 +22,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
     groups:
       go-minor:
         update-types: ["minor", "patch"]
@@ -32,6 +37,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - docker

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -28,7 +28,7 @@ jobs:
       next_version: ${{ steps.check.outputs.next_version }}
       latest_tag: ${{ steps.check.outputs.latest_tag }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
 
@@ -201,17 +201,17 @@ jobs:
       coverage_pct: ${{ steps.metrics.outputs.coverage_pct }}
       code_lines: ${{ steps.metrics.outputs.code_lines }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
 
       - name: Verify unreleased changelog section exists
         run: |
@@ -257,18 +257,18 @@ jobs:
       HAS_RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN != '' }}
       HAS_GHCR_PACKAGE_ADMIN_TOKEN: ${{ secrets.GHCR_PACKAGE_ADMIN_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PR_TOKEN != '' && secrets.RELEASE_PR_TOKEN || github.token }}
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
 
       - name: Extract release metadata
         id: meta
@@ -357,10 +357,10 @@ jobs:
             --password-stdin
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -368,7 +368,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: docker.io
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -393,7 +393,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -430,7 +430,7 @@ jobs:
           echo "Ensured public visibility for ghcr.io/${OWNER_LC}/charts/loki-vl-proxy"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/changelog-pr.yaml
+++ b/.github/workflows/changelog-pr.yaml
@@ -12,11 +12,11 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Verify dashboard and alerting assets are synced to chart
         run: ./scripts/ci/sync_observability_assets.sh --check
@@ -27,7 +27,7 @@ jobs:
       - name: Unit tests (quality gate policy)
         run: python3 -m unittest scripts.ci.tests.test_check_quality_gate scripts.ci.tests.test_check_changelog_pr
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -62,7 +62,7 @@ jobs:
           }'
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage
           path: |
@@ -73,9 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -87,9 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -188,9 +188,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -221,16 +221,16 @@ jobs:
       PROXY_URL_CATEGORIZED: http://127.0.0.1:13102
       SMOKE_QUERY: '{app="e2e-test"}'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -269,9 +269,9 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -563,7 +563,7 @@ jobs:
             | tee load-results.txt
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: benchmarks
           path: |
@@ -597,9 +597,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -614,7 +614,7 @@ jobs:
           fi
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
         with:
           version: v2.11.4
           args: --timeout=5m
@@ -623,7 +623,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Build Docker image
         run: docker build -t loki-vl-proxy:test .
@@ -653,16 +653,16 @@ jobs:
             pattern: '^(TestSetup_IngestLogs|TestQuerySemanticsMatrixManifest|TestQuerySemanticsOperationsInventory|TestQuerySemanticsMatrix|TestGrafanaClickout_.*|TestMissingOps_.*|TestRangeMetricCompatibility.*|TestLogQL_Exhaustive_.*|TestPipeline_.*|TestEdge_DropErrorInstantQueryReturnsAggregatedResult|TestEdge_DetectedFieldsAfterJsonDropPipelineIncludesJsonFields)$'
     name: e2e-compat (${{ matrix.group.name }})
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -730,16 +730,16 @@ jobs:
     env:
       PROXY_IMAGE: loki-vl-proxy:fleet-ci
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -787,29 +787,29 @@ jobs:
             command: --grep @explore-mt
     name: e2e-ui (${{ matrix.shard.name }})
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: test/e2e-ui/package-lock.json
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('test/e2e-ui/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-ms-playwright-
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -851,7 +851,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: playwright-report-${{ matrix.shard.name }}
           path: |
@@ -868,9 +868,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -883,7 +883,7 @@ jobs:
 
       - name: Upload stress test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: stress-results
           path: stress-results.txt
@@ -892,9 +892,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -906,7 +906,7 @@ jobs:
 
       - name: Upload memory-leak test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: memleak-results
           path: memleak-results.txt
@@ -914,15 +914,15 @@ jobs:
   helm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
 
       - name: Helm lint
         run: helm lint charts/loki-vl-proxy/

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,15 +24,15 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
         with:
           languages: go
 
@@ -40,4 +40,4 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a  # v4

--- a/.github/workflows/compat-drilldown.yaml
+++ b/.github/workflows/compat-drilldown.yaml
@@ -25,7 +25,7 @@ jobs:
       grafana_runtime_profiles: ${{ steps.matrix.outputs.grafana_runtime_profiles }}
       grafana_pr_runtime_profiles: ${{ steps.matrix.outputs.grafana_pr_runtime_profiles }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - id: matrix
         run: |
           {
@@ -44,13 +44,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:13.0.1
       PROXY_IMAGE: loki-vl-proxy:compat-drilldown
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -84,13 +84,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:${{ matrix.version }}
       PROXY_IMAGE: loki-vl-proxy:compat-drilldown
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -119,7 +119,7 @@ jobs:
       matrix:
         drilldown_version: ${{ fromJson(needs.drilldown-matrix-source.outputs.drilldown_versions) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Check Drilldown app contracts
         run: bash scripts/compat/check-drilldown-contracts.sh "${{ matrix.drilldown_version }}"
 
@@ -137,13 +137,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:${{ matrix.version }}
       PROXY_IMAGE: loki-vl-proxy:compat-drilldown
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/compat-loki.yaml
+++ b/.github/workflows/compat-loki.yaml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       loki_versions: ${{ steps.matrix.outputs.loki_versions }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - id: matrix
         run: echo "loki_versions=$(jq -c '.stack.loki.matrix_versions' test/e2e-compat/compatibility-matrix.json)" >> "$GITHUB_OUTPUT"
 
@@ -37,13 +37,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:12.4.2
       PROXY_IMAGE: loki-vl-proxy:compat-loki
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -107,13 +107,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:12.4.2
       PROXY_IMAGE: loki-vl-proxy:compat-loki
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/compat-vl.yaml
+++ b/.github/workflows/compat-vl.yaml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       vl_versions: ${{ steps.matrix.outputs.vl_versions }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - id: matrix
         run: echo "vl_versions=$(jq -c '.stack.victorialogs.matrix_versions' test/e2e-compat/compatibility-matrix.json)" >> "$GITHUB_OUTPUT"
 
@@ -37,13 +37,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:12.4.2
       PROXY_IMAGE: loki-vl-proxy:compat-vl
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -76,13 +76,13 @@ jobs:
       GRAFANA_IMAGE: grafana/grafana:12.4.2
       PROXY_IMAGE: loki-vl-proxy:compat-vl
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docs-site.yaml
+++ b/.github/workflows/docs-site.yaml
@@ -35,10 +35,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: '22'
           cache: npm
@@ -76,11 +76,11 @@ jobs:
 
       - name: Configure Pages
         if: github.event_name != 'pull_request' && steps.pages_site.outputs.exists == 'true'
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && steps.pages_site.outputs.exists == 'true'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: website/build
 
@@ -97,4 +97,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -21,16 +21,16 @@ jobs:
     env:
       PROXY_IMAGE: loki-vl-proxy:e2e-pipeline
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload pipeline test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: pipeline-results
           path: pipeline-results.txt

--- a/.github/workflows/ghcr-badges.yaml
+++ b/.github/workflows/ghcr-badges.yaml
@@ -16,7 +16,7 @@ jobs:
   update-badges:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Fetch GHCR pull counts
         id: pulls

--- a/.github/workflows/loc-badges.yaml
+++ b/.github/workflows/loc-badges.yaml
@@ -13,7 +13,7 @@ jobs:
   update-loc-badges:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Count LOC
         id: loc

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-quality-report.yaml
+++ b/.github/workflows/pr-quality-report.yaml
@@ -15,18 +15,18 @@ jobs:
     env:
       PROXY_IMAGE: loki-vl-proxy:pr-quality
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -60,7 +60,7 @@ jobs:
 
       - name: Restore cached base quality snapshot
         id: base-quality-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
           path: .cache/pr-quality/base-quality.json
           key: ${{ runner.os }}-pr-quality-base-${{ github.event.pull_request.base.sha }}-perf-${{ steps.perf-scope.outputs.run_perf }}-schema-v3
@@ -104,7 +104,7 @@ jobs:
             /tmp/pr-head-quality.json
 
       - name: Upload quality artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: pr-quality-report
           path: |
@@ -115,7 +115,7 @@ jobs:
       - name: Publish sticky PR comment
         # Fork PRs run with a read-only token — skip silently rather than failing.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-pr-validation.yaml
+++ b/.github/workflows/release-pr-validation.yaml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
           grep -q "\"service.version\": \"${VERSION}\"" docs/observability.md
 
       - name: Helm lint
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
 
       - name: Run Helm lint
         run: helm lint charts/loki-vl-proxy/

--- a/.github/workflows/security-heavy.yaml
+++ b/.github/workflows/security-heavy.yaml
@@ -17,11 +17,11 @@ jobs:
     env:
       PROXY_IMAGE: loki-vl-proxy:security-heavy
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -42,20 +42,20 @@ jobs:
           scanners: vuln,misconfig,secret
 
       - name: Upload Trivy image SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
         if: always()
         with:
           sarif_file: trivy-image.sarif
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0
         with:
           image: ${{ env.PROXY_IMAGE }}
           format: spdx-json
           output-file: sbom.spdx.json
 
       - name: Upload image security artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: image-security
@@ -70,7 +70,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Semgrep scan
         run: |
@@ -97,7 +97,7 @@ jobs:
             --error
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -106,9 +106,9 @@ jobs:
     name: Heavy / fuzz
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -126,16 +126,16 @@ jobs:
       PROXY_IMAGE: loki-vl-proxy:security-heavy
       PROXY_BASE_URL: http://127.0.0.1:13100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -160,7 +160,7 @@ jobs:
         run: ./scripts/ci/run_nuclei_scan.sh
 
       - name: Upload heavy dast artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: heavy-dast

--- a/.github/workflows/security-pr.yaml
+++ b/.github/workflows/security-pr.yaml
@@ -24,11 +24,11 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
@@ -46,7 +46,7 @@ jobs:
             --exit-code 1
 
       - name: Upload Gitleaks SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
         if: ${{ always() && hashFiles('gitleaks.sarif') != '' }}
         with:
           sarif_file: gitleaks.sarif
@@ -64,7 +64,7 @@ jobs:
             ./...
 
       - name: Upload gosec SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
         if: ${{ always() && hashFiles('gosec.sarif') != '' }}
         with:
           sarif_file: gosec.sarif
@@ -86,7 +86,7 @@ jobs:
             --skip-version-check
 
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
         if: ${{ always() && hashFiles('trivy-fs.sarif') != '' }}
         with:
           sarif_file: trivy-fs.sarif
@@ -133,7 +133,7 @@ jobs:
             --require-check SAST=7
 
       - name: Upload security static artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: security-static
@@ -152,16 +152,16 @@ jobs:
       PROXY_IMAGE: loki-vl-proxy:security-ci
       PROXY_BASE_URL: http://127.0.0.1:13100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version: "1.26.5"
           cache: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: ./Dockerfile
@@ -183,7 +183,7 @@ jobs:
         run: ./scripts/ci/run_zap_scan.sh baseline
 
       - name: Upload runtime security artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: security-runtime

--- a/.github/workflows/vl-ast-coverage.yml
+++ b/.github/workflows/vl-ast-coverage.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check VL upstream AST coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Run VL AST coverage check
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is emitted verbatim only under `-debug-log-raw-queries=true`. The Basic-Auth
   password was never logged. Trusted-proxy `enduser.*` audit fields are
   unchanged.
+- **All GitHub Actions are now pinned to commit SHAs** (with a `# vN` comment so
+  Dependabot keeps them current), clearing 143 Semgrep
+  `github-actions-mutable-action-tag` code-scanning findings across 18 workflows.
+- **Dependabot `cooldown` (7 days) added** to every update ecosystem
+  (github-actions, gomod, docker), so fresh releases bake before a PR is opened —
+  clears the `dependabot-missing-cooldown` findings.
+- **`scripts/check-vl-ast-coverage.py`**: moved the `nosemgrep` suppression onto
+  the `HTTPSConnection` match line (Semgrep only honors it on the match line or
+  the line directly above), clearing the `httpsconnection-detected` finding. The
+  connection is to a fixed, trusted host with default TLS verification.
 
 ## [1.62.0] - 2026-06-11
 

--- a/scripts/check-vl-ast-coverage.py
+++ b/scripts/check-vl-ast-coverage.py
@@ -58,14 +58,13 @@ def fetch_file_list(token: str | None) -> list[str]:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
-        # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         # Semgrep flags HTTPSConnection because TLS verification semantics
         # changed across Python 3.x versions. This script only runs in CI
         # against api.github.com on the pinned 3.x container (Python ≥ 3.4.3
         # has TLS verification on by default — older than any Python we ship).
         # Connecting to a fixed, trusted host with default verification → safe.
-        conn = http.client.HTTPSConnection(VL_API_HOST, timeout=15)
+        # The suppression must sit on the match line itself for Semgrep to honor it.
+        conn = http.client.HTTPSConnection(VL_API_HOST, timeout=15)  # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
         conn.request("GET", VL_API_PATH, headers=headers)
         resp = conn.getresponse()
         body = resp.read()


### PR DESCRIPTION
## What
Supply-chain hardening across CI, clearing the largest bucket of open code-scanning findings.

- **Pin all 143 tag-based `uses:` refs to commit SHAs** across 18 workflows (`actions/checkout@v7` → `@3d3c42e… # v7`, etc.), each with a `# vN` comment so Dependabot's existing `actions-minor` group keeps them updated.
- **Add `cooldown: {default-days: 7}`** to every Dependabot ecosystem (github-actions, gomod, docker) so fresh releases bake before a PR is opened.
- **Fix the `nosemgrep` suppression** in `scripts/check-vl-ast-coverage.py`: it sat several lines above the `HTTPSConnection` call, but Semgrep only honors it on the match line or the line directly above. Moved inline.

## Findings cleared
- 143× `yaml.github-actions.security.github-actions-mutable-action-tag`
- 3× `package_managers.dependabot.dependabot-missing-cooldown`
- 1× `python.lang.security.audit.httpsconnection-detected`

## Verification (local, semgrep 1.161.0)
```
mutable-action-tag:      findings: 0 | files scanned: 18 | errors: 0
dependabot-missing-cooldown: 0 findings
httpsconnection-detected:    0 findings
```
All workflow YAML + `dependabot.yml` parse valid; the Python script compiles. SHAs were resolved from each tag via the GitHub API and match the SHAs already pinned elsewhere in the repo.