### PR TITLE
test(proxy): stop the log-level test from asserting on a shared default logger buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `main` and on open PRs failed at the `Govulncheck` step. Reproduced locally
   with `GOOS=linux`; v1.8.0 completes and reports no vulnerabilities.
 
+### Fixed
+
+- **Flaky unit test `TestNew_RespectsConfiguredLogLevelOverDefaultLogger`.** The
+  test pointed `slog.Default()` at a buffer and asserted the buffer stayed empty,
+  but other tests in the package run proxies whose background backend probes log
+  through the default logger concurrently, so the buffer occasionally captured
+  their lines and the release validation job (`go test ./...` without `-race`)
+  failed. The test now asserts only that its own info message is suppressed.
+
 ## [1.64.0] - 2026-09-12
 
 ### Security

--- a/internal/proxy/log_level_test.go
+++ b/internal/proxy/log_level_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,7 +31,11 @@ func TestNew_RespectsConfiguredLogLevelOverDefaultLogger(t *testing.T) {
 	}
 
 	p.log.Info("suppressed info log")
-	if buf.Len() != 0 {
+	// Other tests in this package run proxies whose background probes log
+	// through slog.Default(), which this test temporarily points at buf. Only
+	// this proxy's own message proves the configured level took precedence;
+	// asserting an empty buffer races with those goroutines and flakes.
+	if strings.Contains(buf.String(), "suppressed info log") {
 		t.Fatalf("expected info log to be suppressed, got %q", buf.String())
 	}
 }


### PR DESCRIPTION
## Summary

The auto-release run for `8bb63d9` failed in `validate-release` on `TestNew_RespectsConfiguredLogLevelOverDefaultLogger`.

**Root cause.** The test replaces `slog.Default()` with a buffer-backed logger and asserts the buffer stays empty after `p.log.Info(...)`. Sibling tests in `internal/proxy` create proxies whose backend-version probes log through the default logger from background goroutines, so the buffer intermittently captures their `upstream_request` / `backend version detected` lines (the captured line in CI came from another test's `127.0.0.1:36661` backend). It passes under `-race` in PR CI purely by timing and fails in the release job's `go test ./... -count=1`.

**Fix.** Assert only that this proxy's own message (`suppressed info log`) is absent, which is the property under test. The `Enabled(LevelInfo)` check is unchanged.

## Verification

- `go test ./internal/proxy -run TestNew_RespectsConfiguredLogLevelOverDefaultLogger -count=3` passes.
- `go vet ./internal/proxy`, `gofmt -l` clean.
- Changelog gate passes (entry under Fixed).