### PR TITLE
fix(docker): correct builder tag to golang:1.26.5-alpine3.24 (unbreak main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dockerfile builder image tag corrected to `golang:1.26.5-alpine3.24`.** The
+  Go 1.26.5 bump referenced `golang:1.26.5-alpine3.22`, which does not exist on
+  Docker Hub (Alpine moved to 3.23/3.24 for the 1.26.5 line), breaking the
+  `docker` build and all e2e jobs on `main`. Verified the image builds.
+
 ### Security
 
 - **Go toolchain bumped to 1.26.5** across the Dockerfile builder image, `go.mod`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.22 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 WORKDIR /app
 ARG VERSION=dev
 ARG REVISION=unknown


### PR DESCRIPTION
## Urgent — fixes broken `main`
#472 bumped the builder to `golang:1.26.5-alpine3.22`, which **does not exist** on Docker Hub (Alpine moved to 3.23/3.24 for the 1.26.5 line). The `docker` build and every downstream e2e job now fail on `main`:

```
ERROR: docker.io/library/golang:1.26.5-alpine3.22: not found
```

## Fix
Pin to `golang:1.26.5-alpine3.24` (newest Alpine for this Go line).

## Verification
`docker build .` → **succeeds**, produces both `loki-vl-proxy` and `healthcheck` binaries. ✅