### PR TITLE
test(proxy): wait for the background labels refresh before asserting a cache hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Flaky unit test `TestHandleLabels_SecondRequestIsCacheHit` under the race
+  detector.** A cache miss on `/labels` serves the synchronous fetch capped to
+  five minutes and schedules a background full-range refresh for wider
+  ranges, so the test's one-hour first request always produces a second,
+  asynchronous backend call. The assertion that the second request adds no
+  backend calls sampled the counter while that refresh was still in flight and
+  attributed it to the second request (`race-stress` job, loaded runner). The
+  test now waits for the counter to settle after the first request, keeping
+  the cache-hit assertion exact.
+
 ## [1.66.0] - 2026-09-12
 
 ### Added

--- a/internal/proxy/label_cache_behavior_test.go
+++ b/internal/proxy/label_cache_behavior_test.go
@@ -346,11 +346,40 @@ func TestHandleLabels_VLInternalFieldsFiltered(t *testing.T) {
 	}
 }
 
+// waitForBackendIdle blocks until the backend call counter has stopped moving.
+// A cache miss on /labels serves the synchronous fetch capped to
+// metadataMaxFieldNamesWindow and then schedules refreshLabelsCacheAsync for
+// the full user range whenever the range is wider, so the first request below
+// (1h > 5m) always produces a second, asynchronous backend call. Sampling the
+// counter while that refresh is in flight attributes it to whichever request
+// happens to be under test (seen under -race on a loaded CI runner as "second
+// request triggered 1 extra VL call"). Waiting for the counter to settle keeps
+// the assertion about the second request exact.
+func waitForBackendIdle(t *testing.T, calls *atomic.Int64) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	last := calls.Load()
+	stable := 0
+	for stable < 20 {
+		if time.Now().After(deadline) {
+			t.Fatalf("backend call counter still moving after 10s (last=%d)", last)
+		}
+		time.Sleep(10 * time.Millisecond)
+		if n := calls.Load(); n != last {
+			last = n
+			stable = 0
+			continue
+		}
+		stable++
+	}
+}
+
 func TestHandleLabels_SecondRequestIsCacheHit(t *testing.T) {
 	srv, calls := fieldNamesServer(t, []string{"app", "env"})
 	_, mux := newBehaviorProxy(t, srv.URL, 5*time.Minute)
 
 	_ = getLabels(t, mux, time.Hour)
+	waitForBackendIdle(t, calls) // let the background full-range refresh land
 	callsAfterFirst := calls.Load()
 
 	_ = getLabels(t, mux, time.Hour)


### PR DESCRIPTION
## Summary

`TestHandleLabels_SecondRequestIsCacheHit` failed in the `race-stress` job on PR #516 with "second request triggered 1 extra VL call(s), expected 0 (cache hit)". It passes locally, including `-race -count=5`.

Root cause: a cache miss on `/labels` serves the synchronous backend fetch capped to `metadataMaxFieldNamesWindow` (5 minutes) and, when the requested range is wider, schedules `refreshLabelsCacheAsync` for the full range. The test's first request uses a one-hour window, so it always produces a second, asynchronous backend call. The assertion sampled the counter before and after the second request; on a loaded runner the background refresh landed between the two samples and was attributed to the second request. Verified by probing the counter after the first request: it moves from 1 to 2 within 50 ms with no further requests.

Fix: wait for the backend call counter to settle after the first request (`waitForBackendIdle`, 10 s deadline), then assert that the second request adds no calls. The cache-hit assertion stays exact; the test now also documents the background refresh.

## Verification

- `go test -race -count=20 -run '^TestHandleLabels_' ./internal/proxy/` passes.
- `go vet`, `gofmt` clean; changelog gate ok.